### PR TITLE
Make Netcat Optional with a var

### DIFF
--- a/roles/confluent.common/defaults/main.yml
+++ b/roles/confluent.common/defaults/main.yml
@@ -17,6 +17,8 @@ debian_java_package_name: openjdk-8-jdk
 ubuntu_java_package_name: openjdk-8-jdk
 ubuntu_java_repository: ppa:openjdk-r/ppa
 
+install_netcat: true
+
 jolokia_version: 1.6.2
 jolokia_jar_url: "http://search.maven.org/remotecontent?filepath=org/jolokia/jolokia-jvm/{{jolokia_version}}/jolokia-jvm-{{jolokia_version}}-agent.jar"
 

--- a/roles/confluent.common/tasks/debian.yml
+++ b/roles/confluent.common/tasks/debian.yml
@@ -90,11 +90,16 @@
     - install_java|bool
     - custom_apt_repo|bool
 
-- name: Install rsync
+- name: Install rsync & CA Certs
   apt:
     name: "{{ item }}"
     state: present
   loop:
     - rsync
     - ca-certificates
-    - netcat-openbsd
+    
+- name: Install Netcat
+  apt:
+    name: netcat-openbsd
+    state: present
+  when: install_netcat|bool

--- a/roles/confluent.common/tasks/redhat.yml
+++ b/roles/confluent.common/tasks/redhat.yml
@@ -41,3 +41,4 @@
   yum:
     name: nc
     state: present
+  when: install_netcat|bool

--- a/roles/confluent.common/tasks/ubuntu.yml
+++ b/roles/confluent.common/tasks/ubuntu.yml
@@ -37,3 +37,4 @@
   apt:
     name: netcat-openbsd
     state: present
+  when: install_netcat|bool


### PR DESCRIPTION
# Description

Adds a variable and check to optional install Netcat within the common role

Fixes # N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Simple test against fresh AWS cluster with `install_netcat` set to false within the `hosts.yaml` file.

**Test Configuration**:

3x ZK
3x Kafka
1x Control Center

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules