### PR TITLE
Set Zookeeper dataDir ownership

### DIFF
--- a/roles/confluent.variables/defaults/main.yml
+++ b/roles/confluent.variables/defaults/main.yml
@@ -4,7 +4,7 @@ zookeeper:
 kerberos:
   keytab_dir: /etc/security/keytabs
 confluent:
-  package_version: 5.3.1-1
+  package_version: 5.3.0-1
   repo_version: 5.3
   support:
     customer_id: anonymous

--- a/roles/confluent.variables/defaults/main.yml
+++ b/roles/confluent.variables/defaults/main.yml
@@ -4,7 +4,7 @@ zookeeper:
 kerberos:
   keytab_dir: /etc/security/keytabs
 confluent:
-  package_version: 5.3.0-1
+  package_version: 5.3.1-1
   repo_version: 5.3
   support:
     customer_id: anonymous

--- a/roles/confluent.zookeeper/tasks/main.yml
+++ b/roles/confluent.zookeeper/tasks/main.yml
@@ -44,6 +44,14 @@
   notify:
     - restart zookeeper
 
+- name: Set Zookeeper dataDir ownership
+  file:
+    path: "{{zookeeper.properties.dataDir}}"
+    owner: "{{zookeeper.user}}"
+    group: "{{zookeeper.group}}"
+    state: directory
+    mode: 0750
+    
 - name: Create Zookeeper myid File
   template:
     src: myid.j2


### PR DESCRIPTION
When providing a custom zookeeper dataDir (ie: /data1), the directory does not have the necessary ownership and permissions for the zookeeper service to start.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

When providing a custom zookeeper dataDir (ie: /data1), the directory does not have the necessary ownership and permissions for the zookeeper service to start / create the `version-2` directory.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Verified functionality against test cluster.

**Test Configuration**:

3 broker / 3 zookeeper setup on separate GCP instances.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules