### PR TITLE
Removed docs that say 0.0.0.0 for zk hostname works

### DIFF
--- a/hosts_example.yml
+++ b/hosts_example.yml
@@ -219,9 +219,6 @@ zookeeper:
   # vars:
   #   zookeeper_user: custom-user
   #   zookeeper_group: custom-group
-  #
-  #   ## To update hostname of current zookeeper host in zookeeper.properties use below variable
-  #   zookeeper_current_node_hostname: 0.0.0.0 # some debian hosts resolve the hostname to localhost, this setting tells zookeeper to listen on all interfaces
   hosts:
     ip-172-31-34-246.us-east-2.compute.internal:
       ## By default the first host will get zookeeper id=1, second gets id=2. Set zookeeper_id to customize


### PR DESCRIPTION
# Description

Known bug around zk restarts when current hostname set to 0.0.0.0
https://github.com/apache/zookeeper/pull/1254

This pr removes that documentation

Default of zookeeper_current_hostname is inventory_hostname so out of the box cp-ansible installs zk fine.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration



**Test Configuration**:


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules