### PR TITLE
Upgrade playbooks to allow for check mode runs

### DIFF
--- a/roles/confluent.kafka_broker/tasks/main.yml
+++ b/roles/confluent.kafka_broker/tasks/main.yml
@@ -178,4 +178,3 @@
   when:
     - health_checks_enabled|bool
     - jolokia_enabled|bool
-    - not ansible_check_mode

--- a/tasks/create_ordered_kafka_groups.yml
+++ b/tasks/create_ordered_kafka_groups.yml
@@ -12,6 +12,7 @@
     return_content: true
     status_code: 200
   register: active_controller_count_query
+  check_mode: false
 
 - set_fact:
     active_controller_count: "{{ active_controller_count_query['json']['value']['Value'] }}"

--- a/tasks/create_ordered_kafka_groups.yml
+++ b/tasks/create_ordered_kafka_groups.yml
@@ -26,13 +26,13 @@
     name: "{{ inventory_hostname }}"
     group: "{{ non_controller_group }}"
   delegate_to: localhost
-  when:
-    - active_controller_count|int == 0
+  changed_when: false
+  when: active_controller_count|int == 0
 
 - name: Add host to Controller Group
   add_host:
     name: "{{ inventory_hostname }}"
     group: "{{ controller_group }}"
   delegate_to: localhost
-  when:
-    - active_controller_count|int == 1
+  changed_when: false
+  when: active_controller_count|int == 1

--- a/tasks/set_kafka_broker_jolokia_ssl_enabled.yml
+++ b/tasks/set_kafka_broker_jolokia_ssl_enabled.yml
@@ -8,6 +8,7 @@
   register: jolokia_ssl_enabled_search
   changed_when: false
   failed_when: false
+  check_mode: false
 
 - name: Set kafka_broker_jolokia_ssl_enabled Variable to Proper value
   set_fact:

--- a/tasks/upgrade_component.yml
+++ b/tasks/upgrade_component.yml
@@ -15,6 +15,8 @@
     remote_src: true
     dest: "/tmp/upgrade/{{ service_name }}/{{ item | basename }}-{{timestamp}}"
   loop: "{{ backup_files }}"
+  # Files cannot be copied because directory is not created in check mode
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: Stop Service
   systemd:
@@ -33,6 +35,8 @@
     state: latest
   loop: "{{ packages }}"
   when: ansible_os_family == "RedHat"
+  # Packages will not be found in check mode because repos not changed
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: Install the Packages - Debian
   apt:
@@ -40,6 +44,8 @@
     update_cache: true
   loop: "{{ packages }}"
   when: ansible_os_family == "Debian"
+  # Packages will not be found in check mode because repos not changed
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: Put back configuration
   copy:
@@ -47,6 +53,8 @@
     remote_src: true
     src: "/tmp/upgrade/{{ service_name }}/{{ item | basename }}-{{timestamp}}"
   loop: "{{ restore_files }}"
+  # Files cannot be copied because directory is not created in check mode
+  ignore_errors: "{{ ansible_check_mode }}"
 
 - name: Restart Service
   systemd:

--- a/tasks/wait_for_urp.yml
+++ b/tasks/wait_for_urp.yml
@@ -1,35 +1,37 @@
 ---
-- name: Wait for Under Replicated Partitions Metric to return 200
-  uri:
-    url: "{{ kafka_broker_jolokia_urp_url }}"
-    validate_certs: false
-    return_content: true
-    status_code: 200
-  register: result
-  until: result.status == 200
-  retries: 60
-  delay: 5
+- block:
+    - name: Wait for Under Replicated Partitions Metric to return 200
+      uri:
+        url: "{{ kafka_broker_jolokia_urp_url }}"
+        validate_certs: false
+        return_content: true
+        status_code: 200
+      register: result
+      until: result.status == 200
+      retries: 60
+      delay: 5
 
-- name: Wait for Under Replicated Partitions Metric to return Data
-  uri:
-    url: "{{ kafka_broker_jolokia_urp_url }}"
-    validate_certs: false
-    return_content: true
-    status_code: 200
-  register: result
-  until: result['json']['value'] is defined
-  retries: 60
-  delay: 5
+    - name: Wait for Under Replicated Partitions Metric to return Data
+      uri:
+        url: "{{ kafka_broker_jolokia_urp_url }}"
+        validate_certs: false
+        return_content: true
+        status_code: 200
+      register: result
+      until: result['json']['value'] is defined
+      retries: 60
+      delay: 5
 
-# curl localhost:7771/jolokia/read/kafka.server:type=ReplicaManager,name=UnderReplicatedPartitions
-# {"request":{"mbean":"kafka.server:name=UnderReplicatedPartitions,type=ReplicaManager","type":"read"},"value":{"Value":0},"timestamp":1565819946,"status":200}
-- name: Wait for Under Replicated Partitions Metric to equal Zero
-  uri:
-    url: "{{ kafka_broker_jolokia_urp_url }}"
-    validate_certs: false
-    return_content: true
-    status_code: 200
-  register: result
-  until: result['json']['value']['Value'] == 0
-  retries: 60
-  delay: 5
+    # curl localhost:7771/jolokia/read/kafka.server:type=ReplicaManager,name=UnderReplicatedPartitions
+    # {"request":{"mbean":"kafka.server:name=UnderReplicatedPartitions,type=ReplicaManager","type":"read"},"value":{"Value":0},"timestamp":1565819946,"status":200}
+    - name: Wait for Under Replicated Partitions Metric to equal Zero
+      uri:
+        url: "{{ kafka_broker_jolokia_urp_url }}"
+        validate_certs: false
+        return_content: true
+        status_code: 200
+      register: result
+      until: result['json']['value']['Value'] == 0
+      retries: 60
+      delay: 5
+  when: not ansible_check_mode

--- a/upgrade_control_center.yml
+++ b/upgrade_control_center.yml
@@ -40,21 +40,8 @@
         - control_center_current_version != confluent_full_package_version
         - control_center_current_version != confluent_package_version
 
-    - name: Wait for webpage to serve HTTP content
-      uri:
-        url: "http://localhost:{{control_center_port}}"
-      register: result
-      until: result.status == 200
-      retries: 60
-      delay: 5
-      when: not ssl_enabled|bool
-
-    - name: Wait for webpage to serve HTTPS content
-      uri:
-        url: "https://localhost:{{control_center_port}}"
-        validate_certs: false
-      register: result
-      until: result.status == 200
-      retries: 60
-      delay: 5
-      when: ssl_enabled|bool
+    - name: Control Center Health Check
+      import_role:
+        name: confluent.control_center
+        tasks_from: health_check.yml
+      when: not ansible_check_mode

--- a/upgrade_kafka_broker.yml
+++ b/upgrade_kafka_broker.yml
@@ -88,6 +88,7 @@
         name: "{{ inventory_hostname }}"
         group: upgrade_non_controllers
       delegate_to: localhost
+      changed_when: false
       when:
         - active_controller_count|int == 0
         - kafka_broker_current_version != confluent_full_package_version
@@ -98,6 +99,7 @@
         name: "{{ inventory_hostname }}"
         group: upgrade_controller
       delegate_to: localhost
+      changed_when: false
       when:
         - active_controller_count|int == 1
         - kafka_broker_current_version != confluent_full_package_version

--- a/upgrade_kafka_connect.yml
+++ b/upgrade_kafka_connect.yml
@@ -41,23 +41,8 @@
         - kafka_connect_current_version != confluent_full_package_version
         - kafka_connect_current_version != confluent_package_version
 
-    - name: Wait for API to return 200 - HTTP
-      uri:
-        url: "http://localhost:{{kafka_connect_rest_port}}/connectors"
-        status_code: 200
-      register: result
-      until: result.status == 200
-      retries: 60
-      delay: 5
-      when: not kafka_connect_ssl_enabled|bool
-
-    - name: Wait for API to return 200 - HTTPS
-      uri:
-        url: "https://localhost:{{kafka_connect_rest_port}}/connectors"
-        status_code: 200
-        validate_certs: false
-      register: result
-      until: result.status == 200
-      retries: 60
-      delay: 5
-      when: kafka_connect_ssl_enabled|bool
+    - name: Kafka Connect Health Check
+      import_role:
+        name: confluent.kafka_connect
+        tasks_from: health_check.yml
+      when: not ansible_check_mode

--- a/upgrade_kafka_rest.yml
+++ b/upgrade_kafka_rest.yml
@@ -40,23 +40,8 @@
         - kafka_rest_current_version != confluent_full_package_version
         - kafka_rest_current_version != confluent_package_version
 
-    - name: Wait for API to return 200 - HTTP
-      uri:
-        url: "http://localhost:{{kafka_rest_port}}/topics"
-        status_code: 200
-      register: result
-      until: result.status == 200
-      retries: 60
-      delay: 5
-      when: not kafka_rest_ssl_enabled|bool
-
-    - name: Wait for API to return 200 - HTTPS
-      uri:
-        url: "https://localhost:{{kafka_rest_port}}/topics"
-        status_code: 200
-        validate_certs: false
-      register: result
-      until: result.status == 200
-      retries: 60
-      delay: 5
-      when: kafka_rest_ssl_enabled|bool
+    - name: Kafka Rest Health Check
+      import_role:
+        name: confluent.kafka_rest
+        tasks_from: health_check.yml
+      when: not ansible_check_mode

--- a/upgrade_schema_registry.yml
+++ b/upgrade_schema_registry.yml
@@ -42,23 +42,8 @@
         - schema_registry_current_version != confluent_full_package_version
         - schema_registry_current_version != confluent_package_version
 
-    - name: Wait for API to return 200 - HTTP
-      uri:
-        url: "http://localhost:{{schema_registry_listener_port}}/config"
-        status_code: 200
-      register: result
-      until: result.status == 200
-      retries: 60
-      delay: 5
-      when: not schema_registry_ssl_enabled|bool
-
-    - name: Wait for API to return 200 - HTTPS
-      uri:
-        url: "https://localhost:{{schema_registry_listener_port}}/config"
-        status_code: 200
-        validate_certs: false
-      register: result
-      until: result.status == 200
-      retries: 60
-      delay: 5
-      when: schema_registry_ssl_enabled|bool
+    - name: Schema Registry Health Check
+      import_role:
+        name: confluent.schema_registry
+        tasks_from: health_check.yml
+      when: not ansible_check_mode

--- a/upgrade_zookeeper.yml
+++ b/upgrade_zookeeper.yml
@@ -19,9 +19,7 @@
       import_role:
         name: confluent.zookeeper
         tasks_from: health_check.yml
-      when:
-        - health_checks_enabled|bool
-        - not ansible_check_mode
+      when: not ansible_check_mode
 
     - name: Get Package Facts
       package_facts:
@@ -121,9 +119,7 @@
         name: confluent.zookeeper
         tasks_from: health_check.yml
       delegate_to: "{{ groups['zookeeper'] | difference([inventory_hostname]) | first }}"
-      when:
-        - health_checks_enabled|bool
-        - not ansible_check_mode
+      when: not ansible_check_mode
 
     - name: Configure Repositories
       import_role:

--- a/upgrade_zookeeper.yml
+++ b/upgrade_zookeeper.yml
@@ -19,6 +19,9 @@
       import_role:
         name: confluent.zookeeper
         tasks_from: health_check.yml
+      when:
+        - health_checks_enabled|bool
+        - not ansible_check_mode
 
     - name: Get Package Facts
       package_facts:
@@ -50,6 +53,7 @@
       args:
         executable: /bin/bash
       register: leader_query
+      check_mode: false
 
     - name: Add host to Follower Group
       add_host:
@@ -104,6 +108,8 @@
         - "{{ zookeeper.config_file }}"
         - "{{ zookeeper.systemd_override }}"
         - "{{ kafka_broker.config_file }}"
+      # Files cannot be copied because directory is not created in check mode
+      ignore_errors: "{{ ansible_check_mode }}"
 
     - name: Stop Service
       systemd:
@@ -115,6 +121,9 @@
         name: confluent.zookeeper
         tasks_from: health_check.yml
       delegate_to: "{{ groups['zookeeper'] | difference([inventory_hostname]) | first }}"
+      when:
+        - health_checks_enabled|bool
+        - not ansible_check_mode
 
     - name: Configure Repositories
       import_role:
@@ -128,6 +137,8 @@
         state: latest
       loop: "{{ zookeeper_packages }}"
       when: ansible_os_family == "RedHat"
+      # Packages will not be found in check mode because repos not changed
+      ignore_errors: "{{ ansible_check_mode }}"
 
     - name: Install the Packages - Debian
       apt:
@@ -135,6 +146,8 @@
         update_cache: true
       loop: "{{ zookeeper_packages }}"
       when: ansible_os_family == "Debian"
+      # Packages will not be found in check mode because repos not changed
+      ignore_errors: "{{ ansible_check_mode }}"
 
     - name: Put back configuration
       copy:
@@ -144,6 +157,8 @@
       loop:
         - "{{ zookeeper.config_file }}"
         - "{{ kafka_broker.config_file }}"
+      # Files cannot be copied because directory is not created in check mode
+      ignore_errors: "{{ ansible_check_mode }}"
 
     - name: Add Disable Admin Server Property
       lineinfile:
@@ -161,3 +176,4 @@
       import_role:
         name: confluent.zookeeper
         tasks_from: health_check.yml
+      when: not ansible_check_mode

--- a/upgrade_zookeeper.yml
+++ b/upgrade_zookeeper.yml
@@ -51,6 +51,7 @@
       args:
         executable: /bin/bash
       register: leader_query
+      changed_when: false
       check_mode: false
 
     - name: Add host to Follower Group


### PR DESCRIPTION
# Description

Enables running the upgrade playbooks with `--check` which will run the playbook without doing any changes to the hosts, but report on the changes that would have occurred.

The hosts ordering tasks, which normally would be skipped were forced to run in check mode, and other were skipped or had their errors ignored because they could not succeed in check mode.


Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Ran all the upgrades with `--check`


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules