### PR TITLE
Control Center RocksDB Customer Path support

### DIFF
--- a/roles/confluent.control_center/defaults/main.yml
+++ b/roles/confluent.control_center/defaults/main.yml
@@ -10,10 +10,11 @@ control_center_java_args:
 
 control_center_final_java_args: "{{ control_center_java_args + [ control_center_custom_java_args ] }}"
 
-control_center_rocksdb_path: /var/lib/confluent/control-center/rocksdb
+control_center_rocksdb_path: ""
 control_center_service_overrides:
   LimitNOFILE: "{{control_center_open_file_limit}}"
 control_center_service_environment_overrides:
+  ROCKSDB_SHAREDLIB_DIR: "{{ control_center_rocksdb_path | default('/tmp') }}"
   CONTROL_CENTER_HEAP_OPTS: "-Xmx6g"
   CONTROL_CENTER_OPTS: "{{ control_center_final_java_args | java_arg_build_out }}"
 

--- a/roles/confluent.control_center/defaults/main.yml
+++ b/roles/confluent.control_center/defaults/main.yml
@@ -10,6 +10,7 @@ control_center_java_args:
 
 control_center_final_java_args: "{{ control_center_java_args + [ control_center_custom_java_args ] }}"
 
+control_center_rocksdb_path: /var/lib/confluent/control-center/rocksdb
 control_center_service_overrides:
   LimitNOFILE: "{{control_center_open_file_limit}}"
 control_center_service_environment_overrides:

--- a/roles/confluent.control_center/defaults/main.yml
+++ b/roles/confluent.control_center/defaults/main.yml
@@ -14,7 +14,7 @@ control_center_rocksdb_path: ""
 control_center_service_overrides:
   LimitNOFILE: "{{control_center_open_file_limit}}"
 control_center_service_environment_overrides:
-  ROCKSDB_SHAREDLIB_DIR: "{{ control_center_rocksdb_path | default('/tmp') }}"
+  ROCKSDB_SHAREDLIB_DIR: "{% if control_center_rocksdb_path != '' %}{{ control_center_rocksdb_path }}{% else %}/tmp{% endif %}"
   CONTROL_CENTER_HEAP_OPTS: "-Xmx6g"
   CONTROL_CENTER_OPTS: "{{ control_center_final_java_args | java_arg_build_out }}"
 

--- a/roles/confluent.control_center/defaults/main.yml
+++ b/roles/confluent.control_center/defaults/main.yml
@@ -15,7 +15,7 @@ control_center_rocksdb_path: ""
 control_center_service_overrides:
   LimitNOFILE:
 control_center_service_environment_overrides:
-  ROCKSDB_SHAREDLIB_DIR: "{% if control_center_rocksdb_path != '' %}{{ control_center_rocksdb_path }}{% else %}/tmp{% endif %}"
+  ROCKSDB_SHAREDLIB_DIR: "{{control_center_rocksdb_path}}"
   CONTROL_CENTER_HEAP_OPTS: "-Xmx6g"
   CONTROL_CENTER_OPTS: "{{ control_center_final_java_args | java_arg_build_out }}"
 

--- a/roles/confluent.control_center/tasks/main.yml
+++ b/roles/confluent.control_center/tasks/main.yml
@@ -81,7 +81,8 @@
     path: "{{control_center_rocksdb_path}}"
     group: "{{control_center.group}}"
     owner: "{{control_center.user}}"
-    recurse: yes
+    mode: '764'
+    state: directory
   when: control_center_rocksdb_path != ""
 
 - name: Set Permission to RocksDB Files
@@ -89,7 +90,7 @@
     path: "{{control_center_rocksdb_path}}"
     group: "{{control_center.group}}"
     owner: "{{control_center.user}}"
-    mode: '764'
+    recurse: yes
   when: control_center_rocksdb_path != ""
 
 - name: Create Control Center log4j Config

--- a/roles/confluent.control_center/tasks/main.yml
+++ b/roles/confluent.control_center/tasks/main.yml
@@ -81,8 +81,15 @@
     path: "{{control_center_rocksdb_path}}"
     group: "{{control_center.group}}"
     owner: "{{control_center.user}}"
-    mode: '764'
     recurse: yes
+  when: control_center_rocksdb_path != ""
+
+- name: Set Permission to RocksDB Files
+  file:
+    path: "{{control_center_rocksdb_path}}"
+    group: "{{control_center.group}}"
+    owner: "{{control_center.user}}"
+    mode: '764'
   when: control_center_rocksdb_path != ""
 
 - name: Create Control Center log4j Config

--- a/roles/confluent.control_center/tasks/main.yml
+++ b/roles/confluent.control_center/tasks/main.yml
@@ -68,6 +68,15 @@
     mode: '764'
     recurse: yes
 
+- name: Create RocksDB Directory
+  file:
+    path: "{{control_center_rocksdb_path}}"
+    group: "{{control_center.group}}"
+    owner: "{{control_center.user}}"
+    mode: '764'
+    recurse: yes
+  when: control_center_rocksdb_path != ""
+
 - name: Create Control Center log4j Config
   template:
     src: control-center_log4j.properties.j2


### PR DESCRIPTION
# Description

Fixes/Improves support for custom defined RocksDB paths. This ensures the path is created with the correct user/group and permissions and sets the appropriate configs within Systemd Overrides.conf.

Custom paths are a common occurrence for secure environments that mount `/tmp` with `noexec`. RocksDB requires execute permissions to run.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested in Lab Env

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules