### PR TITLE
Resolve #77 zookeeper myid.j2 and zookeeper server.N deterministic

### DIFF
--- a/hosts.yml
+++ b/hosts.yml
@@ -19,8 +19,17 @@ ssl_CA:
 zookeeper:
   hosts:
     ip-172-31-24-74.us-east-2.compute.internal:
+      zookeeper:
+        config:
+          myid: 1
     ip-172-31-22-155.us-east-2.compute.internal:
+      zookeeper:
+        config:
+          myid: 2
     ip-172-31-27-4.us-east-2.compute.internal:
+      zookeeper:
+        config:
+          myid: 3
 broker:
   hosts:
     ip-172-31-24-74.us-east-2.compute.internal:

--- a/roles/confluent.zookeeper/defaults/main.yml
+++ b/roles/confluent.zookeeper/defaults/main.yml
@@ -11,6 +11,7 @@ zookeeper:
     autopurge.snapRetainCount: 10
     autopurge.purgeInterval: 1
     dataDir: /var/lib/zookeeper
+    myid: 1
   environment:
     KAFKA_HEAP_OPTS: "-Xmx1000M"
   systemd:

--- a/roles/confluent.zookeeper/templates/myid.j2
+++ b/roles/confluent.zookeeper/templates/myid.j2
@@ -1,5 +1,1 @@
-{% for host in groups['zookeeper'] %}
-{% if host == inventory_hostname %}
-{{ loop.index }}
-{% endif %}
-{% endfor %}
+{{ zookeeper.config.myid }}

--- a/roles/confluent.zookeeper/templates/zookeeper.properties.j2
+++ b/roles/confluent.zookeeper/templates/zookeeper.properties.j2
@@ -2,6 +2,6 @@
 {% for key, value in zookeeper.config.items() %}
 {{key}}={{value}}
 {% endfor %}
-{% for host in groups['zookeeper'] %}
-server.{{ loop.index }}={{ host }}:2888:3888
+{% for host in groups['zookeeper'] | sort %}
+server.{{ hostvars[host]['zookeeper']['config']['myid'] }}={{ host }}:2888:3888
 {% endfor %}


### PR DESCRIPTION
Tested on three centos machines and worked fine:
```
[root@centos1 vagrant]# cat /etc/kafka/zookeeper.properties
# Maintained by Ansible
clientPort=2181
syncLimit=2
autopurge.purgeInterval=1
maxClientCnxns=0
initLimit=5
dataDir=/var/lib/zookeeper
myid=1
autopurge.snapRetainCount=10
server.1=centos1:2888:3888
server.2=centos2:2888:3888
server.3=centos3:2888:3888
[root@centos1 vagrant]# cat /var/lib/zookeeper/myid
1


[root@centos2 vagrant]# cat /etc/kafka/zookeeper.properties
# Maintained by Ansible
clientPort=2181
syncLimit=2
autopurge.purgeInterval=1
maxClientCnxns=0
initLimit=5
dataDir=/var/lib/zookeeper
myid=2
autopurge.snapRetainCount=10
server.1=centos1:2888:3888
server.2=centos2:2888:3888
server.3=centos3:2888:3888
[root@centos2 vagrant]#  cat /var/lib/zookeeper/myid
2


[root@centos3 vagrant]# cat /etc/kafka/zookeeper.properties 
# Maintained by Ansible
clientPort=2181
syncLimit=2
autopurge.purgeInterval=1
maxClientCnxns=0
initLimit=5
dataDir=/var/lib/zookeeper
myid=3
autopurge.snapRetainCount=10
server.1=centos1:2888:3888
server.2=centos2:2888:3888
server.3=centos3:2888:3888
[root@centos3 vagrant]# cat /var/lib/zookeeper/myid 
3
```