### PR TITLE
Use Schema Registry Port variable for Connect AvroConverters

### DIFF
--- a/roles/confluent.connect-distributed/templates/includes/base_connect-distributed.properties.j2
+++ b/roles/confluent.connect-distributed/templates/includes/base_connect-distributed.properties.j2
@@ -1,8 +1,12 @@
+{% set schema_registries = groups.get('schema-registry', []) %}
+
 bootstrap.servers={% for host in groups['broker'] %}{% if loop.index > 1%},{% endif %}{{ host }}:{{broker.config.port}}{% endfor %}
 
-value.converter.schema.registry.url={% for host in groups['schema-registry'] %}{% if loop.index > 1%},{% endif %}http://{{ host }}:8081/{% endfor %}
+{% if schema_registries %}
+value.converter.schema.registry.url={% include './includes/schema_registry_urls.j2' %}
 
-key.converter.schema.registry.url={% for host in groups['schema-registry'] %}{% if loop.index > 1%},{% endif %}http://{{ host }}:8081/{% endfor %}
+key.converter.schema.registry.url={% include './includes/schema_registry_urls.j2' %}
+{% endif %}
 
 {% for key, value in kafka.connect.distributed.config.items() %}
 {{key}}={{value}}

--- a/roles/confluent.connect-distributed/templates/includes/schema_registry_urls.j2
+++ b/roles/confluent.connect-distributed/templates/includes/schema_registry_urls.j2
@@ -1,0 +1,5 @@
+{% for host in groups.get('schema-registry', []) -%}
+{% set schema_registry_port = hostvars[host].get('schema_registry_listener_port', 8081) %}
+{% if loop.index > 1%},{% endif %}
+http://{{ host }}:{{ schema_registry_port }}/
+{%- endfor %}


### PR DESCRIPTION
Closes #36 

`connect-distributed.properties` had a hard-coded port number for the Schema Registry. This makes it configurable per Schema Registry host. 