### PR TITLE
Making current zookeeper nodes hostname configurable & basic jenkins test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,9 +8,20 @@ def config = jobConfig {
 }
 
 def job = {
-    stage("Hello world") {
-        echo "Running unit and integration tests"
-        sh "env"
+    stage('Install Molecule and Latest Ansible') {
+        sh '''
+            sudo pip install --upgrade 'ansible==2.9.*'
+            sudo pip install molecule docker
+        '''
+    }
+
+    withDockerServer([uri: dockerHost()]) {
+        stage('Plaintext - RHEL') {
+            sh '''
+                cd roles/confluent.test
+                molecule test -s plaintext-rhel
+            '''
+        }
     }
 }
 

--- a/hosts_example.yml
+++ b/hosts_example.yml
@@ -171,6 +171,9 @@ zookeeper:
   # vars:
   #   zookeeper_user: custom-user
   #   zookeeper_group: custom-group
+  #
+  #   ## To update hostname of current zookeeper host in zookeeper.properties use below variable
+  #   zookeeper_current_node_hostname: 0.0.0.0 # some debian hosts resolve the hostname to localhost, this setting tells zookeeper to listen on all interfaces
   hosts:
     ip-172-31-34-246.us-east-2.compute.internal:
       ## By default the first host will get zookeeper id=1, second gets id=2. Set zookeeper_id to customize
@@ -290,10 +293,10 @@ kafka_connect:
   #
   ## Adding Connector Paths.
   ## NOTE: This variable is mapped to the `plugin.path` Kafka Connect property.
-  #   kafka_connect_plugins_path: 
+  #   kafka_connect_plugins_path:
   #   - /usr/share/java
   #   - /my/connectors/dir
-  # 
+  #
   ## Installing Connectors From Confluent Hub
   #   kafka_connect_confluent_hub_plugins:
   #   - jcustenborder/kafka-connect-spooldir:2.0.43

--- a/roles/confluent.zookeeper/defaults/main.yml
+++ b/roles/confluent.zookeeper/defaults/main.yml
@@ -22,6 +22,8 @@ zookeeper_service_environment_overrides:
   KAFKA_HEAP_OPTS: "-Xmx1g"
   KAFKA_OPTS: "{{ zookeeper_final_java_args | java_arg_build_out }}"
 
+# In zookeeper.properties, current node's hostname will be 0.0.0.0, meaning zookeeper listens on all interfaces
+zookeeper_current_node_hostname: 0.0.0.0
 zookeeper_peer_port: 2888
 zookeeper_leader_port: 3888
 

--- a/roles/confluent.zookeeper/defaults/main.yml
+++ b/roles/confluent.zookeeper/defaults/main.yml
@@ -22,8 +22,7 @@ zookeeper_service_environment_overrides:
   KAFKA_HEAP_OPTS: "-Xmx1g"
   KAFKA_OPTS: "{{ zookeeper_final_java_args | java_arg_build_out }}"
 
-# In zookeeper.properties, current node's hostname will be 0.0.0.0, meaning zookeeper listens on all interfaces
-zookeeper_current_node_hostname: 0.0.0.0
+zookeeper_current_node_hostname: "{{ inventory_hostname }}"
 zookeeper_peer_port: 2888
 zookeeper_leader_port: 3888
 

--- a/roles/confluent.zookeeper/templates/zookeeper.properties.j2
+++ b/roles/confluent.zookeeper/templates/zookeeper.properties.j2
@@ -3,5 +3,5 @@
 {{key}}={{value}}
 {% endfor %}
 {% for host in groups['zookeeper'] %}
-server.{{ hostvars[host]['zookeeper_id'] | default(groups.zookeeper.index(host) + 1)}}={{ host }}:{{zookeeper_peer_port}}:{{zookeeper_leader_port}}
+server.{{ hostvars[host]['zookeeper_id'] | default(groups.zookeeper.index(host) + 1)}}={{ zookeeper_current_node_hostname if host == inventory_hostname else host }}:{{zookeeper_peer_port}}:{{zookeeper_leader_port}}
 {% endfor %}


### PR DESCRIPTION
# Description

This change makes the current zk node's hostname configurable
This means zk is listening on all interfaces, there were /etc/hosts issues on some debian vms, they should set to 0.0.0.0

Also updating the jenkinsfile to run molecule test

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration



**Test Configuration**:
Tested with a 55 molecule scenario, everything came up


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules