### PR TITLE
Added support for zookeeper "id".

### DIFF
--- a/roles/confluent.zookeeper/templates/myid.j2
+++ b/roles/confluent.zookeeper/templates/myid.j2
@@ -1,5 +1,7 @@
 {% for host in groups['zookeeper'] %}
 {% if host == inventory_hostname %}
-{{ loop.index }}
+{% set zookeeper_vars = hostvars[host].get('zookeeper', dict()) %}
+{% set id = zookeeper_vars.get('id', loop.index) %}
+{{ id }}
 {% endif %}
 {% endfor %}

--- a/roles/confluent.zookeeper/templates/zookeeper.properties.j2
+++ b/roles/confluent.zookeeper/templates/zookeeper.properties.j2
@@ -3,5 +3,7 @@
 {{key}}={{value}}
 {% endfor %}
 {% for host in groups['zookeeper'] %}
-server.{{ loop.index }}={{ host }}:2888:3888
+{% set zookeeper_vars = hostvars[host].get('zookeeper', dict()) %}
+{% set id = zookeeper_vars.get('id', loop.index) %}
+server.{{ id }}={{ host }}:2888:3888
 {% endfor %}


### PR DESCRIPTION
The order of zookeeper nodes listed in the hosts file
is not preserved when generating the server.id entries
in the zookeeper.properties files.
This is because Ansible uses a standard Python dict, which
is hash based and does not preserve insertion order.

This is normally not an issue except when we are trying to define
ZooKeeper groups, which relies on the ids.

This change makes it possible to add and use an artificial id to
each ZooKeeper entry

zookeeper:
  hosts:
   zookeeper-01:
        zookeeper:
            id: 1
   zookeeper-02:
        zookeeper:
            id: 2

If the id is not provided, the template will fall back to using
the loop index to assign an id.

This closes #77 