### PR TITLE
Added support for zookeeper "id"

### DIFF
--- a/roles/confluent.zookeeper/templates/myid.j2
+++ b/roles/confluent.zookeeper/templates/myid.j2
@@ -1,5 +1,7 @@
 {% for host in groups['zookeeper'] %}
 {% if host == inventory_hostname %}
-{{ loop.index }}
+{% set zookeeper_vars = hostvars[host].get('zookeeper', dict()) %}
+{% set id = zookeeper_vars.get('id', loop.index) %}
+{{ id }}
 {% endif %}
 {% endfor %}

--- a/roles/confluent.zookeeper/templates/zookeeper.properties.j2
+++ b/roles/confluent.zookeeper/templates/zookeeper.properties.j2
@@ -3,5 +3,7 @@
 {{key}}={{value}}
 {% endfor %}
 {% for host in groups['zookeeper'] %}
-server.{{ loop.index }}={{ host }}:2888:3888
+{% set zookeeper_vars = hostvars[host].get('zookeeper', dict()) %}
+{% set id = zookeeper_vars.get('id', loop.index) %}
+server.{{ id }}={{ host }}:2888:3888
 {% endfor %}


### PR DESCRIPTION
The order of zookeeper nodes listed in the hosts file
is not preserved when generating the server.id entries
in the zookeeper.properties files.
This is because Ansible uses a standard Python dict, which
is hash based and does not preserve insertion order.

This is normally not an issue except when we are trying to define
ZooKeeper groups, which relies on the ids.

This change makes it possible to add and use an artificial id to
each ZooKeeper entry

zookeeper:
hosts:
zookeeper-01:
zookeeper:
id: 1
zookeeper-02:
zookeeper:
id: 2

If the id is not provided, the template will fall back to using
the loop index to assign an id.

This closes #77

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration



**Test Configuration**:


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules