### PR TITLE
TLS - provided keystore format bugfix

### DIFF
--- a/hosts_example.yml
+++ b/hosts_example.yml
@@ -73,9 +73,9 @@ all:
     #### Certificate Regeneration ####
     ## When using self signed certificates, each playbook run will regenerate the CA, to turn this off, uncomment this line:
     # regenerate_ca: false
-    ## By default, if keystore/truststore files exists for a component, the playbook will not recreate them
-    ## To recreate the keystores and truststores uncomment this line:
-    # regenerate_keystore_and_truststore: true
+    ## By default, the playbook will recreate them keystores and truststores on each run,
+    ## To prevent this, uncomment this line:
+    # regenerate_keystore_and_truststore: false
 
     #### Monitoring Configuration ####
     ## Jolokia is enabled by default. The Jolokia jar gets pulled from the internet and enabled on all the components

--- a/roles/confluent.ssl/tasks/create_keystore_and_truststore.yml
+++ b/roles/confluent.ssl/tasks/create_keystore_and_truststore.yml
@@ -4,15 +4,16 @@
     path: /var/ssl/private/generation
     state: absent
 
-- name: Delete Old Keystore
+- name: Delete Old Certificate Files
   file:
-    path: "{{keystore_path}}"
+    path: "{{item}}"
     state: absent
-
-- name: Delete Old Truststore
-  file:
-    path: "{{truststore_path}}"
-    state: absent
+  loop:
+    - "{{keystore_path}}"
+    - "{{truststore_path}}"
+    - "{{ca_cert_path}}"
+    - "{{cert_path}}"
+    - "{{key_path}}"
 
 - name: Create SSL Certificate Generation Directory
   file:

--- a/roles/confluent.ssl/tasks/provided_keystore_and_truststore.yml
+++ b/roles/confluent.ssl/tasks/provided_keystore_and_truststore.yml
@@ -30,7 +30,7 @@
     keytool -noprompt -importkeystore \
       -srckeystore {{keystore_path}} \
       -srcstorepass {{keystore_storepass}} \
-      -destkeystore /var/ssl/private/{{service_name}}.p12 \
+      -destkeystore /var/ssl/private/generaion/{{service_name}}.p12 \
       -deststoretype PKCS12 \
       -deststorepass {{keystore_storepass}} \
       -destkeypass {{keystore_storepass}} {{extra_args}}
@@ -38,12 +38,12 @@
 
 - name: Export Certificate
   shell: |
-    openssl pkcs12 -in /var/ssl/private/{{service_name}}.p12 \
+    openssl pkcs12 -in /var/ssl/private/generation/{{service_name}}.p12 \
       -nokeys -out {{cert_path}} \
       -passin pass:{{keystore_storepass}}
 
 - name: Export Key
   shell: |
-    openssl pkcs12 -in /var/ssl/private/{{service_name}}.p12 \
+    openssl pkcs12 -in /var/ssl/private/generation/{{service_name}}.p12 \
       -nodes -nocerts -out {{key_path}} \
       -passin pass:{{keystore_storepass}}

--- a/roles/confluent.ssl/tasks/provided_keystore_and_truststore.yml
+++ b/roles/confluent.ssl/tasks/provided_keystore_and_truststore.yml
@@ -17,6 +17,14 @@
     src: "{{ssl_keystore_filepath}}"
     dest: "{{keystore_path}}"
 
+- set_fact:
+    extra_args: ""
+  when: not fips_enabled|bool
+
+- set_fact:
+    extra_args: "-providerpath {{fips_jar_path}} -providerclass {{fips_provider_class}}"
+  when: fips_enabled|bool
+
 - name: Convert Keystore to Pem Format
   shell: |
     keytool -noprompt -importkeystore \
@@ -25,7 +33,7 @@
       -destkeystore /var/ssl/private/{{service_name}}.p12 \
       -deststoretype PKCS12 \
       -deststorepass {{keystore_storepass}} \
-      -destkeypass {{keystore_storepass}}
+      -destkeypass {{keystore_storepass}} {{extra_args}}
   failed_when: false
 
 - name: Export Certificate

--- a/roles/confluent.ssl/tasks/provided_keystore_and_truststore.yml
+++ b/roles/confluent.ssl/tasks/provided_keystore_and_truststore.yml
@@ -17,33 +17,50 @@
     src: "{{ssl_keystore_filepath}}"
     dest: "{{keystore_path}}"
 
-- set_fact:
-    extra_args: ""
-  when: not fips_enabled|bool
+- name: Export the Cert and Key from Keystore
+  block:
+    # Assuming the keystore is already in pkcs12 format
+    - name: Export Certificate from Keystore
+      shell: |
+        openssl pkcs12 -in {{keystore_path}} \
+          -nokeys -out {{cert_path}} \
+          -passin pass:{{keystore_storepass}}
 
-- set_fact:
-    extra_args: "-providerpath {{fips_jar_path}} -providerclass {{fips_provider_class}}"
-  when: fips_enabled|bool
+    - name: Export Key from Keystore
+      shell: |
+        openssl pkcs12 -in {{keystore_path}} \
+          -nodes -nocerts -out {{key_path}} \
+          -passin pass:{{keystore_storepass}}
 
-- name: Convert Keystore to Pem Format
-  shell: |
-    keytool -noprompt -importkeystore \
-      -srckeystore {{keystore_path}} \
-      -srcstorepass {{keystore_storepass}} \
-      -destkeystore /var/ssl/private/generaion/{{service_name}}.p12 \
-      -deststoretype PKCS12 \
-      -deststorepass {{keystore_storepass}} \
-      -destkeypass {{keystore_storepass}} {{extra_args}}
-  failed_when: false
+  rescue:
+    # Failed because the keystore in jks format
+    - set_fact:
+        extra_args: ""
+      when: not fips_enabled|bool
 
-- name: Export Certificate
-  shell: |
-    openssl pkcs12 -in /var/ssl/private/generation/{{service_name}}.p12 \
-      -nokeys -out {{cert_path}} \
-      -passin pass:{{keystore_storepass}}
+    - set_fact:
+        extra_args: "-providerpath {{fips_jar_path}} -providerclass {{fips_provider_class}}"
+      when: fips_enabled|bool
 
-- name: Export Key
-  shell: |
-    openssl pkcs12 -in /var/ssl/private/generation/{{service_name}}.p12 \
-      -nodes -nocerts -out {{key_path}} \
-      -passin pass:{{keystore_storepass}}
+    - name: Convert Keystore to Pem Format
+      shell: |
+        keytool -noprompt -importkeystore \
+          -srckeystore {{keystore_path}} \
+          -srcstorepass {{keystore_storepass}} \
+          -destkeystore /var/ssl/private/generation/{{service_name}}.p12 \
+          -deststoretype PKCS12 \
+          -deststorepass {{keystore_storepass}} \
+          -destkeypass {{keystore_storepass}} {{extra_args}}
+      failed_when: false
+
+    - name: Export Certificate
+      shell: |
+        openssl pkcs12 -in /var/ssl/private/generation/{{service_name}}.p12 \
+          -nokeys -out {{cert_path}} \
+          -passin pass:{{keystore_storepass}}
+
+    - name: Export Key
+      shell: |
+        openssl pkcs12 -in /var/ssl/private/generation/{{service_name}}.p12 \
+          -nodes -nocerts -out {{key_path}} \
+          -passin pass:{{keystore_storepass}}


### PR DESCRIPTION
# Description

Fixes bug where some keystores in pkcs12 format could not be converted a new pkcs12 file on fips enabled hosts... Now there is a try catch where it first attempts cert/key exports on the keystore assuming its in pkcs12 format, and then falls back to doing the jks -p12 conversion

Also, docs bug fix


Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested with both a jks and pkcs12 keystore file, try catch worked as expected.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules