### PR TITLE
RBAC MDS Rest URL default configuration

### DIFF
--- a/hosts_example.yml
+++ b/hosts_example.yml
@@ -185,7 +185,6 @@ all:
     # token_services_private_pem_file: /path/to/tokenKeypair.pem
     # mds_acls_enabled: false #to turn off mds based acls, they are on by default if rbac is on
     # mds_ssl_enabled: true/false #defaults to whatever ssl_enabled var is set to
-    # mds_ssl_mutual_auth_enabled: true/false #defaults to false, uncomment and set to true for MTLS.
     ## Allow the playbooks to configure additional users as system admins on the platform, set the list below
     # rbac_component_additional_system_admins:
     #   - user1

--- a/hosts_example.yml
+++ b/hosts_example.yml
@@ -185,7 +185,7 @@ all:
     # token_services_private_pem_file: /path/to/tokenKeypair.pem
     # mds_acls_enabled: false #to turn off mds based acls, they are on by default if rbac is on
     # mds_ssl_enabled: true/false #defaults to whatever ssl_enabled var is set to
-    # mds_ssl_mutual_auth_enabled: true/false #defaults to whatever ssl_mutual_auth_enabled var is set to
+    # mds_ssl_mutual_auth_enabled: true/false #defaults to false, uncomment and set to true for MTLS.
     ## Allow the playbooks to configure additional users as system admins on the platform, set the list below
     # rbac_component_additional_system_admins:
     #   - user1

--- a/roles/confluent.variables_handlers/defaults/main.yml
+++ b/roles/confluent.variables_handlers/defaults/main.yml
@@ -313,7 +313,7 @@ rbac_enabled_public_pem_path: /var/ssl/private/public.pem
 rbac_enabled_private_pem_path: /var/ssl/private/tokenKeypair.pem
 
 mds_ssl_enabled: "{{ssl_enabled}}"
-mds_ssl_mutual_auth_enabled: "{{ssl_mutual_auth_enabled}}"
+mds_ssl_mutual_auth_enabled: "false"
 mds_http_protocol: "{{ 'https' if mds_ssl_enabled|bool else 'http' }}"
 mds_port: 8090
 

--- a/roles/confluent.variables_handlers/defaults/main.yml
+++ b/roles/confluent.variables_handlers/defaults/main.yml
@@ -313,7 +313,6 @@ rbac_enabled_public_pem_path: /var/ssl/private/public.pem
 rbac_enabled_private_pem_path: /var/ssl/private/tokenKeypair.pem
 
 mds_ssl_enabled: "{{ssl_enabled}}"
-mds_ssl_mutual_auth_enabled: false
 mds_http_protocol: "{{ 'https' if mds_ssl_enabled|bool else 'http' }}"
 mds_port: 8090
 

--- a/roles/confluent.variables_handlers/defaults/main.yml
+++ b/roles/confluent.variables_handlers/defaults/main.yml
@@ -313,7 +313,7 @@ rbac_enabled_public_pem_path: /var/ssl/private/public.pem
 rbac_enabled_private_pem_path: /var/ssl/private/tokenKeypair.pem
 
 mds_ssl_enabled: "{{ssl_enabled}}"
-mds_ssl_mutual_auth_enabled: "false"
+mds_ssl_mutual_auth_enabled: false
 mds_http_protocol: "{{ 'https' if mds_ssl_enabled|bool else 'http' }}"
 mds_port: 8090
 

--- a/roles/confluent.variables_handlers/vars/main.yml
+++ b/roles/confluent.variables_handlers/vars/main.yml
@@ -120,5 +120,5 @@ control_center:
   systemd_file: /usr/lib/systemd/system/{{control_center_service_name}}.service
   systemd_override: /etc/systemd/system/{{control_center_service_name}}.service.d/override.conf
 
-# Prevents setting MTLS to true on MDS Rest Listener.
+# Prevents setting MTLS to true on MDS Rest Listener, as this feature is currently unsupported by Confluent CLI.
 mds_ssl_mutual_auth_enabled: false

--- a/roles/confluent.variables_handlers/vars/main.yml
+++ b/roles/confluent.variables_handlers/vars/main.yml
@@ -119,3 +119,6 @@ control_center:
   config_file: /etc/confluent-control-center/control-center-production.properties
   systemd_file: /usr/lib/systemd/system/{{control_center_service_name}}.service
   systemd_override: /etc/systemd/system/{{control_center_service_name}}.service.d/override.conf
+
+# Prevents setting MTLS to true on MDS Rest Listener.
+mds_ssl_mutual_auth_enabled: false


### PR DESCRIPTION
# Description

Defaulted MTLS on the RBAC Rest listener to false, as CLI does not support MTLS currently.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Ran molecule scenario rbac-mtls-rhel and confirmed that all rbac bindings were created successfully.

**Test Configuration**:

molecule --debug converge -s rbac-mtls-rhel|tee test1.txt

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules