### PR TITLE
Make java installation optional & configurable

### DIFF
--- a/roles/confluent.preflight/defaults/main.yml
+++ b/roles/confluent.preflight/defaults/main.yml
@@ -1,0 +1,7 @@
+install_java: true
+java_package_name: openjdk-8-jdk
+
+debian_java_package_name: "{{ java_package_name }}"
+debian_java_repository: ppa:openjdk-r/ppa
+
+redhat_java_package_name: "{{ java_package_name }}"

--- a/roles/confluent.preflight/defaults/main.yml
+++ b/roles/confluent.preflight/defaults/main.yml
@@ -1,7 +1,9 @@
 install_java: true
 java_package_name: openjdk-8-jdk
 
-debian_java_package_name: "{{ java_package_name }}"
-debian_java_repository: ppa:openjdk-r/ppa
+debian_java_package_name: "{{java_package_name}}"
 
-redhat_java_package_name: "{{ java_package_name }}"
+redhat_java_package_name: "{{java_package_name}}"
+
+ubuntu_java_package_name: "{{java_package_name}}"
+ubuntu_java_repository: ppa:openjdk-r/ppa

--- a/roles/confluent.preflight/tasks/debian.yml
+++ b/roles/confluent.preflight/tasks/debian.yml
@@ -15,9 +15,10 @@
 
 - name: Install Java
   apt:
-    name: openjdk-8-jdk
+    name: "{{debian_java_package_name}}"
     state: present
     default_release: jessie-backports
+  when: install_java
 
 - name: Install rsync
   apt:

--- a/roles/confluent.preflight/tasks/redhat.yml
+++ b/roles/confluent.preflight/tasks/redhat.yml
@@ -1,4 +1,5 @@
 - name: Install Java
   yum:
-    name: "java-1.8.0-openjdk"
+    name: "{{redhat_java_package_name}}"
     state: latest
+  when: install_java

--- a/roles/confluent.preflight/tasks/ubuntu.yml
+++ b/roles/confluent.preflight/tasks/ubuntu.yml
@@ -1,7 +1,10 @@
 - name: Add open JDK repo
   apt_repository:
-    repo: ppa:openjdk-r/ppa
+    repo: "{{ubuntu_java_repository}}"
+  when: install_java
+
 - name: Install Java
   apt:
-    name: "openjdk-8-jdk"
+    name: "{{ubuntu_java_package_name}}"
     update_cache: yes
+  when: install_java


### PR DESCRIPTION
Currently, the playbooks always try to install a hardcoded java version and JDK. This PR changes this to enable users to bypass java installation and specify which java to install.