### PR TITLE
equal to filter needs rolling back

### DIFF
--- a/filter_plugins/filters.py
+++ b/filter_plugins/filters.py
@@ -8,7 +8,8 @@ class FilterModule(object):
             'get_sasl_mechanisms': self.get_sasl_mechanisms,
             'get_hostnames': self.get_hostnames,
             'cert_extension': self.cert_extension,
-            'ssl_required': self.ssl_required
+            'ssl_required': self.ssl_required,
+            'java_arg_build_out': self.java_arg_build_out
         }
 
     def normalize_sasl_protocol(self, protocol):
@@ -62,3 +63,10 @@ class FilterModule(object):
             ssl_enabled = listeners_dict[listener].get('ssl_enabled', default_ssl_enabled)
             ssl_required = ssl_required == True or ssl_enabled == True
         return ssl_required
+
+    def java_arg_build_out(self, java_arg_list):
+        java_args = ''
+        for value in java_arg_list:
+            if value != '':
+                java_args = java_args + ' ' + value
+        return java_args[1:]

--- a/roles/confluent.control_center/defaults/main.yml
+++ b/roles/confluent.control_center/defaults/main.yml
@@ -18,7 +18,7 @@ control_center_service_overrides:
 control_center_service_environment_overrides:
   ROCKSDB_SHAREDLIB_DIR: "{{control_center_rocksdb_path}}"
   CONTROL_CENTER_HEAP_OPTS: "-Xmx6g"
-  CONTROL_CENTER_OPTS: "{{ control_center_final_java_args | reject('equalto', '') | join(' ') }}"
+  CONTROL_CENTER_OPTS: "{{ control_center_final_java_args | java_arg_build_out }}"
 
 control_center:
   appender_log_path: /var/log/confluent/control-center/

--- a/roles/confluent.kafka_broker/defaults/main.yml
+++ b/roles/confluent.kafka_broker/defaults/main.yml
@@ -18,7 +18,7 @@ kafka_broker_service_overrides:
   Group: "{{ kafka_broker_group if kafka_broker_group != kafka_broker_default_group else '' }}"
 kafka_broker_service_environment_overrides:
   KAFKA_HEAP_OPTS: "-Xmx1g"
-  KAFKA_OPTS: "{{ kafka_broker_final_java_args | reject('equalto', '') | join(' ') }}"
+  KAFKA_OPTS: "{{ kafka_broker_final_java_args | java_arg_build_out }}"
 
 kafka_broker_sysctl:
   vm.swappiness: 1

--- a/roles/confluent.kafka_connect/defaults/main.yml
+++ b/roles/confluent.kafka_connect/defaults/main.yml
@@ -15,7 +15,7 @@ kafka_connect_service_overrides:
   Group: "{{ kafka_connect_group if kafka_connect_group != kafka_connect_default_group else '' }}"
 kafka_connect_service_environment_overrides:
   KAFKA_HEAP_OPTS: "-Xms256M -Xmx2G"
-  KAFKA_OPTS: "{{ kafka_connect_final_java_args | reject('equalto', '') | join(' ') }}"
+  KAFKA_OPTS: "{{ kafka_connect_final_java_args | java_arg_build_out }}"
 
 kafka_connect_default_internal_replication_factor: "{{ [ groups['kafka_broker'] | length, 3 ] | min }}"
 

--- a/roles/confluent.kafka_rest/defaults/main.yml
+++ b/roles/confluent.kafka_rest/defaults/main.yml
@@ -15,7 +15,7 @@ kafka_rest_service_overrides:
   Group: "{{ kafka_rest_group if kafka_rest_group != kafka_rest_default_group else '' }}"
 kafka_rest_service_environment_overrides:
   LOG_DIR: /var/log/kafka-rest
-  KAFKAREST_OPTS: "{{ kafka_rest_final_java_args | reject('equalto', '') | join(' ') }}"
+  KAFKAREST_OPTS: "{{ kafka_rest_final_java_args | java_arg_build_out }}"
 
 kafka_rest:
   appender_log_path: /var/log/rest-proxy/

--- a/roles/confluent.ksql/defaults/main.yml
+++ b/roles/confluent.ksql/defaults/main.yml
@@ -18,7 +18,7 @@ ksql_service_overrides:
   Group: "{{ ksql_group if ksql_group != ksql_default_group else '' }}"
 ksql_service_environment_overrides:
   KSQL_HEAP_OPTS: "-Xmx3g"
-  KSQL_OPTS: "{{ ksql_final_java_args | reject('equalto', '') | join(' ') }}"
+  KSQL_OPTS: "{{ ksql_final_java_args | java_arg_build_out }}"
 
 ksql_default_internal_replication_factor: "{{ [ groups['kafka_broker'] | length, 3 ] | min }}"
 

--- a/roles/confluent.schema_registry/defaults/main.yml
+++ b/roles/confluent.schema_registry/defaults/main.yml
@@ -15,7 +15,7 @@ schema_registry_service_overrides:
   Group: "{{ schema_registry_group if schema_registry_group != schema_registry_default_group else '' }}"
 schema_registry_service_environment_overrides:
   SCHEMA_REGISTRY_HEAP_OPTS: "-Xmx1000M"
-  SCHEMA_REGISTRY_OPTS: "{{ schema_registry_final_java_args | reject('equalto', '') | join(' ') }}"
+  SCHEMA_REGISTRY_OPTS: "{{ schema_registry_final_java_args | java_arg_build_out }}"
 
 schema_registry:
   appender_log_path: /var/log/confluent/schema-registry/

--- a/roles/confluent.zookeeper/defaults/main.yml
+++ b/roles/confluent.zookeeper/defaults/main.yml
@@ -16,7 +16,7 @@ zookeeper_service_overrides:
   Group: "{{ zookeeper_group if zookeeper_group != zookeeper_default_group else '' }}"
 zookeeper_service_environment_overrides:
   KAFKA_HEAP_OPTS: "-Xmx1g"
-  KAFKA_OPTS: "{{ zookeeper_final_java_args | reject('equalto', '') | join(' ') }}"
+  KAFKA_OPTS: "{{ zookeeper_final_java_args | java_arg_build_out }}"
 
 zookeeper_peer_port: 2888
 zookeeper_leader_port: 3888


### PR DESCRIPTION
# Description

Equal to filter is no supported in earlier versions of ansible, rolling back small filter change

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration



**Test Configuration**:
All molecule tests must pass


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules