### PR TITLE
Changed ansible_ssh_user to ansible_user due to deprecation.

### DIFF
--- a/hosts_example.yml
+++ b/hosts_example.yml
@@ -65,58 +65,57 @@ all:
 
 zookeeper:
   hosts:
-    ip-172-31-56-107.ec2.internal:
+    ip-172-31-34-246.us-east-2.compute.internal::
       ## By default the first host will get zookeeper id=1, second gets id=2. Set zookeeper_id to customize
       # zookeeper_id: 2
 
       ## For kerberos sasl protocol, EACH host will need these two variables:
       # zookeeper_kerberos_keytab_path: <The path on ansible host to keytab file, eg. /tmp/keytabs/zookeeper-ip-172-31-34-246.us-east-2.compute.internal.keytab>
       # zookeeper_kerberos_principal: <The principal configured in kdc server, eg. zookeeper/ip-172-31-34-246.us-east-2.compute.internal@REALM.EXAMPLE.COM>
-    ip-172-31-52-213.ec2.internal:
+    ip-172-31-37-15.us-east-2.compute.internal:
       # zookeeper_id: 3
-    ip-172-31-59-226.ec2.internal:
+    ip-172-31-34-231.us-east-2.compute.internal:
       # zookeeper_id: 1
 kafka_broker:
   hosts:
-    ip-172-31-51-245.ec2.internal:
+    ip-172-31-34-246.us-east-2.compute.internal:
       ## By default the first host will get broker id=1, second gets id=2. Set broker_id to customize
       # broker_id: 3
 
       ## For kerberos sasl protocol, EACH host will need these two variables:
       # kafka_broker_kerberos_keytab_path: <The path on ansible host to keytab file, eg. /tmp/keytabs/ip-172-31-34-246.us-east-2.compute.internal>
       # kafka_broker_kerberos_principal: <The principal configured in kdc server, eg. kafka/ip-172-31-34-246.us-east-2.compute.internal@REALM.EXAMPLE.COM>
-    ip-172-31-58-145.ec2.internal:
+    ip-172-31-37-15.us-east-2.compute.internal:
       # broker_id: 2
-    ip-172-31-60-71.ec2.internal:
+    ip-172-31-34-231.us-east-2.compute.internal:
       # broker_id: 1
 schema_registry:
   hosts:
-    ip-172-31-62-48.ec2.internal:
+    ip-172-31-34-246.us-east-2.compute.internal:
       ## For kerberos sasl protocol, EACH host will need these two variables:
       # schema_registry_kerberos_keytab_path: <The path on ansible host to keytab file, eg. /tmp/keytabs/schemaregistry-ip-172-31-34-246.us-east-2.compute.internal
       # schema_registry_kerberos_principal: The principal configured in kdc server ex: schemaregistry/ip-172-31-34-246.us-east-2.compute.internal@REALM.EXAMPLE.COM>
 kafka_connect:
   hosts:
-    ip-172-31-49-126.ec2.internal:
-    ip-172-31-62-66.ec2.internal:
+    ip-172-31-34-246.us-east-2.compute.internal:
       ## For kerberos sasl protocol, EACH host will need these two variables:
       # kafka_connect_kerberos_keytab_path: <The path on ansible host to keytab file, eg. /tmp/keytabs/connect-ip-172-31-34-246.us-east-2.compute.internal
       # kafka_connect_kerberos_principal: The principal configured in kdc server ex: connect/ip-172-31-34-246.us-east-2.compute.internal@REALM.EXAMPLE.COM>
 kafka_rest:
   hosts:
-    ip-172-31-57-184.ec2.internal:
+    ip-172-31-34-246.us-east-2.compute.internal:
       ## For kerberos sasl protocol, EACH host will need these two variables:
       # kafka_rest_kerberos_keytab_path: <The path on ansible host to keytab file, eg. /tmp/keytabs/restproxy-ip-172-31-34-246.us-east-2.compute.internal
       # kafka_rest_kerberos_principal: The principal configured in kdc server ex: restproxy/ip-172-31-34-246.us-east-2.compute.internal@REALM.EXAMPLE.COM>
 ksql:
   hosts:
-    ip-172-31-56-2.ec2.internal:
+    ip-172-31-37-15.us-east-2.compute.internal:
       ## For kerberos sasl protocol, EACH host will need these two variables:
       # ksql_kerberos_keytab_path: <The path on ansible host to keytab file, eg. /tmp/keytabs/ksql-ip-172-31-37-15.us-east-2.compute.internal
       # ksql_kerberos_principal: The principal configured in kdc server ex: ksql/ip-172-31-37-15.us-east-2.compute.internal@REALM.EXAMPLE.COM>
 control_center:
   hosts:
-    ip-172-31-57-30.ec2.internal:
+    ip-172-31-37-15.us-east-2.compute.internal:
       ## For kerberos sasl protocol, EACH host will need these two variables:
       # control_center_kerberos_keytab_path: <The path on ansible host to keytab file, eg. /tmp/keytabs/controlcenter-ip-172-31-37-15.us-east-2.compute.internal
       # control_center_kerberos_principal: The principal configured in kdc server ex: controlcenter/ip-172-31-37-15.us-east-2.compute.internal@REALM.EXAMPLE.COM>

--- a/hosts_example.yml
+++ b/hosts_example.yml
@@ -1,7 +1,7 @@
 all:
   vars:
     ansible_connection: ssh
-    ansible_ssh_user: ec2-user
+    ansible__user: ec2-user
     ansible_become: true
 
     ## Required var, with options plaintext, ssl, sasl_ssl, ssl_customcerts, kerberos_ssl, kerberos, kerberos_ssl_customcerts
@@ -65,57 +65,58 @@ all:
 
 zookeeper:
   hosts:
-    ip-172-31-34-246.us-east-2.compute.internal:
+    ip-172-31-56-107.ec2.internal:
       ## By default the first host will get zookeeper id=1, second gets id=2. Set zookeeper_id to customize
       # zookeeper_id: 2
 
       ## For kerberos sasl protocol, EACH host will need these two variables:
       # zookeeper_kerberos_keytab_path: <The path on ansible host to keytab file, eg. /tmp/keytabs/zookeeper-ip-172-31-34-246.us-east-2.compute.internal.keytab>
       # zookeeper_kerberos_principal: <The principal configured in kdc server, eg. zookeeper/ip-172-31-34-246.us-east-2.compute.internal@REALM.EXAMPLE.COM>
-    ip-172-31-37-15.us-east-2.compute.internal:
+    ip-172-31-52-213.ec2.internal:
       # zookeeper_id: 3
-    ip-172-31-34-231.us-east-2.compute.internal:
+    ip-172-31-59-226.ec2.internal:
       # zookeeper_id: 1
 kafka_broker:
   hosts:
-    ip-172-31-34-246.us-east-2.compute.internal:
+    ip-172-31-51-245.ec2.internal:
       ## By default the first host will get broker id=1, second gets id=2. Set broker_id to customize
       # broker_id: 3
 
       ## For kerberos sasl protocol, EACH host will need these two variables:
       # kafka_broker_kerberos_keytab_path: <The path on ansible host to keytab file, eg. /tmp/keytabs/ip-172-31-34-246.us-east-2.compute.internal>
       # kafka_broker_kerberos_principal: <The principal configured in kdc server, eg. kafka/ip-172-31-34-246.us-east-2.compute.internal@REALM.EXAMPLE.COM>
-    ip-172-31-37-15.us-east-2.compute.internal:
+    ip-172-31-58-145.ec2.internal:
       # broker_id: 2
-    ip-172-31-34-231.us-east-2.compute.internal:
+    ip-172-31-60-71.ec2.internal:
       # broker_id: 1
 schema_registry:
   hosts:
-    ip-172-31-34-246.us-east-2.compute.internal:
+    ip-172-31-62-48.ec2.internal:
       ## For kerberos sasl protocol, EACH host will need these two variables:
       # schema_registry_kerberos_keytab_path: <The path on ansible host to keytab file, eg. /tmp/keytabs/schemaregistry-ip-172-31-34-246.us-east-2.compute.internal
       # schema_registry_kerberos_principal: The principal configured in kdc server ex: schemaregistry/ip-172-31-34-246.us-east-2.compute.internal@REALM.EXAMPLE.COM>
 kafka_connect:
   hosts:
-    ip-172-31-34-246.us-east-2.compute.internal:
+    ip-172-31-49-126.ec2.internal:
+    ip-172-31-62-66.ec2.internal:
       ## For kerberos sasl protocol, EACH host will need these two variables:
       # kafka_connect_kerberos_keytab_path: <The path on ansible host to keytab file, eg. /tmp/keytabs/connect-ip-172-31-34-246.us-east-2.compute.internal
       # kafka_connect_kerberos_principal: The principal configured in kdc server ex: connect/ip-172-31-34-246.us-east-2.compute.internal@REALM.EXAMPLE.COM>
 kafka_rest:
   hosts:
-    ip-172-31-34-246.us-east-2.compute.internal:
+    ip-172-31-57-184.ec2.internal:
       ## For kerberos sasl protocol, EACH host will need these two variables:
       # kafka_rest_kerberos_keytab_path: <The path on ansible host to keytab file, eg. /tmp/keytabs/restproxy-ip-172-31-34-246.us-east-2.compute.internal
       # kafka_rest_kerberos_principal: The principal configured in kdc server ex: restproxy/ip-172-31-34-246.us-east-2.compute.internal@REALM.EXAMPLE.COM>
 ksql:
   hosts:
-    ip-172-31-37-15.us-east-2.compute.internal:
+    ip-172-31-56-2.ec2.internal:
       ## For kerberos sasl protocol, EACH host will need these two variables:
       # ksql_kerberos_keytab_path: <The path on ansible host to keytab file, eg. /tmp/keytabs/ksql-ip-172-31-37-15.us-east-2.compute.internal
       # ksql_kerberos_principal: The principal configured in kdc server ex: ksql/ip-172-31-37-15.us-east-2.compute.internal@REALM.EXAMPLE.COM>
 control_center:
   hosts:
-    ip-172-31-37-15.us-east-2.compute.internal:
+    ip-172-31-57-30.ec2.internal:
       ## For kerberos sasl protocol, EACH host will need these two variables:
       # control_center_kerberos_keytab_path: <The path on ansible host to keytab file, eg. /tmp/keytabs/controlcenter-ip-172-31-37-15.us-east-2.compute.internal
       # control_center_kerberos_principal: The principal configured in kdc server ex: controlcenter/ip-172-31-37-15.us-east-2.compute.internal@REALM.EXAMPLE.COM>

--- a/hosts_example.yml
+++ b/hosts_example.yml
@@ -1,7 +1,7 @@
 all:
   vars:
     ansible_connection: ssh
-    ansible__user: ec2-user
+    ansible_user: ec2-user
     ansible_become: true
 
     ## Required var, with options plaintext, ssl, sasl_ssl, ssl_customcerts, kerberos_ssl, kerberos, kerberos_ssl_customcerts
@@ -65,7 +65,7 @@ all:
 
 zookeeper:
   hosts:
-    ip-172-31-34-246.us-east-2.compute.internal::
+    ip-172-31-34-246.us-east-2.compute.internal:
       ## By default the first host will get zookeeper id=1, second gets id=2. Set zookeeper_id to customize
       # zookeeper_id: 2
 


### PR DESCRIPTION
# Description

Modified the example hosts file, specifically changed the variable ansible_ssh_user to ansible_user due to deprecation as per the Ansible documentation here:

https://ansible-tips-and-tricks.readthedocs.io/en/latest/ansible/inventory/

Fixes # (issue)

https://github.com/confluentinc/cp-ansible/issues/95

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Ran the playbook with plaintext across all components, as well as with SSL across all components with the variable change.

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules