### PR TITLE
configure proxy env vars

### DIFF
--- a/all.yml
+++ b/all.yml
@@ -2,8 +2,7 @@
 - name: Generate CA for Self Signed Certs
   hosts: zookeeper[0]
   gather_facts: no
-  tags:
-    - certificate_authority
+  tags: certificate_authority
   tasks:
   - import_role:
       name: confluent.variables_handlers
@@ -16,62 +15,64 @@
 
 - name: Host Prerequisites
   hosts: zookeeper:kafka_broker:schema_registry:kafka_connect:ksql:control_center:kafka_rest
+  tags: common
+  environment: "{{ proxy_env }}"
   tasks:
   - import_role:
       name: confluent.common
 
 - name: Zookeeper Provisioning
   hosts: zookeeper
-  tags:
-    - zookeeper
+  tags: zookeeper
+  environment: "{{ proxy_env }}"
   tasks:
   - import_role:
       name: confluent.zookeeper
 
 - name: Kafka Broker Provisioning
   hosts: kafka_broker
-  tags:
-    - kafka_broker
+  tags: kafka_broker
+  environment: "{{ proxy_env }}"
   tasks:
   - import_role:
       name: confluent.kafka_broker
 
 - name: Schema Registry Provisioning
   hosts: schema_registry
-  tags:
-    - schema_registry
+  tags: schema_registry
+  environment: "{{ proxy_env }}"
   tasks:
   - import_role:
       name: confluent.schema_registry
 
 - name: Kafta Connect Provisioning
   hosts: kafka_connect
-  tags:
-    - kafka_connect
+  tags: kafka_connect
+  environment: "{{ proxy_env }}"
   tasks:
   - import_role:
       name: confluent.kafka_connect
 
 - name: KSQL Provisioning
   hosts: ksql
-  tags:
-    - ksql
+  tags: ksql
+  environment: "{{ proxy_env }}"
   tasks:
   - import_role:
       name: confluent.ksql
 
 - name: Kafka Rest Provisioning
   hosts: kafka_rest
-  tags:
-    - kafka_rest
+  tags: kafka_rest
+  environment: "{{ proxy_env }}"
   tasks:
   - import_role:
       name: confluent.kafka_rest
 
 - name: Control Center Provisioning
   hosts: control_center
-  tags:
-    - control_center
+  tags: control_center
+  environment: "{{ proxy_env }}"
   tasks:
   - import_role:
       name: confluent.control_center

--- a/hosts_example.yml
+++ b/hosts_example.yml
@@ -5,6 +5,13 @@ all:
     ansible_become: true
     ansible_ssh_private_key_file: /tmp/certs/ssh_priv.pem
 
+    #### Setting Proxy Environment variables ####
+    ## To set proxy env vars for the duration of playbook run, uncomment below block and set as necessary
+    # proxy_env:
+    #   http_proxy: http://proxy.example.com:8080
+    #   https_proxy: http://proxy.example.com:8080
+    #   no_proxy: http://proxy.example.com:8080
+
     #### SASL Authentication Configuration ####
     ## By default there will be no SASL Authentication
     ## For SASL/PLAIN uncomment this line:

--- a/roles/confluent.variables_handlers/defaults/main.yml
+++ b/roles/confluent.variables_handlers/defaults/main.yml
@@ -58,6 +58,8 @@ zookeeper_health_check_command: "exec 42<>/dev/tcp/127.0.0.1/{{zookeeper.propert
 
 common_role_completed: false
 
+proxy_env: {}
+
 # Other options: kerberos, plain, scram
 sasl_protocol: none
 

--- a/upgrade_control_center.yml
+++ b/upgrade_control_center.yml
@@ -1,5 +1,6 @@
 - name: Control Center Upgrade
   hosts: control_center
+  environment: "{{ proxy_env }}"
   serial: 1
   tasks:
     - import_role:

--- a/upgrade_kafka_broker.yml
+++ b/upgrade_kafka_broker.yml
@@ -71,7 +71,6 @@
   hosts: kafka_broker
   serial: 1
   tasks:
-
     # Sets active_controller_count var for each host
     - name: Create Ordered Kafka Broker Groups
       import_tasks: tasks/create_ordered_kafka_groups.yml
@@ -127,6 +126,7 @@
 - name: Kafka Broker Upgrade
   # Putting controller group last here with serial=1 has the controller as the last host to run
   hosts: upgrade_non_controllers,upgrade_controller
+  environment: "{{ proxy_env }}"
   serial: 1
   tags:
     - upgrade

--- a/upgrade_kafka_connect.yml
+++ b/upgrade_kafka_connect.yml
@@ -1,5 +1,6 @@
 - name: Kafka Connect Upgrade
   hosts: kafka_connect
+  environment: "{{ proxy_env }}"
   serial: 1
   tasks:
     - import_role:

--- a/upgrade_kafka_rest.yml
+++ b/upgrade_kafka_rest.yml
@@ -1,5 +1,6 @@
 - name: Kafka Rest Upgrade
   hosts: kafka_rest
+  environment: "{{ proxy_env }}"
   serial: 1
   tasks:
     - import_role:

--- a/upgrade_ksql.yml
+++ b/upgrade_ksql.yml
@@ -1,5 +1,6 @@
 - name: KSQL Upgrade
   hosts: ksql
+  environment: "{{ proxy_env }}"
   serial: 1
   tasks:
     - import_role:

--- a/upgrade_schema_registry.yml
+++ b/upgrade_schema_registry.yml
@@ -1,5 +1,6 @@
 - name: Schema Registry Upgrade
   hosts: schema_registry
+  environment: "{{ proxy_env }}"
   serial: 1
   # there is a schema registry leader, should think about the master/follower thing
   # look in schema reg docs

--- a/upgrade_zookeeper.yml
+++ b/upgrade_zookeeper.yml
@@ -77,6 +77,7 @@
 - name: Zookeeper Upgrade
   # Putting leader group last here with serial=1 so the leader runs last
   hosts: upgrade_zookeeper_followers,upgrade_zookeeper_leader
+  environment: "{{ proxy_env }}"
   serial: 1
   tags:
     - upgrade


### PR DESCRIPTION
# Description

Now can set proxy env vars for duration of playbook run. Simply need to set a dictionary in your hosts.yml

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested that the env vars get set when you set the variable in hosts.yml and if you do not nothing breaks

**Test Configuration**:


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules