### PR TITLE
Added the security_mode 'ssl' for defining environment variables

### DIFF
--- a/roles/confluent.kafka-broker/tasks/main.yml
+++ b/roles/confluent.kafka-broker/tasks/main.yml
@@ -115,7 +115,7 @@
     mode: 0640
     owner: "{{kafka.broker.user}}"
     group: "{{kafka.broker.group}}"
-  when: security_mode == "plaintext" or security_mode == "sasl_ssl" or security_mode == "ssl_customcerts"
+  when: security_mode == "plaintext" or security_mode == "ssl" or security_mode == "sasl_ssl" or security_mode == "ssl_customcerts"
   notify:
     - reload systemd
     - restart kafka

--- a/roles/confluent.ksql/tasks/main.yml
+++ b/roles/confluent.ksql/tasks/main.yml
@@ -114,7 +114,7 @@
     mode: 0640
     owner: "{{ksql.user}}"
     group: "{{ksql.group}}"
-  when: security_mode == "plaintext" or security_mode == "sasl_ssl" or security_mode == "ssl_customcerts"
+  when: security_mode == "plaintext" or security_mode == "ssl" or security_mode == "sasl_ssl" or security_mode == "ssl_customcerts"
   notify:
     - reload systemd
     - restart ksql

--- a/roles/confluent.zookeeper/tasks/main.yml
+++ b/roles/confluent.zookeeper/tasks/main.yml
@@ -54,7 +54,7 @@
     mode: 0640
     owner: "{{zookeeper.user}}"
     group: "{{zookeeper.group}}"
-  when: security_mode == "plaintext" or security_mode == "sasl_ssl" or security_mode == "ssl_customcerts"
+  when: security_mode == "plaintext" or security_mode == "ssl" or security_mode == "sasl_ssl" or security_mode == "ssl_customcerts"
   notify:
     - reload systemd
     - restart zookeeper


### PR DESCRIPTION
# Description

When using `security_mode=ssl`, the environment variables (`override.conf`) is not deployed. The reason is a missiong `ssl` check in the `when` condition. 

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested on local env.

# Checklist:

- [x] My code follows the style guidelines of this project
- [ x I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules