### PR TITLE
Enable multiple jenkins jobs to run - 53x branches

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,30 @@
+#!/usr/bin/env groovy
+
+def config = jobConfig {
+    nodeLabel = 'docker-oraclejdk8'
+    slackChannel = '#ansible-eng'
+    timeoutHours = 4
+    runMergeCheck = false
+}
+
+def job = {
+    stage('Install Molecule and Latest Ansible') {
+        sh '''
+            sudo pip install --upgrade 'ansible==2.9.*'
+            sudo pip install molecule docker
+        '''
+    }
+
+    withDockerServer([uri: dockerHost()]) {
+        stage('Plaintext Test') {
+            sh '''
+                env
+
+                cd roles/confluent.test
+                molecule test -s rbac-scram-custom-rhel
+            '''
+        }
+    }
+}
+
+runJob config, job

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,12 +16,10 @@ def job = {
     }
 
     withDockerServer([uri: dockerHost()]) {
-        stage('Plaintext Test') {
+        stage('Plaintext') {
             sh '''
-                env
-
                 cd roles/confluent.test
-                molecule test -s rbac-scram-custom-rhel
+                molecule test -s plaintext-rhel
             '''
         }
     }

--- a/roles/confluent.test/molecule/plaintext-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/plaintext-rhel/molecule.yml
@@ -2,6 +2,7 @@
 driver:
   name: docker
 platforms:
+  # Unset env vars resolve to the empty string
   - name: zookeeper1${CHANGE_ID}${BUILD_NUMBER}
     hostname: zookeeper1${CHANGE_ID}${BUILD_NUMBER}.confluent${CHANGE_ID}${BUILD_NUMBER}
     groups:

--- a/roles/confluent.test/molecule/plaintext-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/plaintext-rhel/molecule.yml
@@ -2,8 +2,8 @@
 driver:
   name: docker
 platforms:
-  - name: zookeeper1
-    hostname: zookeeper1.confluent
+  - name: zookeeper1${CHANGE_ID}
+    hostname: zookeeper1${CHANGE_ID}.confluent${CHANGE_ID}
     groups:
       - zookeeper
     image: geerlingguy/docker-centos7-ansible
@@ -12,9 +12,9 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
     networks:
-      - name: confluent
-  - name: kafka-broker1
-    hostname: kafka-broker1.confluent
+      - name: confluent${CHANGE_ID}
+  - name: kafka-broker1${CHANGE_ID}
+    hostname: kafka-broker1${CHANGE_ID}.confluent${CHANGE_ID}
     groups:
       - kafka_broker
     image: geerlingguy/docker-centos7-ansible
@@ -23,9 +23,9 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
     networks:
-      - name: confluent
-  - name: schema-registry1
-    hostname: schema-registry1.confluent
+      - name: confluent${CHANGE_ID}
+  - name: schema-registry1${CHANGE_ID}
+    hostname: schema-registry1${CHANGE_ID}.confluent${CHANGE_ID}
     groups:
       - schema_registry
     image: geerlingguy/docker-centos7-ansible
@@ -34,8 +34,9 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
     networks:
-      - name: confluent
-  - name: kafka-rest1
+      - name: confluent${CHANGE_ID}
+  - name: kafka-rest1${CHANGE_ID}
+    hostname: schema-kafka-rest1${CHANGE_ID}.confluent${CHANGE_ID}
     groups:
       - kafka_rest
     image: geerlingguy/docker-centos7-ansible
@@ -44,9 +45,9 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
     networks:
-      - name: confluent
-  - name: kafka-connect1
-    hostname: kafka-connect1.confluent
+      - name: confluent${CHANGE_ID}
+  - name: kafka-connect1${CHANGE_ID}
+    hostname: kafka-connect1${CHANGE_ID}.confluent${CHANGE_ID}
     groups:
       - kafka_connect
     image: geerlingguy/docker-centos7-ansible
@@ -55,9 +56,9 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
     networks:
-      - name: confluent
-  - name: ksql1
-    hostname: ksql1.confluent
+      - name: confluent${CHANGE_ID}
+  - name: ksql1${CHANGE_ID}
+    hostname: ksql1${CHANGE_ID}.confluent${CHANGE_ID}
     groups:
       - ksql
     image: geerlingguy/docker-centos7-ansible
@@ -66,9 +67,9 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
     networks:
-      - name: confluent
-  - name: control-center1
-    hostname: control-center1.confluent
+      - name: confluent${CHANGE_ID}
+  - name: control-center1${CHANGE_ID}
+    hostname: control-center1${CHANGE_ID}.confluent${CHANGE_ID}
     groups:
       - control_center
     image: geerlingguy/docker-centos7-ansible
@@ -79,7 +80,7 @@ platforms:
     published_ports:
       - "9021:9021"
     networks:
-      - name: confluent
+      - name: confluent${CHANGE_ID}
 provisioner:
   name: ansible
   config_options:

--- a/roles/confluent.test/molecule/plaintext-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/plaintext-rhel/molecule.yml
@@ -2,8 +2,8 @@
 driver:
   name: docker
 platforms:
-  - name: zookeeper1${CHANGE_ID}
-    hostname: zookeeper1${CHANGE_ID}.confluent${CHANGE_ID}
+  - name: zookeeper1${CHANGE_ID}${BUILD_NUMBER}
+    hostname: zookeeper1${CHANGE_ID}${BUILD_NUMBER}.confluent${CHANGE_ID}${BUILD_NUMBER}
     groups:
       - zookeeper
     image: geerlingguy/docker-centos7-ansible
@@ -12,9 +12,9 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
     networks:
-      - name: confluent${CHANGE_ID}
-  - name: kafka-broker1${CHANGE_ID}
-    hostname: kafka-broker1${CHANGE_ID}.confluent${CHANGE_ID}
+      - name: confluent${CHANGE_ID}${BUILD_NUMBER}
+  - name: kafka-broker1${CHANGE_ID}${BUILD_NUMBER}
+    hostname: kafka-broker1${CHANGE_ID}${BUILD_NUMBER}.confluent${CHANGE_ID}${BUILD_NUMBER}
     groups:
       - kafka_broker
     image: geerlingguy/docker-centos7-ansible
@@ -23,9 +23,9 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
     networks:
-      - name: confluent${CHANGE_ID}
-  - name: schema-registry1${CHANGE_ID}
-    hostname: schema-registry1${CHANGE_ID}.confluent${CHANGE_ID}
+      - name: confluent${CHANGE_ID}${BUILD_NUMBER}
+  - name: schema-registry1${CHANGE_ID}${BUILD_NUMBER}
+    hostname: schema-registry1${CHANGE_ID}${BUILD_NUMBER}.confluent${CHANGE_ID}${BUILD_NUMBER}
     groups:
       - schema_registry
     image: geerlingguy/docker-centos7-ansible
@@ -34,9 +34,9 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
     networks:
-      - name: confluent${CHANGE_ID}
-  - name: kafka-rest1${CHANGE_ID}
-    hostname: schema-kafka-rest1${CHANGE_ID}.confluent${CHANGE_ID}
+      - name: confluent${CHANGE_ID}${BUILD_NUMBER}
+  - name: kafka-rest1${CHANGE_ID}${BUILD_NUMBER}
+    hostname: schema-kafka-rest1${CHANGE_ID}${BUILD_NUMBER}.confluent${CHANGE_ID}${BUILD_NUMBER}
     groups:
       - kafka_rest
     image: geerlingguy/docker-centos7-ansible
@@ -45,9 +45,9 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
     networks:
-      - name: confluent${CHANGE_ID}
-  - name: kafka-connect1${CHANGE_ID}
-    hostname: kafka-connect1${CHANGE_ID}.confluent${CHANGE_ID}
+      - name: confluent${CHANGE_ID}${BUILD_NUMBER}
+  - name: kafka-connect1${CHANGE_ID}${BUILD_NUMBER}
+    hostname: kafka-connect1${CHANGE_ID}${BUILD_NUMBER}.confluent${CHANGE_ID}${BUILD_NUMBER}
     groups:
       - kafka_connect
     image: geerlingguy/docker-centos7-ansible
@@ -56,9 +56,9 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
     networks:
-      - name: confluent${CHANGE_ID}
-  - name: ksql1${CHANGE_ID}
-    hostname: ksql1${CHANGE_ID}.confluent${CHANGE_ID}
+      - name: confluent${CHANGE_ID}${BUILD_NUMBER}
+  - name: ksql1${CHANGE_ID}${BUILD_NUMBER}
+    hostname: ksql1${CHANGE_ID}${BUILD_NUMBER}.confluent${CHANGE_ID}${BUILD_NUMBER}
     groups:
       - ksql
     image: geerlingguy/docker-centos7-ansible
@@ -67,9 +67,9 @@ platforms:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
     networks:
-      - name: confluent${CHANGE_ID}
-  - name: control-center1${CHANGE_ID}
-    hostname: control-center1${CHANGE_ID}.confluent${CHANGE_ID}
+      - name: confluent${CHANGE_ID}${BUILD_NUMBER}
+  - name: control-center1${CHANGE_ID}${BUILD_NUMBER}
+    hostname: control-center1${CHANGE_ID}${BUILD_NUMBER}.confluent${CHANGE_ID}${BUILD_NUMBER}
     groups:
       - control_center
     image: geerlingguy/docker-centos7-ansible
@@ -80,7 +80,7 @@ platforms:
     published_ports:
       - "9021:9021"
     networks:
-      - name: confluent${CHANGE_ID}
+      - name: confluent${CHANGE_ID}${BUILD_NUMBER}
 provisioner:
   name: ansible
   config_options:


### PR DESCRIPTION
# Description

Appends the CHANGE_ID and BUILD_NUMBER env var onto to the docker network and container names

On the jenkins server, these resolve to the PR number and the jenkins build number. If the env vars are not set, then the empty string is used

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Added jenkinsfile and updated the molecule scenario it tests, which must pass

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules