### PR TITLE
Fix Connecthub plugin permissions

### DIFF
--- a/roles/confluent.kafka_connect/defaults/main.yml
+++ b/roles/confluent.kafka_connect/defaults/main.yml
@@ -26,13 +26,13 @@ kafka_connect_secret_registry_key: 39ff95832750c0090d84ddf5344583832efe91ef
 
 kafka_connect_group_id: connect-cluster
 
-kafka_connect_plugins_path: 
+kafka_connect_plugins_path:
 - /usr/share/java
-kafka_connect_confluent_hub_install: "{{kafka_connect_confluent_hub_plugins|length >0}}" 
+
 kafka_connect_confluent_hub_client:
   file: "http://client.hub.confluent.io/confluent-hub-client-latest.tar.gz"
   is_remote: yes
-  install_dir: /etc/kafka/confluent-hub 
+  install_dir: /etc/kafka/confluent-hub
 kafka_connect_confluent_hub_plugins: []
 kafka_connect_confluent_hub_plugins_dest: /usr/share/java
 kafka_connect_plugins: []

--- a/roles/confluent.kafka_connect/molecule/connect-hub/molecule.yml
+++ b/roles/confluent.kafka_connect/molecule/connect-hub/molecule.yml
@@ -48,8 +48,6 @@ provisioner:
   inventory:
     group_vars:
       all:
-        ssl_enabled: true
-
         kafka_connect_confluent_hub_plugins:
           - jcustenborder/kafka-connect-spooldir:2.0.43
 

--- a/roles/confluent.kafka_connect/molecule/connect-hub/molecule.yml
+++ b/roles/confluent.kafka_connect/molecule/connect-hub/molecule.yml
@@ -6,8 +6,8 @@ platforms:
     hostname: zookeeper1.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-debian9-ansible
-    dockerfile: ../../confluent.test/molecule/Dockerfile-debian.j2
+    image: geerlingguy/docker-centos7-ansible
+    dockerfile: ../../../confluent.test/molecule/Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -18,8 +18,8 @@ platforms:
     hostname: kafka-broker1.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-debian9-ansible
-    dockerfile: ../../confluent.test/molecule/Dockerfile-debian.j2
+    image: geerlingguy/docker-centos7-ansible
+    dockerfile: ../../../confluent.test/molecule/Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -30,8 +30,8 @@ platforms:
     hostname: kafka-connect1.confluent
     groups:
       - kafka_connect
-    image: geerlingguy/docker-debian9-ansible
-    dockerfile: ../../confluent.test/molecule/Dockerfile-debian.j2
+    image: geerlingguy/docker-centos7-ansible
+    dockerfile: ../../../confluent.test/molecule/Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/roles/confluent.kafka_connect/molecule/connect-hub/molecule.yml
+++ b/roles/confluent.kafka_connect/molecule/connect-hub/molecule.yml
@@ -1,0 +1,72 @@
+---
+driver:
+  name: docker
+platforms:
+  - name: zookeeper1
+    hostname: zookeeper1.confluent
+    groups:
+      - zookeeper
+    image: geerlingguy/docker-debian9-ansible
+    dockerfile: ../../confluent.test/molecule/Dockerfile-debian.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    networks:
+      - name: confluent
+  - name: kafka-broker1
+    hostname: kafka-broker1.confluent
+    groups:
+      - kafka_broker
+    image: geerlingguy/docker-debian9-ansible
+    dockerfile: ../../confluent.test/molecule/Dockerfile-debian.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    networks:
+      - name: confluent
+  - name: kafka-connect1
+    hostname: kafka-connect1.confluent
+    groups:
+      - kafka_connect
+    image: geerlingguy/docker-debian9-ansible
+    dockerfile: ../../confluent.test/molecule/Dockerfile-debian.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    networks:
+      - name: confluent
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      hash_behaviour: merge
+  playbooks:
+    converge: ../../../../all.yml
+  inventory:
+    group_vars:
+      all:
+        ssl_enabled: true
+
+        kafka_connect_confluent_hub_plugins:
+          - jcustenborder/kafka-connect-spooldir:2.0.43
+
+verifier:
+  name: ansible
+scenario:
+  test_sequence:
+    - lint
+    - dependency
+    - cleanup
+    - destroy
+    - syntax
+    - create
+    - prepare
+    - converge
+    # - idempotence
+    - side_effect
+    - verify
+    - cleanup
+    - destroy

--- a/roles/confluent.kafka_connect/molecule/connect-hub/verify.yml
+++ b/roles/confluent.kafka_connect/molecule/connect-hub/verify.yml
@@ -1,0 +1,12 @@
+---
+- name: Verify - kafka_connect
+  hosts: kafka_connect
+  gather_facts: no
+  tasks:
+    - import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: /etc/kafka/connect-distributed.properties
+        property: security.protocol
+        expected_value: SSL

--- a/roles/confluent.kafka_connect/molecule/connect-hub/verify.yml
+++ b/roles/confluent.kafka_connect/molecule/connect-hub/verify.yml
@@ -3,10 +3,14 @@
   hosts: kafka_connect
   gather_facts: no
   tasks:
-    - import_role:
-        name: confluent.test
-        tasks_from: check_property.yml
-      vars:
-        file_path: /etc/kafka/connect-distributed.properties
-        property: security.protocol
-        expected_value: SSL
+    - name: Get Stats on Connect Hub installed Lib Directory
+      stat:
+        path: /usr/share/java/jcustenborder-kafka-connect-spooldir/lib
+      register: lib_dir_stats
+
+    - name: Assert ownership on lib directory
+      assert:
+        that:
+          - lib_dir_stats.stat.gr_name == "confluent"
+          - lib_dir_stats.stat.pw_name == "cp-kafka-connect"
+        quiet: yes

--- a/roles/confluent.kafka_connect/tasks/confluent_hub.yml
+++ b/roles/confluent.kafka_connect/tasks/confluent_hub.yml
@@ -6,7 +6,7 @@
     group: "{{kafka_connect_group}}"
     owner: "{{kafka_connect_user}}"
     mode: '764'
-  
+
 - name: Installing/Unarchiving Confluent Hub
   unarchive:
     src: "{{kafka_connect_confluent_hub_client.file}}"
@@ -19,9 +19,28 @@
     src: "{{kafka_connect_confluent_hub_client.install_dir}}/bin/confluent-hub"
     dest: "/usr/bin/confluent-hub"
     state: link
-    
+
 - name: "Installing Kafka Connect Connector(s) from Confluent Hub"
   shell: "{{kafka_connect_confluent_hub_client.install_dir}}/bin/confluent-hub install --no-prompt --component-dir {{kafka_connect_confluent_hub_plugins_dest}} {{item}}"
   with_items: "{{kafka_connect_confluent_hub_plugins}}"
   when: kafka_connect_confluent_hub_plugins|length > 0
   notify: restart connect distributed
+
+- name: Set Permissions on Plugin Folder(s)
+  file:
+    path: "{{ kafka_connect_confluent_hub_plugins_dest }}/{{ item.split(':')[0] | replace('/', '-') }}"
+    owner: "{{kafka_connect_user}}"
+    group: "{{kafka_connect_group}}"
+    state: directory
+    mode: 0750
+  loop: "{{ kafka_connect_confluent_hub_plugins }}"
+  when: kafka_connect_confluent_hub_plugins|length > 0
+
+- name: Set Permissions on Plugin Files
+  file:
+    path: "{{ kafka_connect_confluent_hub_plugins_dest }}/{{ item.split(':')[0] | replace('/', '-') }}"
+    owner: "{{kafka_connect_user}}"
+    group: "{{kafka_connect_group}}"
+    recurse: true
+  loop: "{{ kafka_connect_confluent_hub_plugins }}"
+  when: kafka_connect_confluent_hub_plugins|length > 0

--- a/roles/confluent.kafka_connect/tasks/connectors.yml
+++ b/roles/confluent.kafka_connect/tasks/connectors.yml
@@ -8,7 +8,7 @@
     mode: '764'
   when: item != '/usr/share/java'
   with_items: "{{ kafka_connect.properties['plugin.path'].split(',') }}"
-  
+
 - name: Installing Local Plugins
   unarchive:
     src: "{{item}}"
@@ -17,7 +17,7 @@
   with_items: "{{kafka_connect_plugins}}"
   when: kafka_connect_plugins|length > 0
   notify: restart connect distributed
-  
+
 - name: Installing Remote Plugins
   unarchive:
     src: "{{item}}"
@@ -26,7 +26,7 @@
   with_items: "{{kafka_connect_plugins_remote}}"
   when: kafka_connect_plugins_remote|length > 0
   notify: restart connect distributed
-  
+
 - name: Confluent Hub
   include_tasks: confluent_hub.yml
-  when: kafka_connect_confluent_hub_install
+  when: kafka_connect_confluent_hub_plugins|length > 0


### PR DESCRIPTION
# Description

After installing connecthub connectors, the jars are all owned by root. This PR switches the ownership to the connect linux user

It leaves the permissions on the jars as read because thats all java needs.

Also removed a variable that only was used once in place of logic

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration



**Test Configuration**:
Added unit test


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules