### PR TITLE
Fixes to jolokia and prometheus vars + bug fix on file permissions

### DIFF
--- a/roles/confluent.common/tasks/main.yml
+++ b/roles/confluent.common/tasks/main.yml
@@ -24,7 +24,7 @@
 
 - name: Download Jolokia Jar
   get_url:
-    url: "{{jolokia_jar_url}}"
+    url: "{{ jolokia_jar_url }}"
     dest: "{{ jolokia_jar_path }}"
     mode: 0755
   when: jolokia_enabled|bool

--- a/roles/confluent.kafka_broker/defaults/main.yml
+++ b/roles/confluent.kafka_broker/defaults/main.yml
@@ -2,7 +2,7 @@ kafka_broker_open_file_limit: "{{open_file_limit}}"
 
 kafka_broker_jaas_java_arg_buildout: "-Djava.security.auth.login.config={{kafka_broker.jaas_file}}"
 kafka_broker_jolokia_java_arg_buildout: "-javaagent:{{jolokia_jar_path}}=port={{kafka_broker_jolokia_port}},host=0.0.0.0"
-kafka_broker_jmxexporter_java_arg_buildout: "-javaagent:{{jmxexporter_jar_path}}={{kafka_broker_jmxexporter_port}}:{{jmxexporter_install_path}}/kafka.yml"
+kafka_broker_jmxexporter_java_arg_buildout: "-javaagent:{{jmxexporter_jar_path}}={{kafka_broker_jmxexporter_port}}:{{kafka_broker_jmxexporter_config_path}}"
 kafka_broker_ssl_java_arg_buildout: "-Djavax.net.ssl.keyStore={{kafka_broker_keystore_path}} -Djavax.net.ssl.trustStore={{kafka_broker_truststore_path}} -Djavax.net.ssl.keyStorePassword={{kafka_broker_keystore_storepass}} -Djavax.net.ssl.trustStorePassword={{kafka_broker_truststore_storepass}}"
 kafka_broker_log4j_java_arg_buildout: "-Dlog4j.configuration=file:{{kafka_broker.log4j_file}}"
 
@@ -11,8 +11,8 @@ kafka_broker_custom_log4j: true
 kafka_broker_custom_java_args: ""
 kafka_broker_java_args:
   - "{{ kafka_broker_jaas_java_arg_buildout if 'GSSAPI' in kafka_broker_sasl_enabled_mechanisms else '' }}"
-  - "{{ kafka_broker_jolokia_java_arg_buildout if jolokia_enabled|bool else '' }}"
-  - "{{ kafka_broker_jmxexporter_java_arg_buildout if jmxexporter_enabled|bool else '' }}"
+  - "{{ kafka_broker_jolokia_java_arg_buildout if kafka_broker_jolokia_enabled|bool else '' }}"
+  - "{{ kafka_broker_jmxexporter_java_arg_buildout if kafka_broker_jmxexporter_enabled|bool else '' }}"
   - "{{ kafka_broker_ssl_java_arg_buildout if schema_registry_ssl_enabled|bool else '' }}"
   - "{{ kafka_broker_log4j_java_arg_buildout if kafka_broker_custom_log4j|bool else '' }}"
 

--- a/roles/confluent.kafka_broker/tasks/main.yml
+++ b/roles/confluent.kafka_broker/tasks/main.yml
@@ -116,7 +116,10 @@
 - name: Deploy JMX Exporter Config File
   copy:
     src: "kafka.yml"
-    dest: "{{jmxexporter_install_path}}/"
+    dest: "{{kafka_broker_jmxexporter_config_path}}"
+    mode: 0640
+    owner: "{{kafka_broker.user}}"
+    group: "{{kafka_broker.group}}"
   when: jmxexporter_enabled|bool
 
 - name: Create Service Override Directory

--- a/roles/confluent.kafka_connect/defaults/main.yml
+++ b/roles/confluent.kafka_connect/defaults/main.yml
@@ -7,7 +7,7 @@ kafka_connect_custom_log4j: "{{ custom_log4j }}"
 
 kafka_connect_custom_java_args: ""
 kafka_connect_java_args:
-  - "{{ kafka_connect_jolokia_java_arg_buildout if jolokia_enabled|bool else '' }}"
+  - "{{ kafka_connect_jolokia_java_arg_buildout if kafka_connect_jolokia_enabled|bool else '' }}"
   - "{{ kafka_connect_log4j_java_arg_buildout if kafka_connect_custom_log4j|bool else '' }}"
 
 kafka_connect_final_java_args: "{{ kafka_connect_java_args + [ kafka_connect_custom_java_args ] }}"

--- a/roles/confluent.kafka_rest/defaults/main.yml
+++ b/roles/confluent.kafka_rest/defaults/main.yml
@@ -8,7 +8,7 @@ kafka_rest_custom_log4j: "{{ custom_log4j }}"
 
 kafka_rest_custom_java_args: ""
 kafka_rest_java_args:
-  - "{{ kafka_rest_jolokia_java_arg_buildout if jolokia_enabled|bool else '' }}"
+  - "{{ kafka_rest_jolokia_java_arg_buildout if kafka_rest_jolokia_enabled|bool else '' }}"
   - "{{ kafka_rest_ssl_java_arg_buildout if schema_registry_ssl_enabled|bool else '' }}"
   - "{{ kafka_rest_log4j_java_arg_buildout if kafka_rest_custom_log4j|bool else '' }}"
 

--- a/roles/confluent.ksql/defaults/main.yml
+++ b/roles/confluent.ksql/defaults/main.yml
@@ -11,7 +11,7 @@ ksql_custom_log4j: "{{ custom_log4j }}"
 ksql_custom_java_args: ""
 ksql_java_args:
   - "{{ ksql_jaas_java_arg_buildout if kafka_broker_listeners[ksql_kafka_listener_name]['sasl_protocol'] | normalize_sasl_protocol == 'GSSAPI' else '' }}"
-  - "{{ ksql_jolokia_java_arg_buildout if jolokia_enabled|bool else '' }}"
+  - "{{ ksql_jolokia_java_arg_buildout if ksql_jolokia_enabled|bool else '' }}"
   - "{{ ksql_ssl_java_arg_buildout if schema_registry_ssl_enabled|bool else '' }}"
   - "{{ ksql_log4j_java_arg_buildout if ksql_custom_log4j|bool else '' }}"
 

--- a/roles/confluent.schema_registry/defaults/main.yml
+++ b/roles/confluent.schema_registry/defaults/main.yml
@@ -7,7 +7,7 @@ schema_registry_custom_log4j: "{{ custom_log4j }}"
 
 schema_registry_custom_java_args: ""
 schema_registry_java_args:
-  - "{{ schema_registry_jolokia_java_arg_buildout if jolokia_enabled|bool else '' }}"
+  - "{{ schema_registry_jolokia_java_arg_buildout if schema_registry_jolokia_enabled|bool else '' }}"
   - "{{ schema_registry_log4j_java_arg_buildout if schema_registry_custom_log4j|bool else '' }}"
 
 schema_registry_final_java_args: "{{ schema_registry_java_args + [ schema_registry_custom_java_args ] }}"

--- a/roles/confluent.variables_handlers/defaults/main.yml
+++ b/roles/confluent.variables_handlers/defaults/main.yml
@@ -28,7 +28,6 @@ kafka_rest_jolokia_enabled: "{{jolokia_enabled}}"
 kafka_rest_jolokia_port: 7775
 
 jmxexporter_enabled: false
-# jmxexporter_install_path: /opt/prometheus
 jmxexporter_jar_path: /opt/prometheus/jmx_prometheus_javaagent.jar
 zookeeper_jmxexporter_enabled: "{{jmxexporter_enabled}}"
 zookeeper_jmxexporter_config_path: /opt/prometheus/zookeeper.yml

--- a/roles/confluent.variables_handlers/defaults/main.yml
+++ b/roles/confluent.variables_handlers/defaults/main.yml
@@ -14,18 +14,29 @@ confluent:
 
 jolokia_enabled: true
 jolokia_jar_path: /opt/jolokia/jolokia.jar
+zookeeper_jolokia_enabled: "{{jolokia_enabled}}"
 zookeeper_jolokia_port: 7770
+kafka_broker_jolokia_enabled: "{{jolokia_enabled}}"
 kafka_broker_jolokia_port: 7771
+schema_registry_jolokia_enabled: "{{jolokia_enabled}}"
 schema_registry_jolokia_port: 7772
+kafka_connect_jolokia_enabled: "{{jolokia_enabled}}"
 kafka_connect_jolokia_port: 7773
+ksql_jolokia_enabled: "{{jolokia_enabled}}"
 ksql_jolokia_port: 7774
+kafka_rest_jolokia_enabled: "{{jolokia_enabled}}"
 kafka_rest_jolokia_port: 7775
 
 jmxexporter_enabled: false
-jmxexporter_install_path: /opt/prometheus/
+# jmxexporter_install_path: /opt/prometheus
 jmxexporter_jar_path: /opt/prometheus/jmx_prometheus_javaagent.jar
+zookeeper_jmxexporter_enabled: "{{jmxexporter_enabled}}"
+zookeeper_jmxexporter_config_path: /opt/prometheus/zookeeper.yml
+zookeeper_jmxexporter_port: 8079
+kafka_broker_jmxexporter_enabled: "{{jmxexporter_enabled}}"
+kafka_broker_jmxexporter_config_path: /opt/prometheus/kafka.yml
 kafka_broker_jmxexporter_port: 8080
-zookeeper_jmxexporter_port: 8080
+
 
 fips_enabled: false
 fips_jar_path: /usr/share/java/kafka/bc-fips-1.0.1.jar

--- a/roles/confluent.zookeeper/defaults/main.yml
+++ b/roles/confluent.zookeeper/defaults/main.yml
@@ -3,16 +3,16 @@ zookeeper_open_file_limit: "{{open_file_limit}}"
 zookeeper_jaas_java_arg_buildout: "-Djava.security.auth.login.config={{zookeeper.jaas_file}}"
 zookeeper_jolokia_java_arg_buildout: "-javaagent:{{jolokia_jar_path}}=port={{zookeeper_jolokia_port}},host=0.0.0.0"
 zookeeper_log4j_java_arg_buildout: "-Dlog4j.configuration=file:{{zookeeper.log4j_file}}"
-zookeeper_jmxexporter_java_arg_buildout: "-javaagent:{{jmxexporter_jar_path}}={{zookeeper_jmxexporter_port}}:{{jmxexporter_install_path}}/zookeeper.yml"
+zookeeper_jmxexporter_java_arg_buildout: "-javaagent:{{jmxexporter_jar_path}}={{zookeeper_jmxexporter_port}}:{{zookeeper_jmxexporter_config_path}}"
 
 zookeeper_custom_log4j: "{{ custom_log4j }}"
 
 zookeeper_custom_java_args: ""
 zookeeper_java_args:
   - "{{ zookeeper_jaas_java_arg_buildout if 'GSSAPI' in kafka_broker_sasl_enabled_mechanisms else '' }}"
-  - "{{ zookeeper_jolokia_java_arg_buildout if jolokia_enabled|bool else '' }}"
+  - "{{ zookeeper_jolokia_java_arg_buildout if zookeeper_jolokia_enabled|bool else '' }}"
   - "{{ zookeeper_log4j_java_arg_buildout if zookeeper_custom_log4j|bool else '' }}"
-  - "{{ zookeeper_jmxexporter_java_arg_buildout if jmxexporter_enabled|bool else '' }}"
+  - "{{ zookeeper_jmxexporter_java_arg_buildout if zookeeper_jmxexporter_enabled|bool else '' }}"
 
 zookeeper_final_java_args: "{{ zookeeper_java_args + [ zookeeper_custom_java_args ] }}"
 

--- a/roles/confluent.zookeeper/tasks/main.yml
+++ b/roles/confluent.zookeeper/tasks/main.yml
@@ -102,7 +102,10 @@
 - name: Deploy JMX Exporter Config File
   copy:
     src: "zookeeper.yml"
-    dest: "{{jmxexporter_install_path}}/"
+    dest: "{{zookeeper_jmxexporter_config_path}}"
+    mode: 0640
+    owner: "{{zookeeper.user}}"
+    group: "{{zookeeper.group}}"
   when: jmxexporter_enabled|bool
 
 - name: Create Service Override Directory


### PR DESCRIPTION
# Description

Customer discovered bug that permissions on /opt/prometheus/kafka.yml were causing start up to fail. I also introduced additional vars to make each service's jolokia/prometheus exporters togglable

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested with jmx_exporter_enabled set to true/false
All service start as normal, with health checks passing

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules