### PR TITLE
Enable kafka-broker restart on reboot.

### DIFF
--- a/roles/confluent.kafka_broker/tasks/restart.yml
+++ b/roles/confluent.kafka_broker/tasks/restart.yml
@@ -4,6 +4,7 @@
     daemon_reload: true
     name: "{{kafka_broker_service_name}}"
     state: restarted
+    enabled: true
 
 - name: Wait for Under Replicated Partitions on Broker
   include_tasks: ../../tasks/wait_for_urp.yml


### PR DESCRIPTION
Added a "enabled: true" to the confluent.kafka-broker restart
handler so that it will come up after a reboot.  #321

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # 321

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Rebuilt my test cluster and tested reboot of kafka cluster.

**Test Configuration**:

3 node kafka cluster.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [NA] I have commented my code, particularly in hard-to-understand areas
- [NA] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [NA] I have added tests that prove my fix is effective or that my feature works
- [X] Any dependent changes have been merged and published in downstream modules