### PR TITLE
Improved limitnofile logic

### DIFF
--- a/roles/confluent.control_center/defaults/main.yml
+++ b/roles/confluent.control_center/defaults/main.yml
@@ -8,6 +8,7 @@ control_center_java_args:
 
 control_center_final_java_args: "{{ control_center_java_args + [ control_center_custom_java_args ] }}"
 
+# Empty values in below dictionaries will not be written into override.conf
 control_center_service_overrides:
   LimitNOFILE:
 control_center_service_environment_overrides:

--- a/roles/confluent.control_center/defaults/main.yml
+++ b/roles/confluent.control_center/defaults/main.yml
@@ -8,7 +8,7 @@ control_center_java_args:
 
 control_center_final_java_args: "{{ control_center_java_args + [ control_center_custom_java_args ] }}"
 
-# Empty values in below dictionaries will not be written into override.conf
+# C3 already has LimitNOFILE value set, empty value will not get written to override.conf
 control_center_service_overrides:
   LimitNOFILE:
 control_center_service_environment_overrides:

--- a/roles/confluent.control_center/defaults/main.yml
+++ b/roles/confluent.control_center/defaults/main.yml
@@ -1,4 +1,4 @@
-control_center_open_file_limit: "{{open_file_limit}}"
+# control_center_open_file_limit: "{{open_file_limit}}"
 
 control_center_log4j_java_arg_buildout: "-Dlog4j.configuration=file:{{control_center.log4j_file}}"
 
@@ -10,8 +10,8 @@ control_center_java_args:
 
 control_center_final_java_args: "{{ control_center_java_args + [ control_center_custom_java_args ] }}"
 
-control_center_service_overrides:
-  LimitNOFILE: "{{control_center_open_file_limit}}"
+# control_center_service_overrides:
+  # LimitNOFILE: "{{control_center_open_file_limit}}"
 control_center_service_environment_overrides:
   CONTROL_CENTER_HEAP_OPTS: "-Xmx6g"
   CONTROL_CENTER_OPTS: "{{ control_center_final_java_args | java_arg_build_out }}"

--- a/roles/confluent.control_center/defaults/main.yml
+++ b/roles/confluent.control_center/defaults/main.yml
@@ -8,6 +8,8 @@ control_center_java_args:
 
 control_center_final_java_args: "{{ control_center_java_args + [ control_center_custom_java_args ] }}"
 
+control_center_service_overrides:
+  LimitNOFILE:
 control_center_service_environment_overrides:
   CONTROL_CENTER_HEAP_OPTS: "-Xmx6g"
   CONTROL_CENTER_OPTS: "{{ control_center_final_java_args | java_arg_build_out }}"

--- a/roles/confluent.control_center/defaults/main.yml
+++ b/roles/confluent.control_center/defaults/main.yml
@@ -1,5 +1,3 @@
-# control_center_open_file_limit: "{{open_file_limit}}"
-
 control_center_log4j_java_arg_buildout: "-Dlog4j.configuration=file:{{control_center.log4j_file}}"
 
 control_center_custom_log4j: "{{ custom_log4j }}"
@@ -10,8 +8,6 @@ control_center_java_args:
 
 control_center_final_java_args: "{{ control_center_java_args + [ control_center_custom_java_args ] }}"
 
-# control_center_service_overrides:
-  # LimitNOFILE: "{{control_center_open_file_limit}}"
 control_center_service_environment_overrides:
   CONTROL_CENTER_HEAP_OPTS: "-Xmx6g"
   CONTROL_CENTER_OPTS: "{{ control_center_final_java_args | java_arg_build_out }}"

--- a/roles/confluent.control_center/defaults/main.yml
+++ b/roles/confluent.control_center/defaults/main.yml
@@ -8,7 +8,7 @@ control_center_java_args:
 
 control_center_final_java_args: "{{ control_center_java_args + [ control_center_custom_java_args ] }}"
 
-# C3 already has LimitNOFILE value set, empty value will not get written to override.conf
+# C3 already has LimitNOFILE value set in unit file, empty value will not get written to override.conf
 control_center_service_overrides:
   LimitNOFILE:
 control_center_service_environment_overrides:

--- a/roles/confluent.control_center/templates/override.conf.j2
+++ b/roles/confluent.control_center/templates/override.conf.j2
@@ -1,7 +1,4 @@
 [Service]
-{% for key, value in control_center_service_overrides.items() %}
-{{key}}={{value}}
-{% endfor %}
 {% for key, value in control_center_service_environment_overrides.items() %}
 Environment="{{key}}={{value}}"
 {% endfor %}

--- a/roles/confluent.control_center/templates/override.conf.j2
+++ b/roles/confluent.control_center/templates/override.conf.j2
@@ -1,4 +1,11 @@
 [Service]
+{% for key, value in control_center_service_overrides.items() %}
+{% if value %}
+{{key}}={{value}}
+{% endif %}
+{% endfor %}
 {% for key, value in control_center_service_environment_overrides.items() %}
+{% if value %}
 Environment="{{key}}={{value}}"
+{% endif %}
 {% endfor %}

--- a/roles/confluent.kafka_broker/defaults/main.yml
+++ b/roles/confluent.kafka_broker/defaults/main.yml
@@ -1,4 +1,4 @@
-kafka_broker_open_file_limit: "{{open_file_limit}}"
+# kafka_broker_open_file_limit: "{{open_file_limit}}"
 
 kafka_broker_jaas_java_arg_buildout: "-Djava.security.auth.login.config={{kafka_broker.jaas_file}}"
 kafka_broker_jolokia_java_arg_buildout: "-javaagent:{{jolokia_jar_path}}=port={{kafka_broker_jolokia_port}},host=0.0.0.0"
@@ -18,8 +18,8 @@ kafka_broker_java_args:
 
 kafka_broker_final_java_args: "{{ kafka_broker_java_args + [ kafka_broker_custom_java_args ] }}"
 
-kafka_broker_service_overrides:
-  LimitNOFILE: "{{kafka_broker_open_file_limit}}"
+# kafka_broker_service_overrides:
+  # LimitNOFILE: "{{kafka_broker_open_file_limit}}"
 kafka_broker_service_environment_overrides:
   KAFKA_HEAP_OPTS: "-Xmx1g"
   KAFKA_OPTS: "{{ kafka_broker_final_java_args | java_arg_build_out }}"

--- a/roles/confluent.kafka_broker/defaults/main.yml
+++ b/roles/confluent.kafka_broker/defaults/main.yml
@@ -16,7 +16,7 @@ kafka_broker_java_args:
 
 kafka_broker_final_java_args: "{{ kafka_broker_java_args + [ kafka_broker_custom_java_args ] }}"
 
-# Kafka already has LimitNOFILE value set, empty value will not get written to override.conf
+# Kafka already has LimitNOFILE value set in unit file, empty value will not get written to override.conf
 kafka_broker_service_overrides:
   LimitNOFILE:
 kafka_broker_service_environment_overrides:

--- a/roles/confluent.kafka_broker/defaults/main.yml
+++ b/roles/confluent.kafka_broker/defaults/main.yml
@@ -16,6 +16,7 @@ kafka_broker_java_args:
 
 kafka_broker_final_java_args: "{{ kafka_broker_java_args + [ kafka_broker_custom_java_args ] }}"
 
+# Empty values in below dictionaries will not be written into override.conf
 kafka_broker_service_overrides:
   LimitNOFILE:
 kafka_broker_service_environment_overrides:

--- a/roles/confluent.kafka_broker/defaults/main.yml
+++ b/roles/confluent.kafka_broker/defaults/main.yml
@@ -16,7 +16,7 @@ kafka_broker_java_args:
 
 kafka_broker_final_java_args: "{{ kafka_broker_java_args + [ kafka_broker_custom_java_args ] }}"
 
-# Empty values in below dictionaries will not be written into override.conf
+# Kafka already has LimitNOFILE value set, empty value will not get written to override.conf
 kafka_broker_service_overrides:
   LimitNOFILE:
 kafka_broker_service_environment_overrides:

--- a/roles/confluent.kafka_broker/defaults/main.yml
+++ b/roles/confluent.kafka_broker/defaults/main.yml
@@ -16,6 +16,8 @@ kafka_broker_java_args:
 
 kafka_broker_final_java_args: "{{ kafka_broker_java_args + [ kafka_broker_custom_java_args ] }}"
 
+kafka_broker_service_overrides:
+  LimitNOFILE:
 kafka_broker_service_environment_overrides:
   KAFKA_HEAP_OPTS: "-Xmx1g"
   KAFKA_OPTS: "{{ kafka_broker_final_java_args | java_arg_build_out }}"

--- a/roles/confluent.kafka_broker/defaults/main.yml
+++ b/roles/confluent.kafka_broker/defaults/main.yml
@@ -1,5 +1,3 @@
-# kafka_broker_open_file_limit: "{{open_file_limit}}"
-
 kafka_broker_jaas_java_arg_buildout: "-Djava.security.auth.login.config={{kafka_broker.jaas_file}}"
 kafka_broker_jolokia_java_arg_buildout: "-javaagent:{{jolokia_jar_path}}=port={{kafka_broker_jolokia_port}},host=0.0.0.0"
 kafka_broker_jmxexporter_java_arg_buildout: "-javaagent:{{jmxexporter_jar_path}}={{kafka_broker_jmxexporter_port}}:{{kafka_broker_jmxexporter_config_path}}"
@@ -18,8 +16,6 @@ kafka_broker_java_args:
 
 kafka_broker_final_java_args: "{{ kafka_broker_java_args + [ kafka_broker_custom_java_args ] }}"
 
-# kafka_broker_service_overrides:
-  # LimitNOFILE: "{{kafka_broker_open_file_limit}}"
 kafka_broker_service_environment_overrides:
   KAFKA_HEAP_OPTS: "-Xmx1g"
   KAFKA_OPTS: "{{ kafka_broker_final_java_args | java_arg_build_out }}"

--- a/roles/confluent.kafka_broker/templates/override.conf.j2
+++ b/roles/confluent.kafka_broker/templates/override.conf.j2
@@ -1,7 +1,4 @@
 [Service]
-{% for key, value in kafka_broker_service_overrides.items() %}
-{{key}}={{value}}
-{% endfor %}
 {% for key, value in kafka_broker_service_environment_overrides.items() %}
 {% if value != '' %}
 Environment="{{key}}={{value}}"

--- a/roles/confluent.kafka_broker/templates/override.conf.j2
+++ b/roles/confluent.kafka_broker/templates/override.conf.j2
@@ -1,4 +1,9 @@
 [Service]
+{% for key, value in kafka_broker_service_overrides.items() %}
+{% if value %}
+{{key}}={{value}}
+{% endif %}
+{% endfor %}
 {% for key, value in kafka_broker_service_environment_overrides.items() %}
 {% if value != '' %}
 Environment="{{key}}={{value}}"

--- a/roles/confluent.kafka_broker/templates/override.conf.j2
+++ b/roles/confluent.kafka_broker/templates/override.conf.j2
@@ -5,7 +5,7 @@
 {% endif %}
 {% endfor %}
 {% for key, value in kafka_broker_service_environment_overrides.items() %}
-{% if value != '' %}
+{% if value %}
 Environment="{{key}}={{value}}"
 {% endif %}
 {% endfor %}

--- a/roles/confluent.kafka_connect/defaults/main.yml
+++ b/roles/confluent.kafka_connect/defaults/main.yml
@@ -10,7 +10,6 @@ kafka_connect_java_args:
 
 kafka_connect_final_java_args: "{{ kafka_connect_java_args + [ kafka_connect_custom_java_args ] }}"
 
-# Empty values in below dictionaries will not be written into override.conf
 kafka_connect_service_overrides:
   LimitNOFILE: 100000
 kafka_connect_service_environment_overrides:

--- a/roles/confluent.kafka_connect/defaults/main.yml
+++ b/roles/confluent.kafka_connect/defaults/main.yml
@@ -1,5 +1,3 @@
-# kafka_connect_open_file_limit: "{{open_file_limit}}"
-
 kafka_connect_jolokia_java_arg_buildout: "-javaagent:{{jolokia_jar_path}}=port={{kafka_connect_jolokia_port}},host=0.0.0.0"
 kafka_connect_log4j_java_arg_buildout: "-Dlog4j.configuration=file:{{kafka_connect.log4j_file}}"
 
@@ -12,8 +10,6 @@ kafka_connect_java_args:
 
 kafka_connect_final_java_args: "{{ kafka_connect_java_args + [ kafka_connect_custom_java_args ] }}"
 
-# kafka_connect_service_overrides:
-  # LimitNOFILE: "{{kafka_connect_open_file_limit}}"
 kafka_connect_service_environment_overrides:
   KAFKA_HEAP_OPTS: "-Xms256M -Xmx2G"
   KAFKA_OPTS: "{{ kafka_connect_final_java_args | java_arg_build_out }}"

--- a/roles/confluent.kafka_connect/defaults/main.yml
+++ b/roles/confluent.kafka_connect/defaults/main.yml
@@ -12,6 +12,8 @@ kafka_connect_java_args:
 
 kafka_connect_final_java_args: "{{ kafka_connect_java_args + [ kafka_connect_custom_java_args ] }}"
 
+kafka_connect_service_overrides:
+  LimitNOFILE: "{{kafka_connect_open_file_limit}}"
 kafka_connect_service_environment_overrides:
   KAFKA_HEAP_OPTS: "-Xms256M -Xmx2G"
   KAFKA_OPTS: "{{ kafka_connect_final_java_args | java_arg_build_out }}"

--- a/roles/confluent.kafka_connect/defaults/main.yml
+++ b/roles/confluent.kafka_connect/defaults/main.yml
@@ -1,5 +1,3 @@
-kafka_connect_open_file_limit: 100000
-
 kafka_connect_jolokia_java_arg_buildout: "-javaagent:{{jolokia_jar_path}}=port={{kafka_connect_jolokia_port}},host=0.0.0.0"
 kafka_connect_log4j_java_arg_buildout: "-Dlog4j.configuration=file:{{kafka_connect.log4j_file}}"
 
@@ -13,7 +11,7 @@ kafka_connect_java_args:
 kafka_connect_final_java_args: "{{ kafka_connect_java_args + [ kafka_connect_custom_java_args ] }}"
 
 kafka_connect_service_overrides:
-  LimitNOFILE: "{{kafka_connect_open_file_limit}}"
+  LimitNOFILE: 100000
 kafka_connect_service_environment_overrides:
   KAFKA_HEAP_OPTS: "-Xms256M -Xmx2G"
   KAFKA_OPTS: "{{ kafka_connect_final_java_args | java_arg_build_out }}"

--- a/roles/confluent.kafka_connect/defaults/main.yml
+++ b/roles/confluent.kafka_connect/defaults/main.yml
@@ -10,6 +10,7 @@ kafka_connect_java_args:
 
 kafka_connect_final_java_args: "{{ kafka_connect_java_args + [ kafka_connect_custom_java_args ] }}"
 
+# Empty values in below dictionaries will not be written into override.conf
 kafka_connect_service_overrides:
   LimitNOFILE: 100000
 kafka_connect_service_environment_overrides:

--- a/roles/confluent.kafka_connect/defaults/main.yml
+++ b/roles/confluent.kafka_connect/defaults/main.yml
@@ -1,4 +1,4 @@
-kafka_connect_open_file_limit: "{{open_file_limit}}"
+# kafka_connect_open_file_limit: "{{open_file_limit}}"
 
 kafka_connect_jolokia_java_arg_buildout: "-javaagent:{{jolokia_jar_path}}=port={{kafka_connect_jolokia_port}},host=0.0.0.0"
 kafka_connect_log4j_java_arg_buildout: "-Dlog4j.configuration=file:{{kafka_connect.log4j_file}}"
@@ -12,8 +12,8 @@ kafka_connect_java_args:
 
 kafka_connect_final_java_args: "{{ kafka_connect_java_args + [ kafka_connect_custom_java_args ] }}"
 
-kafka_connect_service_overrides:
-  LimitNOFILE: "{{kafka_connect_open_file_limit}}"
+# kafka_connect_service_overrides:
+  # LimitNOFILE: "{{kafka_connect_open_file_limit}}"
 kafka_connect_service_environment_overrides:
   KAFKA_HEAP_OPTS: "-Xms256M -Xmx2G"
   KAFKA_OPTS: "{{ kafka_connect_final_java_args | java_arg_build_out }}"

--- a/roles/confluent.kafka_connect/templates/override.conf.j2
+++ b/roles/confluent.kafka_connect/templates/override.conf.j2
@@ -1,9 +1,11 @@
 [Service]
 {% for key, value in kafka_connect_service_overrides.items() %}
+{% if value %}
 {{key}}={{value}}
+{% endif %}
 {% endfor %}
 {% for key, value in kafka_connect_service_environment_overrides.items() %}
-{% if value != '' %}
+{% if value %}
 Environment="{{key}}={{value}}"
 {% endif %}
 {% endfor %}

--- a/roles/confluent.kafka_connect/templates/override.conf.j2
+++ b/roles/confluent.kafka_connect/templates/override.conf.j2
@@ -1,4 +1,7 @@
 [Service]
+{% for key, value in kafka_connect_service_overrides.items() %}
+{{key}}={{value}}
+{% endfor %}
 {% for key, value in kafka_connect_service_environment_overrides.items() %}
 {% if value != '' %}
 Environment="{{key}}={{value}}"

--- a/roles/confluent.kafka_connect/templates/override.conf.j2
+++ b/roles/confluent.kafka_connect/templates/override.conf.j2
@@ -1,7 +1,4 @@
 [Service]
-{% for key, value in kafka_connect_service_overrides.items() %}
-{{key}}={{value}}
-{% endfor %}
 {% for key, value in kafka_connect_service_environment_overrides.items() %}
 {% if value != '' %}
 Environment="{{key}}={{value}}"

--- a/roles/confluent.kafka_rest/defaults/main.yml
+++ b/roles/confluent.kafka_rest/defaults/main.yml
@@ -10,7 +10,7 @@ kafka_rest_java_args:
 
 kafka_rest_final_java_args: "{{ kafka_rest_java_args + [ kafka_rest_custom_java_args ] }}"
 
-# Rest Proxy already has LimitNOFILE value set, empty value will not get written to override.conf
+# Rest Proxy already has LimitNOFILE value set in unit file, empty value will not get written to override.conf
 kafka_rest_service_overrides:
   LimitNOFILE:
 kafka_rest_service_environment_overrides:

--- a/roles/confluent.kafka_rest/defaults/main.yml
+++ b/roles/confluent.kafka_rest/defaults/main.yml
@@ -10,7 +10,7 @@ kafka_rest_java_args:
 
 kafka_rest_final_java_args: "{{ kafka_rest_java_args + [ kafka_rest_custom_java_args ] }}"
 
-# Empty values in below dictionaries will not be written into override.conf
+# Rest Proxy already has LimitNOFILE value set, empty value will not get written to override.conf
 kafka_rest_service_overrides:
   LimitNOFILE:
 kafka_rest_service_environment_overrides:

--- a/roles/confluent.kafka_rest/defaults/main.yml
+++ b/roles/confluent.kafka_rest/defaults/main.yml
@@ -1,4 +1,4 @@
-kafka_rest_open_file_limit: "{{open_file_limit}}"
+# kafka_rest_open_file_limit: "{{open_file_limit}}"
 
 kafka_rest_jolokia_java_arg_buildout: "-javaagent:{{jolokia_jar_path}}=port={{kafka_rest_jolokia_port}},host=0.0.0.0"
 kafka_rest_log4j_java_arg_buildout: "-Dlog4j.configuration=file:{{kafka_rest.log4j_file}}"
@@ -12,8 +12,8 @@ kafka_rest_java_args:
 
 kafka_rest_final_java_args: "{{ kafka_rest_java_args + [ kafka_rest_custom_java_args ] }}"
 
-kafka_rest_service_overrides:
-  LimitNOFILE: "{{kafka_rest_open_file_limit}}"
+# kafka_rest_service_overrides:
+  # LimitNOFILE: "{{kafka_rest_open_file_limit}}"
 kafka_rest_service_environment_overrides:
   LOG_DIR: /var/log/kafka-rest
   KAFKAREST_OPTS: "{{ kafka_rest_final_java_args | java_arg_build_out }}"

--- a/roles/confluent.kafka_rest/defaults/main.yml
+++ b/roles/confluent.kafka_rest/defaults/main.yml
@@ -1,5 +1,3 @@
-# kafka_rest_open_file_limit: "{{open_file_limit}}"
-
 kafka_rest_jolokia_java_arg_buildout: "-javaagent:{{jolokia_jar_path}}=port={{kafka_rest_jolokia_port}},host=0.0.0.0"
 kafka_rest_log4j_java_arg_buildout: "-Dlog4j.configuration=file:{{kafka_rest.log4j_file}}"
 
@@ -12,8 +10,6 @@ kafka_rest_java_args:
 
 kafka_rest_final_java_args: "{{ kafka_rest_java_args + [ kafka_rest_custom_java_args ] }}"
 
-# kafka_rest_service_overrides:
-  # LimitNOFILE: "{{kafka_rest_open_file_limit}}"
 kafka_rest_service_environment_overrides:
   LOG_DIR: /var/log/kafka-rest
   KAFKAREST_OPTS: "{{ kafka_rest_final_java_args | java_arg_build_out }}"

--- a/roles/confluent.kafka_rest/defaults/main.yml
+++ b/roles/confluent.kafka_rest/defaults/main.yml
@@ -10,6 +10,7 @@ kafka_rest_java_args:
 
 kafka_rest_final_java_args: "{{ kafka_rest_java_args + [ kafka_rest_custom_java_args ] }}"
 
+# Empty values in below dictionaries will not be written into override.conf
 kafka_rest_service_overrides:
   LimitNOFILE:
 kafka_rest_service_environment_overrides:

--- a/roles/confluent.kafka_rest/defaults/main.yml
+++ b/roles/confluent.kafka_rest/defaults/main.yml
@@ -10,6 +10,8 @@ kafka_rest_java_args:
 
 kafka_rest_final_java_args: "{{ kafka_rest_java_args + [ kafka_rest_custom_java_args ] }}"
 
+kafka_rest_service_overrides:
+  LimitNOFILE:
 kafka_rest_service_environment_overrides:
   LOG_DIR: /var/log/kafka-rest
   KAFKAREST_OPTS: "{{ kafka_rest_final_java_args | java_arg_build_out }}"

--- a/roles/confluent.kafka_rest/templates/override.conf.j2
+++ b/roles/confluent.kafka_rest/templates/override.conf.j2
@@ -1,6 +1,11 @@
 [Service]
+{% for key, value in kafka_rest_service_overrides.items() %}
+{% if value %}
+{{key}}={{value}}
+{% endif %}
+{% endfor %}
 {% for key, value in kafka_rest_service_environment_overrides.items() %}
-{% if value != '' %}
+{% if value %}
 Environment="{{key}}={{value}}"
 {% endif %}
 {% endfor %}

--- a/roles/confluent.kafka_rest/templates/override.conf.j2
+++ b/roles/confluent.kafka_rest/templates/override.conf.j2
@@ -1,7 +1,4 @@
 [Service]
-{% for key, value in kafka_rest_service_overrides.items() %}
-{{key}}={{value}}
-{% endfor %}
 {% for key, value in kafka_rest_service_environment_overrides.items() %}
 {% if value != '' %}
 Environment="{{key}}={{value}}"

--- a/roles/confluent.ksql/defaults/main.yml
+++ b/roles/confluent.ksql/defaults/main.yml
@@ -1,5 +1,3 @@
-ksql_open_file_limit: 100000
-
 ksql_streams_state_dir: /var/lib/kafka-streams
 
 ksql_jaas_java_arg_buildout: "-Djava.security.auth.login.config={{ksql.jaas_file}}"
@@ -17,7 +15,7 @@ ksql_java_args:
 ksql_final_java_args: "{{ ksql_java_args + [ ksql_custom_java_args ] }}"
 
 ksql_service_overrides:
-  LimitNOFILE: "{{ ksql_open_file_limit }}"
+  LimitNOFILE: 100000
 ksql_service_environment_overrides:
   KSQL_HEAP_OPTS: "-Xmx3g"
   KSQL_OPTS: "{{ ksql_final_java_args | java_arg_build_out }}"

--- a/roles/confluent.ksql/defaults/main.yml
+++ b/roles/confluent.ksql/defaults/main.yml
@@ -16,12 +16,11 @@ ksql_java_args:
 
 ksql_final_java_args: "{{ ksql_java_args + [ ksql_custom_java_args ] }}"
 
+ksql_service_overrides:
+  LimitNOFILE: "{{ ksql_open_file_limit }}"
 ksql_service_environment_overrides:
   KSQL_HEAP_OPTS: "-Xmx3g"
   KSQL_OPTS: "{{ ksql_final_java_args | java_arg_build_out }}"
-
-ksql_service_overrides:
-  LimitNOFILE: "{{ ksql_open_file_limit }}"
 
 ksql_default_internal_replication_factor: "{{ [ groups['kafka_broker'] | length, 3 ] | min }}"
 

--- a/roles/confluent.ksql/defaults/main.yml
+++ b/roles/confluent.ksql/defaults/main.yml
@@ -14,6 +14,7 @@ ksql_java_args:
 
 ksql_final_java_args: "{{ ksql_java_args + [ ksql_custom_java_args ] }}"
 
+# Empty values in below dictionaries will not be written into override.conf
 ksql_service_overrides:
   LimitNOFILE: 100000
 ksql_service_environment_overrides:

--- a/roles/confluent.ksql/defaults/main.yml
+++ b/roles/confluent.ksql/defaults/main.yml
@@ -14,7 +14,6 @@ ksql_java_args:
 
 ksql_final_java_args: "{{ ksql_java_args + [ ksql_custom_java_args ] }}"
 
-# Empty values in below dictionaries will not be written into override.conf
 ksql_service_overrides:
   LimitNOFILE: 100000
 ksql_service_environment_overrides:

--- a/roles/confluent.ksql/defaults/main.yml
+++ b/roles/confluent.ksql/defaults/main.yml
@@ -1,4 +1,4 @@
-ksql_open_file_limit: "{{open_file_limit}}"
+# ksql_open_file_limit: "{{open_file_limit}}"
 ksql_streams_state_dir: /var/lib/kafka-streams
 
 ksql_jaas_java_arg_buildout: "-Djava.security.auth.login.config={{ksql.jaas_file}}"
@@ -19,8 +19,8 @@ ksql_service_environment_overrides:
   KSQL_HEAP_OPTS: "-Xmx3g"
   KSQL_OPTS: "{{ ksql_final_java_args | java_arg_build_out }}"
 
-ksql_service_overrides:
-  LimitNOFILE: "{{ ksql_open_file_limit }}"
+# ksql_service_overrides:
+  # LimitNOFILE: "{{ ksql_open_file_limit }}"
 
 ksql_default_internal_replication_factor: 3
 

--- a/roles/confluent.ksql/defaults/main.yml
+++ b/roles/confluent.ksql/defaults/main.yml
@@ -1,4 +1,3 @@
-# ksql_open_file_limit: "{{open_file_limit}}"
 ksql_streams_state_dir: /var/lib/kafka-streams
 
 ksql_jaas_java_arg_buildout: "-Djava.security.auth.login.config={{ksql.jaas_file}}"
@@ -18,9 +17,6 @@ ksql_final_java_args: "{{ ksql_java_args + [ ksql_custom_java_args ] }}"
 ksql_service_environment_overrides:
   KSQL_HEAP_OPTS: "-Xmx3g"
   KSQL_OPTS: "{{ ksql_final_java_args | java_arg_build_out }}"
-
-# ksql_service_overrides:
-  # LimitNOFILE: "{{ ksql_open_file_limit }}"
 
 ksql_default_internal_replication_factor: 3
 

--- a/roles/confluent.ksql/templates/override.conf.j2
+++ b/roles/confluent.ksql/templates/override.conf.j2
@@ -1,9 +1,11 @@
 [Service]
 {% for key, value in ksql_service_overrides.items() %}
+{% if value %}
 {{key}}={{value}}
+{% endif %}
 {% endfor %}
 {% for key, value in ksql_service_environment_overrides.items() %}
-{% if value != '' %}
+{% if value %}
 Environment="{{key}}={{value}}"
 {% endif %}
 {% endfor %}

--- a/roles/confluent.ksql/templates/override.conf.j2
+++ b/roles/confluent.ksql/templates/override.conf.j2
@@ -1,4 +1,7 @@
 [Service]
+{% for key, value in ksql_service_overrides.items() %}
+{{key}}={{value}}
+{% endfor %}
 {% for key, value in ksql_service_environment_overrides.items() %}
 {% if value != '' %}
 Environment="{{key}}={{value}}"

--- a/roles/confluent.ksql/templates/override.conf.j2
+++ b/roles/confluent.ksql/templates/override.conf.j2
@@ -1,7 +1,4 @@
 [Service]
-{% for key, value in ksql_service_overrides.items() %}
-{{key}}={{value}}
-{% endfor %}
 {% for key, value in ksql_service_environment_overrides.items() %}
 {% if value != '' %}
 Environment="{{key}}={{value}}"

--- a/roles/confluent.schema_registry/defaults/main.yml
+++ b/roles/confluent.schema_registry/defaults/main.yml
@@ -12,6 +12,8 @@ schema_registry_java_args:
 
 schema_registry_final_java_args: "{{ schema_registry_java_args + [ schema_registry_custom_java_args ] }}"
 
+schema_registry_service_overrides:
+  LimitNOFILE: "{{schema_registry_open_file_limit}}"
 schema_registry_service_environment_overrides:
   SCHEMA_REGISTRY_HEAP_OPTS: "-Xmx1000M"
   SCHEMA_REGISTRY_OPTS: "{{ schema_registry_final_java_args | java_arg_build_out }}"

--- a/roles/confluent.schema_registry/defaults/main.yml
+++ b/roles/confluent.schema_registry/defaults/main.yml
@@ -10,6 +10,7 @@ schema_registry_java_args:
 
 schema_registry_final_java_args: "{{ schema_registry_java_args + [ schema_registry_custom_java_args ] }}"
 
+# Empty values in below dictionaries will not be written into override.conf
 schema_registry_service_overrides:
   LimitNOFILE: 100000
 schema_registry_service_environment_overrides:

--- a/roles/confluent.schema_registry/defaults/main.yml
+++ b/roles/confluent.schema_registry/defaults/main.yml
@@ -1,5 +1,3 @@
-schema_registry_open_file_limit: 100000
-
 schema_registry_jolokia_java_arg_buildout: "-javaagent:{{jolokia_jar_path}}=port={{schema_registry_jolokia_port}},host=0.0.0.0"
 schema_registry_log4j_java_arg_buildout: "-Dlog4j.configuration=file:{{schema_registry.log4j_file}}"
 
@@ -13,7 +11,7 @@ schema_registry_java_args:
 schema_registry_final_java_args: "{{ schema_registry_java_args + [ schema_registry_custom_java_args ] }}"
 
 schema_registry_service_overrides:
-  LimitNOFILE: "{{schema_registry_open_file_limit}}"
+  LimitNOFILE: 100000
 schema_registry_service_environment_overrides:
   SCHEMA_REGISTRY_HEAP_OPTS: "-Xmx1000M"
   SCHEMA_REGISTRY_OPTS: "{{ schema_registry_final_java_args | java_arg_build_out }}"

--- a/roles/confluent.schema_registry/defaults/main.yml
+++ b/roles/confluent.schema_registry/defaults/main.yml
@@ -1,4 +1,4 @@
-schema_registry_open_file_limit: "{{open_file_limit}}"
+# schema_registry_open_file_limit: "{{open_file_limit}}"
 
 schema_registry_jolokia_java_arg_buildout: "-javaagent:{{jolokia_jar_path}}=port={{schema_registry_jolokia_port}},host=0.0.0.0"
 schema_registry_log4j_java_arg_buildout: "-Dlog4j.configuration=file:{{schema_registry.log4j_file}}"
@@ -12,8 +12,8 @@ schema_registry_java_args:
 
 schema_registry_final_java_args: "{{ schema_registry_java_args + [ schema_registry_custom_java_args ] }}"
 
-schema_registry_service_overrides:
-  LimitNOFILE: "{{schema_registry_open_file_limit}}"
+# schema_registry_service_overrides:
+  # LimitNOFILE: "{{schema_registry_open_file_limit}}"
 schema_registry_service_environment_overrides:
   SCHEMA_REGISTRY_HEAP_OPTS: "-Xmx1000M"
   SCHEMA_REGISTRY_OPTS: "{{ schema_registry_final_java_args | java_arg_build_out }}"

--- a/roles/confluent.schema_registry/defaults/main.yml
+++ b/roles/confluent.schema_registry/defaults/main.yml
@@ -10,7 +10,6 @@ schema_registry_java_args:
 
 schema_registry_final_java_args: "{{ schema_registry_java_args + [ schema_registry_custom_java_args ] }}"
 
-# Empty values in below dictionaries will not be written into override.conf
 schema_registry_service_overrides:
   LimitNOFILE: 100000
 schema_registry_service_environment_overrides:

--- a/roles/confluent.schema_registry/defaults/main.yml
+++ b/roles/confluent.schema_registry/defaults/main.yml
@@ -1,5 +1,3 @@
-# schema_registry_open_file_limit: "{{open_file_limit}}"
-
 schema_registry_jolokia_java_arg_buildout: "-javaagent:{{jolokia_jar_path}}=port={{schema_registry_jolokia_port}},host=0.0.0.0"
 schema_registry_log4j_java_arg_buildout: "-Dlog4j.configuration=file:{{schema_registry.log4j_file}}"
 
@@ -12,8 +10,6 @@ schema_registry_java_args:
 
 schema_registry_final_java_args: "{{ schema_registry_java_args + [ schema_registry_custom_java_args ] }}"
 
-# schema_registry_service_overrides:
-  # LimitNOFILE: "{{schema_registry_open_file_limit}}"
 schema_registry_service_environment_overrides:
   SCHEMA_REGISTRY_HEAP_OPTS: "-Xmx1000M"
   SCHEMA_REGISTRY_OPTS: "{{ schema_registry_final_java_args | java_arg_build_out }}"

--- a/roles/confluent.schema_registry/templates/override.conf.j2
+++ b/roles/confluent.schema_registry/templates/override.conf.j2
@@ -1,9 +1,11 @@
 [Service]
 {% for key, value in schema_registry_service_overrides.items() %}
+{% if value %}
 {{key}}={{value}}
+{% endif %}
 {% endfor %}
 {% for key, value in schema_registry_service_environment_overrides.items() %}
-{% if value != '' %}
+{% if value %}
 Environment="{{key}}={{value}}"
 {% endif %}
 {% endfor %}

--- a/roles/confluent.schema_registry/templates/override.conf.j2
+++ b/roles/confluent.schema_registry/templates/override.conf.j2
@@ -1,4 +1,7 @@
 [Service]
+{% for key, value in schema_registry_service_overrides.items() %}
+{{key}}={{value}}
+{% endfor %}
 {% for key, value in schema_registry_service_environment_overrides.items() %}
 {% if value != '' %}
 Environment="{{key}}={{value}}"

--- a/roles/confluent.schema_registry/templates/override.conf.j2
+++ b/roles/confluent.schema_registry/templates/override.conf.j2
@@ -1,7 +1,4 @@
 [Service]
-{% for key, value in schema_registry_service_overrides.items() %}
-{{key}}={{value}}
-{% endfor %}
 {% for key, value in schema_registry_service_environment_overrides.items() %}
 {% if value != '' %}
 Environment="{{key}}={{value}}"

--- a/roles/confluent.variables_handlers/defaults/main.yml
+++ b/roles/confluent.variables_handlers/defaults/main.yml
@@ -47,8 +47,6 @@ custom_yum_repofile: false
 custom_apt_repo: false
 kerberos_configure: true
 
-# open_file_limit: 500000
-
 rbac_enabled: false
 
 confluent_server_enabled: true

--- a/roles/confluent.variables_handlers/defaults/main.yml
+++ b/roles/confluent.variables_handlers/defaults/main.yml
@@ -47,7 +47,7 @@ custom_yum_repofile: false
 custom_apt_repo: false
 kerberos_configure: true
 
-open_file_limit: 500000
+# open_file_limit: 500000
 
 rbac_enabled: false
 

--- a/roles/confluent.zookeeper/defaults/main.yml
+++ b/roles/confluent.zookeeper/defaults/main.yml
@@ -14,6 +14,7 @@ zookeeper_java_args:
 
 zookeeper_final_java_args: "{{ zookeeper_java_args + [ zookeeper_custom_java_args ] }}"
 
+# Empty values in below dictionaries will not be written into override.conf
 zookeeper_service_overrides:
   LimitNOFILE: 100000
 zookeeper_service_environment_overrides:

--- a/roles/confluent.zookeeper/defaults/main.yml
+++ b/roles/confluent.zookeeper/defaults/main.yml
@@ -1,5 +1,3 @@
-# zookeeper_open_file_limit: "{{open_file_limit}}"
-
 zookeeper_jaas_java_arg_buildout: "-Djava.security.auth.login.config={{zookeeper.jaas_file}}"
 zookeeper_jolokia_java_arg_buildout: "-javaagent:{{jolokia_jar_path}}=port={{zookeeper_jolokia_port}},host=0.0.0.0"
 zookeeper_log4j_java_arg_buildout: "-Dlog4j.configuration=file:{{zookeeper.log4j_file}}"
@@ -19,8 +17,6 @@ zookeeper_final_java_args: "{{ zookeeper_java_args + [ zookeeper_custom_java_arg
 zookeeper_service_environment_overrides:
   KAFKA_HEAP_OPTS: "-Xmx1g"
   KAFKA_OPTS: "{{ zookeeper_final_java_args | java_arg_build_out }}"
-# zookeeper_service_overrides:
-  # LimitNOFILE: "{{zookeeper_open_file_limit}}"
 
 zookeeper:
   log_path: /var/log/kafka/

--- a/roles/confluent.zookeeper/defaults/main.yml
+++ b/roles/confluent.zookeeper/defaults/main.yml
@@ -1,5 +1,3 @@
-zookeeper_open_file_limit: 100000
-
 zookeeper_jaas_java_arg_buildout: "-Djava.security.auth.login.config={{zookeeper.jaas_file}}"
 zookeeper_jolokia_java_arg_buildout: "-javaagent:{{jolokia_jar_path}}=port={{zookeeper_jolokia_port}},host=0.0.0.0"
 zookeeper_log4j_java_arg_buildout: "-Dlog4j.configuration=file:{{zookeeper.log4j_file}}"
@@ -17,7 +15,7 @@ zookeeper_java_args:
 zookeeper_final_java_args: "{{ zookeeper_java_args + [ zookeeper_custom_java_args ] }}"
 
 zookeeper_service_overrides:
-  LimitNOFILE: "{{zookeeper_open_file_limit}}"
+  LimitNOFILE: 100000
 zookeeper_service_environment_overrides:
   KAFKA_HEAP_OPTS: "-Xmx1g"
   KAFKA_OPTS: "{{ zookeeper_final_java_args | java_arg_build_out }}"

--- a/roles/confluent.zookeeper/defaults/main.yml
+++ b/roles/confluent.zookeeper/defaults/main.yml
@@ -14,7 +14,6 @@ zookeeper_java_args:
 
 zookeeper_final_java_args: "{{ zookeeper_java_args + [ zookeeper_custom_java_args ] }}"
 
-# Empty values in below dictionaries will not be written into override.conf
 zookeeper_service_overrides:
   LimitNOFILE: 100000
 zookeeper_service_environment_overrides:

--- a/roles/confluent.zookeeper/defaults/main.yml
+++ b/roles/confluent.zookeeper/defaults/main.yml
@@ -16,6 +16,8 @@ zookeeper_java_args:
 
 zookeeper_final_java_args: "{{ zookeeper_java_args + [ zookeeper_custom_java_args ] }}"
 
+zookeeper_service_overrides:
+  LimitNOFILE: "{{zookeeper_open_file_limit}}"
 zookeeper_service_environment_overrides:
   KAFKA_HEAP_OPTS: "-Xmx1g"
   KAFKA_OPTS: "{{ zookeeper_final_java_args | java_arg_build_out }}"

--- a/roles/confluent.zookeeper/defaults/main.yml
+++ b/roles/confluent.zookeeper/defaults/main.yml
@@ -1,4 +1,4 @@
-zookeeper_open_file_limit: "{{open_file_limit}}"
+# zookeeper_open_file_limit: "{{open_file_limit}}"
 
 zookeeper_jaas_java_arg_buildout: "-Djava.security.auth.login.config={{zookeeper.jaas_file}}"
 zookeeper_jolokia_java_arg_buildout: "-javaagent:{{jolokia_jar_path}}=port={{zookeeper_jolokia_port}},host=0.0.0.0"
@@ -19,8 +19,8 @@ zookeeper_final_java_args: "{{ zookeeper_java_args + [ zookeeper_custom_java_arg
 zookeeper_service_environment_overrides:
   KAFKA_HEAP_OPTS: "-Xmx1g"
   KAFKA_OPTS: "{{ zookeeper_final_java_args | java_arg_build_out }}"
-zookeeper_service_overrides:
-  LimitNOFILE: "{{zookeeper_open_file_limit}}"
+# zookeeper_service_overrides:
+  # LimitNOFILE: "{{zookeeper_open_file_limit}}"
 
 zookeeper:
   log_path: /var/log/kafka/

--- a/roles/confluent.zookeeper/templates/override.conf.j2
+++ b/roles/confluent.zookeeper/templates/override.conf.j2
@@ -1,9 +1,11 @@
 [Service]
 {% for key, value in zookeeper_service_overrides.items() %}
+{% if value %}
 {{key}}={{value}}
+{% endif %}
 {% endfor %}
 {% for key, value in zookeeper_service_environment_overrides.items() %}
-{% if value != '' %}
+{% if value %}
 Environment="{{key}}={{value}}"
 {% endif %}
 {% endfor %}

--- a/roles/confluent.zookeeper/templates/override.conf.j2
+++ b/roles/confluent.zookeeper/templates/override.conf.j2
@@ -1,4 +1,7 @@
 [Service]
+{% for key, value in zookeeper_service_overrides.items() %}
+{{key}}={{value}}
+{% endfor %}
 {% for key, value in zookeeper_service_environment_overrides.items() %}
 {% if value != '' %}
 Environment="{{key}}={{value}}"

--- a/roles/confluent.zookeeper/templates/override.conf.j2
+++ b/roles/confluent.zookeeper/templates/override.conf.j2
@@ -1,7 +1,4 @@
 [Service]
-{% for key, value in zookeeper_service_overrides.items() %}
-{{key}}={{value}}
-{% endfor %}
 {% for key, value in zookeeper_service_environment_overrides.items() %}
 {% if value != '' %}
 Environment="{{key}}={{value}}"


### PR DESCRIPTION
# Description

Out of the box these components have the below open file limits set in their unit files
confluent-server/kafka: 1000000
kafka-rest: 100000
c3: 100000

This PR removes code that sets limitnofile values in the overwrite file for the above components. 

It also sets the limitnofile value to 100000 for these services (the remaining components): schema registry, ksql, connect, zookeeper

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Ran install, confirmed the limitnofile is not in override.conf files. also confirmed the other environment variables from override.conf made it into the java process

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules