### PR TITLE
kerberos realm hardcoded to confluent.example.com

### DIFF
--- a/roles/confluent.kerberos/defaults/main.yml
+++ b/roles/confluent.kerberos/defaults/main.yml
@@ -21,7 +21,3 @@ udp_preference_limit: 1000000
 default_tkt_enctypes: des-cbc-md5 des-cbc-crc des3-cbc-sha1
 default_tgs_enctypes: des-cbc-md5 des-cbc-crc des3-cbc-sha1
 permitted_enctypes: des-cbc-md5 des-cbc-crc des3-cbc-sha1
-
-realm_name: CONFLUENT.EXAMPLE.COM
-kdc_hostname: ip-172-31-17-121.us-east-2.compute.internal
-admin_hostname: ip-172-31-17-121.us-east-2.compute.internal

--- a/roles/confluent.kerberos/templates/krb5.conf.j2
+++ b/roles/confluent.kerberos/templates/krb5.conf.j2
@@ -4,7 +4,7 @@
  admin_server = FILE:/var/log/kadmind.log
 
 [libdefaults]
- default_realm = {{ realm_name|upper() }}
+ default_realm = {{ realm|upper() }}
  dns_lookup_realm = {{ dns_lookup_realm }}
  dns_lookup_kdc = {{ dns_lookup_kdc }}
  ticket_lifetime = {{ ticket_lifetime }}
@@ -16,15 +16,15 @@
  permitted_enctypes = {{ permitted_enctypes }}
 
 [realms]
- {{ realm_name| upper() }} = {
+ {{ realm| upper() }} = {
   kdc = {{ kdc_hostname }}:88
   admin_server = {{ admin_hostname }}:749
-  default_domain = {{ realm_name|lower() }}
+  default_domain = {{ realm|lower() }}
  }
 
 [domain_realm]
- .{{ realm_name|lower() }} = {{ realm_name|upper() }}
-  {{ realm_name|lower() }} = {{ realm_name|upper() }}
+ .{{ realm|lower() }} = {{ realm|upper() }}
+  {{ realm|lower() }} = {{ realm|upper() }}
 
-#kdc = {{ kdc_hostname }}.{{ realm_name|lower() }}:88
-#admin_server = {{ admin_hostname }}.{{ realm_name|lower() }}:749
+#kdc = {{ kdc_hostname }}.{{ realm|lower() }}:88
+#admin_server = {{ admin_hostname }}.{{ realm|lower() }}:749


### PR DESCRIPTION
documented variable to use is realm not realm_name, so the kerberos config automatically gets set to confluent.example.com

tested with kerberos playbook and realm name (!= confluent.example.com), services came up