### PR TITLE
zk does not need a limit no file in 60, code cleanup around this variable

### DIFF
--- a/roles/confluent.control_center/defaults/main.yml
+++ b/roles/confluent.control_center/defaults/main.yml
@@ -11,11 +11,11 @@ control_center_final_java_args: "{{ control_center_java_args + [ control_center_
 
 control_center_rocksdb_path: ""
 
-# C3 already has LimitNOFILE value set in unit file, empty value will not get written to override.conf
+# Empty values will not be written into override.conf
 control_center_service_overrides:
-  LimitNOFILE:
   User: "{{ control_center_user if control_center_user != control_center_default_user else '' }}"
   Group: "{{ control_center_group if control_center_group != control_center_default_group else '' }}"
+
 control_center_service_environment_overrides:
   ROCKSDB_SHAREDLIB_DIR: "{{control_center_rocksdb_path}}"
   CONTROL_CENTER_HEAP_OPTS: "-Xmx6g"

--- a/roles/confluent.kafka_broker/defaults/main.yml
+++ b/roles/confluent.kafka_broker/defaults/main.yml
@@ -14,11 +14,11 @@ kafka_broker_java_args:
 kafka_broker_custom_java_args: ""
 kafka_broker_final_java_args: "{{ kafka_broker_java_args + [ kafka_broker_custom_java_args ] }}"
 
-# Kafka already has LimitNOFILE value set in unit file, empty value will not get written to override.conf
+# Key/Value Pairs with empty values will not be written into override.conf
 kafka_broker_service_overrides:
-  LimitNOFILE:
   User: "{{ kafka_broker_user if kafka_broker_user != kafka_broker_default_user else '' }}"
   Group: "{{ kafka_broker_group if kafka_broker_group != kafka_broker_default_group else '' }}"
+
 kafka_broker_service_environment_overrides:
   KAFKA_HEAP_OPTS: "-Xmx1g"
   KAFKA_OPTS: "{{ kafka_broker_final_java_args | java_arg_build_out }}"

--- a/roles/confluent.kafka_connect/defaults/main.yml
+++ b/roles/confluent.kafka_connect/defaults/main.yml
@@ -11,11 +11,12 @@ kafka_connect_java_args:
 kafka_connect_custom_java_args: ""
 kafka_connect_final_java_args: "{{ kafka_connect_java_args + [ kafka_connect_custom_java_args ] }}"
 
-# Empty values will not be written into override.conf
+# Key/Value Pairs with empty values will not be written into override.conf
 kafka_connect_service_overrides:
   LimitNOFILE: 100000
   User: "{{ kafka_connect_user if kafka_connect_user != kafka_connect_default_user else '' }}"
   Group: "{{ kafka_connect_group if kafka_connect_group != kafka_connect_default_group else '' }}"
+
 kafka_connect_service_environment_overrides:
   KAFKA_HEAP_OPTS: "-Xms256M -Xmx2G"
   KAFKA_OPTS: "{{ kafka_connect_final_java_args | java_arg_build_out }}"

--- a/roles/confluent.kafka_rest/defaults/main.yml
+++ b/roles/confluent.kafka_rest/defaults/main.yml
@@ -11,11 +11,11 @@ kafka_rest_java_args:
 kafka_rest_custom_java_args: ""
 kafka_rest_final_java_args: "{{ kafka_rest_java_args + [ kafka_rest_custom_java_args ] }}"
 
-# Rest Proxy already has LimitNOFILE value set in unit file, empty value will not get written to override.conf
+# Key/Value Pairs with empty values will not be written into override.conf
 kafka_rest_service_overrides:
-  LimitNOFILE:
   User: "{{ kafka_rest_user if kafka_rest_user != kafka_rest_default_user else '' }}"
   Group: "{{ kafka_rest_group if kafka_rest_group != kafka_rest_default_group else '' }}"
+
 kafka_rest_service_environment_overrides:
   LOG_DIR: /var/log/kafka-rest
   KAFKAREST_OPTS: "{{ kafka_rest_final_java_args | java_arg_build_out }}"

--- a/roles/confluent.ksql/defaults/main.yml
+++ b/roles/confluent.ksql/defaults/main.yml
@@ -11,11 +11,12 @@ ksql_java_args:
 ksql_custom_java_args: ""
 ksql_final_java_args: "{{ ksql_java_args + [ ksql_custom_java_args ] }}"
 
-# Empty values will not be written into override.conf
+# Key/Value Pairs with empty values will not be written into override.conf
 ksql_service_overrides:
   LimitNOFILE: 100000
   User: "{{ ksql_user if ksql_user != ksql_default_user else '' }}"
   Group: "{{ ksql_group if ksql_group != ksql_default_group else '' }}"
+
 ksql_service_environment_overrides:
   KSQL_HEAP_OPTS: "-Xmx3g"
   KSQL_OPTS: "{{ ksql_final_java_args | java_arg_build_out }}"

--- a/roles/confluent.schema_registry/defaults/main.yml
+++ b/roles/confluent.schema_registry/defaults/main.yml
@@ -11,7 +11,7 @@ schema_registry_java_args:
 schema_registry_custom_java_args: ""
 schema_registry_final_java_args: "{{ schema_registry_java_args + [ schema_registry_custom_java_args ] }}"
 
-# Empty values will not be written into override.conf
+# Key/Value Pairs with empty values will not be written into override.conf
 schema_registry_service_overrides:
   LimitNOFILE: 100000
   User: "{{ schema_registry_user if schema_registry_user != schema_registry_default_user else '' }}"

--- a/roles/confluent.zookeeper/defaults/main.yml
+++ b/roles/confluent.zookeeper/defaults/main.yml
@@ -13,10 +13,11 @@ zookeeper_java_args:
 zookeeper_custom_java_args: ""
 zookeeper_final_java_args: "{{ zookeeper_java_args + [ zookeeper_custom_java_args ] }}"
 
+# Key/Value Pairs with empty values will not be written into override.conf
 zookeeper_service_overrides:
-  LimitNOFILE: 100000
   User: "{{ zookeeper_user if zookeeper_user != zookeeper_default_user else '' }}"
   Group: "{{ zookeeper_group if zookeeper_group != zookeeper_default_group else '' }}"
+
 zookeeper_service_environment_overrides:
   KAFKA_HEAP_OPTS: "-Xmx1g"
   KAFKA_OPTS: "{{ zookeeper_final_java_args | java_arg_build_out }}"


### PR DESCRIPTION
# Description

ZK service file has limitnofile in 60 release, so there is no need to overwrite it
Also improve the comment and code elsewhere around this var

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Jenkins job will test this, its a trivial change

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules