### PR TITLE
Fix admin user reference for SASL_PLAIN listener

### DIFF
--- a/roles/confluent.kafka_broker/templates/listener.j2
+++ b/roles/confluent.kafka_broker/templates/listener.j2
@@ -18,7 +18,7 @@ listener.name.{{listener.value.name|lower}}.ssl.client.auth=required
 {% if listener['value']['sasl_protocol'] | default(sasl_protocol) | normalize_sasl_protocol == 'PLAIN' %}
 listener.name.{{listener.value.name|lower}}.sasl.enabled.mechanisms=PLAIN
 listener.name.{{listener.value.name|lower}}.plain.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required \
-  username="{{sasl_scram_users.admin.principal}}" password="{{sasl_scram_users.admin.password}}" \
+  username="{{sasl_plain_users.admin.principal}}" password="{{sasl_plain_users.admin.password}}" \
 {% for user in sasl_plain_users|dict2items %}
   user_{{ user['value']['principal'] }}="{{ user['value']['password'] }}"{% if loop.index != loop|length %} \
 {% else %}


### PR DESCRIPTION
# Description

Fixes an issue when the admin account of sasl_scram_users group is used for the PLAIN authentication method instead of that of the sasl_plain_users group in the broker listener configuration.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration



**Test Configuration**:


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules