### PR TITLE
Fixes to support hostname aliasing

### DIFF
--- a/roles/confluent.control_center/tasks/health_check.yml
+++ b/roles/confluent.control_center/tasks/health_check.yml
@@ -1,7 +1,7 @@
 ---
 - name: Wait for webpage to serve content
   uri:
-    url: "{{control_center_http_protocol}}://{{inventory_hostname}}:{{control_center_port}}"
+    url: "{{control_center_http_protocol}}://{{ansible_host}}:{{control_center_port}}"
     validate_certs: false
   register: result
   until: result.status == 200
@@ -11,7 +11,7 @@
 
 - name: Wait for webpage to serve content - RBAC
   uri:
-    url: "{{control_center_http_protocol}}://{{inventory_hostname}}:{{control_center_port}}"
+    url: "{{control_center_http_protocol}}://{{ansible_host}}:{{control_center_port}}"
     validate_certs: false
     url_username: "{{control_center_ldap_user}}"
     url_password: "{{control_center_ldap_password}}"

--- a/roles/confluent.control_center/tasks/main.yml
+++ b/roles/confluent.control_center/tasks/main.yml
@@ -53,7 +53,7 @@
     keystore_storepass: "{{control_center_keystore_storepass}}"
     keystore_keypass: "{{control_center_keystore_keypass}}"
     service_name: control_center
-    hostnames: "{{ [inventory_hostname, ansible_fqdn] | unique }}"
+    hostnames: "{{ [ansible_host, ansible_fqdn] | unique }}"
     ca_cert_path: "{{control_center_ca_cert_path}}"
     cert_path: "{{control_center_cert_path}}"
     key_path: "{{control_center_key_path}}"

--- a/roles/confluent.control_center/templates/control-center.properties.j2
+++ b/roles/confluent.control_center/templates/control-center.properties.j2
@@ -16,7 +16,7 @@ confluent.controlcenter.rest.ssl.truststore.password={{control_center_truststore
 {% endfor %}
 
 # Kafka Brokers
-bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['ansible_host'] }}:{{kafka_broker_listeners[control_center_kafka_listener_name]['port']}}{% endfor %}
+bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['ansible_host']|default(host) }}:{{kafka_broker_listeners[control_center_kafka_listener_name]['port']}}{% endfor %}
 
 {% set config_prefix = 'confluent.controlcenter.streams.' %}
 {% set listener = kafka_broker_listeners[control_center_kafka_listener_name] %}
@@ -38,7 +38,7 @@ bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%}
 {% set schema_registries = groups.get('schema_registry', []) %}
 {% if schema_registries %}
 # Schema Registry Configuration
-confluent.controlcenter.schema.registry.url={% for host in groups['schema_registry'] %}{% if loop.index > 1%},{% endif %}{{ schema_registry_http_protocol }}://{{ hostvars[host]['ansible_host'] }}:{{ schema_registry_listener_port }}{% endfor %}
+confluent.controlcenter.schema.registry.url={% for host in groups['schema_registry'] %}{% if loop.index > 1%},{% endif %}{{ schema_registry_http_protocol }}://{{ hostvars[host]['ansible_host']|default(host) }}:{{ schema_registry_listener_port }}{% endfor %}
 
 {% if schema_registry_ssl_enabled|bool %}
 confluent.controlcenter.schema.registry.ssl.truststore.location={{control_center_truststore_path}}
@@ -54,7 +54,7 @@ confluent.controlcenter.schema.registry.ssl.key.password={{control_center_keysto
 # Kafka Connect Configuration
 {% if kafka_connect_cluster_ansible_group_names is defined %}
 {% for ansible_group in kafka_connect_cluster_ansible_group_names %}
-{% for host in groups[ansible_group] %}{% if loop.index == 1%}confluent.controlcenter.connect.{{ hostvars[host]['kafka_connect_group_id'] }}.cluster={% endif %}{% if loop.index > 1%},{% endif %}{{ kafka_connect_http_protocol }}://{{ hostvars[host]['ansible_host'] }}:{{ kafka_connect_rest_port }}{% endfor %}
+{% for host in groups[ansible_group] %}{% if loop.index == 1%}confluent.controlcenter.connect.{{ hostvars[host]['kafka_connect_group_id'] }}.cluster={% endif %}{% if loop.index > 1%},{% endif %}{{ kafka_connect_http_protocol }}://{{ hostvars[host]['ansible_host']|default(host) }}:{{ kafka_connect_rest_port }}{% endfor %}
 
 {% if kafka_connect_ssl_enabled|bool | bool %}
 confluent.controlcenter.connect.{{ hostvars[groups[ansible_group][0]]['kafka_connect_group_id'] }}.ssl.truststore.location={{control_center_truststore_path}}
@@ -66,7 +66,7 @@ confluent.controlcenter.connect.{{ hostvars[groups[ansible_group][0]]['kafka_con
 
 {% endfor %}
 {% else %}
-confluent.controlcenter.connect.default.cluster={% for host in groups['kafka_connect'] %}{% if loop.index > 1%},{% endif %}{{ kafka_connect_http_protocol }}://{{ hostvars[host]['ansible_host'] }}:{{ kafka_connect_rest_port }}{% endfor %}
+confluent.controlcenter.connect.default.cluster={% for host in groups['kafka_connect'] %}{% if loop.index > 1%},{% endif %}{{ kafka_connect_http_protocol }}://{{ hostvars[host]['ansible_host']|default(host) }}:{{ kafka_connect_rest_port }}{% endfor %}
 
 {% if kafka_connect_ssl_enabled|bool %}
 confluent.controlcenter.connect.default.ssl.truststore.location={{control_center_truststore_path}}
@@ -83,7 +83,7 @@ confluent.controlcenter.connect.default.ssl.key.password={{control_center_keysto
 # KSQL Configuration
 {% if ksql_cluster_ansible_group_names is defined %}
 {% for ansible_group in ksql_cluster_ansible_group_names %}
-{% for host in groups[ansible_group] %}{% if loop.index == 1%}confluent.controlcenter.ksql.{{ ansible_group }}.url={% endif %}{% if loop.index > 1%},{% endif %}{{ ksql_http_protocol }}://{{ hostvars[host]['ansible_host'] }}:{{ ksql_listener_port }}{% endfor %}
+{% for host in groups[ansible_group] %}{% if loop.index == 1%}confluent.controlcenter.ksql.{{ ansible_group }}.url={% endif %}{% if loop.index > 1%},{% endif %}{{ ksql_http_protocol }}://{{ hostvars[host]['ansible_host']|default(host) }}:{{ ksql_listener_port }}{% endfor %}
 
 {% if ksql_ssl_enabled|bool | bool %}
 confluent.controlcenter.ksql.{{ ansible_group }}.ssl.truststore.location={{control_center_truststore_path}}
@@ -95,7 +95,7 @@ confluent.controlcenter.ksql.{{ ansible_group }}.ssl.key.password={{control_cent
 
 {% endfor %}
 {% else %}
-confluent.controlcenter.ksql.default.url={% for host in groups['ksql'] %}{% if loop.index > 1%},{% endif %}{{ ksql_http_protocol }}://{{ hostvars[host]['ansible_host'] }}:{{ ksql_listener_port }}{% endfor %}
+confluent.controlcenter.ksql.default.url={% for host in groups['ksql'] %}{% if loop.index > 1%},{% endif %}{{ ksql_http_protocol }}://{{ hostvars[host]['ansible_host']|default(host) }}:{{ ksql_listener_port }}{% endfor %}
 
 {% if ksql_ssl_enabled|bool %}
 confluent.controlcenter.ksql.default.ssl.truststore.location={{control_center_truststore_path}}
@@ -112,7 +112,7 @@ confluent.controlcenter.ksql.default.ssl.key.password={{control_center_keystore_
 confluent.controlcenter.rest.authentication.method=BEARER
 public.key.path={{rbac_enabled_public_pem_path}}
 
-confluent.metadata.bootstrap.server.urls={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{mds_http_protocol}}://{{ hostvars[host]['ansible_host'] }}:{{mds_port}}{% endfor %}
+confluent.metadata.bootstrap.server.urls={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{mds_http_protocol}}://{{ hostvars[host]['ansible_host']|default(host) }}:{{mds_port}}{% endfor %}
 
 confluent.metadata.basic.auth.user.info={{control_center_ldap_user}}:{{control_center_ldap_password}}
 {% endif %}

--- a/roles/confluent.control_center/templates/control-center.properties.j2
+++ b/roles/confluent.control_center/templates/control-center.properties.j2
@@ -16,7 +16,7 @@ confluent.controlcenter.rest.ssl.truststore.password={{control_center_truststore
 {% endfor %}
 
 # Kafka Brokers
-bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ host }}:{{kafka_broker_listeners[control_center_kafka_listener_name]['port']}}{% endfor %}
+bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['ansible_host'] }}:{{kafka_broker_listeners[control_center_kafka_listener_name]['port']}}{% endfor %}
 
 {% set config_prefix = 'confluent.controlcenter.streams.' %}
 {% set listener = kafka_broker_listeners[control_center_kafka_listener_name] %}
@@ -38,7 +38,7 @@ bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%}
 {% set schema_registries = groups.get('schema_registry', []) %}
 {% if schema_registries %}
 # Schema Registry Configuration
-confluent.controlcenter.schema.registry.url={% for host in groups['schema_registry'] %}{% if loop.index > 1%},{% endif %}{{ schema_registry_http_protocol }}://{{ host }}:{{ schema_registry_listener_port }}{% endfor %}
+confluent.controlcenter.schema.registry.url={% for host in groups['schema_registry'] %}{% if loop.index > 1%},{% endif %}{{ schema_registry_http_protocol }}://{{ hostvars[host]['ansible_host'] }}:{{ schema_registry_listener_port }}{% endfor %}
 
 {% if schema_registry_ssl_enabled|bool %}
 confluent.controlcenter.schema.registry.ssl.truststore.location={{control_center_truststore_path}}
@@ -54,7 +54,7 @@ confluent.controlcenter.schema.registry.ssl.key.password={{control_center_keysto
 # Kafka Connect Configuration
 {% if kafka_connect_cluster_ansible_group_names is defined %}
 {% for ansible_group in kafka_connect_cluster_ansible_group_names %}
-{% for host in groups[ansible_group] %}{% if loop.index == 1%}confluent.controlcenter.connect.{{ hostvars[host]['kafka_connect_group_id'] }}.cluster={% endif %}{% if loop.index > 1%},{% endif %}{{ kafka_connect_http_protocol }}://{{ host }}:{{ kafka_connect_rest_port }}{% endfor %}
+{% for host in groups[ansible_group] %}{% if loop.index == 1%}confluent.controlcenter.connect.{{ hostvars[host]['kafka_connect_group_id'] }}.cluster={% endif %}{% if loop.index > 1%},{% endif %}{{ kafka_connect_http_protocol }}://{{ hostvars[host]['ansible_host'] }}:{{ kafka_connect_rest_port }}{% endfor %}
 
 {% if kafka_connect_ssl_enabled|bool | bool %}
 confluent.controlcenter.connect.{{ hostvars[groups[ansible_group][0]]['kafka_connect_group_id'] }}.ssl.truststore.location={{control_center_truststore_path}}
@@ -66,7 +66,7 @@ confluent.controlcenter.connect.{{ hostvars[groups[ansible_group][0]]['kafka_con
 
 {% endfor %}
 {% else %}
-confluent.controlcenter.connect.default.cluster={% for host in groups['kafka_connect'] %}{% if loop.index > 1%},{% endif %}{{ kafka_connect_http_protocol }}://{{ host }}:{{ kafka_connect_rest_port }}{% endfor %}
+confluent.controlcenter.connect.default.cluster={% for host in groups['kafka_connect'] %}{% if loop.index > 1%},{% endif %}{{ kafka_connect_http_protocol }}://{{ hostvars[host]['ansible_host'] }}:{{ kafka_connect_rest_port }}{% endfor %}
 
 {% if kafka_connect_ssl_enabled|bool %}
 confluent.controlcenter.connect.default.ssl.truststore.location={{control_center_truststore_path}}
@@ -83,7 +83,7 @@ confluent.controlcenter.connect.default.ssl.key.password={{control_center_keysto
 # KSQL Configuration
 {% if ksql_cluster_ansible_group_names is defined %}
 {% for ansible_group in ksql_cluster_ansible_group_names %}
-{% for host in groups[ansible_group] %}{% if loop.index == 1%}confluent.controlcenter.ksql.{{ ansible_group }}.url={% endif %}{% if loop.index > 1%},{% endif %}{{ ksql_http_protocol }}://{{ host }}:{{ ksql_listener_port }}{% endfor %}
+{% for host in groups[ansible_group] %}{% if loop.index == 1%}confluent.controlcenter.ksql.{{ ansible_group }}.url={% endif %}{% if loop.index > 1%},{% endif %}{{ ksql_http_protocol }}://{{ hostvars[host]['ansible_host'] }}:{{ ksql_listener_port }}{% endfor %}
 
 {% if ksql_ssl_enabled|bool | bool %}
 confluent.controlcenter.ksql.{{ ansible_group }}.ssl.truststore.location={{control_center_truststore_path}}
@@ -95,7 +95,7 @@ confluent.controlcenter.ksql.{{ ansible_group }}.ssl.key.password={{control_cent
 
 {% endfor %}
 {% else %}
-confluent.controlcenter.ksql.default.url={% for host in groups['ksql'] %}{% if loop.index > 1%},{% endif %}{{ ksql_http_protocol }}://{{ host }}:{{ ksql_listener_port }}{% endfor %}
+confluent.controlcenter.ksql.default.url={% for host in groups['ksql'] %}{% if loop.index > 1%},{% endif %}{{ ksql_http_protocol }}://{{ hostvars[host]['ansible_host'] }}:{{ ksql_listener_port }}{% endfor %}
 
 {% if ksql_ssl_enabled|bool %}
 confluent.controlcenter.ksql.default.ssl.truststore.location={{control_center_truststore_path}}
@@ -112,7 +112,7 @@ confluent.controlcenter.ksql.default.ssl.key.password={{control_center_keystore_
 confluent.controlcenter.rest.authentication.method=BEARER
 public.key.path={{rbac_enabled_public_pem_path}}
 
-confluent.metadata.bootstrap.server.urls={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{mds_http_protocol}}://{{ host }}:{{mds_port}}{% endfor %}
+confluent.metadata.bootstrap.server.urls={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{mds_http_protocol}}://{{ hostvars[host]['ansible_host'] }}:{{mds_port}}{% endfor %}
 
 confluent.metadata.basic.auth.user.info={{control_center_ldap_user}}:{{control_center_ldap_password}}
 {% endif %}

--- a/roles/confluent.kafka_broker/templates/kafka_client.j2
+++ b/roles/confluent.kafka_broker/templates/kafka_client.j2
@@ -36,5 +36,5 @@
 {{config_prefix}}sasl.login.callback.handler.class=io.confluent.kafka.clients.plugins.auth.token.TokenUserLoginCallbackHandler
 {{config_prefix}}sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required \
    username="{{oauth_username}}" password="{{oauth_password}}" \
-   metadataServerUrls="{% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{mds_http_protocol}}://{{ hostvars[host]['ansible_host'] }}:{{mds_port}}{% endfor %}";
+   metadataServerUrls="{% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{mds_http_protocol}}://{{ hostvars[host]['ansible_host']|default(host) }}:{{mds_port}}{% endfor %}";
 {% endif %}

--- a/roles/confluent.kafka_broker/templates/kafka_client.j2
+++ b/roles/confluent.kafka_broker/templates/kafka_client.j2
@@ -36,5 +36,5 @@
 {{config_prefix}}sasl.login.callback.handler.class=io.confluent.kafka.clients.plugins.auth.token.TokenUserLoginCallbackHandler
 {{config_prefix}}sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required \
    username="{{oauth_username}}" password="{{oauth_password}}" \
-   metadataServerUrls="{% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{mds_http_protocol}}://{{ host }}:{{mds_port}}{% endfor %}";
+   metadataServerUrls="{% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{mds_http_protocol}}://{{ hostvars[host]['ansible_host'] }}:{{mds_port}}{% endfor %}";
 {% endif %}

--- a/roles/confluent.kafka_broker/templates/server.properties.j2
+++ b/roles/confluent.kafka_broker/templates/server.properties.j2
@@ -38,7 +38,7 @@ sasl.kerberos.service.name={{kerberos_kafka_broker_primary}}
 {% endfor %}
 
 # Zookeeper Configuration
-zookeeper.connect={% for host in groups['zookeeper'] %}{% if loop.index > 1%},{% endif %}{{ host }}:{{zookeeper_client_port}}{% endfor %}
+zookeeper.connect={% for host in groups['zookeeper'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['ansible_host'] }}:{{zookeeper_client_port}}{% endfor %}
 
 {% if zookeeper_ssl_enabled | bool %}
 zookeeper.ssl.client.enable=true
@@ -66,7 +66,7 @@ zookeeper.set.acl=true
 {% set schema_registries = groups.get('schema_registry', []) %}
 {% if schema_registries %}
 # Schema Registry Configuration
-confluent.schema.registry.url={% for host in groups['schema_registry'] %}{% if loop.index > 1%},{% endif %}{{ schema_registry_http_protocol }}://{{ host }}:{{ schema_registry_listener_port }}{% endfor %}
+confluent.schema.registry.url={% for host in groups['schema_registry'] %}{% if loop.index > 1%},{% endif %}{{ schema_registry_http_protocol }}://{{ hostvars[host]['ansible_host'] }}:{{ schema_registry_listener_port }}{% endfor %}
 
 {% if schema_registry_ssl_enabled|bool %}
 confluent.schema.registry.ssl.truststore.location={{kafka_broker_truststore_path}}
@@ -81,7 +81,7 @@ confluent.schema.registry.ssl.key.password={{kafka_broker_keystore_keypass}}
 {% if kafka_broker_metrics_reporter_enabled|bool %}
 ######## Metrics Reporter #########
 metric.reporters=io.confluent.metrics.reporter.ConfluentMetricsReporter
-confluent.metrics.reporter.bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ host }}:{{kafka_broker_listeners[kafka_broker_inter_broker_listener_name]['port']}}{% endfor %}
+confluent.metrics.reporter.bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['ansible_host'] }}:{{kafka_broker_listeners[kafka_broker_inter_broker_listener_name]['port']}}{% endfor %}
 
 confluent.metrics.reporter.topic.replicas={{kafka_broker_default_interal_replication_factor}}
 {% set config_prefix = 'confluent.metrics.reporter.' %}

--- a/roles/confluent.kafka_broker/templates/server.properties.j2
+++ b/roles/confluent.kafka_broker/templates/server.properties.j2
@@ -38,7 +38,7 @@ sasl.kerberos.service.name={{kerberos_kafka_broker_primary}}
 {% endfor %}
 
 # Zookeeper Configuration
-zookeeper.connect={% for host in groups['zookeeper'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['ansible_host'] }}:{{zookeeper_client_port}}{% endfor %}
+zookeeper.connect={% for host in groups['zookeeper'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['ansible_host']|default(host) }}:{{zookeeper_client_port}}{% endfor %}
 
 {% if zookeeper_ssl_enabled | bool %}
 zookeeper.ssl.client.enable=true
@@ -66,7 +66,7 @@ zookeeper.set.acl=true
 {% set schema_registries = groups.get('schema_registry', []) %}
 {% if schema_registries %}
 # Schema Registry Configuration
-confluent.schema.registry.url={% for host in groups['schema_registry'] %}{% if loop.index > 1%},{% endif %}{{ schema_registry_http_protocol }}://{{ hostvars[host]['ansible_host'] }}:{{ schema_registry_listener_port }}{% endfor %}
+confluent.schema.registry.url={% for host in groups['schema_registry'] %}{% if loop.index > 1%},{% endif %}{{ schema_registry_http_protocol }}://{{ hostvars[host]['ansible_host']|default(host) }}:{{ schema_registry_listener_port }}{% endfor %}
 
 {% if schema_registry_ssl_enabled|bool %}
 confluent.schema.registry.ssl.truststore.location={{kafka_broker_truststore_path}}
@@ -81,7 +81,7 @@ confluent.schema.registry.ssl.key.password={{kafka_broker_keystore_keypass}}
 {% if kafka_broker_metrics_reporter_enabled|bool %}
 ######## Metrics Reporter #########
 metric.reporters=io.confluent.metrics.reporter.ConfluentMetricsReporter
-confluent.metrics.reporter.bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['ansible_host'] }}:{{kafka_broker_listeners[kafka_broker_inter_broker_listener_name]['port']}}{% endfor %}
+confluent.metrics.reporter.bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['ansible_host']|default(host) }}:{{kafka_broker_listeners[kafka_broker_inter_broker_listener_name]['port']}}{% endfor %}
 
 confluent.metrics.reporter.topic.replicas={{kafka_broker_default_interal_replication_factor}}
 {% set config_prefix = 'confluent.metrics.reporter.' %}

--- a/roles/confluent.kafka_connect/tasks/health_check.yml
+++ b/roles/confluent.kafka_connect/tasks/health_check.yml
@@ -1,7 +1,7 @@
 ---
 - name: Wait for API to return 200
   uri:
-    url: "{{kafka_connect_http_protocol}}://{{inventory_hostname}}:{{kafka_connect_rest_port}}/connectors"
+    url: "{{kafka_connect_http_protocol}}://{{ansible_host}}:{{kafka_connect_rest_port}}/connectors"
     status_code: 200
     validate_certs: false
   register: result
@@ -12,7 +12,7 @@
 
 - name: Wait for API to return 200 - RBAC
   uri:
-    url: "{{kafka_connect_http_protocol}}://{{inventory_hostname}}:{{kafka_connect_rest_port}}/connectors"
+    url: "{{kafka_connect_http_protocol}}://{{ansible_host}}:{{kafka_connect_rest_port}}/connectors"
     status_code: 200
     validate_certs: false
     url_username: "{{kafka_connect_ldap_user}}"

--- a/roles/confluent.kafka_connect/tasks/main.yml
+++ b/roles/confluent.kafka_connect/tasks/main.yml
@@ -38,7 +38,7 @@
     keystore_storepass: "{{kafka_connect_keystore_storepass}}"
     keystore_keypass: "{{kafka_connect_keystore_keypass}}"
     service_name: kafka_connect
-    hostnames: "{{ [inventory_hostname, ansible_fqdn] | unique }}"
+    hostnames: "{{ [ansible_host, ansible_fqdn] | unique }}"
     ca_cert_path: "{{kafka_connect_ca_cert_path}}"
     cert_path: "{{kafka_connect_cert_path}}"
     key_path: "{{kafka_connect_key_path}}"

--- a/roles/confluent.kafka_connect/templates/connect-distributed.properties.j2
+++ b/roles/confluent.kafka_connect/templates/connect-distributed.properties.j2
@@ -21,7 +21,7 @@ listeners.{{kafka_connect_http_protocol|lower}}.ssl.truststore.password={{kafka_
 {% endif %}
 
 # Kafka Broker Configuration
-bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ host }}:{{kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']}}{% endfor %}
+bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['ansible_host'] }}:{{kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']}}{% endfor %}
 
 {% set config_prefix = '' %}
 {% set listener = kafka_broker_listeners[kafka_connect_kafka_listener_name] %}
@@ -44,7 +44,7 @@ bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%}
 {% if schema_registries %}
 
 # Schema Registry Configuration
-value.converter.schema.registry.url={% for host in groups['schema_registry'] %}{% if loop.index > 1%},{% endif %}{{ schema_registry_http_protocol }}://{{ host }}:{{ schema_registry_listener_port }}{% endfor %}
+value.converter.schema.registry.url={% for host in groups['schema_registry'] %}{% if loop.index > 1%},{% endif %}{{ schema_registry_http_protocol }}://{{ hostvars[host]['ansible_host'] }}:{{ schema_registry_listener_port }}{% endfor %}
 
 {% if schema_registry_ssl_enabled|bool %}
 value.converter.schema.registry.ssl.truststore.location={{kafka_connect_truststore_path}}
@@ -54,7 +54,7 @@ value.converter.schema.registry.ssl.keystore.password={{kafka_connect_keystore_s
 value.converter.schema.registry.ssl.key.password={{kafka_connect_keystore_keypass}}
 {% endif %}
 
-key.converter.schema.registry.url={% for host in groups['schema_registry'] %}{% if loop.index > 1%},{% endif %}{{ schema_registry_http_protocol }}://{{ host }}:{{ schema_registry_listener_port }}{% endfor %}
+key.converter.schema.registry.url={% for host in groups['schema_registry'] %}{% if loop.index > 1%},{% endif %}{{ schema_registry_http_protocol }}://{{ hostvars[host]['ansible_host'] }}:{{ schema_registry_listener_port }}{% endfor %}
 
 {% if schema_registry_ssl_enabled|bool %}
 key.converter.schema.registry.ssl.truststore.location={{kafka_connect_truststore_path}}
@@ -67,7 +67,7 @@ key.converter.schema.registry.ssl.key.password={{kafka_connect_keystore_keypass}
 
 # Connect Producer Configuration {# Producer should not have jaas config, set in worker properties #}
 
-producer.bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ host }}:{{kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']}}{% endfor %}
+producer.bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['ansible_host'] }}:{{kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']}}{% endfor %}
 
 producer.security.protocol={{kafka_broker_listeners[kafka_connect_kafka_listener_name] | kafka_protocol_defaults(sasl_protocol, ssl_enabled) }}
 {% if kafka_broker_listeners[kafka_connect_kafka_listener_name]['ssl_enabled'] | default(ssl_enabled) | bool %}
@@ -96,7 +96,7 @@ producer.sasl.login.callback.handler.class=io.confluent.kafka.clients.plugins.au
 
 # Connect Consumer Configuration {# Consumers should not have jaas config, set in worker properties #}
 
-consumer.bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ host }}:{{kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']}}{% endfor %}
+consumer.bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['ansible_host'] }}:{{kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']}}{% endfor %}
 
 consumer.security.protocol={{kafka_broker_listeners[kafka_connect_kafka_listener_name] | kafka_protocol_defaults(sasl_protocol, ssl_enabled) }}
 {% if kafka_broker_listeners[kafka_connect_kafka_listener_name]['ssl_enabled'] | default(ssl_enabled) | bool %}
@@ -124,13 +124,13 @@ consumer.sasl.login.callback.handler.class=io.confluent.kafka.clients.plugins.au
 {% endif %}
 
 # Producer Monitoring Configuration
-producer.confluent.monitoring.interceptor.bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ host }}:{{kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']}}{% endfor %}
+producer.confluent.monitoring.interceptor.bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['ansible_host'] }}:{{kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']}}{% endfor %}
 
 {% set config_prefix = 'producer.confluent.monitoring.interceptor.' %}
 {% include 'roles/confluent.kafka_broker/templates/kafka_client.j2' %}
 
 # Consumer Monitoring Configuration
-consumer.confluent.monitoring.interceptor.bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ host }}:{{kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']}}{% endfor %}
+consumer.confluent.monitoring.interceptor.bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['ansible_host'] }}:{{kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']}}{% endfor %}
 
 {% set config_prefix = 'consumer.confluent.monitoring.interceptor.' %}
 {% include 'roles/confluent.kafka_broker/templates/kafka_client.j2' %}
@@ -142,7 +142,7 @@ rest.extension.classes=io.confluent.connect.security.ConnectSecurityExtension{% 
 config.providers=secret
 config.providers.secret.class=io.confluent.connect.secretregistry.rbac.config.provider.InternalSecretConfigProvider
 config.providers.secret.param.master.encryption.key={{kafka_connect_secret_registry_key}}
-config.providers.secret.param.kafkastore.bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ host }}:{{kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']}}{% endfor %}
+config.providers.secret.param.kafkastore.bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['ansible_host'] }}:{{kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']}}{% endfor %}
 
 {% set config_prefix = 'config.providers.secret.param.kafkastore.' %}
 {% include 'roles/confluent.kafka_broker/templates/kafka_client.j2' %}
@@ -152,7 +152,7 @@ config.providers.secret.param.kafkastore.bootstrap.servers={% for host in groups
 rest.servlet.initializor.classes=io.confluent.common.security.jetty.initializer.InstallBearerOrBasicSecurityHandler
 public.key.path={{rbac_enabled_public_pem_path}}
 
-confluent.metadata.bootstrap.server.urls={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{mds_http_protocol}}://{{ host }}:{{mds_port}}{% endfor %}
+confluent.metadata.bootstrap.server.urls={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{mds_http_protocol}}://{{ hostvars[host]['ansible_host'] }}:{{mds_port}}{% endfor %}
 
 confluent.metadata.basic.auth.user.info={{kafka_connect_ldap_user}}:{{kafka_connect_ldap_password}}
 confluent.metadata.http.auth.credentials.provider=BASIC

--- a/roles/confluent.kafka_connect/templates/connect-distributed.properties.j2
+++ b/roles/confluent.kafka_connect/templates/connect-distributed.properties.j2
@@ -7,7 +7,7 @@
 # Kafka Connect Configuration
 listeners={{kafka_connect_http_protocol}}://0.0.0.0:{{kafka_connect_rest_port}}
 rest.advertised.listener={{kafka_connect_http_protocol}}
-rest.advertised.host.name={{inventory_hostname}}
+rest.advertised.host.name={{ansible_host}}
 rest.advertised.port={{kafka_connect_rest_port}}
 {% if kafka_connect_ssl_enabled|bool %}
 listeners.{{kafka_connect_http_protocol|lower}}.ssl.keystore.location={{kafka_connect_keystore_path}}

--- a/roles/confluent.kafka_connect/templates/connect-distributed.properties.j2
+++ b/roles/confluent.kafka_connect/templates/connect-distributed.properties.j2
@@ -21,7 +21,7 @@ listeners.{{kafka_connect_http_protocol|lower}}.ssl.truststore.password={{kafka_
 {% endif %}
 
 # Kafka Broker Configuration
-bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['ansible_host'] }}:{{kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']}}{% endfor %}
+bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['ansible_host']|default(host) }}:{{kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']}}{% endfor %}
 
 {% set config_prefix = '' %}
 {% set listener = kafka_broker_listeners[kafka_connect_kafka_listener_name] %}
@@ -44,7 +44,7 @@ bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%}
 {% if schema_registries %}
 
 # Schema Registry Configuration
-value.converter.schema.registry.url={% for host in groups['schema_registry'] %}{% if loop.index > 1%},{% endif %}{{ schema_registry_http_protocol }}://{{ hostvars[host]['ansible_host'] }}:{{ schema_registry_listener_port }}{% endfor %}
+value.converter.schema.registry.url={% for host in groups['schema_registry'] %}{% if loop.index > 1%},{% endif %}{{ schema_registry_http_protocol }}://{{ hostvars[host]['ansible_host']|default(host) }}:{{ schema_registry_listener_port }}{% endfor %}
 
 {% if schema_registry_ssl_enabled|bool %}
 value.converter.schema.registry.ssl.truststore.location={{kafka_connect_truststore_path}}
@@ -54,7 +54,7 @@ value.converter.schema.registry.ssl.keystore.password={{kafka_connect_keystore_s
 value.converter.schema.registry.ssl.key.password={{kafka_connect_keystore_keypass}}
 {% endif %}
 
-key.converter.schema.registry.url={% for host in groups['schema_registry'] %}{% if loop.index > 1%},{% endif %}{{ schema_registry_http_protocol }}://{{ hostvars[host]['ansible_host'] }}:{{ schema_registry_listener_port }}{% endfor %}
+key.converter.schema.registry.url={% for host in groups['schema_registry'] %}{% if loop.index > 1%},{% endif %}{{ schema_registry_http_protocol }}://{{ hostvars[host]['ansible_host']|default(host) }}:{{ schema_registry_listener_port }}{% endfor %}
 
 {% if schema_registry_ssl_enabled|bool %}
 key.converter.schema.registry.ssl.truststore.location={{kafka_connect_truststore_path}}
@@ -67,7 +67,7 @@ key.converter.schema.registry.ssl.key.password={{kafka_connect_keystore_keypass}
 
 # Connect Producer Configuration {# Producer should not have jaas config, set in worker properties #}
 
-producer.bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['ansible_host'] }}:{{kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']}}{% endfor %}
+producer.bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['ansible_host']|default(host) }}:{{kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']}}{% endfor %}
 
 producer.security.protocol={{kafka_broker_listeners[kafka_connect_kafka_listener_name] | kafka_protocol_defaults(sasl_protocol, ssl_enabled) }}
 {% if kafka_broker_listeners[kafka_connect_kafka_listener_name]['ssl_enabled'] | default(ssl_enabled) | bool %}
@@ -96,7 +96,7 @@ producer.sasl.login.callback.handler.class=io.confluent.kafka.clients.plugins.au
 
 # Connect Consumer Configuration {# Consumers should not have jaas config, set in worker properties #}
 
-consumer.bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['ansible_host'] }}:{{kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']}}{% endfor %}
+consumer.bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['ansible_host']|default(host) }}:{{kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']}}{% endfor %}
 
 consumer.security.protocol={{kafka_broker_listeners[kafka_connect_kafka_listener_name] | kafka_protocol_defaults(sasl_protocol, ssl_enabled) }}
 {% if kafka_broker_listeners[kafka_connect_kafka_listener_name]['ssl_enabled'] | default(ssl_enabled) | bool %}
@@ -124,13 +124,13 @@ consumer.sasl.login.callback.handler.class=io.confluent.kafka.clients.plugins.au
 {% endif %}
 
 # Producer Monitoring Configuration
-producer.confluent.monitoring.interceptor.bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['ansible_host'] }}:{{kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']}}{% endfor %}
+producer.confluent.monitoring.interceptor.bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['ansible_host']|default(host) }}:{{kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']}}{% endfor %}
 
 {% set config_prefix = 'producer.confluent.monitoring.interceptor.' %}
 {% include 'roles/confluent.kafka_broker/templates/kafka_client.j2' %}
 
 # Consumer Monitoring Configuration
-consumer.confluent.monitoring.interceptor.bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['ansible_host'] }}:{{kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']}}{% endfor %}
+consumer.confluent.monitoring.interceptor.bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['ansible_host']|default(host) }}:{{kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']}}{% endfor %}
 
 {% set config_prefix = 'consumer.confluent.monitoring.interceptor.' %}
 {% include 'roles/confluent.kafka_broker/templates/kafka_client.j2' %}
@@ -142,7 +142,7 @@ rest.extension.classes=io.confluent.connect.security.ConnectSecurityExtension{% 
 config.providers=secret
 config.providers.secret.class=io.confluent.connect.secretregistry.rbac.config.provider.InternalSecretConfigProvider
 config.providers.secret.param.master.encryption.key={{kafka_connect_secret_registry_key}}
-config.providers.secret.param.kafkastore.bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['ansible_host'] }}:{{kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']}}{% endfor %}
+config.providers.secret.param.kafkastore.bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['ansible_host']|default(host) }}:{{kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']}}{% endfor %}
 
 {% set config_prefix = 'config.providers.secret.param.kafkastore.' %}
 {% include 'roles/confluent.kafka_broker/templates/kafka_client.j2' %}
@@ -152,7 +152,7 @@ config.providers.secret.param.kafkastore.bootstrap.servers={% for host in groups
 rest.servlet.initializor.classes=io.confluent.common.security.jetty.initializer.InstallBearerOrBasicSecurityHandler
 public.key.path={{rbac_enabled_public_pem_path}}
 
-confluent.metadata.bootstrap.server.urls={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{mds_http_protocol}}://{{ hostvars[host]['ansible_host'] }}:{{mds_port}}{% endfor %}
+confluent.metadata.bootstrap.server.urls={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{mds_http_protocol}}://{{ hostvars[host]['ansible_host']|default(host) }}:{{mds_port}}{% endfor %}
 
 confluent.metadata.basic.auth.user.info={{kafka_connect_ldap_user}}:{{kafka_connect_ldap_password}}
 confluent.metadata.http.auth.credentials.provider=BASIC

--- a/roles/confluent.kafka_rest/tasks/health_check.yml
+++ b/roles/confluent.kafka_rest/tasks/health_check.yml
@@ -1,7 +1,7 @@
 ---
 - name: Wait for API to return 200
   uri:
-    url: "{{kafka_rest_http_protocol}}://{{inventory_hostname}}:{{kafka_rest_port}}/topics"
+    url: "{{kafka_rest_http_protocol}}://{{ansible_host}}:{{kafka_rest_port}}/topics"
     status_code: 200
     validate_certs: false
   register: result
@@ -12,7 +12,7 @@
 
 - name: Wait for API to return 200 - RBAC
   uri:
-    url: "{{kafka_rest_http_protocol}}://{{inventory_hostname}}:{{kafka_rest_port}}/topics"
+    url: "{{kafka_rest_http_protocol}}://{{ansible_host}}:{{kafka_rest_port}}/topics"
     status_code: 200
     validate_certs: false
     url_username: "{{kafka_rest_ldap_user}}"

--- a/roles/confluent.kafka_rest/tasks/main.yml
+++ b/roles/confluent.kafka_rest/tasks/main.yml
@@ -38,7 +38,7 @@
     keystore_storepass: "{{kafka_rest_keystore_storepass}}"
     keystore_keypass: "{{kafka_rest_keystore_keypass}}"
     service_name: kafka_rest
-    hostnames: "{{ [inventory_hostname, ansible_fqdn] | unique }}"
+    hostnames: "{{ [ansible_host, ansible_fqdn] | unique }}"
     ca_cert_path: "{{kafka_rest_ca_cert_path}}"
     cert_path: "{{kafka_rest_cert_path}}"
     key_path: "{{kafka_rest_key_path}}"

--- a/roles/confluent.kafka_rest/templates/kafka-rest.properties.j2
+++ b/roles/confluent.kafka_rest/templates/kafka-rest.properties.j2
@@ -5,7 +5,7 @@
 
 # Kafka Rest Configuration
 listeners={{kafka_rest_http_protocol}}://0.0.0.0:{{kafka_rest_port}}
-host.name={{inventory_hostname}}
+host.name={{ansible_host}}
 {% if kafka_rest_ssl_enabled|bool %}
 ssl.keystore.location={{kafka_rest_keystore_path}}
 ssl.keystore.password={{kafka_rest_keystore_storepass}}

--- a/roles/confluent.kafka_rest/templates/kafka-rest.properties.j2
+++ b/roles/confluent.kafka_rest/templates/kafka-rest.properties.j2
@@ -18,11 +18,11 @@ ssl.client.auth=false
 {% endif %}
 
 # Zookeeper Configuration
-zookeeper.connect={% for host in groups['zookeeper'] %}{% if loop.index > 1%},{% endif %}{{ host }}:{{zookeeper.properties.clientPort}}{% endfor %}
+zookeeper.connect={% for host in groups['zookeeper'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['ansible_host'] }}:{{zookeeper.properties.clientPort}}{% endfor %}
 
 
 # Kafka Broker Configuration
-bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ host }}:{{kafka_broker_listeners[kafka_rest_kafka_listener_name]['port']}}{% endfor %}
+bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['ansible_host'] }}:{{kafka_broker_listeners[kafka_rest_kafka_listener_name]['port']}}{% endfor %}
 
 {% set config_prefix = 'client.' %}
 {% set listener = kafka_broker_listeners[kafka_rest_kafka_listener_name] %}
@@ -44,7 +44,7 @@ bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%}
 {% set schema_registries = groups.get('schema_registry', []) %}
 {% if schema_registries %}
 # Schema Registry Configuration
-schema.registry.url={% for host in groups['schema_registry'] %}{% if loop.index > 1%},{% endif %}{{ schema_registry_http_protocol }}://{{ host }}:{{ schema_registry_listener_port }}{% endfor %}
+schema.registry.url={% for host in groups['schema_registry'] %}{% if loop.index > 1%},{% endif %}{{ schema_registry_http_protocol }}://{{ hostvars[host]['ansible_host'] }}:{{ schema_registry_listener_port }}{% endfor %}
 
 {% if schema_registry_ssl_enabled|bool %}
 schema.registry.ssl.truststore.location={{kafka_rest_truststore_path}}
@@ -56,7 +56,7 @@ schema.registry.ssl.key.password={{kafka_rest_keystore_keypass}}
 {% endif %}
 
 # Monitoring Configuration
-confluent.monitoring.interceptor.bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ host }}:{{kafka_broker_listeners[kafka_rest_kafka_listener_name]['port']}}{% endfor %}
+confluent.monitoring.interceptor.bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['ansible_host'] }}:{{kafka_broker_listeners[kafka_rest_kafka_listener_name]['port']}}{% endfor %}
 
 {% set config_prefix = 'confluent.monitoring.interceptor.' %}
 {% include 'roles/confluent.kafka_broker/templates/kafka_client.j2' %}
@@ -68,7 +68,7 @@ rest.servlet.initializor.classes=io.confluent.common.security.jetty.initializer.
 public.key.path={{rbac_enabled_public_pem_path}}
 client.confluent.metadata.server.urls.max.age.ms=60000
 
-confluent.metadata.bootstrap.server.urls={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{mds_http_protocol}}://{{ host }}:{{mds_port}}{% endfor %}
+confluent.metadata.bootstrap.server.urls={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{mds_http_protocol}}://{{ hostvars[host]['ansible_host'] }}:{{mds_port}}{% endfor %}
 
 confluent.metadata.server.urls.max.age.ms=60000
 confluent.metadata.basic.auth.user.info={{kafka_rest_ldap_user}}:{{kafka_rest_ldap_password}}

--- a/roles/confluent.kafka_rest/templates/kafka-rest.properties.j2
+++ b/roles/confluent.kafka_rest/templates/kafka-rest.properties.j2
@@ -18,11 +18,11 @@ ssl.client.auth=false
 {% endif %}
 
 # Zookeeper Configuration
-zookeeper.connect={% for host in groups['zookeeper'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['ansible_host'] }}:{{zookeeper.properties.clientPort}}{% endfor %}
+zookeeper.connect={% for host in groups['zookeeper'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['ansible_host']|default(host) }}:{{zookeeper.properties.clientPort}}{% endfor %}
 
 
 # Kafka Broker Configuration
-bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['ansible_host'] }}:{{kafka_broker_listeners[kafka_rest_kafka_listener_name]['port']}}{% endfor %}
+bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['ansible_host']|default(host) }}:{{kafka_broker_listeners[kafka_rest_kafka_listener_name]['port']}}{% endfor %}
 
 {% set config_prefix = 'client.' %}
 {% set listener = kafka_broker_listeners[kafka_rest_kafka_listener_name] %}
@@ -44,7 +44,7 @@ bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%}
 {% set schema_registries = groups.get('schema_registry', []) %}
 {% if schema_registries %}
 # Schema Registry Configuration
-schema.registry.url={% for host in groups['schema_registry'] %}{% if loop.index > 1%},{% endif %}{{ schema_registry_http_protocol }}://{{ hostvars[host]['ansible_host'] }}:{{ schema_registry_listener_port }}{% endfor %}
+schema.registry.url={% for host in groups['schema_registry'] %}{% if loop.index > 1%},{% endif %}{{ schema_registry_http_protocol }}://{{ hostvars[host]['ansible_host']|default(host) }}:{{ schema_registry_listener_port }}{% endfor %}
 
 {% if schema_registry_ssl_enabled|bool %}
 schema.registry.ssl.truststore.location={{kafka_rest_truststore_path}}
@@ -56,7 +56,7 @@ schema.registry.ssl.key.password={{kafka_rest_keystore_keypass}}
 {% endif %}
 
 # Monitoring Configuration
-confluent.monitoring.interceptor.bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['ansible_host'] }}:{{kafka_broker_listeners[kafka_rest_kafka_listener_name]['port']}}{% endfor %}
+confluent.monitoring.interceptor.bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['ansible_host']|default(host) }}:{{kafka_broker_listeners[kafka_rest_kafka_listener_name]['port']}}{% endfor %}
 
 {% set config_prefix = 'confluent.monitoring.interceptor.' %}
 {% include 'roles/confluent.kafka_broker/templates/kafka_client.j2' %}
@@ -68,7 +68,7 @@ rest.servlet.initializor.classes=io.confluent.common.security.jetty.initializer.
 public.key.path={{rbac_enabled_public_pem_path}}
 client.confluent.metadata.server.urls.max.age.ms=60000
 
-confluent.metadata.bootstrap.server.urls={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{mds_http_protocol}}://{{ hostvars[host]['ansible_host'] }}:{{mds_port}}{% endfor %}
+confluent.metadata.bootstrap.server.urls={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{mds_http_protocol}}://{{ hostvars[host]['ansible_host']|default(host) }}:{{mds_port}}{% endfor %}
 
 confluent.metadata.server.urls.max.age.ms=60000
 confluent.metadata.basic.auth.user.info={{kafka_rest_ldap_user}}:{{kafka_rest_ldap_password}}

--- a/roles/confluent.ksql/tasks/health_check.yml
+++ b/roles/confluent.ksql/tasks/health_check.yml
@@ -1,7 +1,7 @@
 ---
 - name: Wait for API to return 200
   uri:
-    url: "{{ksql_http_protocol}}://{{inventory_hostname}}:{{ksql_listener_port}}/info"
+    url: "{{ksql_http_protocol}}://{{ansible_host}}:{{ksql_listener_port}}/info"
     status_code: 200
     validate_certs: false
   register: result
@@ -12,7 +12,7 @@
 
 - name: Wait for API to return 200 - RBAC
   uri:
-    url: "{{ksql_http_protocol}}://{{inventory_hostname}}:{{ksql_listener_port}}/info"
+    url: "{{ksql_http_protocol}}://{{ansible_host}}:{{ksql_listener_port}}/info"
     status_code: 200
     validate_certs: false
     url_username: "{{ksql_ldap_user}}"

--- a/roles/confluent.ksql/tasks/main.yml
+++ b/roles/confluent.ksql/tasks/main.yml
@@ -46,7 +46,7 @@
     keystore_storepass: "{{ksql_keystore_storepass}}"
     keystore_keypass: "{{ksql_keystore_keypass}}"
     service_name: ksql
-    hostnames: "{{ [inventory_hostname, ansible_fqdn] | unique }}"
+    hostnames: "{{ [ansible_host, ansible_fqdn] | unique }}"
     ca_cert_path: "{{ksql_ca_cert_path}}"
     cert_path: "{{ksql_cert_path}}"
     key_path: "{{ksql_key_path}}"

--- a/roles/confluent.ksql/templates/ksql-server.properties.j2
+++ b/roles/confluent.ksql/templates/ksql-server.properties.j2
@@ -7,7 +7,7 @@ listeners={{ksql_http_protocol}}://0.0.0.0:{{ksql_listener_port}}
 {% endfor %}
 
 # Kafka Broker Configuration
-bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['ansible_host'] }}:{{kafka_broker_listeners[ksql_kafka_listener_name]['port']}}{% endfor %}
+bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['ansible_host']|default(host) }}:{{kafka_broker_listeners[ksql_kafka_listener_name]['port']}}{% endfor %}
 
 security.protocol={{kafka_broker_listeners[ksql_kafka_listener_name] | kafka_protocol_defaults(sasl_protocol, ssl_enabled) }}
 {% if kafka_broker_listeners[ksql_kafka_listener_name]['ssl_enabled'] | default(ssl_enabled) | bool %}
@@ -42,13 +42,13 @@ sasl.mechanism=OAUTHBEARER
 sasl.login.callback.handler.class=io.confluent.kafka.clients.plugins.auth.token.TokenUserLoginCallbackHandler
 sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required \
    username="{{ksql_ldap_user}}" password="{{ksql_ldap_password}}" \
-   metadataServerUrls="{% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{mds_http_protocol}}://{{ hostvars[host]['ansible_host'] }}:{{mds_port}}{% endfor %}";
+   metadataServerUrls="{% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{mds_http_protocol}}://{{ hostvars[host]['ansible_host']|default(host) }}:{{mds_port}}{% endfor %}";
 {% endif %}
 
 {% set schema_registries = groups.get('schema_registry', []) %}
 {% if schema_registries %}
 # Schema Registry Configuration
-ksql.schema.registry.url={% for host in groups['schema_registry'] %}{% if loop.index > 1%},{% endif %}{{ schema_registry_http_protocol }}://{{ hostvars[host]['ansible_host'] }}:{{ schema_registry_listener_port }}{% endfor %}
+ksql.schema.registry.url={% for host in groups['schema_registry'] %}{% if loop.index > 1%},{% endif %}{{ schema_registry_http_protocol }}://{{ hostvars[host]['ansible_host']|default(host) }}:{{ schema_registry_listener_port }}{% endfor %}
 
 {% if schema_registry_ssl_enabled|bool %}
 ksql.schema.registry.ssl.truststore.location={{ksql_truststore_path}}
@@ -64,7 +64,7 @@ ksql.schema.registry.basic.auth.user.info={{ ksql_ldap_user }}:{{ ksql_ldap_pass
 {% endif %}
 
 # Monitoring Configuration
-confluent.monitoring.interceptor.bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['ansible_host'] }}:{{kafka_broker_listeners[ksql_kafka_listener_name]['port']}}{% endfor %}
+confluent.monitoring.interceptor.bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['ansible_host']|default(host) }}:{{kafka_broker_listeners[ksql_kafka_listener_name]['port']}}{% endfor %}
 
 {% set config_prefix = 'confluent.monitoring.interceptor.' %}
 {% set listener = kafka_broker_listeners[ksql_kafka_listener_name] %}
@@ -91,7 +91,7 @@ websocket.servlet.initializor.classes=io.confluent.common.security.jetty.initial
 oauth.jwt.public.key.path={{rbac_enabled_public_pem_path}}
 public.key.path={{rbac_enabled_public_pem_path}}
 
-confluent.metadata.bootstrap.server.urls={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{mds_http_protocol}}://{{ hostvars[host]['ansible_host'] }}:{{mds_port}}{% endfor %}
+confluent.metadata.bootstrap.server.urls={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{mds_http_protocol}}://{{ hostvars[host]['ansible_host']|default(host) }}:{{mds_port}}{% endfor %}
 
 confluent.metadata.public.key.path={{rbac_enabled_public_pem_path}}
 confluent.metadata.basic.auth.user.info={{ ksql_ldap_user }}:{{ ksql_ldap_password }}

--- a/roles/confluent.ksql/templates/ksql-server.properties.j2
+++ b/roles/confluent.ksql/templates/ksql-server.properties.j2
@@ -7,7 +7,7 @@ listeners={{ksql_http_protocol}}://0.0.0.0:{{ksql_listener_port}}
 {% endfor %}
 
 # Kafka Broker Configuration
-bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ host }}:{{kafka_broker_listeners[ksql_kafka_listener_name]['port']}}{% endfor %}
+bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['ansible_host'] }}:{{kafka_broker_listeners[ksql_kafka_listener_name]['port']}}{% endfor %}
 
 security.protocol={{kafka_broker_listeners[ksql_kafka_listener_name] | kafka_protocol_defaults(sasl_protocol, ssl_enabled) }}
 {% if kafka_broker_listeners[ksql_kafka_listener_name]['ssl_enabled'] | default(ssl_enabled) | bool %}
@@ -42,13 +42,13 @@ sasl.mechanism=OAUTHBEARER
 sasl.login.callback.handler.class=io.confluent.kafka.clients.plugins.auth.token.TokenUserLoginCallbackHandler
 sasl.jaas.config=org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required \
    username="{{ksql_ldap_user}}" password="{{ksql_ldap_password}}" \
-   metadataServerUrls="{% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{mds_http_protocol}}://{{ host }}:{{mds_port}}{% endfor %}";
+   metadataServerUrls="{% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{mds_http_protocol}}://{{ hostvars[host]['ansible_host'] }}:{{mds_port}}{% endfor %}";
 {% endif %}
 
 {% set schema_registries = groups.get('schema_registry', []) %}
 {% if schema_registries %}
 # Schema Registry Configuration
-ksql.schema.registry.url={% for host in groups['schema_registry'] %}{% if loop.index > 1%},{% endif %}{{ schema_registry_http_protocol }}://{{ host }}:{{ schema_registry_listener_port }}{% endfor %}
+ksql.schema.registry.url={% for host in groups['schema_registry'] %}{% if loop.index > 1%},{% endif %}{{ schema_registry_http_protocol }}://{{ hostvars[host]['ansible_host'] }}:{{ schema_registry_listener_port }}{% endfor %}
 
 {% if schema_registry_ssl_enabled|bool %}
 ksql.schema.registry.ssl.truststore.location={{ksql_truststore_path}}
@@ -64,7 +64,7 @@ ksql.schema.registry.basic.auth.user.info={{ ksql_ldap_user }}:{{ ksql_ldap_pass
 {% endif %}
 
 # Monitoring Configuration
-confluent.monitoring.interceptor.bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ host }}:{{kafka_broker_listeners[ksql_kafka_listener_name]['port']}}{% endfor %}
+confluent.monitoring.interceptor.bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['ansible_host'] }}:{{kafka_broker_listeners[ksql_kafka_listener_name]['port']}}{% endfor %}
 
 {% set config_prefix = 'confluent.monitoring.interceptor.' %}
 {% set listener = kafka_broker_listeners[ksql_kafka_listener_name] %}
@@ -91,7 +91,7 @@ websocket.servlet.initializor.classes=io.confluent.common.security.jetty.initial
 oauth.jwt.public.key.path={{rbac_enabled_public_pem_path}}
 public.key.path={{rbac_enabled_public_pem_path}}
 
-confluent.metadata.bootstrap.server.urls={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{mds_http_protocol}}://{{ host }}:{{mds_port}}{% endfor %}
+confluent.metadata.bootstrap.server.urls={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{mds_http_protocol}}://{{ hostvars[host]['ansible_host'] }}:{{mds_port}}{% endfor %}
 
 confluent.metadata.public.key.path={{rbac_enabled_public_pem_path}}
 confluent.metadata.basic.auth.user.info={{ ksql_ldap_user }}:{{ ksql_ldap_password }}

--- a/roles/confluent.schema_registry/tasks/health_check.yml
+++ b/roles/confluent.schema_registry/tasks/health_check.yml
@@ -1,7 +1,7 @@
 ---
 - name: Wait for API to return 200
   uri:
-    url: "{{schema_registry_http_protocol}}://{{inventory_hostname}}:{{schema_registry_listener_port}}/subjects"
+    url: "{{schema_registry_http_protocol}}://{{ansible_host}}:{{schema_registry_listener_port}}/subjects"
     status_code: 200
     validate_certs: false
   register: result
@@ -12,7 +12,7 @@
 
 - name: Wait for API to return 200 - RBAC
   uri:
-    url: "{{schema_registry_http_protocol}}://{{inventory_hostname}}:{{schema_registry_listener_port}}/subjects"
+    url: "{{schema_registry_http_protocol}}://{{ansible_host}}:{{schema_registry_listener_port}}/subjects"
     status_code: 200
     validate_certs: false
     url_username: "{{schema_registry_ldap_user}}"

--- a/roles/confluent.schema_registry/tasks/main.yml
+++ b/roles/confluent.schema_registry/tasks/main.yml
@@ -38,7 +38,7 @@
     keystore_storepass: "{{schema_registry_keystore_storepass}}"
     keystore_keypass: "{{schema_registry_keystore_keypass}}"
     service_name: schema_registry
-    hostnames: "{{ [inventory_hostname, ansible_fqdn] | unique }}"
+    hostnames: "{{ [ansible_host, ansible_fqdn] | unique }}"
     ca_cert_path: "{{schema_registry_ca_cert_path}}"
     cert_path: "{{schema_registry_cert_path}}"
     key_path: "{{schema_registry_key_path}}"

--- a/roles/confluent.schema_registry/templates/schema-registry.properties.j2
+++ b/roles/confluent.schema_registry/templates/schema-registry.properties.j2
@@ -20,7 +20,7 @@ ssl.client.auth=false
 {% endif %}
 
 # Kafka Broker Configuration
-kafkastore.bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['ansible_host'] }}:{{kafka_broker_listeners[schema_registry_kafka_listener_name]['port']}}{% endfor %}
+kafkastore.bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['ansible_host']|default(host) }}:{{kafka_broker_listeners[schema_registry_kafka_listener_name]['port']}}{% endfor %}
 
 {% set config_prefix = 'kafkastore.' %}
 {% set listener = kafka_broker_listeners[schema_registry_kafka_listener_name] %}
@@ -41,7 +41,7 @@ kafkastore.bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.
 
 {% if rbac_enabled|bool %}
 # Zookeeper Configuration
-kafkastore.connection.url={% for host in groups['zookeeper'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['ansible_host'] }}:{{zookeeper.properties.clientPort}}{% endfor %}
+kafkastore.connection.url={% for host in groups['zookeeper'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['ansible_host']|default(host) }}:{{zookeeper.properties.clientPort}}{% endfor %}
 
 
 # RBAC Configuration
@@ -52,7 +52,7 @@ confluent.schema.registry.auth.mechanism=JETTY_AUTH
 public.key.path={{rbac_enabled_public_pem_path}}
 authentication.roles=**
 
-confluent.metadata.bootstrap.server.urls={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ mds_http_protocol }}://{{ hostvars[host]['ansible_host'] }}:{{mds_port}}{% endfor %}
+confluent.metadata.bootstrap.server.urls={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ mds_http_protocol }}://{{ hostvars[host]['ansible_host']|default(host) }}:{{mds_port}}{% endfor %}
 
 confluent.metadata.http.auth.credentials.provider=BASIC
 confluent.metadata.basic.auth.user.info={{ schema_registry_ldap_user }}:{{ schema_registry_ldap_password }}

--- a/roles/confluent.schema_registry/templates/schema-registry.properties.j2
+++ b/roles/confluent.schema_registry/templates/schema-registry.properties.j2
@@ -20,7 +20,7 @@ ssl.client.auth=false
 {% endif %}
 
 # Kafka Broker Configuration
-kafkastore.bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ host }}:{{kafka_broker_listeners[schema_registry_kafka_listener_name]['port']}}{% endfor %}
+kafkastore.bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['ansible_host'] }}:{{kafka_broker_listeners[schema_registry_kafka_listener_name]['port']}}{% endfor %}
 
 {% set config_prefix = 'kafkastore.' %}
 {% set listener = kafka_broker_listeners[schema_registry_kafka_listener_name] %}
@@ -41,7 +41,7 @@ kafkastore.bootstrap.servers={% for host in groups['kafka_broker'] %}{% if loop.
 
 {% if rbac_enabled|bool %}
 # Zookeeper Configuration
-kafkastore.connection.url={% for host in groups['zookeeper'] %}{% if loop.index > 1%},{% endif %}{{ host }}:{{zookeeper.properties.clientPort}}{% endfor %}
+kafkastore.connection.url={% for host in groups['zookeeper'] %}{% if loop.index > 1%},{% endif %}{{ hostvars[host]['ansible_host'] }}:{{zookeeper.properties.clientPort}}{% endfor %}
 
 
 # RBAC Configuration
@@ -52,7 +52,7 @@ confluent.schema.registry.auth.mechanism=JETTY_AUTH
 public.key.path={{rbac_enabled_public_pem_path}}
 authentication.roles=**
 
-confluent.metadata.bootstrap.server.urls={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ mds_http_protocol }}://{{ host }}:{{mds_port}}{% endfor %}
+confluent.metadata.bootstrap.server.urls={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ mds_http_protocol }}://{{ hostvars[host]['ansible_host'] }}:{{mds_port}}{% endfor %}
 
 confluent.metadata.http.auth.credentials.provider=BASIC
 confluent.metadata.basic.auth.user.info={{ schema_registry_ldap_user }}:{{ schema_registry_ldap_password }}

--- a/roles/confluent.schema_registry/templates/schema-registry.properties.j2
+++ b/roles/confluent.schema_registry/templates/schema-registry.properties.j2
@@ -5,7 +5,7 @@
 
 # Schema Registry Configuration
 listeners={{schema_registry_http_protocol}}://0.0.0.0:{{schema_registry_listener_port}}
-host.name={{inventory_hostname}}
+host.name={{ansible_host}}
 inter.instance.protocol={{schema_registry_http_protocol}}
 {% if schema_registry_ssl_enabled|bool %}
 security.protocol=SSL

--- a/roles/confluent.ssl/tasks/self_signed_certs.yml
+++ b/roles/confluent.ssl/tasks/self_signed_certs.yml
@@ -31,8 +31,8 @@
     keytool -genkey -noprompt \
       -storetype pkcs12 \
       -keyalg RSA -keysize 2048 \
-      -alias {{inventory_hostname}} \
-      -dname "CN={{inventory_hostname}},OU=TEST,O=CONFLUENT,L=PaloAlto,S=Ca,C=US" \
+      -alias {{ansible_host}} \
+      -dname "CN={{ansible_host}},OU=TEST,O=CONFLUENT,L=PaloAlto,S=Ca,C=US" \
       -ext "SAN={{hostnames | cert_extension}}" \
       -keystore {{keystore_path}} \
       -storepass {{keystore_storepass}} \
@@ -50,7 +50,7 @@
   shell: |
     keytool -keystore {{keystore_path}} \
       -storetype pkcs12 \
-      -alias {{inventory_hostname}} \
+      -alias {{ansible_host}} \
       -certreq -file /var/ssl/private/generation/client.csr \
       -ext "SAN={{hostnames | cert_extension}}" \
       -storepass {{keystore_storepass}} \
@@ -85,7 +85,7 @@
   shell: |
     keytool -noprompt -keystore {{keystore_path}} \
       -storetype pkcs12 \
-      -alias {{inventory_hostname}} \
+      -alias {{ansible_host}} \
       -import -file {{cert_path}} \
       -ext "SAN={{hostnames | cert_extension}}" \
       -storepass {{keystore_storepass}} \

--- a/roles/confluent.variables_handlers/defaults/main.yml
+++ b/roles/confluent.variables_handlers/defaults/main.yml
@@ -133,8 +133,8 @@ kafka_broker_jolokia_enabled: "{{jolokia_enabled}}"
 kafka_broker_jolokia_port: 7771
 kafka_broker_jolokia_ssl_enabled: "{{ ssl_enabled }}"
 kafka_broker_jolokia_java_arg_ssl_addon: ",keystore={{kafka_broker_keystore_path}},keystorePassword={{kafka_broker_keystore_storepass}},protocol=https"
-kafka_broker_jolokia_urp_url: "{{ 'https' if kafka_broker_jolokia_ssl_enabled|bool else 'http' }}://{{inventory_hostname}}:{{kafka_broker_jolokia_port}}/jolokia/read/kafka.server:type=ReplicaManager,name=UnderReplicatedPartitions"
-kafka_broker_jolokia_active_controller_url: "{{ 'https' if kafka_broker_jolokia_ssl_enabled|bool else 'http' }}://{{inventory_hostname}}:{{kafka_broker_jolokia_port}}/jolokia/read/kafka.controller:type=KafkaController,name=ActiveControllerCount"
+kafka_broker_jolokia_urp_url: "{{ 'https' if kafka_broker_jolokia_ssl_enabled|bool else 'http' }}://{{ansible_host}}:{{kafka_broker_jolokia_port}}/jolokia/read/kafka.server:type=ReplicaManager,name=UnderReplicatedPartitions"
+kafka_broker_jolokia_active_controller_url: "{{ 'https' if kafka_broker_jolokia_ssl_enabled|bool else 'http' }}://{{ansible_host}}:{{kafka_broker_jolokia_port}}/jolokia/read/kafka.controller:type=KafkaController,name=ActiveControllerCount"
 
 kafka_broker_jmxexporter_enabled: "{{jmxexporter_enabled}}"
 kafka_broker_jmxexporter_config_path: /opt/prometheus/kafka.yml

--- a/roles/confluent.zookeeper/defaults/main.yml
+++ b/roles/confluent.zookeeper/defaults/main.yml
@@ -18,7 +18,7 @@ zookeeper_service_environment_overrides:
   KAFKA_HEAP_OPTS: "-Xmx1g"
   KAFKA_OPTS: "{{ zookeeper_final_java_args | java_arg_build_out }}"
 
-zookeeper_current_node_hostname: "{{ inventory_hostname }}"
+zookeeper_current_node_hostname: "{{ ansible_host }}"
 zookeeper_peer_port: 2888
 zookeeper_leader_port: 3888
 

--- a/roles/confluent.zookeeper/tasks/main.yml
+++ b/roles/confluent.zookeeper/tasks/main.yml
@@ -37,7 +37,7 @@
     keystore_storepass: "{{zookeeper_keystore_storepass}}"
     keystore_keypass: "{{zookeeper_keystore_keypass}}"
     service_name: zookeeper
-    hostnames: "{{ [inventory_hostname, ansible_fqdn] | unique }}"
+    hostnames: "{{ [ansible_host, ansible_fqdn] | unique }}"
     ca_cert_path: "{{zookeeper_ca_cert_path}}"
     cert_path: "{{zookeeper_cert_path}}"
     key_path: "{{zookeeper_key_path}}"


### PR DESCRIPTION
# Description

This is a collection of minor fixes to support Ansible hostname aliasing. This is needed in order to allow installing multiple components or a single component in multiple ways on the same machine. 

Due to the way group_vars merging works, having the same hostname in multiple groups results in a single collection of vars for that host. As all groups it was a member of get merged over the top of itself. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested in Dev env, built out a simple test to verify this produces the same results as before, as well as deployed onsite with customer.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules