### PR TITLE
Removes cipher suites in place of java args

### DIFF
--- a/filter_plugins/filters.py
+++ b/filter_plugins/filters.py
@@ -101,7 +101,7 @@ class FilterModule(object):
     def listener_properties(self, listeners_dict, default_ssl_enabled, default_pkcs12_enabled, default_ssl_mutual_auth_enabled, default_sasl_protocol,
                             kafka_broker_truststore_path, kafka_broker_truststore_storepass, kafka_broker_keystore_path, kafka_broker_keystore_storepass, kafka_broker_keystore_keypass,
                             plain_jaas_config, keytab_path, kerberos_principal,
-                            scram_user, scram_password, oauth_pem_path, ssl_cipher_suites ):
+                            scram_user, scram_password, oauth_pem_path ):
         # For kafka broker properties: Takes listeners dictionary and outputs all properties based on the listeners' settings
         # Other inputs help fill out the properties
         final_dict = {}
@@ -112,8 +112,7 @@ class FilterModule(object):
                     'listener.name.' + listeners_dict[listener].get('name').lower() + '.ssl.truststore.password': kafka_broker_truststore_storepass,
                     'listener.name.' + listeners_dict[listener].get('name').lower() + '.ssl.keystore.location': kafka_broker_keystore_path,
                     'listener.name.' + listeners_dict[listener].get('name').lower() + '.ssl.keystore.password': kafka_broker_keystore_storepass,
-                    'listener.name.' + listeners_dict[listener].get('name').lower() + '.ssl.key.password': kafka_broker_keystore_keypass,
-                    'listener.name.' + listeners_dict[listener].get('name').lower() + '.ssl.cipher.suites': ssl_cipher_suites
+                    'listener.name.' + listeners_dict[listener].get('name').lower() + '.ssl.key.password': kafka_broker_keystore_keypass
                 })
             if listeners_dict[listener].get('pkcs12_enabled', default_pkcs12_enabled):
                 final_dict.update({
@@ -155,7 +154,7 @@ class FilterModule(object):
                             config_prefix, truststore_path, truststore_storepass, keystore_path, keystore_storepass, keystore_keypass,
                             omit_jaas_configs, sasl_plain_username, sasl_plain_password, sasl_scram_username, sasl_scram_password,
                             kerberos_kafka_broker_primary, keytab_path, kerberos_principal,
-                            oauth_username, oauth_password, mds_urls, ssl_cipher_suites):
+                            oauth_username, oauth_password, mds_urls):
         # For any kafka client's properties: Takes in a single kafka listener and output properties to connect to that listener
         # Other inputs help fill out the properties
         final_dict = {
@@ -164,8 +163,7 @@ class FilterModule(object):
         if listener_dict.get('ssl_enabled', default_ssl_enabled):
             final_dict.update({
                 config_prefix + 'ssl.truststore.location': truststore_path,
-                config_prefix + 'ssl.truststore.password': truststore_storepass,
-                config_prefix + 'ssl.cipher.suites': ssl_cipher_suites
+                config_prefix + 'ssl.truststore.password': truststore_storepass
             })
         if listener_dict.get('ssl_mutual_auth_enabled', default_ssl_mutual_auth_enabled):
             final_dict.update({
@@ -217,7 +215,7 @@ class FilterModule(object):
         return final_dict
 
     def c3_connect_properties(self, connect_group_list, groups, hostvars, ssl_enabled, http_protocol, port, default_conned_group_id,
-            truststore_path, truststore_storepass, keystore_path, keystore_storepass, keystore_keypass, ssl_cipher_suites ):
+            truststore_path, truststore_storepass, keystore_path, keystore_storepass, keystore_keypass ):
         # For c3's connect properties, inputs a list of ansible groups of connect hosts, as well as their ssl settings
         # Outputs a properties dictionary with properties necessary to connect to each connect group
         # Other inputs help fill out the properties
@@ -237,13 +235,12 @@ class FilterModule(object):
                         'confluent.controlcenter.connect.' + hostvars[groups[ansible_group][0]].get('kafka_connect_group_id', default_conned_group_id) + '.ssl.truststore.password': truststore_storepass,
                         'confluent.controlcenter.connect.' + hostvars[groups[ansible_group][0]].get('kafka_connect_group_id', default_conned_group_id) + '.ssl.keystore.location': keystore_path,
                         'confluent.controlcenter.connect.' + hostvars[groups[ansible_group][0]].get('kafka_connect_group_id', default_conned_group_id) + '.ssl.keystore.password': keystore_storepass,
-                        'confluent.controlcenter.connect.' + hostvars[groups[ansible_group][0]].get('kafka_connect_group_id', default_conned_group_id) + '.ssl.key.password': keystore_keypass,
-                        'confluent.controlcenter.connect.' + hostvars[groups[ansible_group][0]].get('kafka_connect_group_id', default_conned_group_id) + '.ssl.cipher.suites': ssl_cipher_suites
+                        'confluent.controlcenter.connect.' + hostvars[groups[ansible_group][0]].get('kafka_connect_group_id', default_conned_group_id) + '.ssl.key.password': keystore_keypass
                     })
         return final_dict
 
     def c3_ksql_properties(self, ksql_group_list, groups, hostvars, ssl_enabled, http_protocol, port,
-            truststore_path, truststore_storepass, keystore_path, keystore_storepass, keystore_keypass, ssl_cipher_suites ):
+            truststore_path, truststore_storepass, keystore_path, keystore_storepass, keystore_keypass ):
         # For c3's ksql properties, inputs a list of ansible groups of ksql hosts, as well as their ssl settings
         # Outputs a properties dictionary with properties necessary to connect to each ksql group
         # Other inputs help fill out the properties
@@ -264,6 +261,5 @@ class FilterModule(object):
                         'confluent.controlcenter.ksql.' + ansible_group + '.ssl.keystore.location': keystore_path,
                         'confluent.controlcenter.ksql.' + ansible_group + '.ssl.keystore.password': keystore_storepass,
                         'confluent.controlcenter.ksql.' + ansible_group + '.ssl.key.password': keystore_keypass,
-                        'confluent.controlcenter.ksql.' + ansible_group + '.ssl.cipher.suites': ssl_cipher_suites
                     })
         return final_dict

--- a/roles/confluent.control_center/defaults/main.yml
+++ b/roles/confluent.control_center/defaults/main.yml
@@ -3,7 +3,8 @@
 
 control_center_custom_log4j: "{{ custom_log4j }}"
 
-control_center_java_args: []
+control_center_java_args:
+  - "{% if control_center_ssl_enabled|bool %}-Djdk.tls.ephemeralDHKeySize=2048{% endif %}"
 
 control_center_custom_java_args: ""
 control_center_final_java_args: "{{ control_center_java_args + [ control_center_custom_java_args ] }}"

--- a/roles/confluent.kafka_broker/defaults/main.yml
+++ b/roles/confluent.kafka_broker/defaults/main.yml
@@ -4,6 +4,7 @@
 kafka_broker_custom_log4j: true
 
 kafka_broker_java_args:
+  - "{% if kafka_broker_listeners | ssl_required(ssl_enabled) | bool %}-Djdk.tls.ephemeralDHKeySize=2048{% endif %}"
   - "{% if 'GSSAPI' in kafka_broker_sasl_enabled_mechanisms or zookeeper_sasl_protocol in ['kerberos', 'digest'] %}-Djava.security.auth.login.config={{kafka_broker.jaas_file}}{% endif %}"
   - "{% if kafka_broker_jolokia_enabled|bool %}-javaagent:{{jolokia_jar_path}}=port={{kafka_broker_jolokia_port}},host=0.0.0.0{% if kafka_broker_jolokia_ssl_enabled|bool %}{{kafka_broker_jolokia_java_arg_ssl_addon}}{% endif %}{% endif %}"
   - "{% if kafka_broker_jmxexporter_enabled|bool %}-javaagent:{{jmxexporter_jar_path}}={{kafka_broker_jmxexporter_port}}:{{kafka_broker_jmxexporter_config_path}}{% endif %}"

--- a/roles/confluent.kafka_connect/defaults/main.yml
+++ b/roles/confluent.kafka_connect/defaults/main.yml
@@ -4,6 +4,7 @@
 kafka_connect_custom_log4j: "{{ custom_log4j }}"
 
 kafka_connect_java_args:
+  - "{% if kafka_connect_ssl_enabled|bool %}-Djdk.tls.ephemeralDHKeySize=2048{% endif %}"
   - "{% if kafka_connect_jolokia_enabled|bool %}-javaagent:{{jolokia_jar_path}}=port={{kafka_connect_jolokia_port}},host=0.0.0.0{% if kafka_connect_jolokia_ssl_enabled|bool %},keystore={{kafka_connect_keystore_path}},keystorePassword={{kafka_connect_keystore_storepass}},protocol=https{% endif %}{% endif %}"
   - "{% if kafka_connect_custom_log4j|bool %}-Dlog4j.configuration=file:{{kafka_connect.log4j_file}}{% endif %}"
 

--- a/roles/confluent.kafka_rest/defaults/main.yml
+++ b/roles/confluent.kafka_rest/defaults/main.yml
@@ -4,6 +4,7 @@
 kafka_rest_custom_log4j: "{{ custom_log4j }}"
 
 kafka_rest_java_args:
+  - "{% if kafka_rest_ssl_enabled|bool %}-Djdk.tls.ephemeralDHKeySize=2048{% endif %}"
   - "{% if kafka_rest_jolokia_enabled|bool %}-javaagent:{{jolokia_jar_path}}=port={{kafka_rest_jolokia_port}},host=0.0.0.0{% if kafka_rest_jolokia_ssl_enabled|bool %},keystore={{kafka_rest_keystore_path}},keystorePassword={{kafka_rest_keystore_storepass}},protocol=https{% endif %}{% endif %}"
   - "{% if kafka_rest_custom_log4j|bool %}-Dlog4j.configuration=file:{{kafka_rest.log4j_file}}{% endif %}"
 

--- a/roles/confluent.ksql/defaults/main.yml
+++ b/roles/confluent.ksql/defaults/main.yml
@@ -4,6 +4,7 @@
 ksql_custom_log4j: "{{ custom_log4j }}"
 
 ksql_java_args:
+  - "{% if ksql_ssl_enabled|bool %}-Djdk.tls.ephemeralDHKeySize=2048{% endif %}"
   - "{% if ksql_jolokia_enabled|bool %}-javaagent:{{jolokia_jar_path}}=port={{ksql_jolokia_port}},host=0.0.0.0{% if ksql_jolokia_ssl_enabled|bool %},keystore={{ksql_keystore_path}},keystorePassword={{ksql_keystore_storepass}},protocol=https{% endif %}{% endif %}"
   - "{% if ksql_custom_log4j|bool %}-Dlog4j.configuration=file:{{ksql.log4j_file}}{% endif %}"
 

--- a/roles/confluent.schema_registry/defaults/main.yml
+++ b/roles/confluent.schema_registry/defaults/main.yml
@@ -4,6 +4,7 @@
 schema_registry_custom_log4j: "{{ custom_log4j }}"
 
 schema_registry_java_args:
+  - "{% if schema_registry_ssl_enabled|bool %}-Djdk.tls.ephemeralDHKeySize=2048{% endif %}"
   - "{% if schema_registry_jolokia_enabled|bool %}-javaagent:{{jolokia_jar_path}}=port={{schema_registry_jolokia_port}},host=0.0.0.0{% if schema_registry_jolokia_ssl_enabled|bool %},keystore={{schema_registry_keystore_path}},keystorePassword={{schema_registry_keystore_storepass}},protocol=https{% endif %}{% endif %}"
   - "{% if schema_registry_custom_log4j|bool %}-Dlog4j.configuration=file:{{schema_registry.log4j_file}}{% endif %}"
 

--- a/roles/confluent.variables_handlers/defaults/main.yml
+++ b/roles/confluent.variables_handlers/defaults/main.yml
@@ -51,8 +51,6 @@ ssl_self_signed_ca_cert_filename: snakeoil-ca-1.crt
 ssl_self_signed_ca_key_filename: snakeoil-ca-1.key
 ssl_self_signed_ca_password: capassword123
 
-ssl_cipher_suites: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
-
 # Zookeeper Variables
 zookeeper_user: "{{zookeeper_default_user}}"
 zookeeper_group: "{{zookeeper_default_group}}"

--- a/roles/confluent.variables_handlers/vars/main.yml
+++ b/roles/confluent.variables_handlers/vars/main.yml
@@ -32,13 +32,11 @@ zookeeper_properties:
       secureClientPort: "{{zookeeper_client_port}}"
       serverCnxnFactory: org.apache.zookeeper.server.NettyServerCnxnFactory
       authProvider.x509: org.apache.zookeeper.server.auth.X509AuthenticationProvider
-      ssl.ciphersuites: "{{ssl_cipher_suites}}"
       ssl.keyStore.location: "{{zookeeper_keystore_path}}"
       ssl.keyStore.password: "{{zookeeper_keystore_storepass}}"
       ssl.trustStore.location: "{{zookeeper_truststore_path}}"
       ssl.trustStore.password: "{{zookeeper_truststore_storepass}}"
       sslQuorum: "true"
-      ssl.quorum.ciphersuites: "{{ssl_cipher_suites}}"
       ssl.quorum.keyStore.location: "{{zookeeper_keystore_path}}"
       ssl.quorum.keyStore.password: "{{zookeeper_keystore_storepass}}"
       ssl.quorum.trustStore.location: "{{zookeeper_truststore_path}}"
@@ -137,7 +135,6 @@ kafka_broker_properties:
     enabled: "{{ zookeeper_ssl_enabled }}"
     properties:
       zookeeper.ssl.client.enable: 'true'
-      zookeeper.ssl.cipher.suites: "{{ssl_cipher_suites}}"
       zookeeper.clientCnxnSocket: org.apache.zookeeper.ClientCnxnSocketNetty
       zookeeper.ssl.truststore.location: "{{kafka_broker_truststore_path}}"
       zookeeper.ssl.truststore.password: "{{kafka_broker_truststore_storepass}}"
@@ -172,7 +169,6 @@ kafka_broker_properties:
       confluent.schema.registry.ssl.keystore.location: "{{kafka_broker_keystore_path}}"
       confluent.schema.registry.ssl.keystore.password: "{{kafka_broker_keystore_storepass}}"
       confluent.schema.registry.ssl.key.password: "{{kafka_broker_keystore_keypass}}"
-      confluent.schema.registry.ssl.cipher.suites: "{{ssl_cipher_suites}}"
   rbac:
     enabled: "{{ rbac_enabled }}"
     properties:
@@ -191,7 +187,6 @@ kafka_broker_properties:
   mds_ssl:
     enabled: "{{ mds_ssl_enabled }}"
     properties:
-      confluent.metadata.server.ssl.cipher.suites: "{{ssl_cipher_suites}}"
       confluent.metadata.server.ssl.keystore.location: "{{kafka_broker_keystore_path}}"
       confluent.metadata.server.ssl.keystore.password: "{{kafka_broker_keystore_storepass}}"
       confluent.metadata.server.ssl.key.password: "{{kafka_broker_keystore_keypass}}"
@@ -202,7 +197,7 @@ kafka_broker_properties:
     properties: "{{ kafka_broker_listeners | listener_properties(ssl_enabled, pkcs12_enabled, ssl_mutual_auth_enabled, sasl_protocol,
                             kafka_broker_truststore_path, kafka_broker_truststore_storepass, kafka_broker_keystore_path, kafka_broker_keystore_storepass, kafka_broker_keystore_keypass,
                             plain_jaas_config, kafka_broker_keytab_path, kafka_broker_kerberos_principal|default('kafka'),
-                            sasl_scram_users.admin.principal, sasl_scram_users.admin.password, rbac_enabled_public_pem_path, ssl_cipher_suites ) }}"
+                            sasl_scram_users.admin.principal, sasl_scram_users.admin.password, rbac_enabled_public_pem_path ) }}"
   metrics_reporter:
     enabled: "{{kafka_broker_metrics_reporter_enabled}}"
     properties:
@@ -211,12 +206,11 @@ kafka_broker_properties:
       confluent.metrics.reporter.topic.replicas: "{{kafka_broker_default_interal_replication_factor}}"
   metrics_reporter_client:
     enabled: "{{kafka_broker_metrics_reporter_enabled}}"
-    # filter expects all params to be defined, some have dummy defaults
     properties: "{{ kafka_broker_listeners[kafka_broker_inter_broker_listener_name] | client_properties(ssl_enabled, pkcs12_enabled, ssl_mutual_auth_enabled, sasl_protocol,
                             'confluent.metrics.reporter.', kafka_broker_truststore_path, kafka_broker_truststore_storepass, kafka_broker_keystore_path, kafka_broker_keystore_storepass, kafka_broker_keystore_keypass,
                             false, sasl_plain_users.admin.principal, sasl_plain_users.admin.password, sasl_scram_users.admin.principal, sasl_scram_users.admin.password,
                             kerberos_kafka_broker_primary|default('kafka'), kafka_broker_keytab_path, kafka_broker_kerberos_principal|default('kafka'),
-                            'user', 'pass', mds_urls, ssl_cipher_suites) }}"
+                            'user', 'pass', mds_urls) }}"
 
 kafka_broker_combined_properties: "{{kafka_broker_properties | combine_properties}}"
 
@@ -263,7 +257,6 @@ schema_registry_properties:
       ssl.keystore.location: "{{schema_registry_keystore_path}}"
       ssl.keystore.password: "{{schema_registry_keystore_storepass}}"
       ssl.key.password: "{{schema_registry_keystore_keypass}}"
-      ssl.cipher.suites: "{{ssl_cipher_suites}}"
   truststore:
     enabled: "{{schema_registry_ssl_mutual_auth_enabled|bool or mds_ssl_enabled|bool}}"
     properties:
@@ -279,7 +272,7 @@ schema_registry_properties:
                             'kafkastore.', schema_registry_truststore_path, schema_registry_truststore_storepass, schema_registry_keystore_path, schema_registry_keystore_storepass, schema_registry_keystore_keypass,
                             false, sasl_plain_users.schema_registry.principal, sasl_plain_users.schema_registry.password, sasl_scram_users.schema_registry.principal, sasl_scram_users.schema_registry.password,
                             kerberos_kafka_broker_primary|default('kafka'), schema_registry_keytab_path, schema_registry_kerberos_principal|default('kafka'),
-                            schema_registry_ldap_user, schema_registry_ldap_password, mds_urls, ssl_cipher_suites) }}"
+                            schema_registry_ldap_user, schema_registry_ldap_password, mds_urls) }}"
   rbac:
     enabled: "{{rbac_enabled}}"
     properties:
@@ -362,7 +355,6 @@ kafka_connect_properties:
       listeners.https.ssl.keystore.location: "{{kafka_connect_keystore_path}}"
       listeners.https.ssl.keystore.password: "{{kafka_connect_keystore_storepass}}"
       listeners.https.ssl.key.password: "{{kafka_connect_keystore_keypass}}"
-      listeners.https.ssl.cipher.suites: "{{ssl_cipher_suites}}"
   mtls:
     enabled: "{{ kafka_connect_ssl_mutual_auth_enabled }}"
     properties:
@@ -382,48 +374,46 @@ kafka_connect_properties:
       value.converter.schema.registry.ssl.keystore.location: "{{kafka_connect_keystore_path}}"
       value.converter.schema.registry.ssl.keystore.password: "{{kafka_connect_keystore_storepass}}"
       value.converter.schema.registry.ssl.key.password: "{{kafka_connect_keystore_keypass}}"
-      value.converter.schema.registry.ssl.cipher.suites: "{{ssl_cipher_suites}}"
       key.converter.schema.registry.ssl.truststore.location: "{{kafka_connect_truststore_path}}"
       key.converter.schema.registry.ssl.truststore.password: "{{kafka_connect_truststore_storepass}}"
       key.converter.schema.registry.ssl.keystore.location: "{{kafka_connect_keystore_path}}"
       key.converter.schema.registry.ssl.keystore.password: "{{kafka_connect_keystore_storepass}}"
       key.converter.schema.registry.ssl.key.password: "{{kafka_connect_keystore_keypass}}"
-      key.converter.schema.registry.ssl.cipher.suites: "{{ssl_cipher_suites}}"
   kafka_client:
     enabled: true
     properties: "{{ kafka_broker_listeners[kafka_connect_kafka_listener_name] | client_properties(ssl_enabled, pkcs12_enabled, ssl_mutual_auth_enabled, sasl_protocol,
                             '', kafka_connect_truststore_path, kafka_connect_truststore_storepass, kafka_connect_keystore_path, kafka_connect_keystore_storepass, kafka_connect_keystore_keypass,
                             false, sasl_plain_users.kafka_connect.principal, sasl_plain_users.kafka_connect.password, sasl_scram_users.kafka_connect.principal, sasl_scram_users.kafka_connect.password,
                             kerberos_kafka_broker_primary|default('kafka'), kafka_connect_keytab_path, kafka_connect_kerberos_principal|default('kafka'),
-                            kafka_connect_ldap_user, kafka_connect_ldap_password, mds_urls, ssl_cipher_suites) }}"
+                            kafka_connect_ldap_user, kafka_connect_ldap_password, mds_urls) }}"
   producer:
     enabled: true
     properties: "{{ kafka_broker_listeners[kafka_connect_kafka_listener_name] | client_properties(ssl_enabled, pkcs12_enabled, ssl_mutual_auth_enabled, sasl_protocol,
                             'producer.', kafka_connect_truststore_path, kafka_connect_truststore_storepass, kafka_connect_keystore_path, kafka_connect_keystore_storepass, kafka_connect_keystore_keypass,
                             true, sasl_plain_users.kafka_connect.principal, sasl_plain_users.kafka_connect.password, sasl_scram_users.kafka_connect.principal, sasl_scram_users.kafka_connect.password,
                             kerberos_kafka_broker_primary|default('kafka'), kafka_connect_keytab_path, kafka_connect_kerberos_principal|default('kafka'),
-                            kafka_connect_ldap_user, kafka_connect_ldap_password, mds_urls, ssl_cipher_suites) }}"
+                            kafka_connect_ldap_user, kafka_connect_ldap_password, mds_urls) }}"
   consumer:
     enabled: true
     properties: "{{ kafka_broker_listeners[kafka_connect_kafka_listener_name] | client_properties(ssl_enabled, pkcs12_enabled, ssl_mutual_auth_enabled, sasl_protocol,
                             'consumer.', kafka_connect_truststore_path, kafka_connect_truststore_storepass, kafka_connect_keystore_path, kafka_connect_keystore_storepass, kafka_connect_keystore_keypass,
                             true, sasl_plain_users.kafka_connect.principal, sasl_plain_users.kafka_connect.password, sasl_scram_users.kafka_connect.principal, sasl_scram_users.kafka_connect.password,
                             kerberos_kafka_broker_primary|default('kafka'), kafka_connect_keytab_path, kafka_connect_kerberos_principal|default('kafka'),
-                            kafka_connect_ldap_user, kafka_connect_ldap_password, mds_urls, ssl_cipher_suites) }}"
+                            kafka_connect_ldap_user, kafka_connect_ldap_password, mds_urls) }}"
   producer_monitoring_interceptor:
     enabled: true
     properties: "{{ kafka_broker_listeners[kafka_connect_kafka_listener_name] | client_properties(ssl_enabled, pkcs12_enabled, ssl_mutual_auth_enabled, sasl_protocol,
                             'producer.confluent.monitoring.interceptor.', kafka_connect_truststore_path, kafka_connect_truststore_storepass, kafka_connect_keystore_path, kafka_connect_keystore_storepass, kafka_connect_keystore_keypass,
                             false, sasl_plain_users.kafka_connect.principal, sasl_plain_users.kafka_connect.password, sasl_scram_users.kafka_connect.principal, sasl_scram_users.kafka_connect.password,
                             kerberos_kafka_broker_primary|default('kafka'), kafka_connect_keytab_path, kafka_connect_kerberos_principal|default('kafka'),
-                            kafka_connect_ldap_user, kafka_connect_ldap_password, mds_urls, ssl_cipher_suites) }}"
+                            kafka_connect_ldap_user, kafka_connect_ldap_password, mds_urls) }}"
   consumer_monitoring_interceptor:
     enabled: true
     properties: "{{ kafka_broker_listeners[kafka_connect_kafka_listener_name] | client_properties(ssl_enabled, pkcs12_enabled, ssl_mutual_auth_enabled, sasl_protocol,
                             'consumer.confluent.monitoring.interceptor.', kafka_connect_truststore_path, kafka_connect_truststore_storepass, kafka_connect_keystore_path, kafka_connect_keystore_storepass, kafka_connect_keystore_keypass,
                             false, sasl_plain_users.kafka_connect.principal, sasl_plain_users.kafka_connect.password, sasl_scram_users.kafka_connect.principal, sasl_scram_users.kafka_connect.password,
                             kerberos_kafka_broker_primary|default('kafka'), kafka_connect_keytab_path, kafka_connect_kerberos_principal|default('kafka'),
-                            kafka_connect_ldap_user, kafka_connect_ldap_password, mds_urls, ssl_cipher_suites) }}"
+                            kafka_connect_ldap_user, kafka_connect_ldap_password, mds_urls) }}"
   rbac:
     enabled: "{{rbac_enabled}}"
     properties:
@@ -448,7 +438,7 @@ kafka_connect_properties:
                             'config.providers.secret.param.kafkastore.', kafka_connect_truststore_path, kafka_connect_truststore_storepass, kafka_connect_keystore_path, kafka_connect_keystore_storepass, kafka_connect_keystore_keypass,
                             false, sasl_plain_users.kafka_connect.principal, sasl_plain_users.kafka_connect.password, sasl_scram_users.kafka_connect.principal, sasl_scram_users.kafka_connect.password,
                             kerberos_kafka_broker_primary|default('kafka'), kafka_connect_keytab_path, kafka_connect_kerberos_principal|default('kafka'),
-                            kafka_connect_ldap_user, kafka_connect_ldap_password, mds_urls, ssl_cipher_suites) }}"
+                            kafka_connect_ldap_user, kafka_connect_ldap_password, mds_urls) }}"
 
 kafka_connect_combined_properties: "{{kafka_connect_properties | combine_properties}}"
 
@@ -501,7 +491,6 @@ ksql_properties:
       ssl.keystore.location: "{{ksql_keystore_path}}"
       ssl.keystore.password: "{{ksql_keystore_storepass}}"
       ssl.key.password: "{{ksql_keystore_keypass}}"
-      ssl.cipher.suites: "{{ssl_cipher_suites}}"
   mtls:
     enabled: "{{ ksql_ssl_mutual_auth_enabled }}"
     properties:
@@ -544,7 +533,6 @@ ksql_properties:
       ksql.schema.registry.ssl.keystore.location: "{{ksql_keystore_path}}"
       ksql.schema.registry.ssl.keystore.password: "{{ksql_keystore_storepass}}"
       ksql.schema.registry.ssl.key.password: "{{ksql_keystore_keypass}}"
-      ksql.schema.registry.ssl.cipher.suites: "{{ssl_cipher_suites}}"
   sr_rbac:
     enabled: "{{ 'schema_registry' in groups and rbac_enabled|bool }}"
     properties:
@@ -557,7 +545,7 @@ ksql_properties:
                             'confluent.monitoring.interceptor.', ksql_truststore_path, ksql_truststore_storepass, ksql_keystore_path, ksql_keystore_storepass, ksql_keystore_keypass,
                             false, sasl_plain_users.ksql.principal, sasl_plain_users.ksql.password, sasl_scram_users.ksql.principal, sasl_scram_users.ksql.password,
                             kerberos_kafka_broker_primary|default('kafka'), ksql_keytab_path, ksql_kerberos_principal|default('ksql'),
-                            kafka_connect_ldap_user, kafka_connect_ldap_password, mds_urls, ssl_cipher_suites) }}"
+                            kafka_connect_ldap_user, kafka_connect_ldap_password, mds_urls) }}"
   rbac:
     enabled: "{{rbac_enabled}}"
     properties:
@@ -617,7 +605,6 @@ kafka_rest_properties:
       ssl.keystore.location: "{{kafka_rest_keystore_path}}"
       ssl.keystore.password: "{{kafka_rest_keystore_storepass}}"
       ssl.key.password: "{{kafka_rest_keystore_keypass}}"
-      ssl.cipher.suites: "{{ssl_cipher_suites}}"
   truststore:
     enabled: "{{kafka_rest_ssl_mutual_auth_enabled|bool or mds_ssl_enabled|bool}}"
     properties:
@@ -633,7 +620,7 @@ kafka_rest_properties:
                             'client.', kafka_rest_truststore_path, kafka_rest_truststore_storepass, kafka_rest_keystore_path, kafka_rest_keystore_storepass, kafka_rest_keystore_keypass,
                             false, sasl_plain_users.kafka_rest.principal, sasl_plain_users.kafka_rest.password, sasl_scram_users.kafka_rest.principal, sasl_scram_users.kafka_rest.password,
                             kerberos_kafka_broker_primary|default('kafka'), kafka_rest_keytab_path, kafka_rest_kerberos_principal|default('rp'),
-                            kafka_rest_ldap_user, kafka_rest_ldap_password, mds_urls, ssl_cipher_suites) }}"
+                            kafka_rest_ldap_user, kafka_rest_ldap_password, mds_urls) }}"
   sr:
     enabled: "{{ 'schema_registry' in groups }}"
     properties:
@@ -646,7 +633,6 @@ kafka_rest_properties:
       schema.registry.ssl.keystore.location: "{{kafka_rest_keystore_path}}"
       schema.registry.ssl.keystore.password: "{{kafka_rest_keystore_storepass}}"
       schema.registry.ssl.key.password: "{{kafka_rest_keystore_keypass}}"
-      schema.registry.ssl.cipher.suites: "{{ssl_cipher_suites}}"
   monitoring_interceptor:
     # TODO interceptors only if c3 on right?
     enabled: true
@@ -654,7 +640,7 @@ kafka_rest_properties:
                             'confluent.monitoring.interceptor.', kafka_rest_truststore_path, kafka_rest_truststore_storepass, kafka_rest_keystore_path, kafka_rest_keystore_storepass, kafka_rest_keystore_keypass,
                             false, sasl_plain_users.kafka_rest.principal, sasl_plain_users.kafka_rest.password, sasl_scram_users.kafka_rest.principal, sasl_scram_users.kafka_rest.password,
                             kerberos_kafka_broker_primary|default('kafka'), kafka_rest_keytab_path, kafka_rest_kerberos_principal|default('rp'),
-                            kafka_rest_ldap_user, kafka_rest_ldap_password, mds_urls, ssl_cipher_suites) }}"
+                            kafka_rest_ldap_user, kafka_rest_ldap_password, mds_urls) }}"
   rbac:
     enabled: "{{rbac_enabled}}"
     properties:
@@ -708,7 +694,6 @@ control_center_properties:
       confluent.controlcenter.rest.ssl.keystore.location: "{{control_center_keystore_path}}"
       confluent.controlcenter.rest.ssl.keystore.password: "{{control_center_keystore_storepass}}"
       confluent.controlcenter.rest.ssl.key.password: "{{control_center_keystore_keypass}}"
-      confluent.controlcenter.rest.ssl.cipher.suites: "{{ssl_cipher_suites}}"
   mtls:
     enabled: "{{ control_center_ssl_mutual_auth_enabled }}"
     properties:
@@ -721,7 +706,7 @@ control_center_properties:
                             'confluent.controlcenter.streams.', control_center_truststore_path, control_center_truststore_storepass, control_center_keystore_path, control_center_keystore_storepass, control_center_keystore_keypass,
                             false, sasl_plain_users.control_center.principal, sasl_plain_users.control_center.password, sasl_scram_users.control_center.principal, sasl_scram_users.control_center.password,
                             kerberos_kafka_broker_primary|default('kafka'), control_center_keytab_path, control_center_kerberos_principal|default('c3'),
-                            control_center_ldap_user, control_center_ldap_password, mds_urls, ssl_cipher_suites) }}"
+                            control_center_ldap_user, control_center_ldap_password, mds_urls) }}"
   sr:
     enabled: "{{ 'schema_registry' in groups }}"
     properties:
@@ -734,7 +719,6 @@ control_center_properties:
       confluent.controlcenter.schema.registry.ssl.keystore.location: "{{control_center_keystore_path}}"
       confluent.controlcenter.schema.registry.ssl.keystore.password: "{{control_center_keystore_storepass}}"
       confluent.controlcenter.schema.registry.ssl.key.password: "{{control_center_keystore_keypass}}"
-      confluent.controlcenter.schema.registry.ssl.cipher.suites: "{{ssl_cipher_suites}}"
   sr_rbac:
     enabled: "{{ 'schema_registry' in groups and rbac_enabled|bool }}"
     properties:
@@ -744,12 +728,12 @@ control_center_properties:
     enabled: "{{ 'kafka_connect' in groups }}"
     properties: "{{ kafka_connect_cluster_ansible_group_names | default(['kafka_connect']) | c3_connect_properties(groups, hostvars, kafka_connect_ssl_enabled,
         kafka_connect_http_protocol, kafka_connect_rest_port, kafka_connect_group_id, control_center_truststore_path, control_center_truststore_storepass,
-        control_center_keystore_path, control_center_keystore_storepass, control_center_keystore_keypass, ssl_cipher_suites) }}"
+        control_center_keystore_path, control_center_keystore_storepass, control_center_keystore_keypass) }}"
   ksql:
     enabled: "{{ 'ksql' in groups }}"
     properties: "{{ ksql_cluster_ansible_group_names | default(['ksql']) | c3_ksql_properties(groups, hostvars, ksql_ssl_enabled,
         ksql_http_protocol, ksql_listener_port, control_center_truststore_path, control_center_truststore_storepass,
-        control_center_keystore_path, control_center_keystore_storepass, control_center_keystore_keypass, ssl_cipher_suites) }}"
+        control_center_keystore_path, control_center_keystore_storepass, control_center_keystore_keypass) }}"
   rbac:
     enabled: "{{rbac_enabled}}"
     properties:

--- a/roles/confluent.zookeeper/defaults/main.yml
+++ b/roles/confluent.zookeeper/defaults/main.yml
@@ -4,6 +4,7 @@
 zookeeper_custom_log4j: "{{ custom_log4j }}"
 
 zookeeper_java_args:
+  - "{% if zookeeper_ssl_enabled|bool %}-Djdk.tls.ephemeralDHKeySize=2048{% endif %}"
   - "{% if zookeeper_sasl_protocol in ['kerberos', 'digest'] %}-Djava.security.auth.login.config={{zookeeper.jaas_file}}{% endif %}"
   - "{% if zookeeper_jolokia_enabled|bool %}-javaagent:{{jolokia_jar_path}}=port={{zookeeper_jolokia_port}},host=0.0.0.0{% endif %}"
   - "{% if zookeeper_custom_log4j|bool %}-Dlog4j.configuration=file:{{zookeeper.log4j_file}}{% endif %}"


### PR DESCRIPTION
# Description

In rhel8, to resolve the "dh too small" error, one solution was to add the cipher suites ssl properties. Instead you can add a java argument that directly handles dh keys by adding this: `-Djdk.tls.ephemeralDHKeySize=2048`

https://stackoverflow.com/questions/24502672/how-to-expand-dh-key-size-to-2048-in-java-8

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Ran on the rhel8 molecule scenario, but all scenarios must still pass

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules