### PR TITLE
Rbac vars need documentation/ defaults

### DIFF
--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -324,6 +324,14 @@ Default:  7770
 
 ***
 
+### zookeeper_jolokia_ssl_enabled
+
+Boolean to enable TLS encryption on Zookeeper jolokia metrics
+
+Default:  "{{ zookeeper_ssl_enabled }}"
+
+***
+
 ### zookeeper_jmxexporter_enabled
 
 Boolean to enable Prometheus Exporter Agent installation and configuration on zookeeper
@@ -409,6 +417,14 @@ Default:  "{{jolokia_enabled}}"
 Port to expose kafka jolokia metrics. Beware of port collisions if colocating components on same host
 
 Default:  7771
+
+***
+
+### kafka_broker_jolokia_ssl_enabled
+
+Boolean to enable TLS encryption on Kafka jolokia metrics
+
+Default:  "{{ ssl_enabled }}"
 
 ***
 
@@ -985,6 +1001,102 @@ Default:  8090
 Boolean to configure TLS encryption on the MDS Server. (Or if is confligured with TLS encyption when external_mds_enabled: true)
 
 Default:  "{{ssl_enabled}}"
+
+***
+
+### mds_super_user
+
+LDAP User which will be granted super user permissions to create role bindings in the MDS
+
+Default:  mds
+
+***
+
+### mds_super_user_password
+
+Password to mds_super_user LDAP User
+
+Default:  password
+
+***
+
+### schema_registry_ldap_user
+
+LDAP User for Schema Registry to authenticate as
+
+Default:  schema-registry
+
+***
+
+### schema_registry_ldap_password
+
+Password to schema_registry_ldap_user LDAP User
+
+Default:  password
+
+***
+
+### kafka_connect_ldap_user
+
+LDAP User for Connect to authenticate as
+
+Default:  connect
+
+***
+
+### kafka_connect_ldap_password
+
+Password to kafka_connect_ldap_user LDAP User
+
+Default:  password
+
+***
+
+### ksql_ldap_user
+
+LDAP User for ksqlDB to authenticate as
+
+Default:  ksql
+
+***
+
+### ksql_ldap_password
+
+Password to ksql_ldap_user LDAP User
+
+Default:  password
+
+***
+
+### kafka_rest_ldap_user
+
+LDAP User for Rest Proxy to authenticate as
+
+Default:  kafka-rest
+
+***
+
+### kafka_rest_ldap_password
+
+Password to kafka_rest_ldap_user LDAP User
+
+Default:  password
+
+***
+
+### control_center_ldap_user
+
+LDAP User for Control Center to authenticate as
+
+Default:  control-center
+
+***
+
+### control_center_ldap_password
+
+Password to control_center_ldap_user LDAP User
+
+Default:  password
 
 ***
 

--- a/roles/confluent.variables/defaults/main.yml
+++ b/roles/confluent.variables/defaults/main.yml
@@ -649,6 +649,42 @@ mds_acls_enabled: "{{rbac_enabled}}"
 rbac_enabled_public_pem_path: /var/ssl/private/public.pem
 rbac_enabled_private_pem_path: /var/ssl/private/tokenKeypair.pem
 
+### LDAP User which will be granted super user permissions to create role bindings in the MDS
+mds_super_user: mds
+
+### Password to mds_super_user LDAP User
+mds_super_user_password: password
+
+### LDAP User for Schema Registry to authenticate as
+schema_registry_ldap_user: schema-registry
+
+### Password to schema_registry_ldap_user LDAP User
+schema_registry_ldap_password: password
+
+### LDAP User for Connect to authenticate as
+kafka_connect_ldap_user: connect
+
+### Password to kafka_connect_ldap_user LDAP User
+kafka_connect_ldap_password: password
+
+### LDAP User for ksqlDB to authenticate as
+ksql_ldap_user: ksql
+
+### Password to ksql_ldap_user LDAP User
+ksql_ldap_password: password
+
+### LDAP User for Rest Proxy to authenticate as
+kafka_rest_ldap_user: kafka-rest
+
+### Password to kafka_rest_ldap_user LDAP User
+kafka_rest_ldap_password: password
+
+### LDAP User for Control Center to authenticate as
+control_center_ldap_user: control-center
+
+### Password to control_center_ldap_user LDAP User
+control_center_ldap_password: password
+
 ### Boolean to describe if kafka group in inventory file should be configured as MDS Server. If set to true, you must also set mds_broker_bootstrap_servers, mds_broker_listener, mds_ssl_enabled
 external_mds_enabled: false
 


### PR DESCRIPTION
# Description

Bugfix around if you are installing rbac without all the components it is discovered that some vars do not have defaults. This adds the dummy defaults to the ldap user vars and updates the docs

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tried rbac molecule scenario without ksql group


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules