### PR TITLE
Zookeeper server-to-server and client-to-server DIGEST-MD5 authentication

### DIFF
--- a/hosts_example.yml
+++ b/hosts_example.yml
@@ -21,6 +21,13 @@ all:
     ## For SASL/GSSAPI uncomment this line and see Kerberos Configuration properties below
     # sasl_protocol: kerberos
 
+    ## Zookeeper server-to-server and client-to-server DIGEST-MD5 authentication
+    ## Do NOT MIX it with sasl_protocol: kerberos
+    # zookeeper_sasl_digestmd5_enabled: true
+    # zookeeper_sasl_digestmd5_superuser_login: zksuper # This user gonna be the only owner of root znode and also be claimed as ultimate superuser via '-Dzookeeper.superUser=' system property
+    # zookeeper_sasl_digestmd5_superuser_password: 7a418176-d2ee-4c69-bc92-51d57e85a28b
+    # zookeeper_sasl_digestmd5_internode_password: f6d987ee-d4e7-40cd-98b5-9f68e7aa1a62
+
     #### Kerberos Configuration ####
     ## Applicable when sasl_protocol is kerberos
     # kerberos_kafka_broker_primary: <Name of the primary set on the kafka brokers' principal eg. kafka>

--- a/roles/confluent.common/defaults/main.yml
+++ b/roles/confluent.common/defaults/main.yml
@@ -17,8 +17,8 @@ confluent_common_repository_redhat_dist_enabled: 1
 
 install_java: true
 redhat_java_package_name: java-1.8.0-openjdk
-debian_java_package_name: openjdk-8-jdk
-ubuntu_java_package_name: openjdk-8-jdk
+debian_java_package_name: openjdk-11-jdk-headless
+ubuntu_java_package_name: openjdk-11-jdk-headless
 ubuntu_java_repository: ppa:openjdk-r/ppa
 
 jolokia_version: 1.6.2

--- a/roles/confluent.common/tasks/debian.yml
+++ b/roles/confluent.common/tasks/debian.yml
@@ -62,6 +62,15 @@
 
 - meta: flush_handlers
 
+- name: Install Java - Buster
+  apt:
+    name: "{{ debian_java_package_name }}"
+    state: present
+  when:
+    - install_java|bool
+    - not custom_apt_repo|bool
+    - ansible_distribution_release == "buster"
+
 - name: Install Java - jessie
   apt:
     name: "{{ debian_java_package_name }}"

--- a/roles/confluent.kafka_broker/defaults/main.yml
+++ b/roles/confluent.kafka_broker/defaults/main.yml
@@ -3,12 +3,13 @@ kafka_broker_jolokia_java_arg_buildout: "-javaagent:{{jolokia_jar_path}}=port={{
 kafka_broker_jmxexporter_java_arg_buildout: "-javaagent:{{jmxexporter_jar_path}}={{kafka_broker_jmxexporter_port}}:{{kafka_broker_jmxexporter_config_path}}"
 kafka_broker_ssl_java_arg_buildout: "-Djavax.net.ssl.keyStore={{kafka_broker_keystore_path}} -Djavax.net.ssl.trustStore={{kafka_broker_truststore_path}} -Djavax.net.ssl.keyStorePassword={{kafka_broker_keystore_storepass}} -Djavax.net.ssl.trustStorePassword={{kafka_broker_truststore_storepass}}"
 kafka_broker_log4j_java_arg_buildout: "-Dlog4j.configuration=file:{{kafka_broker.log4j_file}}"
-
+kafka_broker_heap_opts: "-Xmx1g"
 kafka_broker_custom_log4j: true
 
 kafka_broker_custom_java_args: ""
 kafka_broker_java_args:
   - "{{ kafka_broker_jaas_java_arg_buildout if 'GSSAPI' in kafka_broker_sasl_enabled_mechanisms else '' }}"
+  - "{{ kafka_broker_jaas_java_arg_buildout if zookeeper_sasl_digestmd5_enabled else '' }}"
   - "{{ kafka_broker_jolokia_java_arg_buildout if kafka_broker_jolokia_enabled|bool else '' }}"
   - "{{ kafka_broker_jmxexporter_java_arg_buildout if kafka_broker_jmxexporter_enabled|bool else '' }}"
   - "{{ kafka_broker_ssl_java_arg_buildout if schema_registry_ssl_enabled|bool else '' }}"
@@ -22,7 +23,7 @@ kafka_broker_service_overrides:
   User: "{{ kafka_broker_user if kafka_broker_user != kafka_broker_default_user else '' }}"
   Group: "{{ kafka_broker_group if kafka_broker_group != kafka_broker_default_group else '' }}"
 kafka_broker_service_environment_overrides:
-  KAFKA_HEAP_OPTS: "-Xmx1g"
+  KAFKA_HEAP_OPTS: "{{kafka_broker_heap_opts}}"
   KAFKA_OPTS: "{{ kafka_broker_final_java_args | java_arg_build_out }}"
 
 kafka_broker_sysctl:

--- a/roles/confluent.kafka_broker/tasks/main.yml
+++ b/roles/confluent.kafka_broker/tasks/main.yml
@@ -109,18 +109,21 @@
     mode: 0640
     owner: "{{kafka_broker_user}}"
     group: "{{kafka_broker_group}}"
-  when: "'GSSAPI' in kafka_broker_sasl_enabled_mechanisms"
+  when: ("'GSSAPI' in kafka_broker_sasl_enabled_mechanisms") or
+        (zookeeper_sasl_digestmd5_enabled)
   notify:
     - Restart Kafka
 
 - name: Create SCRAM Users
   shell: |
-    kafka-configs --zookeeper localhost:{{zookeeper.properties.clientPort}} --alter \
+    kafka-configs --zookeeper localhost:{{ zookeeper.properties.clientPort }} --alter \
       --add-config 'SCRAM-SHA-256=[password={{ item.value['password'] }}]' \
       --entity-type users --entity-name {{ item.value['principal'] }}
   loop: "{{ sasl_scram_users|dict2items }}"
   delegate_to: "{{ groups['zookeeper'][0] }}"
   run_once: true
+  environment:
+    - KAFKA_OPTS: "{{'-Djava.security.auth.login.config=' + kafka_broker.jaas_file if zookeeper_sasl_digestmd5_enabled else ''}}"
   when: "'SCRAM-SHA-256' in kafka_broker_sasl_enabled_mechanisms"
 
 - name: Deploy JMX Exporter Config File

--- a/roles/confluent.kafka_broker/templates/kafka_server_jaas.conf.j2
+++ b/roles/confluent.kafka_broker/templates/kafka_server_jaas.conf.j2
@@ -1,3 +1,4 @@
+{% if sasl_protocol == 'kerberos' %}
 // Specifies a unique keytab and principal name for each broker
 KafkaServer {
     com.sun.security.auth.module.Krb5LoginModule required
@@ -15,3 +16,11 @@ Client {
     keyTab="{{kerberos.keytab_dir}}/{{kafka_broker_kerberos_keytab_path | basename}}"
     principal="{{kafka_broker_kerberos_principal}}";
 };
+{% endif %}
+{% if zookeeper_sasl_digestmd5_enabled %}
+Client {
+    org.apache.zookeeper.server.auth.DigestLoginModule required
+    username="{{zookeeper_sasl_digestmd5_superuser_login}}"
+    password="{{zookeeper_sasl_digestmd5_superuser_password}}";
+};
+{% endif %}

--- a/roles/confluent.kafka_broker/templates/server.properties.j2
+++ b/roles/confluent.kafka_broker/templates/server.properties.j2
@@ -91,3 +91,6 @@ confluent.metrics.reporter.sasl.mechanism=SCRAM-SHA-256
 confluent.metrics.reporter.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required \
    username="{{sasl_scram_users.admin.principal}}" password="{{sasl_scram_users.admin.password}}";
 {% endif %}
+{% if zookeeper_sasl_digestmd5_enabled %}
+zookeeper.set.acl=true
+{% endif %}

--- a/roles/confluent.variables_handlers/defaults/main.yml
+++ b/roles/confluent.variables_handlers/defaults/main.yml
@@ -1,3 +1,5 @@
+zookeeper_sasl_digestmd5_enabled: false
+
 kerberos:
   keytab_dir: /etc/security/keytabs
 

--- a/roles/confluent.zookeeper/defaults/main.yml
+++ b/roles/confluent.zookeeper/defaults/main.yml
@@ -2,12 +2,14 @@ zookeeper_jaas_java_arg_buildout: "-Djava.security.auth.login.config={{zookeeper
 zookeeper_jolokia_java_arg_buildout: "-javaagent:{{jolokia_jar_path}}=port={{zookeeper_jolokia_port}},host=0.0.0.0"
 zookeeper_log4j_java_arg_buildout: "-Dlog4j.configuration=file:{{zookeeper.log4j_file}}"
 zookeeper_jmxexporter_java_arg_buildout: "-javaagent:{{jmxexporter_jar_path}}={{zookeeper_jmxexporter_port}}:{{zookeeper_jmxexporter_config_path}}"
-
+zookeeper_heap_opts: "-Xmx1g"
 zookeeper_custom_log4j: "{{ custom_log4j }}"
 
 zookeeper_custom_java_args: ""
 zookeeper_java_args:
   - "{{ zookeeper_jaas_java_arg_buildout if 'GSSAPI' in kafka_broker_sasl_enabled_mechanisms else '' }}"
+  - "{{ zookeeper_jaas_java_arg_buildout if zookeeper_sasl_digestmd5_enabled else '' }}"
+  - "{{ '-Dzookeeper.superUser=' + zookeeper_sasl_digestmd5_superuser_login if zookeeper_sasl_digestmd5_enabled else '' }}"
   - "{{ zookeeper_jolokia_java_arg_buildout if zookeeper_jolokia_enabled|bool else '' }}"
   - "{{ zookeeper_log4j_java_arg_buildout if zookeeper_custom_log4j|bool else '' }}"
   - "{{ zookeeper_jmxexporter_java_arg_buildout if zookeeper_jmxexporter_enabled|bool else '' }}"
@@ -19,7 +21,7 @@ zookeeper_service_overrides:
   User: "{{ zookeeper_user if zookeeper_user != zookeeper_default_user else '' }}"
   Group: "{{ zookeeper_group if zookeeper_group != zookeeper_default_group else '' }}"
 zookeeper_service_environment_overrides:
-  KAFKA_HEAP_OPTS: "-Xmx1g"
+  KAFKA_HEAP_OPTS: "{{zookeeper_heap_opts}}"
   KAFKA_OPTS: "{{ zookeeper_final_java_args | java_arg_build_out }}"
 
 zookeeper_peer_port: 2888

--- a/roles/confluent.zookeeper/tasks/main.yml
+++ b/roles/confluent.zookeeper/tasks/main.yml
@@ -96,9 +96,11 @@
     mode: 0640
     owner: "{{zookeeper_user}}"
     group: "{{zookeeper_group}}"
-  when: "'GSSAPI' in kafka_broker_sasl_enabled_mechanisms"
+  when: ("'GSSAPI' in kafka_broker_sasl_enabled_mechanisms") or
+        (zookeeper_sasl_digestmd5_enabled)
   notify:
     - restart zookeeper
+  
 
 - name: Deploy JMX Exporter Config File
   copy:
@@ -146,3 +148,23 @@
   when:
     - health_checks_enabled|bool
     - not ansible_check_mode
+
+- name: "Set zookeeper ACLs: {{zookeeper_sasl_digestmd5_superuser_login}} - Full, anyone - Read"
+  shell: |
+    /usr/bin/zookeeper-shell {{groups['zookeeper'][0]}}:{{zookeeper.properties.clientPort}} setAcl / 'sasl:{{zookeeper_sasl_digestmd5_superuser_login}}:cdraw,world:anyone:r'
+  delegate_to: "{{ groups['zookeeper'][0] }}"
+  run_once: true
+  environment:
+    - KAFKA_OPTS: "-Djava.security.auth.login.config={{kafka_broker.jaas_file}}"
+  when: zookeeper_sasl_digestmd5_enabled
+
+
+- name: Make CLI tools work with secured zookeeper, add KAFKA_OPTS environment variable into /etc/profile
+  lineinfile:
+    dest: "/etc/profile"
+    state: present
+    regexp: "^export KAFKA_OPTS"
+    line: "export KAFKA_OPTS=-Djava.security.auth.login.config={{kafka_broker.jaas_file}}"
+  when: zookeeper_sasl_digestmd5_enabled
+
+  

--- a/roles/confluent.zookeeper/templates/zookeeper.properties.j2
+++ b/roles/confluent.zookeeper/templates/zookeeper.properties.j2
@@ -1,7 +1,22 @@
 # Maintained by Ansible
+# SSSD requiers to define hostname in /etc/hosts, it can make zookeeper listen on localhost. So use ansible_default_ipv4 insted of hostname
 {% for key, value in zookeeper.properties.items() %}
 {{key}}={{value}}
 {% endfor %}
+
+{% if zookeeper_sasl_digestmd5_enabled %}
+quorum.auth.enableSasl=true
+quorum.auth.learnerRequireSasl=true
+quorum.auth.serverRequireSasl=true
+quorum.auth.learner.loginContext=QuorumLearner
+quorum.auth.server.loginContext=QuorumServer
+quorum.cnxn.threads.size=20
+requireClientAuthScheme=sasl
 {% for host in groups['zookeeper'] %}
-server.{{ hostvars[host]['zookeeper_id'] | default(groups.zookeeper.index(host) + 1)}}={{ host }}:{{zookeeper_peer_port}}:{{zookeeper_leader_port}}
+authProvider.{{ hostvars[host]['zookeeper_id'] | default(groups.zookeeper.index(host) + 1)}}=org.apache.zookeeper.server.auth.SASLAuthenticationProvider
+{% endfor %}
+{% endif %}
+
+{% for host in groups['zookeeper'] %}
+server.{{ hostvars[host]['zookeeper_id'] | default(groups.zookeeper.index(host) + 1)}}={{ hostvars[host]['ansible_default_ipv4']['address'] }}:{{zookeeper_peer_port}}:{{zookeeper_leader_port}}
 {% endfor %}

--- a/roles/confluent.zookeeper/templates/zookeeper.properties.j2
+++ b/roles/confluent.zookeeper/templates/zookeeper.properties.j2
@@ -1,5 +1,4 @@
 # Maintained by Ansible
-# SSSD requiers to define hostname in /etc/hosts, it can make zookeeper listen on localhost. So use ansible_default_ipv4 insted of hostname
 {% for key, value in zookeeper.properties.items() %}
 {{key}}={{value}}
 {% endfor %}
@@ -17,6 +16,8 @@ authProvider.{{ hostvars[host]['zookeeper_id'] | default(groups.zookeeper.index(
 {% endfor %}
 {% endif %}
 
+#Usually hostname or fqdn is defined in /etc/hosts as 127.0.1.1, it makes zookeeper listen on it and loosing ability to accept incoming connection
+#So make in listen on 0.0.0.0
 {% for host in groups['zookeeper'] %}
-server.{{ hostvars[host]['zookeeper_id'] | default(groups.zookeeper.index(host) + 1)}}={{ hostvars[host]['ansible_default_ipv4']['address'] }}:{{zookeeper_peer_port}}:{{zookeeper_leader_port}}
+server.{{ hostvars[host]['zookeeper_id'] | default(groups.zookeeper.index(host) + 1)}}={{ '0.0.0.0' if host == inventory_hostname else hostvars[host]['ansible_fqdn']  }}:{{zookeeper_peer_port}}:{{zookeeper_leader_port}}
 {% endfor %}

--- a/roles/confluent.zookeeper/templates/zookeeper_jaas.conf.j2
+++ b/roles/confluent.zookeeper/templates/zookeeper_jaas.conf.j2
@@ -1,3 +1,4 @@
+{% if sasl_protocol == 'kerberos' %}
 // Specifies a unique keytab and principal name for each ZooKeeper node
 Server {
     com.sun.security.auth.module.Krb5LoginModule required
@@ -7,3 +8,23 @@ Server {
     useTicketCache=false
     principal="{{zookeeper_kerberos_principal}}";
 };
+{% endif %}
+
+{% if zookeeper_sasl_digestmd5_enabled %}
+QuorumServer {
+       org.apache.zookeeper.server.auth.DigestLoginModule required
+       user_zookeeper="{{zookeeper_sasl_digestmd5_internode_password}}";
+};
+
+QuorumLearner {
+       org.apache.zookeeper.server.auth.DigestLoginModule required
+       username="zookeeper"
+       password="{{zookeeper_sasl_digestmd5_internode_password}}";
+};
+
+Server {
+    org.apache.zookeeper.server.auth.DigestLoginModule required
+    user_{{zookeeper_sasl_digestmd5_superuser_login}}="{{zookeeper_sasl_digestmd5_superuser_password}}";
+};
+
+{% endif %}


### PR DESCRIPTION
# Description
PR adds ability to enable zookeeper server-to-server and client-to-server DIGEST-MD5 authentication.
It suppose to protect zookeeper from:
- kafka's scram credential spoofing 
- malicious/accidentall znode deletetion by any unauthenticated user
- znode flooding by any unauthenticated user


Fixes #215 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [v] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [v] This change requires a documentation update

# How Has This Been Tested?
Not really well. 
Tested it only with zookeeper and kafka_broker deployments, with SCRAM and PLAIN auth types.


**Test Configuration**:


# Checklist:

- [ ] My code follows the style guidelines of this project
- [v] I have performed a self-review of my own code
- [v] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [v] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules