### PR TITLE
Added variables for Confluent MetricsReporter

### DIFF
--- a/roles/confluent.common/defaults/main.yml
+++ b/roles/confluent.common/defaults/main.yml
@@ -6,6 +6,9 @@ broker:
     port: 9092
 confluent:
   package_name: confluent-platform-2.11
+  support:
+    customer_id: anonymous
+    metrics_enabled: true
   repository:
     debian:
     redhat:

--- a/roles/confluent.kafka-broker/defaults/main.yml
+++ b/roles/confluent.kafka-broker/defaults/main.yml
@@ -28,5 +28,6 @@ kafka:
       zookeeper.connection.timeout.ms: 6000
       metric.reporters: io.confluent.metrics.reporter.ConfluentMetricsReporter
       confluent.metrics.reporter.bootstrap.servers: "{{inventory_hostname}}:{{broker.config.port}}"
+      confluent.metrics.reporter.topic.replicas: 3
       ssl.endpoint.identification.algorithm: ""
       confluent.metrics.reporter.ssl.endpoint.identification.algorithm: ""

--- a/roles/confluent.kafka-broker/templates/server.properties.j2
+++ b/roles/confluent.kafka-broker/templates/server.properties.j2
@@ -9,3 +9,6 @@ listeners=PLAINTEXT://:{{broker.config.port}}
 {% for key, value in kafka.broker.config.items() %}
 {{key}}={{value}}
 {% endfor %}
+
+confluent.support.metrics.enable={{confluent.support.metrics_enabled|bool|lower}}
+confluent.support.customer.id={{confluent.support.customer_id}}

--- a/roles/confluent.kafka-broker/templates/server_sasl_ssl.properties.j2
+++ b/roles/confluent.kafka-broker/templates/server_sasl_ssl.properties.j2
@@ -32,3 +32,6 @@ confluent.metrics.reporter.sasl.jaas.config=org.apache.kafka.common.security.pla
 {% for key, value in kafka.broker.config.items() %}
 {{key}}={{value}}
 {% endfor %}
+
+confluent.support.metrics.enable={{confluent.support.metrics_enabled|bool|lower}}
+confluent.support.customer.id={{confluent.support.customer_id}}

--- a/roles/confluent.kafka-broker/templates/server_ssl.properties.j2
+++ b/roles/confluent.kafka-broker/templates/server_ssl.properties.j2
@@ -24,3 +24,6 @@ confluent.metrics.reporter.ssl.key.password=confluent
 {% for key, value in kafka.broker.config.items() %}
 {{key}}={{value}}
 {% endfor %}
+
+confluent.support.metrics.enable={{confluent.support.metrics_enabled|bool|lower}}
+confluent.support.customer.id={{confluent.support.customer_id}}


### PR DESCRIPTION
Kafka Cluster of 1 broker was failing to start with the default metrics reporter replication factor, so added these defaults 

```yaml
confluent:
+  support:
+    customer_id: anonymous
+    metrics_enabled: true
kafka:
  broker:
    config:
+      confluent.metrics.reporter.topic.replicas: 3
```

Also updated `server.properties` with the relevant settings. 

Ideally, that bottom piece should be broken out to a [separate template and included in the rest](https://stackoverflow.com/a/42760481/2308683)