### PR TITLE
fips related properties for ZK TLS setup

### DIFF
--- a/roles/confluent.kafka_broker/templates/server.properties.j2
+++ b/roles/confluent.kafka_broker/templates/server.properties.j2
@@ -45,9 +45,17 @@ zookeeper.ssl.client.enable=true
 zookeeper.clientCnxnSocket=org.apache.zookeeper.ClientCnxnSocketNetty
 zookeeper.ssl.truststore.location={{kafka_broker_truststore_path}}
 zookeeper.ssl.truststore.password={{kafka_broker_truststore_storepass}}
+{% if fips_enabled | bool %}
+zookeeper.ssl.trustmanager.algorithm=PKIX
+zookeeper.ssl.truststore.type=pkcs12
+{% endif %}
 {% if zookeeper_ssl_mutual_auth_enabled | bool %}
 zookeeper.ssl.keystore.location={{kafka_broker_keystore_path}}
 zookeeper.ssl.keystore.password={{kafka_broker_keystore_storepass}}
+{% if fips_enabled | bool %}
+zookeeper.ssl.keymanager.algorithm=PKIX
+zookeeper.ssl.keystore.type=pkcs12
+{% endif %}
 {% endif %}
 {% endif %}
 {% if zookeeper_sasl_protocol in ['kerberos', 'digest'] %}


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)
When installing with ZK TL and fips mode the key/trust stores should be pkcs12 with additional properties configured to reflect that. Not sure if this is a bug as additional broker properties fix that too, but this adds automated install just like it is done for other components in fips mode.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Installed with mTLS and fips mode, everything looks ok

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration



**Test Configuration**:

ZK in mTLS mode

    zookeeper_ssl_enabled: true
    zookeeper_ssl_mutual_auth_enabled: true

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules