### PR TITLE
Fix plugin folder permission

### DIFF
--- a/roles/confluent.kafka_connect/tasks/confluent_hub.yml
+++ b/roles/confluent.kafka_connect/tasks/confluent_hub.yml
@@ -28,7 +28,7 @@
 
 - name: Fix Plugin Folder(s) Permission
   file:
-    path: "{{ kafka_connect_confluent_hub_plugins_dest }}/{{ item.split(':')[0] | regex_replace('/', '-') }}"
+    path: "{{ kafka_connect_confluent_hub_plugins_dest }}/{{ item.split(':')[0] | replace('/', '-') }}"
     mode: o+rX
     recurse: yes
   loop: "{{ kafka_connect_confluent_hub_plugins }}"

--- a/roles/confluent.kafka_connect/tasks/confluent_hub.yml
+++ b/roles/confluent.kafka_connect/tasks/confluent_hub.yml
@@ -32,3 +32,5 @@
     mode: o+rX
     recurse: yes
   loop: "{{ kafka_connect_confluent_hub_plugins }}"
+  when: kafka_connect_confluent_hub_plugins|length > 0
+  notify: restart connect distributed

--- a/roles/confluent.kafka_connect/tasks/confluent_hub.yml
+++ b/roles/confluent.kafka_connect/tasks/confluent_hub.yml
@@ -6,7 +6,7 @@
     group: "{{kafka_connect_group}}"
     owner: "{{kafka_connect_user}}"
     mode: '764'
-  
+
 - name: Installing/Unarchiving Confluent Hub
   unarchive:
     src: "{{kafka_connect_confluent_hub_client.file}}"
@@ -19,9 +19,16 @@
     src: "{{kafka_connect_confluent_hub_client.install_dir}}/bin/confluent-hub"
     dest: "/usr/bin/confluent-hub"
     state: link
-    
+
 - name: "Installing Kafka Connect Connector(s) from Confluent Hub"
   shell: "{{kafka_connect_confluent_hub_client.install_dir}}/bin/confluent-hub install --no-prompt --component-dir {{kafka_connect_confluent_hub_plugins_dest}} {{item}}"
-  with_items: "{{kafka_connect_confluent_hub_plugins}}"
+  loop: "{{kafka_connect_confluent_hub_plugins}}"
   when: kafka_connect_confluent_hub_plugins|length > 0
   notify: restart connect distributed
+
+- name: Fix Plugin Folder(s) Permission
+  file:
+    path: "{{ kafka_connect_confluent_hub_plugins_dest }}/{{ item.split(':')[0] | regex_replace('/', '-') }}"
+    mode: o+rX
+    recurse: yes
+  loop: "{{ kafka_connect_confluent_hub_plugins }}"


### PR DESCRIPTION
# Description

confluent-hub installs a Kafka connect plugin without permission for others

Example:
```
tree -Cugp /usr/share/java/confluentinc-connect-transforms/
/usr/share/java/confluentinc-connect-transforms/
|-- [drwxr-x--- root     root    ]  assets
|   `-- [-rw-r----- root     root    ]  confluent.png
|-- [drwxr-x--- root     root    ]  doc
|   `-- [-rw-r----- root     root    ]  README.md
|-- [drwxr-x--- root     root    ]  etc
|   |-- [-rw-r----- root     root    ]  drop.properties
|   |-- [-rw-r----- root     root    ]  extract-topic.properties
|   `-- [-rw-r----- root     root    ]  message-timestamp-router.properties
|-- [drwxr-x--- root     root    ]  lib
|   |-- [-rw-r----- root     root    ]  accessors-smart-1.2.jar
|   |-- [-rw-r----- root     root    ]  asm-5.0.4.jar
|   |-- [-rw-r----- root     root    ]  connect-transforms-1.3.2.jar
|   |-- [-rw-r----- root     root    ]  connect-utils-0.1.0.jar
|   |-- [-rw-r----- root     root    ]  joda-time-2.10.3.jar
|   |-- [-rw-r----- root     root    ]  json-path-2.4.0.jar
|   |-- [-rw-r----- root     root    ]  json-smart-2.3.jar
|   `-- [-rw-r----- root     root    ]  slf4j-api-1.7.25.jar
`-- [-rw-r----- root     root    ]  manifest.json
```

As a result, Kafka connect can’t load a plugin during starting because it works with non-root privileges (e.g. cp-kafka-connect user).

```
[2020-04-08 15:21:31,734] ERROR Could not get listing for plugin path: /usr/share/java. Ignoring. (org.apache.kafka.connect.runtime.isolation.DelegatingClassLoader)
  java.nio.file.AccessDeniedException: /usr/share/java/confluentinc-connect-transforms
```

The fix based on the official documentation that says "_the component archive name must follow this convention:_"

`${componentOwner}-${componentName}-${componentVersion}.zip`

It allows defining a plugin target folder name and add missed privileges `o+rX`

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

The fix was tested on real dev/prod Kafka clusters.

How to test:

* define `kafka_connect_confluent_hub_plugins` variable

example:

```
    kafka_connect_confluent_hub_plugins:
      - confluentinc/connect-transforms:latest
```

* run a playbook that calls `confluent.kafka_connect` role
* go to your host and check the plugin folder and files permission

example of results with the fix:

```
tree -Cugp /usr/share/java/confluentinc-connect-transforms/
/usr/share/java/confluentinc-connect-transforms/
|-- [drwxr-xr-x root     root    ]  assets
|   `-- [-rw-r--r-- root     root    ]  confluent.png
|-- [drwxr-xr-x root     root    ]  doc
|   `-- [-rw-r--r-- root     root    ]  README.md
|-- [drwxr-xr-x root     root    ]  etc
|   |-- [-rw-r--r-- root     root    ]  drop.properties
|   |-- [-rw-r--r-- root     root    ]  extract-topic.properties
|   `-- [-rw-r--r-- root     root    ]  message-timestamp-router.properties
|-- [drwxr-xr-x root     root    ]  lib
|   |-- [-rw-r--r-- root     root    ]  accessors-smart-1.2.jar
|   |-- [-rw-r--r-- root     root    ]  asm-5.0.4.jar
|   |-- [-rw-r--r-- root     root    ]  connect-transforms-1.3.2.jar
|   |-- [-rw-r--r-- root     root    ]  connect-utils-0.1.0.jar
|   |-- [-rw-r--r-- root     root    ]  joda-time-2.10.3.jar
|   |-- [-rw-r--r-- root     root    ]  json-path-2.4.0.jar
|   |-- [-rw-r--r-- root     root    ]  json-smart-2.3.jar
|   `-- [-rw-r--r-- root     root    ]  slf4j-api-1.7.25.jar
`-- [-rw-r--r-- root     root    ]  manifest.json
```

**Test Configuration**:


# Checklist:

- [] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules