### PR TITLE
JMX exporter support

### DIFF
--- a/group_vars/all/shared_vars.yml
+++ b/group_vars/all/shared_vars.yml
@@ -20,3 +20,7 @@ ksql_jolokia_port: 7774
 kafka_rest_jolokia_port: 7775
 
 open_file_limit: 500000
+
+jmxexporter_install_path: /opt/prometheus/
+jmxexporter_jar_path: /opt/prometheus/jmx_prometheus_javaagent.jar
+kafka_broker_jmxexporter_port: 8080

--- a/hosts_example.yml
+++ b/hosts_example.yml
@@ -31,6 +31,10 @@ all:
     ## To disable, uncomment this line:
     # jolokia_enabled: false
 
+    ## JMX Exporter is disabled by default. When enabled, JMX Exporter jar will be pulled from the Internet and enabled on the broker *only*.
+    ## To enable, uncomment this line:
+    # jmxexporter_enabled: true
+
     ## To set custom properties for each service
     ## Find property options in the Confluent Documentation
     # zookeeper:

--- a/roles/confluent.common/tasks/main.yml
+++ b/roles/confluent.common/tasks/main.yml
@@ -22,3 +22,16 @@
     url: "http://search.maven.org/remotecontent?filepath=org/jolokia/jolokia-jvm/{{jolokia_version}}/jolokia-jvm-{{jolokia_version}}-agent.jar"
     dest: "{{ jolokia_jar_path }}"
   when: jolokia_enabled|bool
+
+- name: set up prometheus install folder
+  file:
+    path: /opt/prometheus
+    state: directory
+    mode: 0755
+  when: jmxexporter_enabled|bool
+
+- name: install prometheus JMX exporter
+  get_url:
+    url: https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.12.0/jmx_prometheus_javaagent-0.12.0.jar
+    dest: "{{ jmxexporter_jar_path }}"
+  when: jmxexporter_enabled|bool

--- a/roles/confluent.kafka_broker/defaults/main.yml
+++ b/roles/confluent.kafka_broker/defaults/main.yml
@@ -7,7 +7,10 @@ kafka_broker_jaas_java_arg: "{{ kafka_broker_jaas_java_arg_buildout if security_
 kafka_broker_jolokia_java_arg_buildout: "-javaagent:{{jolokia_jar_path}}=port={{kafka_broker_jolokia_port}},host=0.0.0.0"
 kafka_broker_jolokia_java_arg: "{{ kafka_broker_jolokia_java_arg_buildout if jolokia_enabled|bool else '' }}"
 
-kafka_broker_kafka_opts_buildout: "{{ kafka_broker_jolokia_java_arg + ' ' + kafka_broker_jaas_java_arg if kafka_broker_jolokia_java_arg != '' or kafka_broker_jaas_java_arg != '' else '' }}"
+kafka_broker_jmxexporter_java_arg_buildout: "-javaagent:{{jmxexporter_jar_path}}={{kafka_broker_jmxexporter_port}}:{{jmxexporter_install_path}}/kafka.yml"
+kafka_broker_jmxexporter_java_arg: "{{ kafka_broker_jmxexporter_java_arg_buildout if jmxexporter_enabled|bool else '' }}"
+
+kafka_broker_kafka_opts_buildout: "{{ kafka_broker_jmxexporter_java_arg + ' ' + kafka_broker_jolokia_java_arg + ( ' ' + kafka_broker_jaas_java_arg if kafka_broker_jaas_java_arg != '' else '' ) }}"
 
 kafka_broker_service_overrides:
   LimitNOFILE: "{{kafka_broker_open_file_limit}}"

--- a/roles/confluent.kafka_broker/files/kafka.yml
+++ b/roles/confluent.kafka_broker/files/kafka.yml
@@ -1,0 +1,88 @@
+lowercaseOutputName: true
+
+rules:
+# Special cases and very specific rules
+- pattern : kafka.server<type=(.+), name=(.+), clientId=(.+), topic=(.+), partition=(.*)><>Value
+  name: kafka_server_$1_$2
+  type: GAUGE
+  labels:
+    clientId: "$3"
+    topic: "$4"
+    partition: "$5"
+- pattern : kafka.server<type=(.+), name=(.+), clientId=(.+), brokerHost=(.+), brokerPort=(.+)><>Value
+  name: kafka_server_$1_$2
+  type: GAUGE
+  labels:
+    clientId: "$3"
+    broker: "$4:$5"
+- pattern : kafka.coordinator.(\w+)<type=(.+), name=(.+)><>Value
+  name: kafka_coordinator_$1_$2_$3
+  type: GAUGE
+
+# Generic per-second counters with 0-2 key/value pairs
+- pattern: kafka.(\w+)<type=(.+), name=(.+)PerSec\w*, (.+)=(.+), (.+)=(.+)><>Count
+  name: kafka_$1_$2_$3_total
+  type: COUNTER
+  labels:
+    "$4": "$5"
+    "$6": "$7"
+- pattern: kafka.(\w+)<type=(.+), name=(.+)PerSec\w*, (.+)=(.+)><>Count
+  name: kafka_$1_$2_$3_total
+  type: COUNTER
+  labels:
+    "$4": "$5"
+- pattern: kafka.(\w+)<type=(.+), name=(.+)PerSec\w*><>Count
+  name: kafka_$1_$2_$3_total
+  type: COUNTER
+
+# Generic gauges with 0-2 key/value pairs
+- pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+), (.+)=(.+)><>Value
+  name: kafka_$1_$2_$3
+  type: GAUGE
+  labels:
+    "$4": "$5"
+    "$6": "$7"
+- pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+)><>Value
+  name: kafka_$1_$2_$3
+  type: GAUGE
+  labels:
+    "$4": "$5"
+- pattern: kafka.(\w+)<type=(.+), name=(.+)><>Value
+  name: kafka_$1_$2_$3
+  type: GAUGE
+
+# Emulate Prometheus 'Summary' metrics for the exported 'Histogram's.
+#
+# Note that these are missing the '_sum' metric!
+- pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+), (.+)=(.+)><>Count
+  name: kafka_$1_$2_$3_count
+  type: COUNTER
+  labels:
+    "$4": "$5"
+    "$6": "$7"
+- pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.*), (.+)=(.+)><>(\d+)thPercentile
+  name: kafka_$1_$2_$3
+  type: GAUGE
+  labels:
+    "$4": "$5"
+    "$6": "$7"
+    quantile: "0.$8"
+- pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.+)><>Count
+  name: kafka_$1_$2_$3_count
+  type: COUNTER
+  labels:
+    "$4": "$5"
+- pattern: kafka.(\w+)<type=(.+), name=(.+), (.+)=(.*)><>(\d+)thPercentile
+  name: kafka_$1_$2_$3
+  type: GAUGE
+  labels:
+    "$4": "$5"
+    quantile: "0.$6"
+- pattern: kafka.(\w+)<type=(.+), name=(.+)><>Count
+  name: kafka_$1_$2_$3_count
+  type: COUNTER
+- pattern: kafka.(\w+)<type=(.+), name=(.+)><>(\d+)thPercentile
+  name: kafka_$1_$2_$3
+  type: GAUGE
+  labels:
+    quantile: "0.$4"

--- a/roles/confluent.kafka_broker/tasks/main.yml
+++ b/roles/confluent.kafka_broker/tasks/main.yml
@@ -118,6 +118,11 @@
   notify:
     - restart kafka
 
+- name: deploy JMX exporter config file
+  copy:
+    src: "kafka.yml"
+    dest: "{{jmxexporter_install_path}}/"
+
 - name: Create Service Override Directory
   file:
     path: "{{kafka_broker.systemd_override}}"

--- a/roles/confluent.variables/defaults/main.yml
+++ b/roles/confluent.variables/defaults/main.yml
@@ -1,1 +1,2 @@
 jolokia_enabled: true
+jmxexporter_enabled: false


### PR DESCRIPTION
# Description

Added [JMX Exporter](https://github.com/prometheus/jmx_exporter) support to kafka broker. When enabled, this will make many of the broker's JMX metrics available via HTTP for consumption in Prometheus.

Dependencies: this will download the JMX exporter jar.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Tested with Confluent Platform 5.3.x.


**Test Configuration**: 
* CP 5.3.1
* set jmxexporter_enabled: true in hosts.yml (inventory file)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules