### PR TITLE
Corrected variable name ssl_provided_keystore_and_truststore.

### DIFF
--- a/hosts_example.yml
+++ b/hosts_example.yml
@@ -37,7 +37,7 @@ all:
     # ssl_key_filepath: "/tmp/certs/{{inventory_hostname}}-key.pem"
     ## Option 2: Custom Keystores and Truststores
     ## CP-Ansible can move keystores/truststores to their corresponding hosts and configure the components to use them. Set These vars
-    # provided_keystore_and_truststore: true
+    # ssl_provided_keystore_and_truststore: true
     # ssl_keystore_filepath: "/tmp/certs/{{inventory_hostname}}-keystore.jks"
     # ssl_keystore_key_password: mystorepassword
     # ssl_keystore_store_password: mystorepassword


### PR DESCRIPTION
# Description

Corrected the variable name ssl_provided_keystore_and_truststore.  Was missing the 'ssl_'.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Deployed on RHEL 7 in test environment.

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules