### PR TITLE
Ksql backwards compatibility support

### DIFF
--- a/roles/confluent.variables_handlers/defaults/main.yml
+++ b/roles/confluent.variables_handlers/defaults/main.yml
@@ -226,8 +226,8 @@ ksql_cert_path: "/var/ssl/private/ksql.crt"
 ksql_key_path: "/var/ssl/private/ksql.key"
 ksql_kafka_listener_name: internal
 ksql:
-  log4j_file: "{{confluent_package_version is version('5.5.0', '>=')}} ? /etc/ksqldb/ksql-server_log4j.properties : /etc/ksql/ksql-server_log4j.properties"
-  jaas_file: "{{confluent_package_version is version('5.5.0', '>=')}} ? /etc/ksqldb/ksql-server_jaas.conf : /etc/ksql/ksql-server_jaas.conf"
+  log4j_file: "{{(confluent_package_version is version('5.5.0', '>=')) | ternary('/etc/ksqldb/ksql-server_log4j.properties' , '/etc/ksql/ksql-server_log4j.properties')}}"
+  jaas_file: "{{(confluent_package_version is version('5.5.0', '>=')) | ternary('/etc/ksqldb/ksql-server_jaas.conf' , '/etc/ksql/ksql-server_jaas.conf')}}"
 
 ksql_jolokia_enabled: "{{jolokia_enabled}}"
 ksql_jolokia_port: 7774

--- a/roles/confluent.variables_handlers/defaults/main.yml
+++ b/roles/confluent.variables_handlers/defaults/main.yml
@@ -226,8 +226,8 @@ ksql_cert_path: "/var/ssl/private/ksql.crt"
 ksql_key_path: "/var/ssl/private/ksql.key"
 ksql_kafka_listener_name: internal
 ksql:
-  log4j_file: "/etc/ksqldb/ksql-server_log4j.properties"
-  jaas_file: "/etc/ksqldb/ksql-server_jaas.conf"
+  log4j_file: "{{confluent_package_version is version('5.5.0', '>=')}} ? /etc/ksqldb/ksql-server_log4j.properties : /etc/ksql/ksql-server_log4j.properties"
+  jaas_file: "{{confluent_package_version is version('5.5.0', '>=')}} ? /etc/ksqldb/ksql-server_jaas.conf : /etc/ksql/ksql-server_jaas.conf"
 
 ksql_jolokia_enabled: "{{jolokia_enabled}}"
 ksql_jolokia_port: 7774

--- a/roles/confluent.variables_handlers/vars/main.yml
+++ b/roles/confluent.variables_handlers/vars/main.yml
@@ -68,13 +68,14 @@ kafka_connect:
   systemd_file: /usr/lib/systemd/system/{{kafka_connect_service_name}}.service
   systemd_override: /etc/systemd/system/{{kafka_connect_service_name}}.service.d/override.conf
 
-ksql_service_name: "{{confluent_package_version is version('5.5.0', '>=')}} ? confluent-ksqldb : confluent-ksql"
+ksql_service_name: "{{(confluent_package_version is version('5.5.0', '>=')) | ternary('confluent-ksqldb' , 'confluent-ksql')}}"
+ksql_main_package: "{{(confluent_package_version is version('5.5.0', '>=')) | ternary('confluent-ksqldb' , 'confluent-ksql')}}"
 ksql_packages:
   - confluent-common
   - confluent-rest-utils
   - confluent-metadata-service
   - "{{ kafka_broker_main_package }}"
-  - "{{confluent_package_version is version('5.5.0', '>=')}} ? confluent-ksqldb : confluent-ksql"
+  - "{{ ksql_main_package }}"
   - confluent-security
   - confluent-rebalancer
   - confluent-control-center-fe
@@ -82,7 +83,7 @@ ksql_packages:
 ksql_default_user: cp-ksql
 ksql_default_group: confluent
 ksql:
-  config_file: "{{confluent_package_version is version('5.5.0', '>=')}} ? /etc/ksqldb/ksql-server.properties : /etc/ksql/ksql-server.properties"
+  config_file: "{{(confluent_package_version is version('5.5.0', '>=')) | ternary('/etc/ksqldb/ksql-server.properties' , '/etc/ksql/ksql-server.properties')}}"
   systemd_file: /usr/lib/systemd/system/{{ksql_service_name}}.service
   systemd_override: /etc/systemd/system/{{ksql_service_name}}.service.d/override.conf
 

--- a/roles/confluent.variables_handlers/vars/main.yml
+++ b/roles/confluent.variables_handlers/vars/main.yml
@@ -68,13 +68,13 @@ kafka_connect:
   systemd_file: /usr/lib/systemd/system/{{kafka_connect_service_name}}.service
   systemd_override: /etc/systemd/system/{{kafka_connect_service_name}}.service.d/override.conf
 
-ksql_service_name: confluent-ksqldb
+ksql_service_name: "{{confluent_package_version is version('5.5.0', '>=')}} ? confluent-ksqldb : confluent-ksql"
 ksql_packages:
   - confluent-common
   - confluent-rest-utils
   - confluent-metadata-service
   - "{{ kafka_broker_main_package }}"
-  - confluent-ksqldb
+  - "{{confluent_package_version is version('5.5.0', '>=')}} ? confluent-ksqldb : confluent-ksql"
   - confluent-security
   - confluent-rebalancer
   - confluent-control-center-fe
@@ -82,7 +82,7 @@ ksql_packages:
 ksql_default_user: cp-ksql
 ksql_default_group: confluent
 ksql:
-  config_file: "/etc/ksqldb/ksql-server.properties"
+  config_file: "{{confluent_package_version is version('5.5.0', '>=')}} ? /etc/ksqldb/ksql-server.properties : /etc/ksql/ksql-server.properties"
   systemd_file: /usr/lib/systemd/system/{{ksql_service_name}}.service
   systemd_override: /etc/systemd/system/{{ksql_service_name}}.service.d/override.conf
 


### PR DESCRIPTION
# Description

Allows current and future version of cp-ansible to be used to install older pre 5.5.0 versions without overrides to the packaging

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Used in building out personal test KSQL on 5.4.2 and used with customer for Ansible upgrade. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules