### PR TITLE
Integrate KSQL,Schema Registry,Connect and Control Center

### DIFF
--- a/all.yml
+++ b/all.yml
@@ -26,6 +26,10 @@
   tasks:
   - import_role:
       name: confluent.connect-distributed
+- hosts: ksql
+  tasks:
+  - import_role:
+      name: confluent.ksql
 - hosts: control-center
   tasks:
   - import_role:
@@ -34,10 +38,6 @@
   tasks:
   - import_role:
       name: confluent.kafka-rest
-- hosts: ksql
-  tasks:
-  - import_role:
-      name: confluent.ksql
 - hosts: tools
   tasks:
   - import_role:

--- a/plaintext/all.yml
+++ b/plaintext/all.yml
@@ -18,6 +18,10 @@
   tasks:
   - import_role:
       name: confluent.connect-distributed
+- hosts: ksql
+  tasks:
+  - import_role:
+      name: confluent.ksql
 - hosts: control-center
   tasks:
   - import_role:
@@ -26,7 +30,3 @@
   tasks:
   - import_role:
       name: confluent.kafka-rest
-- hosts: ksql
-  tasks:
-  - import_role:
-      name: confluent.ksql

--- a/roles/confluent.connect-distributed/defaults/main.yml
+++ b/roles/confluent.connect-distributed/defaults/main.yml
@@ -9,6 +9,7 @@ kafka:
       environment:
         KAFKA_HEAP_OPTS: "-Xms256M -Xmx2G"
       config:
+        rest.port: 8083
         consumer.interceptor.classes: io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor
         producer.interceptor.classes: io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor
         ssl.endpoint.identification.algorithm: ""

--- a/roles/confluent.control-center/defaults/main.yml
+++ b/roles/confluent.control-center/defaults/main.yml
@@ -11,6 +11,8 @@ confluent:
       config:
         confluent.controlcenter.streams.num.stream.threads: 8
         confluent.controlcenter.data.dir: /var/lib/confluent/control-center
+        confluent.controlcenter.ksql.enable: 'true'
+        confluent.controlcenter.schema.registry.enable: 'true'
         confluent.controlcenter.streams.ssl.endpoint.identification.algorithm: ""
         confluent.controlcenter.rest.ssl.endpoint.identification.algorithm: ""
       systemd:

--- a/roles/confluent.control-center/templates/includes/base_control-center.properties.j2
+++ b/roles/confluent.control-center/templates/includes/base_control-center.properties.j2
@@ -1,5 +1,30 @@
+{% set cfg = confluent.control.center.config %}
+{% set connect_servers = groups.get('connect-distributed', []) %}
+{% set schema_registries = groups.get('schema-registry', []) %}
+{% set ksql_servers = groups.get('ksql', []) %}
+
 bootstrap.servers={% for host in groups['broker'] %}{% if loop.index > 1%},{% endif %}{{ host }}:{{broker.config.port}}{% endfor %}
 
-{% for key, value in confluent.control.center.config.items() %}
+{% for key, value in cfg.items() %}
 {{key}}={{value}}
 {% endfor %}
+
+{% if ksql_servers and cfg.get('confluent.controlcenter.ksql.enable', 'false').lower() == 'true' %}
+{% set ksql_server_port = hostvars[ksql_servers[0]].get('ksql_listener_port', 8088) %}
+# KSQL Server
+confluent.controlcenter.ksql.url=http://{{ ksql_servers[0] }}:{{ ksql_server_port }}
+{% endif %}
+
+{% if schema_registries and cfg.get('confluent.controlcenter.schema.registry.enable', 'false').lower() == 'true' %}
+{% set schema_registry_port = hostvars[schema_registries[0]].get('schema_registry_listener_port', 8081) %}
+# Schema Registry
+confluent.controlcenter.schema.registry.url=http://{{ schema_registries[0] }}:{{ schema_registry_port }}
+{% endif %}
+
+{% if connect_servers %}
+# Kafka Connect
+confluent.controlcenter.connect.cluster={% for host in connect_servers -%}{% if loop.index > 1%},{% endif %}
+{% set connect_config = hostvars[host].get('kafka', dict()).get('connect', dict()).get('distributed', dict()).get('config', dict()) %}
+http://{{ host }}:{{ connect_config.get('rest.port', 8083) }}
+{%- endfor %}
+{% endif %}

--- a/roles/confluent.control-center/templates/includes/base_control-center.properties.j2
+++ b/roles/confluent.control-center/templates/includes/base_control-center.properties.j2
@@ -16,9 +16,12 @@ confluent.controlcenter.ksql.url=http://{{ ksql_servers[0] }}:{{ ksql_server_por
 {% endif %}
 
 {% if schema_registries and cfg.get('confluent.controlcenter.schema.registry.enable', 'false').lower() == 'true' %}
-{% set schema_registry_port = hostvars[schema_registries[0]].get('schema_registry_listener_port', 8081) %}
 # Schema Registry
-confluent.controlcenter.schema.registry.url=http://{{ schema_registries[0] }}:{{ schema_registry_port }}
+confluent.controlcenter.schema.registry.url={% for host in groups.get('schema-registry', []) -%}
+{% set schema_registry_port = hostvars[host].get('schema_registry_listener_port', 8081) %}
+{% if loop.index > 1%},{% endif %}
+http://{{ host }}:{{ schema_registry_port }}
+{%- endfor %}
 {% endif %}
 
 {% if connect_servers %}

--- a/roles/confluent.ksql/defaults/main.yml
+++ b/roles/confluent.ksql/defaults/main.yml
@@ -1,3 +1,5 @@
+ksql_listener_port: 8088
+
 ksql:
   config_file: /etc/ksql/ksql-server.properties
   service_name: confluent-ksql
@@ -8,7 +10,7 @@ ksql:
     KSQL_HEAP_OPTS: "-Xmx3g"
   config:
     application.id: ksql-server
-    listeners: http://localhost:8088
+    listeners: http://localhost:{{ksql_listener_port}}
     ssl.endpoint.identification.algorithm: ""
   systemd:
     enabled: yes

--- a/roles/confluent.schema-registry/defaults/main.yml
+++ b/roles/confluent.schema-registry/defaults/main.yml
@@ -1,3 +1,5 @@
+schema_registry_listener_port: 8081
+
 schema:
   registry:
     user: cp-schema-registry
@@ -6,7 +8,7 @@ schema:
     service_name: confluent-schema-registry
     systemd_override: /etc/systemd/system/confluent-schema-registry.service.d
     config:
-      listeners: http://0.0.0.0:8081
+      listeners: http://0.0.0.0:{{schema_registry_listener_port}}
       kafkastore.topic: _schemas
       debug: false
       kafkastore.ssl.endpoint.identification.algorithm: ""

--- a/sasl_ssl/all.yml
+++ b/sasl_ssl/all.yml
@@ -22,6 +22,10 @@
   tasks:
   - import_role:
       name: confluent.connect-distributed
+- hosts: ksql
+  tasks:
+  - import_role:
+      name: confluent.ksql
 - hosts: control-center
   tasks:
   - import_role:
@@ -30,7 +34,3 @@
   tasks:
   - import_role:
       name: confluent.kafka-rest
-- hosts: ksql
-  tasks:
-  - import_role:
-      name: confluent.ksql

--- a/ssl/all.yml
+++ b/ssl/all.yml
@@ -22,6 +22,10 @@
   tasks:
   - import_role:
       name: confluent.connect-distributed
+- hosts: ksql
+  tasks:
+  - import_role:
+      name: confluent.ksql
 - hosts: control-center
   tasks:
   - import_role:
@@ -30,7 +34,3 @@
   tasks:
   - import_role:
       name: confluent.kafka-rest
-- hosts: ksql
-  tasks:
-  - import_role:
-      name: confluent.ksql


### PR DESCRIPTION
Closes #48 

Needed to pull out listener ports for Schema Registry and KSQL listener ports outside of the top config keys because doing `{{ksql.config.port}}` or `{{ksql.listener_port}}`, for example, was throwing a recursive property error. 

## Connect

<img width="549" alt="screen shot 2018-09-08 at 10 15 19 pm" src="https://user-images.githubusercontent.com/1930631/45261286-98018b00-b3c4-11e8-9332-c956a544fb70.png">

## KSQL

<img width="610" alt="screen shot 2018-09-08 at 10 15 37 pm" src="https://user-images.githubusercontent.com/1930631/45261287-9afc7b80-b3c4-11e8-8dd3-05cb36c71a1a.png">

## Registry

<img width="561" alt="screen shot 2018-09-08 at 10 16 03 pm" src="https://user-images.githubusercontent.com/1930631/45261288-a18af300-b3c4-11e8-9830-3092ffecd90e.png">
