### PR TITLE
KSQL/RP missing monitoring interceptors properties

### DIFF
--- a/roles/confluent.kafka_rest/defaults/main.yml
+++ b/roles/confluent.kafka_rest/defaults/main.yml
@@ -26,3 +26,5 @@ kafka_rest:
   appender_log_file_size: 100MB
   properties:
     id: "{{groups.kafka_rest.index(inventory_hostname) + 1}}"
+    producer.interceptor.classes: io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor
+    consumer.interceptor.classes: io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor

--- a/roles/confluent.kafka_rest/templates/kafka-rest.properties.j2
+++ b/roles/confluent.kafka_rest/templates/kafka-rest.properties.j2
@@ -64,3 +64,36 @@ schema.registry.ssl.keystore.password={{kafka_rest_keystore_storepass}}
 schema.registry.ssl.key.password={{kafka_rest_keystore_keypass}}
 {% endif %}
 {% endif %}
+
+# Monitoring Configuration
+confluent.monitoring.interceptor.bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ host }}:{{kafka_broker_listeners[kafka_rest_kafka_listener_name]['port']}}{% endfor %}
+
+confluent.monitoring.interceptor.security.protocol={{kafka_broker_listeners[kafka_rest_kafka_listener_name] | kafka_protocol_defaults(sasl_protocol, ssl_enabled) }}
+{% if kafka_broker_listeners[kafka_rest_kafka_listener_name]['ssl_enabled'] | default(ssl_enabled) | bool %}
+confluent.monitoring.interceptor.ssl.truststore.location={{kafka_rest_truststore_path}}
+confluent.monitoring.interceptor.ssl.truststore.password={{kafka_rest_truststore_storepass}}
+{% if kafka_broker_listeners[kafka_rest_kafka_listener_name]['ssl_mutual_auth_enabled'] | default(ssl_mutual_auth_enabled) | bool %}
+confluent.monitoring.interceptor.ssl.keystore.location={{kafka_rest_keystore_path}}
+confluent.monitoring.interceptor.ssl.keystore.password={{kafka_rest_keystore_storepass}}
+confluent.monitoring.interceptor.ssl.key.password={{kafka_rest_keystore_keypass}}
+{% endif %}
+{% endif %}
+{% if kafka_broker_listeners[kafka_rest_kafka_listener_name]['sasl_protocol'] | default(sasl_protocol) | normalize_sasl_protocol == 'PLAIN' %}
+confluent.monitoring.interceptor.sasl.mechanism=PLAIN
+confluent.monitoring.interceptor.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required \
+   username="{{sasl_plain_users.kafka_rest.principal}}" password="{{sasl_plain_users.kafka_rest.password}}";
+{% endif %}
+{% if kafka_broker_listeners[kafka_rest_kafka_listener_name]['sasl_protocol'] | default(sasl_protocol) | normalize_sasl_protocol == 'GSSAPI' %}
+confluent.monitoring.interceptor.sasl.mechanism=GSSAPI
+confluent.monitoring.interceptor.sasl.kerberos.service.name={{kerberos_kafka_broker_primary}}
+confluent.monitoring.interceptor.sasl.jaas.config=com.sun.security.auth.module.Krb5LoginModule required \
+   useKeyTab=true \
+   storeKey=true \
+   keyTab="{{kerberos.keytab_dir}}/{{kafka_rest_kerberos_keytab_path | basename}}" \
+   principal="{{kafka_rest_kerberos_principal}}";
+{% endif %}
+{% if kafka_broker_listeners[kafka_rest_kafka_listener_name]['sasl_protocol'] | default(sasl_protocol) | normalize_sasl_protocol == 'SCRAM-SHA-256' %}
+confluent.monitoring.interceptor.sasl.mechanism=SCRAM-SHA-256
+confluent.monitoring.interceptor.sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required \
+   username="{{sasl_scram_users.kafka_rest.principal}}" password="{{sasl_scram_users.kafka_rest.password}}";
+{% endif %}

--- a/roles/confluent.ksql/defaults/main.yml
+++ b/roles/confluent.ksql/defaults/main.yml
@@ -48,3 +48,5 @@ ksql:
     ksql.streams.num.standby.replicas: 1
     ksql.streams.producer.delivery.timeout.ms: 2147483647
     ksql.streams.producer.max.block.ms: 9223372036854775807
+    producer.interceptor.classes: io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor
+    consumer.interceptor.classes: io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor

--- a/roles/confluent.ksql/templates/ksql-server.properties.j2
+++ b/roles/confluent.ksql/templates/ksql-server.properties.j2
@@ -54,6 +54,8 @@ ksql.schema.registry.ssl.key.password={{ksql_keystore_keypass}}
 {% endif %}
 
 # Monitoring Configuration
+confluent.monitoring.interceptor.bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ host }}:{{kafka_broker_listeners[ksql_kafka_listener_name]['port']}}{% endfor %}
+
 confluent.monitoring.interceptor.security.protocol={{kafka_broker_listeners[ksql_kafka_listener_name] | kafka_protocol_defaults(sasl_protocol, ssl_enabled) }}
 {% if kafka_broker_listeners[ksql_kafka_listener_name]['ssl_enabled'] | default(ssl_enabled) | bool %}
 confluent.monitoring.interceptor.ssl.truststore.location={{ksql_truststore_path}}

--- a/roles/confluent.variables_handlers/vars/main.yml
+++ b/roles/confluent.variables_handlers/vars/main.yml
@@ -93,6 +93,9 @@ kafka_rest_packages:
   - "{{ kafka_broker_main_package }}"
   - confluent-kafka-rest
   - confluent-security
+  - confluent-rebalancer
+  - confluent-control-center-fe
+  - confluent-control-center
 kafka_rest_default_user: cp-kafka-rest
 kafka_rest_default_group: confluent
 kafka_rest:

--- a/roles/confluent.variables_handlers/vars/main.yml
+++ b/roles/confluent.variables_handlers/vars/main.yml
@@ -75,6 +75,9 @@ ksql_packages:
   - "{{ kafka_broker_main_package }}"
   - confluent-ksql
   - confluent-security
+  - confluent-rebalancer
+  - confluent-control-center-fe
+  - confluent-control-center
 ksql_default_user: cp-ksql
 ksql_default_group: confluent
 ksql:


### PR DESCRIPTION
# Description

KSQL and RP are missing monitoring interceptors properties: https://docs.confluent.io/5.4.1/control-center/installation/clients.html#ksql

Need to make sure the c3 packages are installed on host to get the interceptors jars

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration



**Test Configuration**:


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules