### PR TITLE
Added support to specify the hostname for a listener. Fixes #162.

### DIFF
--- a/roles/confluent.kafka_broker/templates/server.properties.j2
+++ b/roles/confluent.kafka_broker/templates/server.properties.j2
@@ -9,7 +9,7 @@ broker.id={{ broker_id | default(groups.kafka_broker.index(inventory_hostname) +
 {{key}}={{value}}
 {% endfor %}
 
-listeners={% for listener in kafka_broker_listeners|dict2items %}{% if loop.index > 1%},{% endif %}{{ listener['value']['name'] }}://:{{ listener['value']['port'] }}{% endfor %}
+listeners={% for listener in kafka_broker_listeners|dict2items %}{% if loop.index > 1%},{% endif %}{{ listener['value']['name'] }}://{{ listener['value']['hostname'] | default('') }}:{{ listener['value']['port'] }}{% endfor %}
 
 listener.security.protocol.map={% for listener in kafka_broker_listeners|dict2items %}{% if loop.index > 1%},{% endif %}{{ listener['value']['name'] }}:{{ listener['value']['sasl_protocol'] | kafka_protocol(listener['value']['ssl_enabled'])}}{% endfor %}
 

--- a/roles/confluent.variables/defaults/main.yml
+++ b/roles/confluent.variables/defaults/main.yml
@@ -4,7 +4,7 @@ zookeeper:
 kerberos:
   keytab_dir: /etc/security/keytabs
 confluent:
-  package_version: 5.3.1-1
+  package_version: 5.3.0-1
   repo_version: 5.3
   support:
     customer_id: anonymous

--- a/roles/confluent.variables/defaults/main.yml
+++ b/roles/confluent.variables/defaults/main.yml
@@ -4,7 +4,7 @@ zookeeper:
 kerberos:
   keytab_dir: /etc/security/keytabs
 confluent:
-  package_version: 5.3.0-1
+  package_version: 5.3.1-1
   repo_version: 5.3
   support:
     customer_id: anonymous


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes #162

## Type of change
- [x] New feature (non-breaking change which adds functionality)
# How Has This Been Tested?

I tested this configuration in my lab. After the change advertisements were fully qualified. 


**Test Configuration**:

The following configuration was used for testing.

```yaml
kafka_broker_default_listeners:
  external:
    hostname: "{{ansible_fqdn}}"
  internal:
    hostname: "{{ansible_fqdn}}"
```

Expected output:

```properties
listeners=EXTERNAL://primary-broker-001.custenborder.com:9092,INTERNAL://primary-broker-001.custenborder.com:9091
```