### PR TITLE
Parallel restart if the certs have been updated

### DIFF
--- a/roles/confluent.kafka_broker/tasks/restart_kafka.yml
+++ b/roles/confluent.kafka_broker/tasks/restart_kafka.yml
@@ -14,7 +14,8 @@
   when:
     - "hostvars[item].inventory_hostname == inventory_hostname"
     - substate.stdout == 'SubState=running'
+    - not certs_updated|bool
 
 - name: Restart Kafka in Parallel
   include: restart.yml
-  when: substate.stdout != 'SubState=running'
+  when: substate.stdout != 'SubState=running' or certs_updated|bool

--- a/roles/confluent.zookeeper/tasks/restart_zookeeper.yml
+++ b/roles/confluent.zookeeper/tasks/restart_zookeeper.yml
@@ -14,7 +14,8 @@
   when:
     - "hostvars[item].inventory_hostname == inventory_hostname"
     - substate.stdout == 'SubState=running'
+    - not certs_updated|bool
 
 - name: Restart Zookeeper in Parallel
   include: restart.yml
-  when: substate.stdout != 'SubState=running'
+  when: substate.stdout != 'SubState=running' or certs_updated|bool


### PR DESCRIPTION
# Description

Because keystores get fully replaced, serial restart of the brokers/zk leads to ssl errors. Adds conditional

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Ran the mtls-ubuntu role twice, saw that it does parallel restart on kafka and zk


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules