### PR TITLE
Fixing Deprecated ksql property in c3

### DIFF
--- a/roles/confluent.control_center/templates/control-center.properties.j2
+++ b/roles/confluent.control_center/templates/control-center.properties.j2
@@ -74,6 +74,6 @@ confluent.controlcenter.connect.default.cluster={% for host in groups['kafka_con
 {% set ksql_servers = groups.get('ksql', []) %}
 {% if ksql_servers and cfg.get('confluent.controlcenter.ksql.enable', 'false').lower() == 'true' %}
 # KSQL Configuration
-confluent.controlcenter.ksql.url={{ ksql_http_protocol }}://{{ ksql_servers[0] }}:{{ ksql_listener_port }}
+confluent.controlcenter.ksql.default.url={% for host in groups['ksql'] %}{% if loop.index > 1%},{% endif %}{{ ksql_http_protocol }}://{{ host }}:{{ ksql_listener_port }}{% endfor %}
 
 {% endif %}


### PR DESCRIPTION

# Description

moving away from deprecated variable and naming the single ksql cluster default, as connect is named

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Ran basic install and made sure ksql is in c3 as before


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules