### PR TITLE
fix duplicating log4j java arg

### DIFF
--- a/roles/confluent.control_center/defaults/main.yml
+++ b/roles/confluent.control_center/defaults/main.yml
@@ -1,8 +1,7 @@
 ---
 control_center_custom_log4j: "{{ custom_log4j }}"
 
-control_center_java_args:
-  - "{% if control_center_custom_log4j|bool %}-Dlog4j.configuration=file:{{control_center.log4j_file}}{% endif %}"
+control_center_java_args: []
 
 control_center_custom_java_args: ""
 control_center_final_java_args: "{{ control_center_java_args + [ control_center_custom_java_args ] }}"
@@ -19,6 +18,7 @@ control_center_service_environment_overrides:
   ROCKSDB_SHAREDLIB_DIR: "{{control_center_rocksdb_path}}"
   CONTROL_CENTER_HEAP_OPTS: "-Xmx6g"
   CONTROL_CENTER_OPTS: "{{ control_center_final_java_args | java_arg_build_out }}"
+  CONTROL_CENTER_LOG4J_OPTS: "{% if control_center_custom_log4j|bool %}-Dlog4j.configuration=file:{{control_center.log4j_file}}{% endif %}"
 
 control_center:
   appender_log_path: /var/log/confluent/control-center/


### PR DESCRIPTION
# Description

log4j java arg was getting written twice, this fixes that

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

All existing molecule scenarios should pass, I confirmed manually with `systemctl status confluent-control-center -l` that the process does not have duplicating log4j java arg now

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules