### PR TITLE
Improvements on Zk kerberos

### DIFF
--- a/hosts_example.yml
+++ b/hosts_example.yml
@@ -22,6 +22,10 @@ all:
     ## For SASL/GSSAPI uncomment this line and see Kerberos Configuration properties below
     # sasl_protocol: kerberos
 
+    #### Zookeeper SASL Authentication ####
+    ## By default when sasl_protocol = kerberos, zookeeper will also use sasl kerberos. It can also be configured with:
+    # zookeeper_sasl_protocol: <none/kerberos>
+
     #### Kerberos Configuration ####
     ## Applicable when sasl_protocol is kerberos
     # kerberos_kafka_broker_primary: <Name of the primary set on the kafka brokers' principal eg. kafka>

--- a/roles/confluent.kafka_broker/defaults/main.yml
+++ b/roles/confluent.kafka_broker/defaults/main.yml
@@ -2,7 +2,7 @@
 kafka_broker_custom_log4j: true
 
 kafka_broker_java_args:
-  - "{% if 'GSSAPI' in kafka_broker_sasl_enabled_mechanisms %}-Djava.security.auth.login.config={{kafka_broker.jaas_file}}{% endif %}"
+  - "{% if 'GSSAPI' in kafka_broker_sasl_enabled_mechanisms or zookeeper_sasl_protocol == 'kerberos' %}-Djava.security.auth.login.config={{kafka_broker.jaas_file}}{% endif %}"
   - "{% if kafka_broker_jolokia_enabled|bool %}-javaagent:{{jolokia_jar_path}}=port={{kafka_broker_jolokia_port}},host=0.0.0.0{% if kafka_broker_jolokia_ssl_enabled|bool %}{{kafka_broker_jolokia_java_arg_ssl_addon}}{% endif %}{% endif %}"
   - "{% if kafka_broker_jmxexporter_enabled|bool %}-javaagent:{{jmxexporter_jar_path}}={{kafka_broker_jmxexporter_port}}:{{kafka_broker_jmxexporter_config_path}}{% endif %}"
   - "{% if schema_registry_ssl_enabled|bool %}-Djavax.net.ssl.keyStore={{kafka_broker_keystore_path}} -Djavax.net.ssl.trustStore={{kafka_broker_truststore_path}} -Djavax.net.ssl.keyStorePassword={{kafka_broker_keystore_storepass}} -Djavax.net.ssl.trustStorePassword={{kafka_broker_truststore_storepass}}{% endif %}"

--- a/roles/confluent.kafka_broker/tasks/main.yml
+++ b/roles/confluent.kafka_broker/tasks/main.yml
@@ -53,7 +53,7 @@
     kerberos_user: "{{kafka_broker_user}}"
     kerberos_keytab_path: "{{kafka_broker_kerberos_keytab_path}}"
     kerberos_handler: "Restart Kafka"
-  when: "'GSSAPI' in kafka_broker_sasl_enabled_mechanisms"
+  when: "'GSSAPI' in kafka_broker_sasl_enabled_mechanisms or zookeeper_sasl_protocol == 'kerberos'"
 
 - name: Set Permissions on /var/lib/kafka
   file:
@@ -115,7 +115,8 @@
     mode: 0640
     owner: "{{kafka_broker_user}}"
     group: "{{kafka_broker_group}}"
-  when: "'GSSAPI' in kafka_broker_sasl_enabled_mechanisms"
+  # when: "'GSSAPI' in kafka_broker_sasl_enabled_mechanisms"
+  when: "'GSSAPI' in kafka_broker_sasl_enabled_mechanisms or zookeeper_sasl_protocol == 'kerberos'"
   notify:
     - Restart Kafka
 

--- a/roles/confluent.kafka_broker/tasks/main.yml
+++ b/roles/confluent.kafka_broker/tasks/main.yml
@@ -115,7 +115,6 @@
     mode: 0640
     owner: "{{kafka_broker_user}}"
     group: "{{kafka_broker_group}}"
-  # when: "'GSSAPI' in kafka_broker_sasl_enabled_mechanisms"
   when: "'GSSAPI' in kafka_broker_sasl_enabled_mechanisms or zookeeper_sasl_protocol == 'kerberos'"
   notify:
     - Restart Kafka

--- a/roles/confluent.kafka_broker/templates/kafka_server_jaas.conf.j2
+++ b/roles/confluent.kafka_broker/templates/kafka_server_jaas.conf.j2
@@ -1,4 +1,4 @@
-// Specifies a unique keytab and principal name for each broker
+{% if zookeeper_sasl_protocol == 'kerberos' %}
 KafkaServer {
     com.sun.security.auth.module.Krb5LoginModule required
     useKeyTab=true
@@ -6,8 +6,9 @@ KafkaServer {
     keyTab="{{kerberos.keytab_dir}}/{{kafka_broker_kerberos_keytab_path | basename}}"
     principal="{{kafka_broker_kerberos_principal}}";
 };
+{% endif %}
+{% if zookeeper_sasl_protocol == 'kerberos' %}
 
-// ZooKeeper client authentication
 Client {
     com.sun.security.auth.module.Krb5LoginModule required
     useKeyTab=true
@@ -15,3 +16,4 @@ Client {
     keyTab="{{kerberos.keytab_dir}}/{{kafka_broker_kerberos_keytab_path | basename}}"
     principal="{{kafka_broker_kerberos_principal}}";
 };
+{% endif %}

--- a/roles/confluent.kafka_broker/templates/kafka_server_jaas.conf.j2
+++ b/roles/confluent.kafka_broker/templates/kafka_server_jaas.conf.j2
@@ -1,4 +1,4 @@
-{% if zookeeper_sasl_protocol == 'kerberos' %}
+{% if 'GSSAPI' in kafka_broker_sasl_enabled_mechanisms %}
 KafkaServer {
     com.sun.security.auth.module.Krb5LoginModule required
     useKeyTab=true

--- a/roles/confluent.kafka_broker/templates/server.properties.j2
+++ b/roles/confluent.kafka_broker/templates/server.properties.j2
@@ -9,6 +9,9 @@ broker.id={{ broker_id | default(groups.kafka_broker.index(inventory_hostname) +
 {{key}}={{value}}
 {% endfor %}
 
+{% if zookeeper_sasl_protocol == 'kerberos' %}
+zookeeper.set.acl=true
+{% endif %}
 {% if fips_enabled|bool %}
 enable.fips=true
 security.providers=io.confluent.kafka.security.fips.provider.BcFipsProviderCreator,io.confluent.kafka.security.fips.provider.BcFipsJsseProviderCreator

--- a/roles/confluent.test/molecule/zookeeper-kerberos/.gitignore
+++ b/roles/confluent.test/molecule/zookeeper-kerberos/.gitignore
@@ -1,0 +1,1 @@
+keytabs/

--- a/roles/confluent.test/molecule/zookeeper-kerberos/molecule.yml
+++ b/roles/confluent.test/molecule/zookeeper-kerberos/molecule.yml
@@ -127,6 +127,9 @@ provisioner:
       kafka_broker:
         kafka_broker_kerberos_principal: "{{kerberos_kafka_broker_primary}}/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
         kafka_broker_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/kafka_broker-{{inventory_hostname}}.keytab"
+
+        kafka_broker_custom_java_args: "-Dsun.security.krb5.debug=true"
+
       schema_registry:
         schema_registry_kerberos_principal: "schema_registry/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
         schema_registry_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/schema_registry-{{inventory_hostname}}.keytab"

--- a/roles/confluent.test/molecule/zookeeper-kerberos/molecule.yml
+++ b/roles/confluent.test/molecule/zookeeper-kerberos/molecule.yml
@@ -140,7 +140,6 @@ provisioner:
         keytab_output_directory: "{{scenario_name}}/keytabs"
 
         kerberos_principals:
-          # Wish there was a better way to create this list, this will do for now
           - principal: "zookeeper/zookeeper1.confluent@{{kerberos.realm | upper}}"
             keytab_path: "keytabs/zookeeper-zookeeper1.keytab"
 

--- a/roles/confluent.test/molecule/zookeeper-kerberos/molecule.yml
+++ b/roles/confluent.test/molecule/zookeeper-kerberos/molecule.yml
@@ -26,30 +26,30 @@ platforms:
     privileged: true
     networks:
       - name: confluent
-  # - name: zookeeper2
-  #   hostname: zookeeper2.confluent
-  #   groups:
-  #     - zookeeper
-  #   image: geerlingguy/docker-centos7-ansible
-  #   dockerfile: ../Dockerfile.j2
-  #   command: ""
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:ro
-  #   privileged: true
-  #   networks:
-  #     - name: confluent
-  # - name: zookeeper3
-  #   hostname: zookeeper3.confluent
-  #   groups:
-  #     - zookeeper
-  #   image: geerlingguy/docker-centos7-ansible
-  #   dockerfile: ../Dockerfile.j2
-  #   command: ""
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:ro
-  #   privileged: true
-  #   networks:
-  #     - name: confluent
+  - name: zookeeper2
+    hostname: zookeeper2.confluent
+    groups:
+      - zookeeper
+    image: geerlingguy/docker-centos7-ansible
+    dockerfile: ../Dockerfile.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    networks:
+      - name: confluent
+  - name: zookeeper3
+    hostname: zookeeper3.confluent
+    groups:
+      - zookeeper
+    image: geerlingguy/docker-centos7-ansible
+    dockerfile: ../Dockerfile.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    networks:
+      - name: confluent
   - name: kafka-broker1
     hostname: kafka-broker1.confluent
     groups:
@@ -74,18 +74,18 @@ platforms:
     privileged: true
     networks:
       - name: confluent
-  # - name: kafka-broker3
-  #   hostname: kafka-broker3.confluent
-  #   groups:
-  #     - kafka_broker
-  #   image: geerlingguy/docker-centos7-ansible
-  #   dockerfile: ../Dockerfile.j2
-  #   command: ""
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:ro
-  #   privileged: true
-  #   networks:
-  #     - name: confluent
+  - name: kafka-broker3
+    hostname: kafka-broker3.confluent
+    groups:
+      - kafka_broker
+    image: geerlingguy/docker-centos7-ansible
+    dockerfile: ../Dockerfile.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    networks:
+      - name: confluent
   - name: schema-registry1
     hostname: schema-registry1.confluent
     groups:
@@ -147,7 +147,7 @@ provisioner:
           - principal: "zookeeper/zookeeper2.confluent@{{kerberos.realm | upper}}"
             keytab_path: "keytabs/zookeeper-zookeeper2.keytab"
 
-          - principal: "zookeeper/zookeeper2.confluent@{{kerberos.realm | upper}}"
+          - principal: "zookeeper/zookeeper3.confluent@{{kerberos.realm | upper}}"
             keytab_path: "keytabs/zookeeper-zookeeper3.keytab"
 
           - principal: "{{kerberos_kafka_broker_primary}}/kafka-broker1.confluent@{{kerberos.realm | upper}}"

--- a/roles/confluent.test/molecule/zookeeper-kerberos/molecule.yml
+++ b/roles/confluent.test/molecule/zookeeper-kerberos/molecule.yml
@@ -26,30 +26,30 @@ platforms:
     privileged: true
     networks:
       - name: confluent
-  - name: zookeeper2
-    hostname: zookeeper2.confluent
-    groups:
-      - zookeeper
-    image: geerlingguy/docker-centos7-ansible
-    dockerfile: ../Dockerfile.j2
-    command: ""
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
-    networks:
-      - name: confluent
-  - name: zookeeper3
-    hostname: zookeeper3.confluent
-    groups:
-      - zookeeper
-    image: geerlingguy/docker-centos7-ansible
-    dockerfile: ../Dockerfile.j2
-    command: ""
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
-    networks:
-      - name: confluent
+  # - name: zookeeper2
+  #   hostname: zookeeper2.confluent
+  #   groups:
+  #     - zookeeper
+  #   image: geerlingguy/docker-centos7-ansible
+  #   dockerfile: ../Dockerfile.j2
+  #   command: ""
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  #   privileged: true
+  #   networks:
+  #     - name: confluent
+  # - name: zookeeper3
+  #   hostname: zookeeper3.confluent
+  #   groups:
+  #     - zookeeper
+  #   image: geerlingguy/docker-centos7-ansible
+  #   dockerfile: ../Dockerfile.j2
+  #   command: ""
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  #   privileged: true
+  #   networks:
+  #     - name: confluent
   - name: kafka-broker1
     hostname: kafka-broker1.confluent
     groups:
@@ -62,30 +62,30 @@ platforms:
     privileged: true
     networks:
       - name: confluent
-  - name: kafka-broker2
-    hostname: kafka-broker2.confluent
-    groups:
-      - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
-    dockerfile: ../Dockerfile.j2
-    command: ""
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
-    networks:
-      - name: confluent
-  - name: kafka-broker3
-    hostname: kafka-broker3.confluent
-    groups:
-      - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
-    dockerfile: ../Dockerfile.j2
-    command: ""
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
-    networks:
-      - name: confluent
+  # - name: kafka-broker2
+  #   hostname: kafka-broker2.confluent
+  #   groups:
+  #     - kafka_broker
+  #   image: geerlingguy/docker-centos7-ansible
+  #   dockerfile: ../Dockerfile.j2
+  #   command: ""
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  #   privileged: true
+  #   networks:
+  #     - name: confluent
+  # - name: kafka-broker3
+  #   hostname: kafka-broker3.confluent
+  #   groups:
+  #     - kafka_broker
+  #   image: geerlingguy/docker-centos7-ansible
+  #   dockerfile: ../Dockerfile.j2
+  #   command: ""
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  #   privileged: true
+  #   networks:
+  #     - name: confluent
   - name: schema-registry1
     hostname: schema-registry1.confluent
     groups:

--- a/roles/confluent.test/molecule/zookeeper-kerberos/molecule.yml
+++ b/roles/confluent.test/molecule/zookeeper-kerberos/molecule.yml
@@ -1,0 +1,181 @@
+---
+driver:
+  name: docker
+platforms:
+  - name: kerberos1
+    hostname: kerberos1.confluent
+    groups:
+      - kerberos_server
+    image: geerlingguy/docker-centos7-ansible
+    dockerfile: ../Dockerfile.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    networks:
+      - name: confluent
+  - name: zookeeper1
+    hostname: zookeeper1.confluent
+    groups:
+      - zookeeper
+    image: geerlingguy/docker-centos7-ansible
+    dockerfile: ../Dockerfile.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    networks:
+      - name: confluent
+  - name: zookeeper2
+    hostname: zookeeper2.confluent
+    groups:
+      - zookeeper
+    image: geerlingguy/docker-centos7-ansible
+    dockerfile: ../Dockerfile.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    networks:
+      - name: confluent
+  - name: zookeeper3
+    hostname: zookeeper3.confluent
+    groups:
+      - zookeeper
+    image: geerlingguy/docker-centos7-ansible
+    dockerfile: ../Dockerfile.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    networks:
+      - name: confluent
+  - name: kafka-broker1
+    hostname: kafka-broker1.confluent
+    groups:
+      - kafka_broker
+    image: geerlingguy/docker-centos7-ansible
+    dockerfile: ../Dockerfile.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    networks:
+      - name: confluent
+  - name: kafka-broker2
+    hostname: kafka-broker2.confluent
+    groups:
+      - kafka_broker
+    image: geerlingguy/docker-centos7-ansible
+    dockerfile: ../Dockerfile.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    networks:
+      - name: confluent
+  - name: kafka-broker3
+    hostname: kafka-broker3.confluent
+    groups:
+      - kafka_broker
+    image: geerlingguy/docker-centos7-ansible
+    dockerfile: ../Dockerfile.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    networks:
+      - name: confluent
+  - name: schema-registry1
+    hostname: schema-registry1.confluent
+    groups:
+      - schema_registry
+    image: geerlingguy/docker-centos7-ansible
+    dockerfile: ../Dockerfile.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    networks:
+      - name: confluent
+provisioner:
+  name: ansible
+  config_options:
+    defaults:
+      hash_behaviour: merge
+  playbooks:
+    prepare: ../kerberos.yml
+    converge: ../../../../all.yml
+  inventory:
+    group_vars:
+      all:
+        scenario_name: zookeeper-kerberos
+
+        zookeeper_sasl_protocol: kerberos
+        sasl_protocol: scram
+
+        kerberos_kafka_broker_primary: kafka
+        kerberos:
+          realm: realm.example.com
+          kdc_hostname: kerberos1
+          admin_hostname: kerberos1
+
+      zookeeper:
+        # Paths are relative to all.yml
+        zookeeper_kerberos_principal: "zookeeper/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
+        zookeeper_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/zookeeper-{{inventory_hostname}}.keytab"
+      kafka_broker:
+        kafka_broker_kerberos_principal: "{{kerberos_kafka_broker_primary}}/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
+        kafka_broker_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/kafka_broker-{{inventory_hostname}}.keytab"
+      schema_registry:
+        schema_registry_kerberos_principal: "schema_registry/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
+        schema_registry_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/schema_registry-{{inventory_hostname}}.keytab"
+
+      kerberos_server:
+        realm_name: "{{ kerberos.realm | upper }}"
+
+        keytab_output_directory: "{{scenario_name}}/keytabs"
+
+        kerberos_principals:
+          # Wish there was a better way to create this list, this will do for now
+          - principal: "zookeeper/zookeeper1.confluent@{{kerberos.realm | upper}}"
+            keytab_path: "keytabs/zookeeper-zookeeper1.keytab"
+
+          - principal: "zookeeper/zookeeper2.confluent@{{kerberos.realm | upper}}"
+            keytab_path: "keytabs/zookeeper-zookeeper2.keytab"
+
+          - principal: "zookeeper/zookeeper2.confluent@{{kerberos.realm | upper}}"
+            keytab_path: "keytabs/zookeeper-zookeeper3.keytab"
+
+          - principal: "{{kerberos_kafka_broker_primary}}/kafka-broker1.confluent@{{kerberos.realm | upper}}"
+            keytab_path: "keytabs/kafka_broker-kafka-broker1.keytab"
+
+          - principal: "{{kerberos_kafka_broker_primary}}/kafka-broker2.confluent@{{kerberos.realm | upper}}"
+            keytab_path: "keytabs/kafka_broker-kafka-broker2.keytab"
+
+          - principal: "{{kerberos_kafka_broker_primary}}/kafka-broker3.confluent@{{kerberos.realm | upper}}"
+            keytab_path: "keytabs/kafka_broker-kafka-broker3.keytab"
+
+          - principal: "schema_registry/schema-registry1.confluent@{{kerberos.realm | upper}}"
+            keytab_path: "keytabs/schema_registry-schema-registry1.keytab"
+
+verifier:
+  name: ansible
+lint: |
+  set -e
+  yamllint -c ../../.yamllint ../..
+scenario:
+  test_sequence:
+    - lint
+    - dependency
+    - cleanup
+    - destroy
+    - syntax
+    - create
+    - prepare
+    - converge
+    # - idempotence
+    - side_effect
+    - verify
+    - cleanup
+    - destroy

--- a/roles/confluent.test/molecule/zookeeper-kerberos/molecule.yml
+++ b/roles/confluent.test/molecule/zookeeper-kerberos/molecule.yml
@@ -62,18 +62,18 @@ platforms:
     privileged: true
     networks:
       - name: confluent
-  # - name: kafka-broker2
-  #   hostname: kafka-broker2.confluent
-  #   groups:
-  #     - kafka_broker
-  #   image: geerlingguy/docker-centos7-ansible
-  #   dockerfile: ../Dockerfile.j2
-  #   command: ""
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:ro
-  #   privileged: true
-  #   networks:
-  #     - name: confluent
+  - name: kafka-broker2
+    hostname: kafka-broker2.confluent
+    groups:
+      - kafka_broker
+    image: geerlingguy/docker-centos7-ansible
+    dockerfile: ../Dockerfile.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    networks:
+      - name: confluent
   # - name: kafka-broker3
   #   hostname: kafka-broker3.confluent
   #   groups:

--- a/roles/confluent.test/molecule/zookeeper-kerberos/verify.yml
+++ b/roles/confluent.test/molecule/zookeeper-kerberos/verify.yml
@@ -1,0 +1,72 @@
+---
+- name: Verify - kafka_broker
+  hosts: kafka_broker
+  gather_facts: false
+  tasks:
+    - import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: /etc/kafka/server.properties
+        property: sasl.enabled.mechanisms
+        expected_value: GSSAPI
+
+- name: Verify - schema_registry
+  hosts: schema_registry
+  gather_facts: false
+  tasks:
+    - import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: /etc/schema-registry/schema-registry.properties
+        property: kafkastore.security.protocol
+        expected_value: SASL_PLAINTEXT
+
+- name: Verify - kafka_connect
+  hosts: kafka_connect
+  gather_facts: false
+  tasks:
+    - import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: /etc/kafka/connect-distributed.properties
+        property: security.protocol
+        expected_value: SASL_PLAINTEXT
+
+- name: Verify - kafka_rest
+  hosts: kafka_rest
+  gather_facts: false
+  tasks:
+    - import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: /etc/kafka-rest/kafka-rest.properties
+        property: client.security.protocol
+        expected_value: SASL_PLAINTEXT
+
+- name: Verify - ksql
+  hosts: ksql
+  gather_facts: false
+  tasks:
+    - import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: /etc/ksqldb/ksql-server.properties
+        property: security.protocol
+        expected_value: SASL_PLAINTEXT
+
+- name: Verify - control_center
+  hosts: control_center
+  gather_facts: false
+  tasks:
+    - import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: /etc/confluent-control-center/control-center-production.properties
+        property: confluent.controlcenter.streams.security.protocol
+        expected_value: SASL_PLAINTEXT

--- a/roles/confluent.test/molecule/zookeeper-kerberos/verify.yml
+++ b/roles/confluent.test/molecule/zookeeper-kerberos/verify.yml
@@ -1,4 +1,16 @@
 ---
+- name: Verify - zookeeper
+  hosts: zookeeper
+  gather_facts: false
+  tasks:
+    - import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: /etc/kafka/zookeeper.properties
+        property: authProvider.sasl
+        expected_value: org.apache.zookeeper.server.auth.SASLAuthenticationProvider
+
 - name: Verify - kafka_broker
   hosts: kafka_broker
   gather_facts: false
@@ -9,7 +21,7 @@
       vars:
         file_path: /etc/kafka/server.properties
         property: sasl.enabled.mechanisms
-        expected_value: GSSAPI
+        expected_value: SCRAM-SHA-256
 
 - name: Verify - schema_registry
   hosts: schema_registry
@@ -21,52 +33,4 @@
       vars:
         file_path: /etc/schema-registry/schema-registry.properties
         property: kafkastore.security.protocol
-        expected_value: SASL_PLAINTEXT
-
-- name: Verify - kafka_connect
-  hosts: kafka_connect
-  gather_facts: false
-  tasks:
-    - import_role:
-        name: confluent.test
-        tasks_from: check_property.yml
-      vars:
-        file_path: /etc/kafka/connect-distributed.properties
-        property: security.protocol
-        expected_value: SASL_PLAINTEXT
-
-- name: Verify - kafka_rest
-  hosts: kafka_rest
-  gather_facts: false
-  tasks:
-    - import_role:
-        name: confluent.test
-        tasks_from: check_property.yml
-      vars:
-        file_path: /etc/kafka-rest/kafka-rest.properties
-        property: client.security.protocol
-        expected_value: SASL_PLAINTEXT
-
-- name: Verify - ksql
-  hosts: ksql
-  gather_facts: false
-  tasks:
-    - import_role:
-        name: confluent.test
-        tasks_from: check_property.yml
-      vars:
-        file_path: /etc/ksqldb/ksql-server.properties
-        property: security.protocol
-        expected_value: SASL_PLAINTEXT
-
-- name: Verify - control_center
-  hosts: control_center
-  gather_facts: false
-  tasks:
-    - import_role:
-        name: confluent.test
-        tasks_from: check_property.yml
-      vars:
-        file_path: /etc/confluent-control-center/control-center-production.properties
-        property: confluent.controlcenter.streams.security.protocol
         expected_value: SASL_PLAINTEXT

--- a/roles/confluent.variables_handlers/defaults/main.yml
+++ b/roles/confluent.variables_handlers/defaults/main.yml
@@ -66,6 +66,8 @@ zookeeper:
   log4j_file: /etc/kafka/zookeeper_log4j.properties
   jaas_file: /etc/kafka/zookeeper_jaas.conf
 
+zookeeper_sasl_protocol: "{{sasl_protocol if sasl_protocol == 'kerberos' else 'none'}}"
+
 zookeeper_jolokia_enabled: "{{jolokia_enabled}}"
 zookeeper_jolokia_port: 7770
 

--- a/roles/confluent.zookeeper/defaults/main.yml
+++ b/roles/confluent.zookeeper/defaults/main.yml
@@ -2,7 +2,7 @@
 zookeeper_custom_log4j: "{{ custom_log4j }}"
 
 zookeeper_java_args:
-  - "{% if 'GSSAPI' in kafka_broker_sasl_enabled_mechanisms %}-Djava.security.auth.login.config={{zookeeper.jaas_file}}{% endif %}"
+  - "{% if zookeeper_sasl_protocol == 'kerberos' %}-Djava.security.auth.login.config={{zookeeper.jaas_file}}{% endif %}"
   - "{% if zookeeper_jolokia_enabled|bool %}-javaagent:{{jolokia_jar_path}}=port={{zookeeper_jolokia_port}},host=0.0.0.0{% endif %}"
   - "{% if zookeeper_custom_log4j|bool %}-Dlog4j.configuration=file:{{zookeeper.log4j_file}}{% endif %}"
   - "{% if zookeeper_jmxexporter_enabled|bool %}-javaagent:{{jmxexporter_jar_path}}={{zookeeper_jmxexporter_port}}:{{zookeeper_jmxexporter_config_path}}{% endif %}"

--- a/roles/confluent.zookeeper/tasks/main.yml
+++ b/roles/confluent.zookeeper/tasks/main.yml
@@ -36,7 +36,8 @@
     kerberos_user: "{{zookeeper_user}}"
     kerberos_keytab_path: "{{zookeeper_kerberos_keytab_path}}"
     kerberos_handler: "restart zookeeper"
-  when: "'GSSAPI' in kafka_broker_sasl_enabled_mechanisms"
+  when: zookeeper_sasl_protocol == 'kerberos'
+  # when: "'GSSAPI' in kafka_broker_sasl_enabled_mechanisms"
 
 - name: Set Zookeeper dataDir ownership
   file:
@@ -97,7 +98,8 @@
     mode: 0640
     owner: "{{zookeeper_user}}"
     group: "{{zookeeper_group}}"
-  when: "'GSSAPI' in kafka_broker_sasl_enabled_mechanisms"
+  # when: "'GSSAPI' in kafka_broker_sasl_enabled_mechanisms"
+  when: zookeeper_sasl_protocol == 'kerberos'
   notify:
     - restart zookeeper
 

--- a/roles/confluent.zookeeper/tasks/main.yml
+++ b/roles/confluent.zookeeper/tasks/main.yml
@@ -37,7 +37,6 @@
     kerberos_keytab_path: "{{zookeeper_kerberos_keytab_path}}"
     kerberos_handler: "restart zookeeper"
   when: zookeeper_sasl_protocol == 'kerberos'
-  # when: "'GSSAPI' in kafka_broker_sasl_enabled_mechanisms"
 
 - name: Set Zookeeper dataDir ownership
   file:
@@ -98,7 +97,6 @@
     mode: 0640
     owner: "{{zookeeper_user}}"
     group: "{{zookeeper_group}}"
-  # when: "'GSSAPI' in kafka_broker_sasl_enabled_mechanisms"
   when: zookeeper_sasl_protocol == 'kerberos'
   notify:
     - restart zookeeper

--- a/roles/confluent.zookeeper/templates/zookeeper.properties.j2
+++ b/roles/confluent.zookeeper/templates/zookeeper.properties.j2
@@ -2,6 +2,9 @@
 {% for key, value in zookeeper.properties.items() %}
 {{key}}={{value}}
 {% endfor %}
+{% if zookeeper_sasl_protocol == 'kerberos' %}
+authProvider.sasl=org.apache.zookeeper.server.auth.SASLAuthenticationProvider
+{% endif %}
 {% for host in groups['zookeeper'] %}
 server.{{ hostvars[host]['zookeeper_id'] | default(groups.zookeeper.index(host) + 1)}}={{ host }}:{{zookeeper_peer_port}}:{{zookeeper_leader_port}}
 {% endfor %}

--- a/roles/confluent.zookeeper/templates/zookeeper.properties.j2
+++ b/roles/confluent.zookeeper/templates/zookeeper.properties.j2
@@ -4,6 +4,8 @@
 {% endfor %}
 {% if zookeeper_sasl_protocol == 'kerberos' %}
 authProvider.sasl=org.apache.zookeeper.server.auth.SASLAuthenticationProvider
+kerberos.removeHostFromPrincipal=true
+kerberos.removeRealmFromPrincipal=true
 {% endif %}
 {% for host in groups['zookeeper'] %}
 server.{{ hostvars[host]['zookeeper_id'] | default(groups.zookeeper.index(host) + 1)}}={{ host }}:{{zookeeper_peer_port}}:{{zookeeper_leader_port}}


### PR DESCRIPTION
# Description

Now you can configure sasl gssapi on zookeeper independent of the kafka listeners
Should pave the way for sasl digest md5

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Created a new molecule scenario, that does zookeeper sasl protocol = kerberos and kafka just has scram, this validate the user creation not impacted

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules