### PR TITLE
Updated Zookeeper timeout from 6000ms to 18000ms as per defaults in 5…

### DIFF
--- a/roles/confluent.kafka_broker/defaults/main.yml
+++ b/roles/confluent.kafka_broker/defaults/main.yml
@@ -68,7 +68,7 @@ kafka_broker:
     socket.send.buffer.bytes: 102400
     transaction.state.log.min.isr: 2
     transaction.state.log.replication.factor: "{{ [ groups['kafka_broker'] | length, kafka_broker_default_replication_factor ] | min }}"
-    zookeeper.connection.timeout.ms: 6000
+    zookeeper.connection.timeout.ms: 18000
     confluent.license.topic.replication.factor: "{{ [ groups['kafka_broker'] | length, kafka_broker_default_replication_factor ] | min }}"
     confluent.metadata.topic.replication.factor: "{{ [ groups['kafka_broker'] | length, kafka_broker_default_replication_factor ] | min }}"
     metric.reporters: io.confluent.metrics.reporter.ConfluentMetricsReporter


### PR DESCRIPTION
….4.0 release.

# Description

Updated zookeeper.connection.timeout.ms from 6000ms to 18000ms as per the new default with the 5.4.0 release of CP.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Deployed a full cluster on AWS on RHEL 7 to confirm change takes affect.


**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules