### PR TITLE
Set truststore and keystore permissions

### DIFF
--- a/roles/confluent.ssl/tasks/main.yml
+++ b/roles/confluent.ssl/tasks/main.yml
@@ -32,10 +32,13 @@
   include_tasks: provided_keystore_and_truststore.yml
   when: ssl_provided_keystore_and_truststore|bool
 
-- set_fact:
-    certs_updated: true
-
 - name: Delete SSL Certificate Generation Directory
   file:
     path: /var/ssl/private/generation
     state: absent
+
+- name: Set truststore and keystore file permissions
+  command: find /var/ssl/private/ -type f -exec chmod 0644 {} \;
+
+- set_fact:
+    certs_updated: true


### PR DESCRIPTION
* Set permissions of the truststore and keystore files so the SSL enabled components can read the file and start without failure
* Move the certs_updated fact to run after the permissions to truststore and keystore are applied

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

* Verified permissions are appropriately set on the truststore and keystore files.
* Verified services successfully start.

In <5.4.0-post verisons of cp-ansible, the truststore/clientstore names were consistent across components (client.truststore.jks, client.keystore.jks) - in 5.4.0 they include the component name in the file names (ie: kafka_broker.truststore.jks, kafka_broker.keystore.jks), so without explicitly creating a task to set the permissions on each truststore/keystore file for each confluent component, using the command module seemed to the most efficient/least amount of code to perform this task.  Using the file module to apply permissions recursively gives too much permission unnecessarily and also doesn't support generic wildcard matches (ie: *.truststore.jks and *.keystore.jks)

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Tested on cluster installed with cp-ansible 5.4.0-post.  Without this change the truststore/keystore files didn't have the necessary permissions which allowed the component/service to start because it couldn't read the truststore/keystore files.



**Test Configuration**:

full cp-ansible deployment, all services on their own hosts.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules