### PR TITLE
Removed extraneous directory ownership task.

### DIFF
--- a/roles/confluent.ksql/tasks/main.yml
+++ b/roles/confluent.ksql/tasks/main.yml
@@ -66,14 +66,6 @@
   include_tasks: rbac.yml
   when: rbac_enabled|bool
 
-- name: Change streams directory ownership
-  file:
-    path: "{{ksql_streams_state_dir}}"
-    owner: "{{ksql_user}}"
-    group: "{{ksql_group}}"
-    state: directory
-    mode: 0750
-
 - name: Create Ksql Config
   template:
     src: ksql-server.properties.j2


### PR DESCRIPTION
# Description

This PR removes an extraneous directory ownership task from KSQL.  We already set ownership and permissions in another task.

Fixes # (issue)

https://github.com/confluentinc/cp-ansible/issues/244

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I have tested this change using the following molecule scenarios and validating that the permissions and ownership of the dir are set correctly inside the container:

1. rbac-mtls-provided-ubuntu
2. mtls-customcerts-rhel

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules