### PR TITLE
Remove netcat

### DIFF
--- a/roles/confluent.common/tasks/debian.yml
+++ b/roles/confluent.common/tasks/debian.yml
@@ -97,9 +97,3 @@
   loop:
     - rsync
     - ca-certificates
-    
-- name: Install Netcat
-  apt:
-    name: netcat-openbsd
-    state: present
-  when: install_netcat|bool

--- a/roles/confluent.common/tasks/redhat.yml
+++ b/roles/confluent.common/tasks/redhat.yml
@@ -37,8 +37,3 @@
     state: present
   when: install_java|bool
 
-- name: Install NetCat
-  yum:
-    name: nc
-    state: present
-  when: install_netcat|bool

--- a/roles/confluent.common/tasks/ubuntu.yml
+++ b/roles/confluent.common/tasks/ubuntu.yml
@@ -33,8 +33,3 @@
     name: "{{ubuntu_java_package_name}}"
   when: install_java|bool
 
-- name: Install NetCat
-  apt:
-    name: netcat-openbsd
-    state: present
-  when: install_netcat|bool

--- a/roles/confluent.kafka_broker/tasks/main.yml
+++ b/roles/confluent.kafka_broker/tasks/main.yml
@@ -105,7 +105,7 @@
 
 - name: Create SCRAM Users
   shell: |
-    kafka-configs --zookeeper localhost:2181 --alter \
+    kafka-configs --zookeeper localhost:{{zookeeper.properties.clientPort}} --alter \
       --add-config 'SCRAM-SHA-256=[password={{ item.value['password'] }}]' \
       --entity-type users --entity-name {{ item.value['principal'] }}
   loop: "{{ sasl_scram_users|dict2items }}"

--- a/roles/confluent.variables_handlers/defaults/main.yml
+++ b/roles/confluent.variables_handlers/defaults/main.yml
@@ -54,6 +54,7 @@ rbac_enabled: false
 confluent_server_enabled: true
 
 health_checks_enabled: true
+zookeeper_health_check_command: "exec 42<>/dev/tcp/127.0.0.1/{{zookeeper.properties.clientPort}}; echo -e 'srvr' >&42; cat <&42"
 
 # Other options: kerberos, plain, scram
 sasl_protocol: none

--- a/roles/confluent.variables_handlers/defaults/main.yml
+++ b/roles/confluent.variables_handlers/defaults/main.yml
@@ -53,7 +53,6 @@ rbac_enabled: false
 
 confluent_server_enabled: true
 
-install_netcat: true
 health_checks_enabled: true
 
 # Other options: kerberos, plain, scram

--- a/roles/confluent.zookeeper/tasks/health_check.yml
+++ b/roles/confluent.zookeeper/tasks/health_check.yml
@@ -1,0 +1,18 @@
+---
+- name: Wait for Zookeeper Status
+  shell: "{{zookeeper_health_check_command}}"
+  args:
+    executable: /bin/bash
+  register: srvr
+  until: srvr.rc == 0
+  retries: 60
+  delay: 5
+
+- name: Wait for Zookeeper Quorum
+  shell: "{{zookeeper_health_check_command}}"
+  args:
+    executable: /bin/bash
+  register: srvr
+  until: '"Latency min/avg/max:" in srvr.stdout'
+  retries: 60
+  delay: 5

--- a/roles/confluent.zookeeper/tasks/main.yml
+++ b/roles/confluent.zookeeper/tasks/main.yml
@@ -140,20 +140,6 @@
     enabled: yes
     state: started
 
-- name: Wait for Zookeeper Status
-  shell: "exec 42<>/dev/tcp/127.0.0.1/{{zookeeper.properties.clientPort}}; echo -e 'srvr' >&42 ;cat <&42"
-  register: srvr
-  until: srvr.rc == 0
-  retries: 60
-  delay: 5
-  when:
-    - health_checks_enabled|bool
-
-- name: Wait for Zookeeper Quorum
-  shell: "exec 42<>/dev/tcp/127.0.0.1/{{zookeeper.properties.clientPort}}; echo -e 'srvr' >&42 ;cat <&42"
-  register: srvr
-  until: '"Latency min/avg/max:" in srvr.stdout'
-  retries: 60
-  delay: 5
-  when:
-    - health_checks_enabled|bool
+- name: Zookeeper Health Check
+  include_tasks: health_check.yml
+  when: health_checks_enabled|bool

--- a/roles/confluent.zookeeper/tasks/main.yml
+++ b/roles/confluent.zookeeper/tasks/main.yml
@@ -141,7 +141,7 @@
     state: started
 
 - name: Wait for Zookeeper Status
-  shell: exec 42<>/dev/tcp/127.0.0.1/2181; echo -e "srvr" >&42 ;cat <&42
+  shell: "exec 42<>/dev/tcp/127.0.0.1/{{zookeeper.properties.clientPort}}; echo -e 'srvr' >&42 ;cat <&42"
   register: srvr
   until: srvr.rc == 0
   retries: 60
@@ -150,7 +150,7 @@
     - health_checks_enabled|bool
 
 - name: Wait for Zookeeper Quorum
-  shell: exec 42<>/dev/tcp/127.0.0.1/2181; echo -e "srvr" >&42 ;cat <&42
+  shell: "exec 42<>/dev/tcp/127.0.0.1/{{zookeeper.properties.clientPort}}; echo -e 'srvr' >&42 ;cat <&42"
   register: srvr
   until: '"Latency min/avg/max:" in srvr.stdout'
   retries: 60

--- a/roles/confluent.zookeeper/tasks/main.yml
+++ b/roles/confluent.zookeeper/tasks/main.yml
@@ -141,21 +141,19 @@
     state: started
 
 - name: Wait for Zookeeper Status
-  shell: echo srvr | nc localhost 2181
+  shell: exec 42<>/dev/tcp/127.0.0.1/2181; echo -e "srvr" >&42 ;cat <&42
   register: srvr
   until: srvr.rc == 0
   retries: 60
   delay: 5
   when:
     - health_checks_enabled|bool
-    - install_netcat|bool
 
 - name: Wait for Zookeeper Quorum
-  shell: echo srvr | nc localhost 2181
+  shell: exec 42<>/dev/tcp/127.0.0.1/2181; echo -e "srvr" >&42 ;cat <&42
   register: srvr
   until: '"Latency min/avg/max:" in srvr.stdout'
   retries: 60
   delay: 5
   when:
     - health_checks_enabled|bool
-    - install_netcat|bool

--- a/upgrade_zookeeper.yml
+++ b/upgrade_zookeeper.yml
@@ -15,14 +15,14 @@
         state: started
 
     - name: Wait for Zookeeper Status
-      shell: exec 42<>/dev/tcp/127.0.0.1/2181; echo -e "srvr" >&42 ;cat <&42
+      shell: exec 42<>/dev/tcp/127.0.0.1/{{zookeeper.properties.clientPort}}; echo -e "srvr" >&42 ;cat <&42
       register: srvr
       until: srvr.rc == 0
       retries: 30
       delay: 5
 
     - name: Wait for Zookeeper Quorum
-      shell: exec 42<>/dev/tcp/127.0.0.1/2181; echo -e "srvr" >&42 ;cat <&42
+      shell: exec 42<>/dev/tcp/127.0.0.1/{{zookeeper.properties.clientPort}}; echo -e "srvr" >&42 ;cat <&42
       register: srvr
       until: '"Latency min/avg/max:" in srvr.stdout'
       retries: 30
@@ -54,7 +54,7 @@
         msg: "Current version: {{zookeeper_current_version}}   Upgrade to version: {{confluent_package_version}}"
 
     - name: Get Leader/Follower
-      shell: exec 42<>/dev/tcp/127.0.0.1/2181; echo -e "srvr" >&42 ;cat <&42 | grep Mode
+      shell: exec 42<>/dev/tcp/127.0.0.1/{{zookeeper.properties.clientPort}}; echo -e "srvr" >&42 ;cat <&42 | grep Mode
       register: leader_query
 
     - name: Add host to Follower Group
@@ -116,7 +116,7 @@
         state: stopped
 
     - name: Wait for Zookeeper Status on Another Zookeeper Node
-      shell: exec 42<>/dev/tcp/127.0.0.1/2181; echo -e "srvr" >&42 ;cat <&42
+      shell: exec 42<>/dev/tcp/127.0.0.1/{{zookeeper.properties.clientPort}}; echo -e "srvr" >&42 ;cat <&42
       register: srvr
       until: srvr.rc == 0
       retries: 30
@@ -124,7 +124,7 @@
       delegate_to: "{{ groups['zookeeper'] | difference([inventory_hostname]) | first }}"
 
     - name: Wait for Zookeeper Quorum on Another Zookeeper Node
-      shell: exec 42<>/dev/tcp/127.0.0.1/2181; echo -e "srvr" >&42 ;cat <&42
+      shell: exec 42<>/dev/tcp/127.0.0.1/{{zookeeper.properties.clientPort}}; echo -e "srvr" >&42 ;cat <&42
       register: srvr
       until: '"Latency min/avg/max:" in srvr.stdout'
       retries: 30
@@ -190,14 +190,14 @@
         state: restarted
 
     - name: Wait for Zookeeper Status
-      shell: exec 42<>/dev/tcp/127.0.0.1/2181; echo -e "srvr" >&42 ;cat <&42
+      shell: exec 42<>/dev/tcp/127.0.0.1/{{zookeeper.properties.clientPort}}; echo -e "srvr" >&42 ;cat <&42
       register: srvr
       until: srvr.rc == 0
       retries: 30
       delay: 5
 
     - name: Wait for Zookeeper Quorum
-      shell: exec 42<>/dev/tcp/127.0.0.1/2181; echo -e "srvr" >&42 ;cat <&42
+      shell: exec 42<>/dev/tcp/127.0.0.1/{{zookeeper.properties.clientPort}}; echo -e "srvr" >&42 ;cat <&42
       register: srvr
       until: '"Latency min/avg/max:" in srvr.stdout'
       retries: 30

--- a/upgrade_zookeeper.yml
+++ b/upgrade_zookeeper.yml
@@ -14,19 +14,10 @@
         name: "{{zookeeper_service_name}}"
         state: started
 
-    - name: Wait for Zookeeper Status
-      shell: exec 42<>/dev/tcp/127.0.0.1/{{zookeeper.properties.clientPort}}; echo -e "srvr" >&42 ;cat <&42
-      register: srvr
-      until: srvr.rc == 0
-      retries: 30
-      delay: 5
-
-    - name: Wait for Zookeeper Quorum
-      shell: exec 42<>/dev/tcp/127.0.0.1/{{zookeeper.properties.clientPort}}; echo -e "srvr" >&42 ;cat <&42
-      register: srvr
-      until: '"Latency min/avg/max:" in srvr.stdout'
-      retries: 30
-      delay: 5
+    - name: Zookeeper Health Check
+      import_role:
+        name: confluent.zookeeper
+        tasks_from: health_check.yml
 
     - name: Get Package Facts
       package_facts:
@@ -54,7 +45,9 @@
         msg: "Current version: {{zookeeper_current_version}}   Upgrade to version: {{confluent_package_version}}"
 
     - name: Get Leader/Follower
-      shell: exec 42<>/dev/tcp/127.0.0.1/{{zookeeper.properties.clientPort}}; echo -e "srvr" >&42 ;cat <&42 | grep Mode
+      shell: "{{zookeeper_health_check_command}} | grep Mode"
+      args:
+        executable: /bin/bash
       register: leader_query
 
     - name: Add host to Follower Group
@@ -116,19 +109,9 @@
         state: stopped
 
     - name: Wait for Zookeeper Status on Another Zookeeper Node
-      shell: exec 42<>/dev/tcp/127.0.0.1/{{zookeeper.properties.clientPort}}; echo -e "srvr" >&42 ;cat <&42
-      register: srvr
-      until: srvr.rc == 0
-      retries: 30
-      delay: 5
-      delegate_to: "{{ groups['zookeeper'] | difference([inventory_hostname]) | first }}"
-
-    - name: Wait for Zookeeper Quorum on Another Zookeeper Node
-      shell: exec 42<>/dev/tcp/127.0.0.1/{{zookeeper.properties.clientPort}}; echo -e "srvr" >&42 ;cat <&42
-      register: srvr
-      until: '"Latency min/avg/max:" in srvr.stdout'
-      retries: 30
-      delay: 5
+      import_role:
+        name: confluent.zookeeper
+        tasks_from: health_check.yml
       delegate_to: "{{ groups['zookeeper'] | difference([inventory_hostname]) | first }}"
 
     - name: Configure Repositories
@@ -189,16 +172,7 @@
         name: "{{ zookeeper_service_name }}"
         state: restarted
 
-    - name: Wait for Zookeeper Status
-      shell: exec 42<>/dev/tcp/127.0.0.1/{{zookeeper.properties.clientPort}}; echo -e "srvr" >&42 ;cat <&42
-      register: srvr
-      until: srvr.rc == 0
-      retries: 30
-      delay: 5
-
-    - name: Wait for Zookeeper Quorum
-      shell: exec 42<>/dev/tcp/127.0.0.1/{{zookeeper.properties.clientPort}}; echo -e "srvr" >&42 ;cat <&42
-      register: srvr
-      until: '"Latency min/avg/max:" in srvr.stdout'
-      retries: 30
-      delay: 5
+    - name: Zookeeper Health Check
+      import_role:
+        name: confluent.zookeeper
+        tasks_from: health_check.yml

--- a/upgrade_zookeeper.yml
+++ b/upgrade_zookeeper.yml
@@ -14,27 +14,15 @@
         name: "{{zookeeper_service_name}}"
         state: started
 
-    - name: Install NetCat - RedHat
-      yum:
-        name: nc
-        state: present
-      when: ansible_os_family == "RedHat"
-
-    - name: Install NetCat - Debian
-      apt:
-        name: netcat-openbsd
-        state: present
-      when: ansible_os_family == "Debian"
-
     - name: Wait for Zookeeper Status
-      shell: echo srvr | nc localhost 2181
+      shell: exec 42<>/dev/tcp/127.0.0.1/2181; echo -e "srvr" >&42 ;cat <&42
       register: srvr
       until: srvr.rc == 0
       retries: 30
       delay: 5
 
     - name: Wait for Zookeeper Quorum
-      shell: echo srvr | nc localhost 2181
+      shell: exec 42<>/dev/tcp/127.0.0.1/2181; echo -e "srvr" >&42 ;cat <&42
       register: srvr
       until: '"Latency min/avg/max:" in srvr.stdout'
       retries: 30
@@ -66,7 +54,7 @@
         msg: "Current version: {{zookeeper_current_version}}   Upgrade to version: {{confluent_package_version}}"
 
     - name: Get Leader/Follower
-      shell: echo srvr | nc localhost 2181 | grep Mode
+      shell: exec 42<>/dev/tcp/127.0.0.1/2181; echo -e "srvr" >&42 ;cat <&42 | grep Mode
       register: leader_query
 
     - name: Add host to Follower Group
@@ -128,7 +116,7 @@
         state: stopped
 
     - name: Wait for Zookeeper Status on Another Zookeeper Node
-      shell: echo srvr | nc localhost 2181
+      shell: exec 42<>/dev/tcp/127.0.0.1/2181; echo -e "srvr" >&42 ;cat <&42
       register: srvr
       until: srvr.rc == 0
       retries: 30
@@ -136,7 +124,7 @@
       delegate_to: "{{ groups['zookeeper'] | difference([inventory_hostname]) | first }}"
 
     - name: Wait for Zookeeper Quorum on Another Zookeeper Node
-      shell: echo srvr | nc localhost 2181
+      shell: exec 42<>/dev/tcp/127.0.0.1/2181; echo -e "srvr" >&42 ;cat <&42
       register: srvr
       until: '"Latency min/avg/max:" in srvr.stdout'
       retries: 30
@@ -202,14 +190,14 @@
         state: restarted
 
     - name: Wait for Zookeeper Status
-      shell: echo srvr | nc localhost 2181
+      shell: exec 42<>/dev/tcp/127.0.0.1/2181; echo -e "srvr" >&42 ;cat <&42
       register: srvr
       until: srvr.rc == 0
       retries: 30
       delay: 5
 
     - name: Wait for Zookeeper Quorum
-      shell: echo srvr | nc localhost 2181
+      shell: exec 42<>/dev/tcp/127.0.0.1/2181; echo -e "srvr" >&42 ;cat <&42
       register: srvr
       until: '"Latency min/avg/max:" in srvr.stdout'
       retries: 30


### PR DESCRIPTION
# Description

Netcat is not allowed on our systems due to the security constraints.
Instead of netcat, make use of bash's file descriptor redirection.

Link:
* https://www.gnu.org/software/bash/manual/html_node/Redirections.html#Redirections

Fixes # (issue)

## Type of change

- [?] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [?] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I have tested the installation of zookeeper with this code change.
I have _NOT_ tested the upgrade of zookeeper.


**Test Configuration**:


# Checklist:

- [ ] My code follows the style guidelines of this project
- [partial] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules