### PR TITLE
Ca bundle

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,31 +1,39 @@
 # Description
 
-Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+This PR allows the user to skip the plays that copies the CA, cert and key.
 
-Fixes # (issue)
+Relevant when these are provided by other sources, for example another Ansible playbook.
+
+Also allows import of a full CA chain into truststores.
 
 ## Type of change
 
 - [ ] Bug fix (non-breaking change which fixes an issue)
-- [ ] New feature (non-breaking change which adds functionality)
+- [X] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] This change requires a documentation update
 
 # How Has This Been Tested?
 
-Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
+Was tested on a 3 broker, 3 zookeeper cluster. Running common, kafka_broker, kafka_connect, kafka_rest, ksql, schema_registry and zookeeper roles. 
 
+All nodes running CentOS Linux release 7.7.1908 (Core)
 
+added the following in `/inventory/group_vars/all.yml` instead of `hosts.yml` since I have myltiple inventories.
 
-**Test Configuration**:
+```
+ssl_custom_certs_skip_copy: true
+ssl_add_ca_chain: true
+```
+
 
 
 # Checklist:
 
-- [ ] My code follows the style guidelines of this project
-- [ ] I have performed a self-review of my own code
-- [ ] I have commented my code, particularly in hard-to-understand areas
-- [ ] I have made corresponding changes to the documentation
-- [ ] My changes generate no new warnings
+- [ ] My code follows the style guidelines of this project *(didn't find any style guide)*
+- [x] I have performed a self-review of my own code
+- [x] I have commented my code, particularly in hard-to-understand areas
+- [x] I have made corresponding changes to the documentation
+- [x] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
-- [ ] Any dependent changes have been merged and published in downstream modules
+- [x] Any dependent changes have been merged and published in downstream modules (no dependencies)

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,39 +1,31 @@
 # Description
 
-This PR allows the user to skip the plays that copies the CA, cert and key.
+Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
 
-Relevant when these are provided by other sources, for example another Ansible playbook.
-
-Also allows import of a full CA chain into truststores.
+Fixes # (issue)
 
 ## Type of change
 
 - [ ] Bug fix (non-breaking change which fixes an issue)
-- [X] New feature (non-breaking change which adds functionality)
+- [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] This change requires a documentation update
 
 # How Has This Been Tested?
 
-Was tested on a 3 broker, 3 zookeeper cluster. Running common, kafka_broker, kafka_connect, kafka_rest, ksql, schema_registry and zookeeper roles. 
+Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
 
-All nodes running CentOS Linux release 7.7.1908 (Core)
 
-added the following in `/inventory/group_vars/all.yml` instead of `hosts.yml` since I have myltiple inventories.
 
-```
-ssl_custom_certs_skip_copy: true
-ssl_add_ca_chain: true
-```
-
+**Test Configuration**:
 
 
 # Checklist:
 
-- [ ] My code follows the style guidelines of this project *(didn't find any style guide)*
-- [x] I have performed a self-review of my own code
-- [x] I have commented my code, particularly in hard-to-understand areas
-- [x] I have made corresponding changes to the documentation
-- [x] My changes generate no new warnings
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
 - [ ] I have added tests that prove my fix is effective or that my feature works
-- [x] Any dependent changes have been merged and published in downstream modules (no dependencies)
+- [ ] Any dependent changes have been merged and published in downstream modules

--- a/hosts_example.yml
+++ b/hosts_example.yml
@@ -46,6 +46,12 @@ all:
     # ssl_signed_cert_filepath: "/tmp/certs/{{inventory_hostname}}-signed.crt"
     # ssl_key_filepath: "/tmp/certs/{{inventory_hostname}}-key.pem"
     # ssl_key_password: <password for key for each host, will be inputting in the form -passin pass:{{ssl_key_password}} >
+
+    ## Skip copying your CA, cert and key if they are provided by ahother source. For example another Ansible task.
+    # ssl_custom_certs_skip_copy: true
+    ## If your CA file contains a chain of CAs, uncomment the following line to make sure all
+    ## the CAs are imported into your truststores
+    # ssl_add_ca_chain: true
     ## Option 2: Custom Keystores and Truststores
     ## CP-Ansible can move keystores/truststores to their corresponding hosts and configure the components to use them. Set These vars
     # ssl_provided_keystore_and_truststore: true

--- a/roles/confluent.ssl/tasks/custom_certs.yml
+++ b/roles/confluent.ssl/tasks/custom_certs.yml
@@ -1,18 +1,33 @@
 ---
+- set_fact:
+    ssl_ca_cert: "/var/ssl/private/generation/{{ssl_ca_cert_filepath|basename}}"
+    ssl_signed_cert: /var/ssl/private/generation/signed.crt
+    ssl_key: /var/ssl/private/generation/key.pem
+  when: not ssl_custom_certs_skip_copy
+
+- set_fact:
+    ssl_ca_cert: "{{ssl_ca_cert_filepath|basename}}"
+    ssl_signed_cert: "{{ssl_ca_cert_filepath}}"
+    ssl_key:  "{{ssl_signed_cert_filepath}}"
+  when: ssl_custom_certs_skip_copy
+
 - name: Copy CA Cert to Host
   copy:
     src: "{{ssl_ca_cert_filepath}}"
-    dest: "/var/ssl/private/generation/{{ssl_ca_cert_filepath|basename}}"
+    dest: /var/ssl/private/generation/signed.crt
+  when: not ssl_custom_certs_skip_copy
 
 - name: Copy Signed Cert to Host
   copy:
     src: "{{ssl_signed_cert_filepath}}"
     dest: /var/ssl/private/generation/signed.crt
+  when: not ssl_custom_certs_skip_copy
 
 - name: Copy Key to Host
   copy:
     src: "{{ssl_key_filepath}}"
     dest: /var/ssl/private/generation/key.pem
+  when: not ssl_custom_certs_skip_copy
 
 - set_fact:
     extra_args: ""
@@ -27,15 +42,20 @@
     keytool -noprompt -keystore {{truststore_path}} \
       -storetype pkcs12 \
       -alias CARoot \
-      -import -file /var/ssl/private/generation/{{ssl_ca_cert_filepath|basename}} \
+      -import -file {{ssl_ca_cert}} \
       -storepass {{truststore_storepass}} \
       -keypass {{truststore_storepass}} {{extra_args}}
+  when: not ssl_add_ca_chain
+
+- name: Create Truststore and Import the CA Chain
+  include_tasks: import_ca_chain.yml
+  when: ssl_add_ca_chain
 
 - name: Put Key and Signed Cert into pkcs12 Format
   shell: |
     openssl pkcs12 -export \
-      -in /var/ssl/private/generation/signed.crt \
-      -inkey /var/ssl/private/generation/key.pem \
+      -in {{ssl_signed_cert}} \
+      -inkey {{ssl_key}} \
       -passin pass:{{ssl_key_password}} \
       -out /var/ssl/private/generation/client.p12 \
       -name kafkassl \
@@ -58,6 +78,6 @@
       -storetype pkcs12 \
       -keyalg RSA \
       -alias CARoot \
-      -import -file /var/ssl/private/generation/{{ssl_ca_cert_filepath|basename}} \
+      -import -file {{ssl_ca_cert}} \
       -storepass {{keystore_storepass}} \
       -keypass {{keystore_storepass}} {{extra_args}}

--- a/roles/confluent.ssl/tasks/import_ca_chain.yml
+++ b/roles/confluent.ssl/tasks/import_ca_chain.yml
@@ -1,0 +1,21 @@
+---
+
+- name: Create trustCA directory
+  file:
+    path: /var/ssl/private/generation/trustCAs
+    state: directory
+    mode: 0755
+
+- name: Split CA Certificate Bundle into Cert Files
+  shell: |
+    cat {{ssl_ca_cert_filepath}} | awk 'split_after==1{n++;split_after=0} /-----END CERTIFICATE-----/ {split_after=1} {print > ("/var/ssl/private/generation/trustCAs/ca" n ".pem")}'
+
+- name: Create Truststore with Certificates
+  shell: |
+    for file in /var/ssl/private/generation/trustCAs/*; do
+        fileName="${file##*/}"
+        keytool -noprompt -keystore {{truststore_path}} \
+            -alias "$fileName" \
+            -trustcacerts -import -file "$file" \
+            -deststorepass {{truststore_storepass}}
+    done

--- a/roles/confluent.variables_handlers/defaults/main.yml
+++ b/roles/confluent.variables_handlers/defaults/main.yml
@@ -70,6 +70,9 @@ certs_updated: false
 
 ssl_provided_keystore_and_truststore: false
 ssl_custom_certs: false
+ssl_custom_certs_skip_copy: false
+ssl_add_ca_chain: false
+
 # With self_signed on and ssl_enabled off, self_signed var should not get honored
 self_signed: "{{ false if ssl_provided_keystore_and_truststore|bool or ssl_custom_certs|bool else true }}"
 ssl_self_signed_ca_cert_filename: snakeoil-ca-1.crt


### PR DESCRIPTION
This PR allows the user to skip the plays that copies the CA, cert and key.
 
Relevant when these are provided by other sources, for example another Ansible playbook.

Also allows import of a full CA chain into truststores.
 
 ## Type of change
 
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] This change requires a documentation update
 
 # How Has This Been Tested?
 
Was tested on a 3 broker, 3 zookeeper cluster. Running common, kafka_broker, kafka_connect, kafka_rest, ksql, schema_registry and zookeeper roles. 

All nodes running CentOS Linux release 7.7.1908 (Core)
 
Added the following in `/inventory/group_vars/all.yml` instead of `hosts.yml` since I have myltiple inventories.
 
```
ssl_custom_certs_skip_copy: true
ssl_add_ca_chain: true
```

 # Checklist:

- [ ] My code follows the style guidelines of this project *(didn't find any style guide)*
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules (no dependencies)
