### PR TITLE
adding advertised listeners property, additional hostnames in auto generated certs, check if keystores/truststores exists before regen

### DIFF
--- a/filter_plugins/filters.py
+++ b/filter_plugins/filters.py
@@ -6,6 +6,8 @@ class FilterModule(object):
             'kafka_protocol': self.kafka_protocol,
             'kafka_protocol_defaults': self.kafka_protocol_defaults,
             'get_sasl_mechanisms': self.get_sasl_mechanisms,
+            'get_hostnames': self.get_hostnames,
+            'cert_extension': self.cert_extension,
             'ssl_required': self.ssl_required,
             'java_arg_build_out': self.java_arg_build_out
         }
@@ -43,6 +45,17 @@ class FilterModule(object):
             sasl_protocol = listeners_dict[listener].get('sasl_protocol', default_sasl_protocol)
             mechanisms = mechanisms + [self.normalize_sasl_protocol(sasl_protocol)]
         return mechanisms
+
+    def get_hostnames(self, listeners_dict, default_hostname):
+        hostnames = []
+        for listener in listeners_dict:
+            hostname = listeners_dict[listener].get('hostname', default_hostname)
+            hostnames = hostnames + [hostname]
+        return hostnames
+
+    def cert_extension(self, hostnames):
+        extension = 'dns:'+",dns:".join(hostnames)
+        return extension
 
     def ssl_required(self, listeners_dict, default_ssl_enabled):
         ssl_required = False

--- a/hosts_example.yml
+++ b/hosts_example.yml
@@ -47,6 +47,13 @@ all:
     # ssl_truststore_filepath: "/tmp/certs/truststore.jks"
     # ssl_truststore_password: truststorepass
 
+    #### Certificate Regeneration ####
+    ## When using self signed certificates, each playbook run will regenerate the CA, to turn this off, uncomment this line:
+    # regenerate_ca: false
+    ## By default, if keystore/truststore files exists for a component, the playbook will not recreate them
+    ## To recreate the keystores and truststores uncomment this line:
+    # regenerate_keystore_and_truststore: true
+
     #### Monitoring Configuration ####
     ## Jolokia is enabled by default. The Jolokia jar gets pulled from the internet and enabled on all the components
     ## To disable, uncomment this line:

--- a/roles/confluent.control_center/tasks/main.yml
+++ b/roles/confluent.control_center/tasks/main.yml
@@ -38,6 +38,7 @@
     keystore_storepass: "{{control_center_keystore_storepass}}"
     keystore_keypass: "{{control_center_keystore_keypass}}"
     service_name: control_center
+    hostnames: "{{ [inventory_hostname] }}"
   when: control_center_ssl_enabled|bool or kafka_broker_listeners[control_center_kafka_listener_name]['ssl_enabled'] | default(ssl_enabled) | bool
 
 - name: Configure Kerberos

--- a/roles/confluent.kafka_broker/tasks/main.yml
+++ b/roles/confluent.kafka_broker/tasks/main.yml
@@ -29,11 +29,6 @@
     system: yes
     group: "{{kafka_broker.group}}"
 
-# prestep to ssl role, need to gather all hostnames (ie external/internal for aws) and pass to ssl role by some var
-
-# - set_fact:
-#     hostnames: "{{ kafka_broker_listeners | get_hostnames(inventory_hostname) | unique }}"
-
 - include_role:
     name: confluent.ssl
   vars:
@@ -81,7 +76,7 @@
     group: "{{kafka_broker.group}}"
     owner: "{{kafka_broker.user}}"
     mode: '764'
-    recurse: yes
+    # recurse: yes
 
 - name: Create Kafka Broker log4j Config
   template:

--- a/roles/confluent.kafka_broker/tasks/main.yml
+++ b/roles/confluent.kafka_broker/tasks/main.yml
@@ -76,7 +76,7 @@
     group: "{{kafka_broker.group}}"
     owner: "{{kafka_broker.user}}"
     mode: '764'
-    # recurse: yes
+    recurse: yes
 
 - name: Create Kafka Broker log4j Config
   template:

--- a/roles/confluent.kafka_broker/tasks/main.yml
+++ b/roles/confluent.kafka_broker/tasks/main.yml
@@ -29,6 +29,11 @@
     system: yes
     group: "{{kafka_broker.group}}"
 
+# prestep to ssl role, need to gather all hostnames (ie external/internal for aws) and pass to ssl role by some var
+
+# - set_fact:
+#     hostnames: "{{ kafka_broker_listeners | get_hostnames(inventory_hostname) | unique }}"
+
 - include_role:
     name: confluent.ssl
   vars:
@@ -38,6 +43,7 @@
     keystore_storepass: "{{kafka_broker_keystore_storepass}}"
     keystore_keypass: "{{kafka_broker_keystore_keypass}}"
     service_name: kafka_broker
+    hostnames: "{{ kafka_broker_listeners | get_hostnames(inventory_hostname) | unique }}"
   when: kafka_broker_listeners | ssl_required(ssl_enabled)
 
 - name: Configure Kerberos

--- a/roles/confluent.kafka_broker/templates/server.properties.j2
+++ b/roles/confluent.kafka_broker/templates/server.properties.j2
@@ -14,9 +14,11 @@ enable.fips=true
 security.providers=io.confluent.kafka.security.fips.provider.BcFipsProviderCreator,io.confluent.kafka.security.fips.provider.BcFipsJsseProviderCreator
 {% endif %}
 
-listeners={% for listener in kafka_broker_listeners|dict2items %}{% if loop.index > 1%},{% endif %}{{ listener['value']['name'] }}://{{ listener['value']['hostname'] | default('') }}:{{ listener['value']['port'] }}{% endfor %}
-
 listener.security.protocol.map={% for listener in kafka_broker_listeners|dict2items %}{% if loop.index > 1%},{% endif %}{{ listener['value']['name'] }}:{{ listener['value'] | kafka_protocol_defaults(sasl_protocol, ssl_enabled)}}{% endfor %}
+
+listeners={% for listener in kafka_broker_listeners|dict2items %}{% if loop.index > 1%},{% endif %}{{ listener['value']['name'] }}://:{{ listener['value']['port'] }}{% endfor %}
+
+advertised.listeners={% for listener in kafka_broker_listeners|dict2items %}{% if loop.index > 1%},{% endif %}{{ listener['value']['name'] }}://{{ listener['value']['hostname'] | default(inventory_hostname) }}:{{ listener['value']['port'] }}{% endfor %}
 
 
 ## Inter Broker Listener Configuration

--- a/roles/confluent.kafka_connect/tasks/main.yml
+++ b/roles/confluent.kafka_connect/tasks/main.yml
@@ -2,7 +2,7 @@
 - include_role:
     name: confluent.common
   when: not common_role_completed|bool
-  
+
 # Install Packages
 - name: Install the Kafka Connect Packages
   yum:
@@ -38,6 +38,7 @@
     keystore_storepass: "{{kafka_connect_keystore_storepass}}"
     keystore_keypass: "{{kafka_connect_keystore_keypass}}"
     service_name: kafka_connect
+    hostnames: "{{ [inventory_hostname] }}"
   when: kafka_connect_ssl_enabled|bool or kafka_broker_listeners[kafka_connect_kafka_listener_name]['ssl_enabled'] | default(ssl_enabled) | bool
 
 - name: Configure Kerberos

--- a/roles/confluent.kafka_rest/tasks/main.yml
+++ b/roles/confluent.kafka_rest/tasks/main.yml
@@ -38,6 +38,7 @@
     keystore_storepass: "{{kafka_rest_keystore_storepass}}"
     keystore_keypass: "{{kafka_rest_keystore_keypass}}"
     service_name: kafka_rest
+    hostnames: "{{ [inventory_hostname] }}"
   when: kafka_rest_ssl_enabled|bool or kafka_broker_listeners[kafka_rest_kafka_listener_name]['ssl_enabled'] | default(ssl_enabled) | bool
 
 - name: Configure Kerberos

--- a/roles/confluent.ksql/tasks/main.yml
+++ b/roles/confluent.ksql/tasks/main.yml
@@ -38,6 +38,7 @@
     keystore_storepass: "{{ksql_keystore_storepass}}"
     keystore_keypass: "{{ksql_keystore_keypass}}"
     service_name: ksql
+    hostnames: "{{ [inventory_hostname] }}"
   when: ksql_ssl_enabled|bool or kafka_broker_listeners[ksql_kafka_listener_name]['ssl_enabled'] | default(ssl_enabled) | bool
 
 - name: Configure Kerberos

--- a/roles/confluent.schema_registry/tasks/main.yml
+++ b/roles/confluent.schema_registry/tasks/main.yml
@@ -38,6 +38,7 @@
     keystore_storepass: "{{schema_registry_keystore_storepass}}"
     keystore_keypass: "{{schema_registry_keystore_keypass}}"
     service_name: schema_registry
+    hostnames: "{{ [inventory_hostname] }}"
   when: schema_registry_ssl_enabled|bool or kafka_broker_listeners[schema_registry_kafka_listener_name]['ssl_enabled'] | default(ssl_enabled) | bool
 
 - name: Configure Kerberos

--- a/roles/confluent.ssl/tasks/create_keystore_and_truststore.yml
+++ b/roles/confluent.ssl/tasks/create_keystore_and_truststore.yml
@@ -1,0 +1,82 @@
+---
+- name: Delete SSL Certificate Generation Directory
+  file:
+    path: /var/ssl/private/generation
+    state: absent
+
+- name: Delete Old Keystore
+  file:
+    path: "{{keystore_path}}"
+    state: absent
+
+- name: Delete Old Truststore
+  file:
+    path: "{{truststore_path}}"
+    state: absent
+
+- name: Create SSL Certificate Generation Directory
+  file:
+    path: /var/ssl/private/generation
+    state: directory
+    mode: 0755
+
+- name: Create Keystore and Truststore with Self Signed Certs
+  include_tasks: self_signed_certs.yml
+  when: self_signed|bool
+
+- name: Create Keystore and Truststore with Custom Certs
+  include_tasks: custom_certs.yml
+  when: ssl_custom_certs|bool
+
+- name: Copy Provided Keystore and Truststore to Host
+  include_tasks: provided_keystore_and_truststore.yml
+  when: ssl_provided_keystore_and_truststore|bool
+
+- name: Delete SSL Certificate Generation Directory
+  file:
+    path: /var/ssl/private/generation
+    state: absent
+  when: delete_generation_dir|bool
+
+- set_fact:
+    user: "{{kafka_broker.user}}"
+    group: "{{kafka_broker.group}}"
+  when: service_name == 'kafka_broker'
+
+- set_fact:
+    user: "{{schema_registry.user}}"
+    group: "{{schema_registry.group}}"
+  when: service_name == 'schema_registry'
+
+- set_fact:
+    user: "{{kafka_rest.user}}"
+    group: "{{kafka_rest.group}}"
+  when: service_name == 'kafka_rest'
+
+- set_fact:
+    user: "{{kafka_connect.user}}"
+    group: "{{kafka_connect.group}}"
+  when: service_name == 'kafka_connect'
+
+- set_fact:
+    user: "{{ksql.user}}"
+    group: "{{ksql.group}}"
+  when: service_name == 'ksql'
+
+- set_fact:
+    user: "{{control_center.user}}"
+    group: "{{control_center.group}}"
+  when: service_name == 'control_center'
+
+- name: Set Truststore and Keystore File Permissions
+  file:
+    path: "{{item}}"
+    owner: "{{user}}"
+    group: "{{group}}"
+    mode: '0644'
+  loop:
+    - "{{keystore_path}}"
+    - "{{truststore_path}}"
+
+- set_fact:
+    certs_updated: true

--- a/roles/confluent.ssl/tasks/main.yml
+++ b/roles/confluent.ssl/tasks/main.yml
@@ -1,82 +1,14 @@
 ---
-- name: Delete SSL Certificate Directory
-  file:
-    path: /var/ssl/private/generation
-    state: absent
-
-- name: Delete Old Keystore
-  file:
+- name: Register if Keystore Exists
+  stat:
     path: "{{keystore_path}}"
-    state: absent
+  register: keystore
 
-- name: Delete Old Truststore
-  file:
+- name: Register if Truststore Exists
+  stat:
     path: "{{truststore_path}}"
-    state: absent
+  register: truststore
 
-- name: Create SSL Certificate Generation Directory
-  file:
-    path: /var/ssl/private/generation
-    state: directory
-    mode: 0755
-
-- name: Create Keystore and Truststore with Self Signed Certs
-  include_tasks: self_signed_certs.yml
-  when: self_signed|bool
-
-- name: Create Keystore and Truststore with Custom Certs
-  include_tasks: custom_certs.yml
-  when: ssl_custom_certs|bool
-
-- name: Copy Provided Keystore and Truststore to Host
-  include_tasks: provided_keystore_and_truststore.yml
-  when: ssl_provided_keystore_and_truststore|bool
-
-- name: Delete SSL Certificate Generation Directory
-  file:
-    path: /var/ssl/private/generation
-    state: absent
-  when: delete_generation_dir|bool
-
-- set_fact:
-    user: "{{kafka_broker.user}}"
-    group: "{{kafka_broker.group}}"
-  when: service_name == 'kafka_broker'
-
-- set_fact:
-    user: "{{schema_registry.user}}"
-    group: "{{schema_registry.group}}"
-  when: service_name == 'schema_registry'
-
-- set_fact:
-    user: "{{kafka_rest.user}}"
-    group: "{{kafka_rest.group}}"
-  when: service_name == 'kafka_rest'
-
-- set_fact:
-    user: "{{kafka_connect.user}}"
-    group: "{{kafka_connect.group}}"
-  when: service_name == 'kafka_connect'
-
-- set_fact:
-    user: "{{ksql.user}}"
-    group: "{{ksql.group}}"
-  when: service_name == 'ksql'
-
-- set_fact:
-    user: "{{control_center.user}}"
-    group: "{{control_center.group}}"
-  when: service_name == 'control_center'
-
-- name: Set Truststore and Keystore File Permissions
-  file:
-    path: "{{item}}"
-    owner: "{{user}}"
-    group: "{{group}}"
-    mode: '0644'
-  loop:
-    - "{{keystore_path}}"
-    - "{{truststore_path}}"
-
-- set_fact:
-    certs_updated: true
+- name: Create Keystore and Truststore
+  include_tasks: create_keystore_and_truststore.yml
+  when: keystore.stat.exists == false or truststore.stat.exists == false or regenerate_keystore_and_truststore == true

--- a/roles/confluent.ssl/tasks/main.yml
+++ b/roles/confluent.ssl/tasks/main.yml
@@ -11,4 +11,4 @@
 
 - name: Create Keystore and Truststore
   include_tasks: create_keystore_and_truststore.yml
-  when: keystore.stat.exists == false or truststore.stat.exists == false or regenerate_keystore_and_truststore == true
+  when: not keystore.stat.exists|bool or not truststore.stat.exists|bool or regenerate_keystore_and_truststore|bool

--- a/roles/confluent.ssl/tasks/self_signed_certs.yml
+++ b/roles/confluent.ssl/tasks/self_signed_certs.yml
@@ -30,7 +30,7 @@
       -keyalg RSA -keysize 2048 \
       -alias {{inventory_hostname}} \
       -dname "CN={{service_name}},OU=TEST,O=CONFLUENT,L=PaloAlto,S=Ca,C=US" \
-      -ext "SAN=dns:{{inventory_hostname}}" \
+      -ext "SAN={{hostnames | cert_extension}}" \
       -keystore {{keystore_path}} \
       -storepass {{keystore_storepass}} \
       -keypass {{keystore_storepass}} {{extra_args}}
@@ -41,7 +41,7 @@
       -storetype pkcs12 \
       -alias {{inventory_hostname}} \
       -certreq -file /var/ssl/private/generation/client.csr \
-      -ext "SAN=dns:{{inventory_hostname}}" \
+      -ext "SAN={{hostnames | cert_extension}}" \
       -storepass {{keystore_storepass}} \
       -keypass {{keystore_storepass}} {{extra_args}}
 
@@ -76,6 +76,6 @@
       -storetype pkcs12 \
       -alias {{inventory_hostname}} \
       -import -file /var/ssl/private/generation/client-signed.crt \
-      -ext "SAN=dns:{{inventory_hostname}}" \
+      -ext "SAN={{hostnames | cert_extension}}" \
       -storepass {{keystore_storepass}} \
       -keypass {{keystore_storepass}} {{extra_args}}

--- a/roles/confluent.ssl/tasks/self_signed_certs.yml
+++ b/roles/confluent.ssl/tasks/self_signed_certs.yml
@@ -19,9 +19,12 @@
 
 - name: Create Truststore and Import the CA Cert
   shell: |
-    keytool -noprompt -keystore {{truststore_path}} -storetype pkcs12 \
-      -alias CARoot -import -file /var/ssl/private/generation/snakeoil-ca-1.crt \
-      -storepass {{truststore_storepass}} -keypass {{truststore_storepass}} {{extra_args}}
+    keytool -noprompt -keystore {{truststore_path}} \
+      -storetype pkcs12 \
+      -alias CARoot \
+      -import -file /var/ssl/private/generation/{{ssl_self_signed_ca_cert_filename}} \
+      -storepass {{truststore_storepass}} \
+      -keypass {{truststore_storepass}} {{extra_args}}
 
 - name: Create Keystore
   shell: |

--- a/roles/confluent.ssl/templates/openssl-san.cnf.j2
+++ b/roles/confluent.ssl/templates/openssl-san.cnf.j2
@@ -8,4 +8,5 @@ CN = {{service_name}}
 extendedKeyUsage = serverAuth , clientAuth
 subjectAltName = @alt_names
 [alt_names]
-DNS = {{inventory_hostname}}
+{% for i in range(0,hostnames | length) %}DNS.{{i}} = {{ hostnames[i] }}
+{% endfor %}

--- a/roles/confluent.variables_handlers/defaults/main.yml
+++ b/roles/confluent.variables_handlers/defaults/main.yml
@@ -63,6 +63,9 @@ sasl_protocol: none
 
 ssl_enabled: false
 ssl_mutual_auth_enabled: false
+
+regenerate_ca: true
+regenerate_keystore_and_truststore: false
 certs_updated: false
 
 ssl_provided_keystore_and_truststore: false
@@ -72,7 +75,6 @@ self_signed: "{{ false if ssl_provided_keystore_and_truststore|bool or ssl_custo
 ssl_self_signed_ca_cert_filename: snakeoil-ca-1.crt
 ssl_self_signed_ca_key_filename: snakeoil-ca-1.key
 ssl_self_signed_ca_password: capassword123
-regenerate_ca: true
 
 kafka_broker_default_listeners:
   external:

--- a/tasks/certificate_authority.yml
+++ b/tasks/certificate_authority.yml
@@ -14,6 +14,13 @@
       -subj '/CN=ca1.test.confluent.io/OU=TEST/O=CONFLUENT/L=PaloAlto/S=Ca/C=US' \
       -passin pass:{{ssl_self_signed_ca_password}} -passout pass:{{ssl_self_signed_ca_password}}
 
+# TODO should create a truststore for testing purposes
+# - name: Create Truststore and Import the CA Cert
+#   shell: |
+#     keytool -noprompt -keystore {{truststore_path}} -storetype pkcs12 \
+#       -alias CARoot -import -file /var/ssl/private/generation/snakeoil-ca-1.crt \
+#       -storepass {{truststore_storepass}} -keypass {{truststore_storepass}}
+
 - name: Copy Generated SSL Files Back to Ansible Host
   synchronize:
     src: /var/ssl/private/generation/

--- a/tasks/certificate_authority.yml
+++ b/tasks/certificate_authority.yml
@@ -14,16 +14,14 @@
       -subj '/CN=ca1.test.confluent.io/OU=TEST/O=CONFLUENT/L=PaloAlto/S=Ca/C=US' \
       -passin pass:{{ssl_self_signed_ca_password}} -passout pass:{{ssl_self_signed_ca_password}}
 
-# TODO should create a truststore for testing purposes
-# - name: Create Truststore and Import the CA Cert
-#   shell: |
-#     keytool -noprompt -keystore {{truststore_path}} -storetype pkcs12 \
-#       -alias CARoot -import -file /var/ssl/private/generation/snakeoil-ca-1.crt \
-#       -storepass {{truststore_storepass}} -keypass {{truststore_storepass}}
-
 - name: Copy Generated SSL Files Back to Ansible Host
   synchronize:
     src: /var/ssl/private/generation/
     dest: generated_ssl_files
     mode: pull
     use_ssh_args: yes
+
+- name: Delete SSL Certificate Generation Directory
+  file:
+    path: /var/ssl/private/generation
+    state: absent


### PR DESCRIPTION
# Description

Can now have a hostname on each listener (which helps in aws land) and those hostnames get set in the autogenerated certs in the extension

Also now ssl role has a task that checks if keystores/truststores are created before running everything

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration



**Test Configuration**:


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules