### PR TITLE
Allow services to read jolokia.jar

### DIFF
--- a/roles/confluent.common/tasks/main.yml
+++ b/roles/confluent.common/tasks/main.yml
@@ -21,6 +21,7 @@
   get_url:
     url: "http://search.maven.org/remotecontent?filepath=org/jolokia/jolokia-jvm/{{jolokia_version}}/jolokia-jvm-{{jolokia_version}}-agent.jar"
     dest: "{{ jolokia_jar_path }}"
+    mode: 0755
   when: jolokia_enabled|bool
 
 - name: Create Prometheus install directory

--- a/roles/confluent.variables/defaults/main.yml
+++ b/roles/confluent.variables/defaults/main.yml
@@ -4,7 +4,7 @@ zookeeper:
 kerberos:
   keytab_dir: /etc/security/keytabs
 confluent:
-  package_version: 5.3.0-1
+  package_version: 5.3.1-1
   repo_version: 5.3
   support:
     customer_id: anonymous


### PR DESCRIPTION
Services fail to start due to insufficient privileges to jolokia.jar which is enabled by default.

Nov 07 00:33:47 sbx-kafka-jontest-zookeeper-2 systemd[1]: confluent-zookeeper.service failed.
Nov 07 00:33:51 sbx-kafka-jontest-zookeeper-2 systemd[1]: Started Apache Kafka - ZooKeeper.
Nov 07 00:33:51 sbx-kafka-jontest-zookeeper-2 zookeeper-server-start[3110]: Error opening zip file or JAR manifest missing : /opt/jolokia/jolokia.jar
Nov 07 00:33:51 sbx-kafka-jontest-zookeeper-2 zookeeper-server-start[3110]: Error occurred during initialization of VM
Nov 07 00:33:51 sbx-kafka-jontest-zookeeper-2 systemd[1]: confluent-zookeeper.service: main process exited, code=exited, status=1/FAILURE

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration



**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules