### PR TITLE
mod lookup plugin name from 'loop' to 'list'

### DIFF
--- a/roles/confluent.kafka-broker/tasks/main.yml
+++ b/roles/confluent.kafka-broker/tasks/main.yml
@@ -14,7 +14,7 @@
     group: "{{kafka.broker.group}}"
     state: directory
     mode: 0755
-  loop: "{{kafka.broker.datadir}}"
+  list: "{{kafka.broker.datadir}}"
 - name: broker plaintext config
   template:
     src: server.properties.j2


### PR DESCRIPTION
I had an error to create kafka-broker as follows:
```
FAILED! => {"msg": "Unexpected failure in finding the lookup named '{{kafka.broker.datadir}}' in the available lookup plugins"}
```
I think, it should be `list`, and this code works.