### PR TITLE
Removed deprecated property related to RBAC configuration.

### DIFF
--- a/roles/confluent.kafka_broker/templates/server.properties.j2
+++ b/roles/confluent.kafka_broker/templates/server.properties.j2
@@ -125,7 +125,6 @@ confluent.metadata.server.ssl.client.auth=true
 authorizer.class.name=io.confluent.kafka.security.authorizer.ConfluentServerAuthorizer
 confluent.authorizer.access.rule.providers=CONFLUENT{% if mds_acls_enabled|bool %},ZK_ACL{% endif %}
 
-confluent.authorizer.group.provider=CONFLUENT
 super.users={{super_users | join(';')}}
 
 # LDAP Configuration


### PR DESCRIPTION
# Description

As per internal discussions with the security team, the following property is deprecated and no longer used by the Confluent RBAC implementation:

confluent.authorizer.group.provider=CONFLUENT

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

This has been tested using the following molecule scenarios:

rbac-kerberos-debian
rbac-mtls-rhel


**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules