### PR TITLE
Upgrade kafka playbooks now make sure controller is last to be touched before any restarts

### DIFF
--- a/tasks/create_ordered_kafka_groups.yml
+++ b/tasks/create_ordered_kafka_groups.yml
@@ -1,0 +1,35 @@
+---
+# Run these tasks over kafka_broker group with serial: 1
+# Creates two groups: controller and non_controllers
+- import_role:
+    name: confluent.variables_handlers
+
+- name: Get ActiveControllerCount
+  uri:
+    url: "http://localhost:{{kafka_broker_jolokia_port}}/jolokia/read/kafka.controller:type=KafkaController,name=ActiveControllerCount"
+    return_content: yes
+    status_code: 200
+  register: active_controller_count_query
+
+- set_fact:
+    active_controller_count: "{{ active_controller_count_query['json']['value']['Value'] }}"
+
+- debug:
+    msg: "Active Controller: {{inventory_hostname}}"
+  when: active_controller_count|int == 1
+
+- name: Add host to Non Controller Group
+  add_host:
+    name: "{{ inventory_hostname }}"
+    group: "{{ non_controller_group }}"
+  delegate_to: localhost
+  when:
+    - active_controller_count|int == 0
+
+- name: Add host to Controller Group
+  add_host:
+    name: "{{ inventory_hostname }}"
+    group: "{{ controller_group }}"
+  delegate_to: localhost
+  when:
+    - active_controller_count|int == 1

--- a/tasks/create_ordered_kafka_groups.yml
+++ b/tasks/create_ordered_kafka_groups.yml
@@ -1,6 +1,6 @@
 ---
 # Run these tasks over kafka_broker group with serial: 1
-# Creates two groups: controller and non_controllers
+# Creates two variable defined groups: non_controller_group, controller
 - import_role:
     name: confluent.variables_handlers
 

--- a/upgrade_kafka_broker.yml
+++ b/upgrade_kafka_broker.yml
@@ -75,8 +75,6 @@
 
 - name: Kafka Broker Upgrade - Host Ordering
   hosts: kafka_broker
-  # Running serial=1 because add_host has problems
-  # https://stackoverflow.com/questions/42106527/ansible-how-to-call-module-add-host-for-all-hosts-of-the-play
   serial: 1
   tasks:
 
@@ -157,6 +155,17 @@
 
     - name: Wait for Under Replicated Partitions on Broker
       import_tasks: tasks/wait_for_urp.yml
+
+# Kafka Restarted, need to figure out the new controller
+- name: Kafka Broker - Host Ordering
+  hosts: kafka_broker
+  serial: 1
+  tasks:
+    - name: Create Ordered Kafka Broker Groups
+      import_tasks: tasks/create_ordered_kafka_groups.yml
+      vars:
+        controller_group: kafka_broker_controller
+        non_controller_group: kafka_broker_non_controllers
 
 - name: Kafka Broker Upgrade - Set Inter-Broker Protocol to Current Version
   hosts: kafka_broker_non_controllers,kafka_broker_controller

--- a/upgrade_kafka_broker.yml
+++ b/upgrade_kafka_broker.yml
@@ -48,9 +48,6 @@
         line: "inter.broker.protocol.version={{inter_broker_protocol_version}}"
         regexp: inter.broker.protocol.version.*
         state: present
-      # notify:
-      #   - Restart Kafka
-      #   - Wait for URP
 
     - name: Set Log Message Format Version to Current Version
       lineinfile:
@@ -58,9 +55,6 @@
         line: "log.message.format.version={{log_message_format_version}}"
         regexp: log.message.format.version.*
         state: present
-      # notify:
-      #   - Restart Kafka
-      #   - Wait for URP
 
     - name: Make sure Controlled Shutdown Property is not set to False
       lineinfile:

--- a/upgrade_kafka_broker.yml
+++ b/upgrade_kafka_broker.yml
@@ -1,5 +1,17 @@
-- name: Kafka Broker Upgrade - Config Prep
+- name: Kafka Broker - Host Ordering
   hosts: kafka_broker
+  # Running serial=1 because add_host has problems
+  # https://stackoverflow.com/questions/42106527/ansible-how-to-call-module-add-host-for-all-hosts-of-the-play
+  serial: 1
+  tasks:
+    - name: Create Ordered Kafka Broker Groups
+      import_tasks: tasks/create_ordered_kafka_groups.yml
+      vars:
+        controller_group: controller
+        non_controller_group: non_controllers
+
+- name: Kafka Broker Upgrade - Config Prep
+  hosts: non_controllers,controller
   gather_facts: no
   serial: 1
   vars:
@@ -20,11 +32,6 @@
         confluent_server_enabled: false
       when: ansible_facts.packages['confluent-kafka-2.12'] is defined
 
-    - name: Kafka is Running
-      systemd:
-        name: "{{kafka_broker_service_name}}"
-        state: started
-
     - set_fact:
         inter_broker_protocol_version: 2.3
         log_message_format_version: 2.3
@@ -41,6 +48,9 @@
         line: "inter.broker.protocol.version={{inter_broker_protocol_version}}"
         regexp: inter.broker.protocol.version.*
         state: present
+      # notify:
+      #   - Restart Kafka
+      #   - Wait for URP
 
     - name: Set Log Message Format Version to Current Version
       lineinfile:
@@ -48,6 +58,9 @@
         line: "log.message.format.version={{log_message_format_version}}"
         regexp: log.message.format.version.*
         state: present
+      # notify:
+      #   - Restart Kafka
+      #   - Wait for URP
 
     - name: Make sure Controlled Shutdown Property is not set to False
       lineinfile:
@@ -66,8 +79,13 @@
   # https://stackoverflow.com/questions/42106527/ansible-how-to-call-module-add-host-for-all-hosts-of-the-play
   serial: 1
   tasks:
-    - import_role:
-        name: confluent.variables_handlers
+
+    # Sets active_controller_count var for each host
+    - name: Create Ordered Kafka Broker Groups
+      import_tasks: tasks/create_ordered_kafka_groups.yml
+      vars:
+        controller_group: controller
+        non_controller_group: non_controllers
 
     - name: Get Package Facts
       package_facts:
@@ -93,20 +111,6 @@
 
     - debug:
         msg: "Current version: {{kafka_broker_current_version}}   Upgrade to version: {{confluent_package_version}}"
-
-    - name: Get ActiveControllerCount
-      uri:
-        url: "http://localhost:{{kafka_broker_jolokia_port}}/jolokia/read/kafka.controller:type=KafkaController,name=ActiveControllerCount"
-        return_content: yes
-        status_code: 200
-      register: active_controller_count_query
-
-    - set_fact:
-        active_controller_count: "{{ active_controller_count_query['json']['value']['Value'] }}"
-
-    - debug:
-        msg: "Active Controller: {{inventory_hostname}}"
-      when: active_controller_count|int == 1
 
     - name: Add host to Non Controller Group
       add_host:
@@ -155,7 +159,7 @@
       import_tasks: tasks/wait_for_urp.yml
 
 - name: Kafka Broker Upgrade - Set Inter-Broker Protocol to Current Version
-  hosts: kafka_broker
+  hosts: kafka_broker_non_controllers,kafka_broker_controller
   gather_facts: no
   serial: 1
   tags:

--- a/upgrade_kafka_broker_log_format.yml
+++ b/upgrade_kafka_broker_log_format.yml
@@ -1,5 +1,17 @@
-- name: Kafka Broker Upgrade - Set Log Message Format Version to Current Version
+- name: Kafka Broker - Host Ordering
   hosts: kafka_broker
+  # Running serial=1 because add_host has problems
+  # https://stackoverflow.com/questions/42106527/ansible-how-to-call-module-add-host-for-all-hosts-of-the-play
+  serial: 1
+  tasks:
+    - name: Create Ordered Kafka Broker Groups
+      import_tasks: tasks/create_ordered_kafka_groups.yml
+      vars:
+        controller_group: controller
+        non_controller_group: non_controllers
+
+- name: Kafka Broker Upgrade - Set Log Message Format Version to Current Version
+  hosts: non_controllers,controller
   gather_facts: no
   serial: 1
   vars:


### PR DESCRIPTION
# Description

Now the upgrade kafka playbooks take extra care to do restarts on the controller last

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


Tested locally, with 3 broker cluster, will run it through jenkins as well


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules