### PR TITLE
Rbac- mds advertised listener

### DIFF
--- a/roles/confluent.kafka_broker/templates/server.properties.j2
+++ b/roles/confluent.kafka_broker/templates/server.properties.j2
@@ -80,7 +80,7 @@ confluent.metrics.reporter.topic.replicas={{kafka_broker_default_interal_replica
 {% if rbac_enabled|bool %}
 # MDS Configuration
 confluent.metadata.server.listeners={{mds_http_protocol}}://0.0.0.0:{{mds_port}}
-confluent.metadata.server.advertised.listeners={{mds_http_protocol}}://{{ inventory_hostname }}:{{mds_port}}
+confluent.metadata.server.advertised.listeners={{mds_http_protocol}}://{{ mds_advertised_listener_hostname | default(inventory_hostname) }}:{{mds_port}}
 confluent.metadata.server.token.auth.enable=true
 confluent.metadata.server.token.max.lifetime.ms=3600000
 confluent.metadata.server.token.key.path={{rbac_enabled_private_pem_path}}


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Adding variable: mds_advertised_listener_hostname
If set on each kafka host will allow you to put a different hostname into the mds advertised listener
Before this, the setting was set as the broker's hostname
Still defaulting to the hostname so without the var set

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration



**Test Configuration**:
Tested on aws with public ip in the advertised listener spot and it had no impact on the components reaching the mds server over the internal ip

Also the current molecule scenarios MUST still pass


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules