### PR TITLE
Support for multiple Connect Workers on a single machine

### DIFF
--- a/roles/confluent.control_center/templates/control-center.properties.j2
+++ b/roles/confluent.control_center/templates/control-center.properties.j2
@@ -54,7 +54,7 @@ confluent.controlcenter.schema.registry.ssl.key.password={{control_center_keysto
 # Kafka Connect Configuration
 {% if kafka_connect_cluster_ansible_group_names is defined %}
 {% for ansible_group in kafka_connect_cluster_ansible_group_names %}
-{% for host in groups[ansible_group] %}{% if loop.index == 1%}confluent.controlcenter.connect.{{ hostvars[host]['kafka_connect_group_id'] }}.cluster={% endif %}{% if loop.index > 1%},{% endif %}{{ kafka_connect_http_protocol }}://{{ host }}:{{ kafka_connect_rest_port }}{% endfor %}
+{% for host in groups[ansible_group] %}{% if loop.index == 1%}confluent.controlcenter.connect.{{ hostvars[host]['kafka_connect_group_id'] }}.cluster={% endif %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['kafka_connect_http_protocol'] }}://{{ host }}:{{ hostvars[host]['kafka_connect_rest_port'] }}{% endfor %}
 
 {% if kafka_connect_ssl_enabled|bool | bool %}
 confluent.controlcenter.connect.{{ hostvars[groups[ansible_group][0]]['kafka_connect_group_id'] }}.ssl.truststore.location={{control_center_truststore_path}}
@@ -66,7 +66,7 @@ confluent.controlcenter.connect.{{ hostvars[groups[ansible_group][0]]['kafka_con
 
 {% endfor %}
 {% else %}
-confluent.controlcenter.connect.default.cluster={% for host in groups['kafka_connect'] %}{% if loop.index > 1%},{% endif %}{{ kafka_connect_http_protocol }}://{{ host }}:{{ kafka_connect_rest_port }}{% endfor %}
+confluent.controlcenter.connect.default.cluster={% for host in groups['kafka_connect'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['kafka_connect_http_protocol'] }}://{{ host }}:{{ hostvars[host]['kafka_connect_rest_port'] }}{% endfor %}
 
 {% if kafka_connect_ssl_enabled|bool %}
 confluent.controlcenter.connect.default.ssl.truststore.location={{control_center_truststore_path}}

--- a/roles/confluent.control_center/templates/control-center.properties.j2
+++ b/roles/confluent.control_center/templates/control-center.properties.j2
@@ -54,7 +54,7 @@ confluent.controlcenter.schema.registry.ssl.key.password={{control_center_keysto
 # Kafka Connect Configuration
 {% if kafka_connect_cluster_ansible_group_names is defined %}
 {% for ansible_group in kafka_connect_cluster_ansible_group_names %}
-{% for host in groups[ansible_group] %}{% if loop.index == 1%}confluent.controlcenter.connect.{{ hostvars[host]['kafka_connect_group_id'] }}.cluster={% endif %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['kafka_connect_http_protocol'] }}://{{ host }}:{{ hostvars[host]['kafka_connect_rest_port'] }}{% endfor %}
+{% for host in groups[ansible_group] %}{% if loop.index == 1%}confluent.controlcenter.connect.{{ hostvars[host]['kafka_connect_group_id'] }}.cluster={% endif %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['kafka_connect_http_protocol']|default(kafka_connect_http_protocol) }}://{{ host }}:{{ hostvars[host]['kafka_connect_rest_port']|default(kafka_connect_rest_port) }}{% endfor %}
 
 {% if kafka_connect_ssl_enabled|bool | bool %}
 confluent.controlcenter.connect.{{ hostvars[groups[ansible_group][0]]['kafka_connect_group_id'] }}.ssl.truststore.location={{control_center_truststore_path}}
@@ -66,7 +66,7 @@ confluent.controlcenter.connect.{{ hostvars[groups[ansible_group][0]]['kafka_con
 
 {% endfor %}
 {% else %}
-confluent.controlcenter.connect.default.cluster={% for host in groups['kafka_connect'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['kafka_connect_http_protocol'] }}://{{ host }}:{{ hostvars[host]['kafka_connect_rest_port'] }}{% endfor %}
+confluent.controlcenter.connect.default.cluster={% for host in groups['kafka_connect'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['kafka_connect_http_protocol']|default(kafka_connect_http_protocol) }}://{{ host }}:{{ hostvars[host]['kafka_connect_rest_port']|default(kafka_connect_rest_port) }}{% endfor %}
 
 {% if kafka_connect_ssl_enabled|bool %}
 confluent.controlcenter.connect.default.ssl.truststore.location={{control_center_truststore_path}}

--- a/roles/confluent.kafka_connect/defaults/main.yml
+++ b/roles/confluent.kafka_connect/defaults/main.yml
@@ -39,8 +39,8 @@ kafka_connect_plugins_dest: /usr/share/java
 
 kafka_connect_service_name: "{{kafka_connect_default_service_name}}"
 kafka_connect_config_file: "{{kafka_connect_default_config_file}}"
-kafka_connect_systemd_file: /usr/lib/systemd/system/{{kafka_connect_config_file}}.service
-kafka_connect_systemd_override_file: /etc/systemd/system/{{kafka_connect_config_file}}.service.d/override.conf
+kafka_connect_systemd_file: "{{default_systemd_dir}}/{{kafka_connect_service_name}}.service"
+kafka_connect_systemd_override_file: /etc/systemd/system/{{kafka_connect_service_name}}.service.d/override.conf
 kafka_connect:
   appender_log_path: /var/log/kafka/
   appender_log_name: connect-distributed.log

--- a/roles/confluent.kafka_connect/defaults/main.yml
+++ b/roles/confluent.kafka_connect/defaults/main.yml
@@ -37,7 +37,10 @@ kafka_connect_plugins: []
 kafka_connect_plugins_remote: []
 kafka_connect_plugins_dest: /usr/share/java
 
-
+kafka_connect_service_name: "{{kafka_connect_default_service_name}}"
+kafka_connect_config_file: "{{kafka_connect_default_config_file}}"
+kafka_connect_systemd_file: /usr/lib/systemd/system/{{kafka_connect_config_file}}.service
+kafka_connect_systemd_override_file: /etc/systemd/system/{{kafka_connect_config_file}}.service.d/override.conf
 kafka_connect:
   appender_log_path: /var/log/kafka/
   appender_log_name: connect-distributed.log

--- a/roles/confluent.kafka_connect/tasks/main.yml
+++ b/roles/confluent.kafka_connect/tasks/main.yml
@@ -87,11 +87,11 @@
     group: "{{kafka_connect_group}}"
   notify: restart connect distributed
   
-- name: Create custom systemd file
-  copy:
-    src: "{{kafka_connect_default_systemd_file}}"
+- name: Create Custom systemd file
+  template:
+    src: systemd.j2
     dest: "{{kafka_connect_systemd_file}}"
-    remote_src: yes
+    mode: 0640
   when: kafka_connect_service_name != kafka_connect_default_service_name
 
 - name: Create Service Override Directory

--- a/roles/confluent.kafka_connect/tasks/main.yml
+++ b/roles/confluent.kafka_connect/tasks/main.yml
@@ -61,7 +61,7 @@
 - name: Create Connect Distributed Config
   template:
     src: connect-distributed.properties.j2
-    dest: "{{kafka_connect.config_file}}"
+    dest: "{{kafka_connect_config_file}}"
     mode: 0640
     owner: "{{kafka_connect_user}}"
     group: "{{kafka_connect_group}}"
@@ -86,10 +86,17 @@
     owner: "{{kafka_connect_user}}"
     group: "{{kafka_connect_group}}"
   notify: restart connect distributed
+  
+- name: Create custom systemd file
+  copy:
+    src: "{{kafka_connect_default_systemd_file}}"
+    dest: "{{kafka_connect_systemd_file}}"
+    remote_src: yes
+  when: kafka_connect_service_name != kafka_connect_default_service_name
 
 - name: Create Service Override Directory
   file:
-    path: "{{kafka_connect.systemd_override | dirname}}"
+    path: "{{kafka_connect_default_systemd_override_file | dirname}}"
     owner: "{{kafka_connect_user}}"
     group: "{{kafka_connect_group}}"
     state: directory
@@ -98,7 +105,7 @@
 - name: Write Service Overrides
   template:
     src: override.conf.j2
-    dest: "{{ kafka_connect.systemd_override }}"
+    dest: "{{ kafka_connect_default_systemd_override_file }}"
     mode: 0640
     owner: "{{kafka_connect_user}}"
     group: "{{kafka_connect_group}}"

--- a/roles/confluent.kafka_connect/tasks/main.yml
+++ b/roles/confluent.kafka_connect/tasks/main.yml
@@ -96,7 +96,7 @@
 
 - name: Create Service Override Directory
   file:
-    path: "{{kafka_connect_default_systemd_override_file | dirname}}"
+    path: "{{kafka_connect_systemd_override_file | dirname}}"
     owner: "{{kafka_connect_user}}"
     group: "{{kafka_connect_group}}"
     state: directory
@@ -105,7 +105,7 @@
 - name: Write Service Overrides
   template:
     src: override.conf.j2
-    dest: "{{ kafka_connect_default_systemd_override_file }}"
+    dest: "{{ kafka_connect_systemd_override_file }}"
     mode: 0640
     owner: "{{kafka_connect_user}}"
     group: "{{kafka_connect_group}}"

--- a/roles/confluent.kafka_connect/tasks/main.yml
+++ b/roles/confluent.kafka_connect/tasks/main.yml
@@ -86,7 +86,7 @@
     owner: "{{kafka_connect_user}}"
     group: "{{kafka_connect_group}}"
   notify: restart connect distributed
-  
+
 - name: Create Custom systemd file
   template:
     src: systemd.j2

--- a/roles/confluent.kafka_connect/templates/systemd.j2
+++ b/roles/confluent.kafka_connect/templates/systemd.j2
@@ -1,0 +1,15 @@
+[Unit]
+Description=Apache Kafka Connect - distributed
+Documentation=http://docs.confluent.io/
+After=network.target confluent-server.target
+
+[Service]
+Type=simple
+User=cp-kafka-connect
+Group=confluent
+ExecStart=/usr/bin/connect-distributed {{kafka_connect_config_file}}
+TimeoutStopSec=180
+Restart=no
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/confluent.variables_handlers/vars/main.yml
+++ b/roles/confluent.variables_handlers/vars/main.yml
@@ -1,4 +1,5 @@
 ---
+default_systemd_dir: /lib/systemd/system
 zookeeper_service_name: confluent-zookeeper
 zookeeper_main_package: "{{ 'confluent-server' if confluent_server_enabled|bool else 'confluent-kafka-2.12'}}"
 zookeeper_packages:
@@ -10,7 +11,7 @@ zookeeper_default_user: cp-kafka
 zookeeper_default_group: confluent
 zookeeper:
   config_file: /etc/kafka/zookeeper.properties
-  systemd_file: /usr/lib/systemd/system/{{zookeeper_service_name}}.service
+  systemd_file: "{{default_systemd_dir}}/{{zookeeper_service_name}}.service"
   systemd_override: /etc/systemd/system/{{zookeeper_service_name}}.service.d/override.conf
 
 kafka_broker_service_name: "{{ 'confluent-server' if confluent_server_enabled|bool else 'confluent-kafka'}}"
@@ -26,7 +27,7 @@ kafka_broker_default_user: cp-kafka
 kafka_broker_default_group: confluent
 kafka_broker:
   config_file: /etc/kafka/server.properties
-  systemd_file: /usr/lib/systemd/system/{{kafka_broker_service_name}}.service
+  systemd_file: "{{default_systemd_dir}}/{{kafka_broker_service_name}}.service"
   systemd_override: /etc/systemd/system/{{kafka_broker_service_name}}.service.d/override.conf
 
 schema_registry_service_name: confluent-schema-registry
@@ -41,7 +42,7 @@ schema_registry_default_user: cp-schema-registry
 schema_registry_default_group: confluent
 schema_registry:
   config_file: /etc/schema-registry/schema-registry.properties
-  systemd_file: /usr/lib/systemd/system/{{schema_registry_service_name}}.service
+  systemd_file: "{{default_systemd_dir}}/{{schema_registry_service_name}}.service"
   systemd_override: /etc/systemd/system/{{schema_registry_service_name}}.service.d/override.conf
 
 kafka_connect_default_service_name: confluent-kafka-connect
@@ -64,7 +65,7 @@ kafka_connect_packages:
 kafka_connect_default_user: cp-kafka-connect
 kafka_connect_default_group: confluent
 kafka_connect_default_config_file: /etc/kafka/connect-distributed.properties
-kafka_connect_default_systemd_file: /usr/lib/systemd/system/{{kafka_connect_default_service_name}}.service
+kafka_connect_default_systemd_file: "{{default_systemd_dir}}/{{kafka_connect_default_service_name}}.service"
 kafka_connect_default_systemd_override_file: /etc/systemd/system/{{kafka_connect_default_service_name}}.service.d/override.conf
 
 ksql_service_name: confluent-ksqldb
@@ -82,7 +83,7 @@ ksql_default_user: cp-ksql
 ksql_default_group: confluent
 ksql:
   config_file: "/etc/ksqldb/ksql-server.properties"
-  systemd_file: /usr/lib/systemd/system/{{ksql_service_name}}.service
+  systemd_file: "{{default_systemd_dir}}/{{ksql_service_name}}.service"
   systemd_override: /etc/systemd/system/{{ksql_service_name}}.service.d/override.conf
 
 kafka_rest_service_name: confluent-kafka-rest
@@ -100,7 +101,7 @@ kafka_rest_default_user: cp-kafka-rest
 kafka_rest_default_group: confluent
 kafka_rest:
   config_file: /etc/kafka-rest/kafka-rest.properties
-  systemd_file: /usr/lib/systemd/system/{{kafka_rest_service_name}}.service
+  systemd_file: "{{default_systemd_dir}}/{{kafka_rest_service_name}}.service"
   systemd_override: /etc/systemd/system/{{kafka_rest_service_name}}.service.d/override.conf
 
 control_center_service_name: confluent-control-center
@@ -116,5 +117,5 @@ control_center_default_user: cp-control-center
 control_center_default_group: confluent
 control_center:
   config_file: /etc/confluent-control-center/control-center-production.properties
-  systemd_file: /usr/lib/systemd/system/{{control_center_service_name}}.service
+  systemd_file: "{{default_systemd_dir}}/{{control_center_service_name}}.service"
   systemd_override: /etc/systemd/system/{{control_center_service_name}}.service.d/override.conf

--- a/roles/confluent.variables_handlers/vars/main.yml
+++ b/roles/confluent.variables_handlers/vars/main.yml
@@ -44,7 +44,7 @@ schema_registry:
   systemd_file: /usr/lib/systemd/system/{{schema_registry_service_name}}.service
   systemd_override: /etc/systemd/system/{{schema_registry_service_name}}.service.d/override.conf
 
-kafka_connect_service_name: confluent-kafka-connect
+kafka_connect_default_service_name: confluent-kafka-connect
 kafka_connect_packages:
   - confluent-common
   - confluent-rest-utils
@@ -63,10 +63,9 @@ kafka_connect_packages:
   - confluent-schema-registry
 kafka_connect_default_user: cp-kafka-connect
 kafka_connect_default_group: confluent
-kafka_connect:
-  config_file: /etc/kafka/connect-distributed.properties
-  systemd_file: /usr/lib/systemd/system/{{kafka_connect_service_name}}.service
-  systemd_override: /etc/systemd/system/{{kafka_connect_service_name}}.service.d/override.conf
+kafka_connect_default_config_file: /etc/kafka/connect-distributed.properties
+kafka_connect_default_systemd_file: /usr/lib/systemd/system/{{kafka_connect_default_service_name}}.service
+kafka_connect_default_systemd_override_file: /etc/systemd/system/{{kafka_connect_default_service_name}}.service.d/override.conf
 
 ksql_service_name: confluent-ksqldb
 ksql_packages:

--- a/upgrade_kafka_connect.yml
+++ b/upgrade_kafka_connect.yml
@@ -33,10 +33,10 @@
         service_name: "{{ kafka_connect_service_name }}"
         packages: "{{ kafka_connect_packages }}"
         backup_files:
-          - "{{ kafka_connect.config_file }}"
-          - "{{ kafka_connect.systemd_override }}"
+          - "{{ kafka_connect_config_file }}"
+          - "{{ kafka_connect_systemd_override_file }}"
         restore_files:
-          - "{{ kafka_connect.config_file }}"
+          - "{{ kafka_connect_config_file }}"
       when:
         - kafka_connect_current_version != confluent_full_package_version
         - kafka_connect_current_version != confluent_package_version


### PR DESCRIPTION
# Description

Allows for a user to install multiple connect workers on a single machine. Allowing uses to run multiple clusters without requiring more VM/Physical Machines. Documentation wasn't done as not to encourage this usage.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Used in personal dev test build out. Given to customer to support their install.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules