### PR TITLE
Custom certs option did not take key pass as parameter

### DIFF
--- a/hosts_example.yml
+++ b/hosts_example.yml
@@ -45,6 +45,7 @@ all:
     # ssl_ca_cert_filepath: "/tmp/certs/ca.crt"
     # ssl_signed_cert_filepath: "/tmp/certs/{{inventory_hostname}}-signed.crt"
     # ssl_key_filepath: "/tmp/certs/{{inventory_hostname}}-key.pem"
+    # ssl_key_password: <password for key for each host, will be inputting in the form -passin pass:{{ssl_key_password}} >
     ## Option 2: Custom Keystores and Truststores
     ## CP-Ansible can move keystores/truststores to their corresponding hosts and configure the components to use them. Set These vars
     # ssl_provided_keystore_and_truststore: true

--- a/roles/confluent.ssl/tasks/custom_certs.yml
+++ b/roles/confluent.ssl/tasks/custom_certs.yml
@@ -36,6 +36,7 @@
     openssl pkcs12 -export \
       -in /var/ssl/private/generation/signed.crt \
       -inkey /var/ssl/private/generation/key.pem \
+      -passin pass:{{ssl_key_password}} \
       -out /var/ssl/private/generation/client.p12 \
       -name kafkassl \
       -passout pass:mykeypassword


### PR DESCRIPTION
# Description

Custom keys previously did not have password parameter, which is a security bug

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Updated my cert generation script to put password on key, and then tested custom certs playbook w key has input parameter


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules