### PR TITLE
Adding retries to the java install and other installs

### DIFF
--- a/roles/confluent.common/tasks/debian.yml
+++ b/roles/confluent.common/tasks/debian.yml
@@ -74,6 +74,10 @@
     name: "{{ debian_java_package_name }}"
     state: present
     default_release: jessie-backports
+  register: java_install_result
+  until: java_install_result is success
+  retries: 10
+  delay: 5
   when:
     - install_java|bool
     - not custom_apt_repo|bool
@@ -84,6 +88,10 @@
     name: "{{ debian_java_package_name }}"
     state: present
     default_release: stretch-backports
+  register: java_install_result
+  until: java_install_result is success
+  retries: 10
+  delay: 5
   when:
     - install_java|bool
     - not custom_apt_repo|bool
@@ -93,6 +101,10 @@
   apt:
     name: "{{ debian_java_package_name }}"
     state: present
+  register: java_install_result
+  until: java_install_result is success
+  retries: 10
+  delay: 5
   when:
     - install_java|bool
     - custom_apt_repo|bool

--- a/roles/confluent.common/tasks/main.yml
+++ b/roles/confluent.common/tasks/main.yml
@@ -43,6 +43,10 @@
     url: "{{ jolokia_jar_url }}"
     dest: "{{ jolokia_jar_path }}"
     mode: 0755
+  register: joklokia_download_result
+  until: joklokia_download_result is success
+  retries: 5
+  delay: 5
   when:
     - jolokia_enabled|bool
     - not ansible_check_mode
@@ -59,6 +63,10 @@
     url: "{{ jmxexporter_jar_url }}"
     dest: "{{ jmxexporter_jar_path }}"
     mode: 0755
+  register: prometheus_download_result
+  until: prometheus_download_result is success
+  retries: 5
+  delay: 5
   when:
     - jmxexporter_enabled|bool
     - not ansible_check_mode
@@ -67,7 +75,10 @@
   shell: "curl -L https://cnfl.io/cli | sh -s -- -b {{ confluent_cli_path | dirname }}"
   args:
     creates: "{{ confluent_cli_path }}"
+  register: cli_download_result
+  until: cli_download_result is success
   retries: 5
+  delay: 5
   when:
     - confluent_cli_download_enabled|bool
     - confluent_cli_custom_download_url is not defined
@@ -77,6 +88,10 @@
     url: "{{ confluent_cli_custom_download_url }}"
     dest: "{{ confluent_cli_path }}"
     mode: 0755
+  register: cli_download_result
+  until: cli_download_result is success
+  retries: 5
+  delay: 5
   when:
     - confluent_cli_download_enabled|bool
     - confluent_cli_custom_download_url is defined

--- a/roles/confluent.common/tasks/redhat.yml
+++ b/roles/confluent.common/tasks/redhat.yml
@@ -35,6 +35,10 @@
   yum:
     name: "{{redhat_java_package_name}}"
     state: present
+  register: result
+  retries: 10
+  until: result | succeeded
+  delay: 5
   when: install_java|bool
 
 - name: Install OpenSSL

--- a/roles/confluent.common/tasks/redhat.yml
+++ b/roles/confluent.common/tasks/redhat.yml
@@ -36,7 +36,7 @@
     name: "{{redhat_java_package_name}}"
     state: present
   register: java_install_result
-  until: java_install_result | succeeded
+  until: java_install_result is success
   retries: 10
   delay: 5
   when: install_java|bool

--- a/roles/confluent.common/tasks/redhat.yml
+++ b/roles/confluent.common/tasks/redhat.yml
@@ -35,8 +35,8 @@
   yum:
     name: "{{redhat_java_package_name}}"
     state: present
-  register: java_install
-  until: java_install | succeeded
+  register: java_install_result
+  until: java_install_result | succeeded
   retries: 10
   delay: 5
   when: install_java|bool

--- a/roles/confluent.common/tasks/redhat.yml
+++ b/roles/confluent.common/tasks/redhat.yml
@@ -35,9 +35,9 @@
   yum:
     name: "{{redhat_java_package_name}}"
     state: present
-  register: result
+  register: java_install
+  until: java_install | succeeded
   retries: 10
-  until: result | succeeded
   delay: 5
   when: install_java|bool
 

--- a/roles/confluent.common/tasks/ubuntu.yml
+++ b/roles/confluent.common/tasks/ubuntu.yml
@@ -31,6 +31,10 @@
 - name: Install Java
   apt:
     name: "{{ubuntu_java_package_name}}"
+  register: java_install_result
+  until: java_install_result is success
+  retries: 10
+  delay: 5
   when: install_java|bool
 
 - name: Install OpenSSL

--- a/roles/confluent.control_center/tasks/health_check.yml
+++ b/roles/confluent.control_center/tasks/health_check.yml
@@ -5,7 +5,7 @@
     validate_certs: false
   register: result
   until: result.status == 200
-  retries: 60
+  retries: 40
   delay: 10
   when: not rbac_enabled|bool and not control_center_ssl_mutual_auth_enabled|bool
 
@@ -17,7 +17,7 @@
     client_key: "{{control_center_key_path}}"
   register: result
   until: result.status == 200
-  retries: 60
+  retries: 40
   delay: 10
   when: not rbac_enabled|bool and control_center_ssl_mutual_auth_enabled|bool
 
@@ -30,7 +30,7 @@
     force_basic_auth: true
   register: result
   until: result.status == 200
-  retries: 60
+  retries: 40
   delay: 10
   when: rbac_enabled|bool and not control_center_ssl_mutual_auth_enabled|bool
 
@@ -45,6 +45,6 @@
     force_basic_auth: true
   register: result
   until: result.status == 200
-  retries: 60
+  retries: 40
   delay: 10
   when: rbac_enabled|bool and control_center_ssl_mutual_auth_enabled|bool

--- a/roles/confluent.kafka_broker/tasks/wait_for_urp.yml
+++ b/roles/confluent.kafka_broker/tasks/wait_for_urp.yml
@@ -8,7 +8,7 @@
         status_code: 200
       register: result
       until: result.status == 200
-      retries: 60
+      retries: 40
       delay: 5
 
     - name: Wait for Under Replicated Partitions Metric to return Data
@@ -19,7 +19,7 @@
         status_code: 200
       register: result
       until: result['json']['value'] is defined
-      retries: 60
+      retries: 40
       delay: 5
 
     # curl localhost:7771/jolokia/read/kafka.server:type=ReplicaManager,name=UnderReplicatedPartitions
@@ -32,6 +32,6 @@
         status_code: 200
       register: result
       until: result['json']['value']['Value'] == 0
-      retries: 60
+      retries: 40
       delay: 5
   when: not ansible_check_mode

--- a/roles/confluent.kafka_connect/tasks/health_check.yml
+++ b/roles/confluent.kafka_connect/tasks/health_check.yml
@@ -6,7 +6,7 @@
     validate_certs: false
   register: result
   until: result.status == 200
-  retries: 60
+  retries: 40
   delay: 10
   when: not rbac_enabled|bool and not kafka_connect_ssl_mutual_auth_enabled|bool
 
@@ -19,7 +19,7 @@
     client_key: "{{kafka_connect_key_path}}"
   register: result
   until: result.status == 200
-  retries: 60
+  retries: 40
   delay: 10
   when: not rbac_enabled|bool and kafka_connect_ssl_mutual_auth_enabled|bool
 
@@ -33,7 +33,7 @@
     force_basic_auth: true
   register: result
   until: result.status == 200
-  retries: 60
+  retries: 40
   delay: 10
   when: rbac_enabled|bool and not kafka_connect_ssl_mutual_auth_enabled|bool
 
@@ -49,6 +49,6 @@
     force_basic_auth: true
   register: result
   until: result.status == 200
-  retries: 60
+  retries: 40
   delay: 10
   when: rbac_enabled|bool and kafka_connect_ssl_mutual_auth_enabled|bool

--- a/roles/confluent.kafka_rest/tasks/health_check.yml
+++ b/roles/confluent.kafka_rest/tasks/health_check.yml
@@ -6,7 +6,7 @@
     validate_certs: false
   register: result
   until: result.status == 200
-  retries: 60
+  retries: 30
   delay: 5
   when: not rbac_enabled|bool and not kafka_rest_ssl_mutual_auth_enabled|bool
 
@@ -19,7 +19,7 @@
     client_key: "{{kafka_rest_key_path}}"
   register: result
   until: result.status == 200
-  retries: 60
+  retries: 30
   delay: 5
   when: not rbac_enabled|bool and kafka_rest_ssl_mutual_auth_enabled|bool
 
@@ -33,7 +33,7 @@
     force_basic_auth: true
   register: result
   until: result.status == 200
-  retries: 60
+  retries: 30
   delay: 5
   when: rbac_enabled|bool and not kafka_rest_ssl_mutual_auth_enabled|bool
 
@@ -49,6 +49,6 @@
     force_basic_auth: true
   register: result
   until: result.status == 200
-  retries: 60
+  retries: 30
   delay: 5
   when: rbac_enabled|bool and kafka_rest_ssl_mutual_auth_enabled|bool

--- a/roles/confluent.ksql/tasks/health_check.yml
+++ b/roles/confluent.ksql/tasks/health_check.yml
@@ -6,7 +6,7 @@
     validate_certs: false
   register: result
   until: result.status == 200
-  retries: 60
+  retries: 40
   delay: 5
   when: not rbac_enabled|bool and not ksql_ssl_mutual_auth_enabled|bool
 
@@ -19,7 +19,7 @@
     client_key: "{{ksql_key_path}}"
   register: result
   until: result.status == 200
-  retries: 60
+  retries: 40
   delay: 5
   when: not rbac_enabled|bool and ksql_ssl_mutual_auth_enabled|bool
 
@@ -33,7 +33,7 @@
     force_basic_auth: true
   register: result
   until: result.status == 200
-  retries: 60
+  retries: 40
   delay: 5
   when: rbac_enabled|bool and not ksql_ssl_mutual_auth_enabled|bool
 
@@ -49,6 +49,6 @@
     force_basic_auth: true
   register: result
   until: result.status == 200
-  retries: 60
+  retries: 40
   delay: 5
   when: rbac_enabled|bool and not ksql_ssl_mutual_auth_enabled|bool

--- a/roles/confluent.schema_registry/tasks/health_check.yml
+++ b/roles/confluent.schema_registry/tasks/health_check.yml
@@ -6,7 +6,7 @@
     validate_certs: false
   register: result
   until: result.status == 200
-  retries: 60
+  retries: 30
   delay: 5
   when: not rbac_enabled|bool and not schema_registry_ssl_mutual_auth_enabled|bool
 
@@ -19,7 +19,7 @@
     client_key: "{{schema_registry_key_path}}"
   register: result
   until: result.status == 200
-  retries: 60
+  retries: 30
   delay: 5
   when: not rbac_enabled|bool and schema_registry_ssl_mutual_auth_enabled|bool
 
@@ -33,7 +33,7 @@
     force_basic_auth: true
   register: result
   until: result.status == 200
-  retries: 60
+  retries: 30
   delay: 5
   when: rbac_enabled|bool and not schema_registry_ssl_mutual_auth_enabled|bool
 
@@ -49,6 +49,6 @@
     force_basic_auth: true
   register: result
   until: result.status == 200
-  retries: 60
+  retries: 30
   delay: 5
   when: rbac_enabled|bool and schema_registry_ssl_mutual_auth_enabled|bool

--- a/roles/confluent.zookeeper/tasks/health_check.yml
+++ b/roles/confluent.zookeeper/tasks/health_check.yml
@@ -5,7 +5,7 @@
     executable: /bin/bash
   register: srvr
   until: srvr.rc == 0
-  retries: 60
+  retries: 30
   delay: 5
   changed_when: false
 
@@ -15,6 +15,6 @@
     executable: /bin/bash
   register: srvr
   until: '"Latency min/avg/max:" in srvr.stdout'
-  retries: 60
+  retries: 30
   delay: 5
   changed_when: false


### PR DESCRIPTION
# Description

Some ppl have noticed some hosts failing to install java, giving it 10 retries
Also giving other jar/cli installs retries
Lowering the number of retries on the component health checks

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Hard to replicate the bug, but retries are only helpful so this should be good.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules