### PR TITLE
Update ubuntu dockerfile, remove docker image build on jenkins test

### DIFF
--- a/roles/confluent.common/tasks/ubuntu.yml
+++ b/roles/confluent.common/tasks/ubuntu.yml
@@ -21,6 +21,11 @@
 
 - meta: flush_handlers
 
+- name: Make Sure man pages Directory Exists
+  file:
+    path: /usr/share/man/man1
+    state: directory
+
 - name: Add open JDK repo
   apt_repository:
     repo: "{{ubuntu_java_repository}}"

--- a/roles/confluent.test/molecule/Dockerfile-ubuntu.j2
+++ b/roles/confluent.test/molecule/Dockerfile-ubuntu.j2
@@ -1,30 +1,8 @@
 FROM {{ item.image }}
 
-RUN apt-get update -y && \
-    mkdir -p /usr/share/man/man1 && \
-    apt-get install -y \
-       apt-utils \
-       locales \
-       gnupg \
-       python3-setuptools \
-       python3-pip \
-       software-properties-common \
-       openjdk-8-jdk \
-       rsync \
-       ca-certificates \
-       openssl \
-       unzip \
-       curl \
-       wget \
-       rsyslog \
-       systemd \
-       systemd-cron \
-       sudo \
-       iproute2 \
-    && rm -Rf /var/lib/apt/lists/* \
-    && rm -Rf /usr/share/doc && rm -Rf /usr/share/man \
-    && apt-get clean && \
-    sed -i 's/^\($ModLoad imklog\)/#\1/' /etc/rsyslog.conf
+RUN mkdir -p /usr/share/man/man1 && \
+    apt-get update -y && \
+    apt-get install -y openjdk-8-jdk wget gnupg
 
 RUN wget -qO - https://packages.confluent.io/deb/5.5/archive.key | sudo apt-key add - && \
     add-apt-repository "deb [arch=amd64] https://packages.confluent.io/deb/5.5 stable main" && \

--- a/roles/confluent.test/molecule/rbac-scram-custom-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/rbac-scram-custom-rhel/molecule.yml
@@ -7,7 +7,7 @@ platforms:
     groups:
       - ldap_server
     image: geerlingguy/docker-centos7-ansible
-    dockerfile: ../Dockerfile.j2
+    # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -19,7 +19,7 @@ platforms:
     groups:
       - zookeeper
     image: geerlingguy/docker-centos7-ansible
-    dockerfile: ../Dockerfile.j2
+    # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -31,7 +31,7 @@ platforms:
     groups:
       - kafka_broker
     image: geerlingguy/docker-centos7-ansible
-    dockerfile: ../Dockerfile.j2
+    # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -43,7 +43,7 @@ platforms:
     groups:
       - kafka_broker
     image: geerlingguy/docker-centos7-ansible
-    dockerfile: ../Dockerfile.j2
+    # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -55,7 +55,7 @@ platforms:
     groups:
       - kafka_broker
     image: geerlingguy/docker-centos7-ansible
-    dockerfile: ../Dockerfile.j2
+    # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -67,7 +67,7 @@ platforms:
     groups:
       - schema_registry
     image: geerlingguy/docker-centos7-ansible
-    dockerfile: ../Dockerfile.j2
+    # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -79,7 +79,7 @@ platforms:
     groups:
       - kafka_rest
     image: geerlingguy/docker-centos7-ansible
-    dockerfile: ../Dockerfile.j2
+    # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -91,7 +91,7 @@ platforms:
     groups:
       - kafka_connect
     image: geerlingguy/docker-centos7-ansible
-    dockerfile: ../Dockerfile.j2
+    # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -103,7 +103,7 @@ platforms:
     groups:
       - ksql
     image: geerlingguy/docker-centos7-ansible
-    dockerfile: ../Dockerfile.j2
+    # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -115,7 +115,7 @@ platforms:
     groups:
       - control_center
     image: geerlingguy/docker-centos7-ansible
-    dockerfile: ../Dockerfile.j2
+    # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro


### PR DESCRIPTION
# Description

Removes unnecessary steps in the ubuntu dockerfile
Adds ubuntu man pages task which enables our install to succeed on bare ubuntu image
Removes docker image build on molecule scenario Jenkins orchestrates

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Ran the mtls-ubuntu scenario with/without dockerfile- succeeds
Other scenario gets tested with jenkins

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules