### PR TITLE
Changed Platform installation to not upgrade on RedHat systems

### DIFF
--- a/roles/confluent.common/tasks/debian.yml
+++ b/roles/confluent.common/tasks/debian.yml
@@ -10,3 +10,4 @@
   apt:
     name: "{{confluent.package_name}}"
     update_cache: yes
+    state: present

--- a/roles/confluent.common/tasks/redhat.yml
+++ b/roles/confluent.common/tasks/redhat.yml
@@ -22,4 +22,4 @@
 - name: Install the Confluent Platform
   yum:
     name: "{{confluent.package_name}}"
-    state: latest
+    state: present


### PR DESCRIPTION
# Description
This pull request changes the installation task that is run on redhat systems to not upgrade the confluent platform.
Additionally it adds a line to the debian task to add some transparency to what happens. "present" is the default value, but I always find that it helps to explicitly specify it as not everybody knows all default values.

Fixes #125