### PR TITLE
Add Optional Param Overrides for Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,38 @@
 #!/usr/bin/env groovy
 
+import static groovy.json.JsonOutput.*
+
+/* These are variables that can be used to test an un-released version of the Confluent Platform that resides at
+ * a different HTTPS Endpoint other than `https://packages.confluent.io`. You do not need to specify *any* of them
+ * for normal testing purposes, and are purely here for Confluent Inc's usage only.
+ */
+
+// The version to install, set to the "next" version to test the "next" version.
+def confluent_package_version = string(name: 'CONFLUENT_PACKAGE_VERSION',
+    defaultValue: '',
+    description: 'Confluent Version to install and test (ie: 5.4.1)'
+)
+
+// The HTTP(S) endpoint from which to obtain the platform packages
+def confluent_common_repository_baseurl = string(name: 'CONFLUENT_PACKAGE_BASEURL',
+    defaultValue: '',
+    description: 'Packaging Base URL from where to download packages (ie: https://packages.confluent.io)'
+)
+
+// Confluent's nightly packages use a different version scheme, so this parameter controls the "suffix" value
+// of the packages that are installed.
+def confluent_release_quality = choice(name: 'CONFLUENT_RELEASE_QUALITY',
+    choices: ['prod', 'snapshot'],
+    defaultValue: 'prod',
+    description: 'Determines the release extention (suffix) (ie: "prod" for public releases, "snapshot" for nightly builds)',
+)
+
 def config = jobConfig {
     nodeLabel = 'docker-oraclejdk8'
     slackChannel = '#ansible-eng'
     timeoutHours = 4
     runMergeCheck = false
+    properties = [parameters([confluent_package_version, confluent_common_repository_baseurl, confluent_release_quality])]
 }
 
 def job = {
@@ -15,12 +43,54 @@ def job = {
         '''
     }
 
+    def override_config = [:]
+
+    if(params.CONFLUENT_PACKAGE_BASEURL) {
+        override_config['confluent_common_repository_baseurl'] = params.CONFLUENT_PACKAGE_BASEURL
+    }
+
+    if(params.CONFLUENT_PACKAGE_VERSION) {
+        override_config['confluent_package_version'] = params.CONFLUENT_PACKAGE_VERSION
+
+        if(confluent_release_quality != 'prod') {
+            // 'prod' case doesn't need anything overriden
+            switch(params.CONFLUENT_RELEASE_QUALITY) {
+                case "snapshot":
+                    override_config['confluent_package_redhat_suffix'] = "-${params.CONFLUENT_PACKAGE_VERSION}-0.1.SNAPSHOT"
+                    override_config['confluent_package_debian_suffix'] = "=${params.CONFLUENT_PACKAGE_VERSION}~SNAPSHOT-1"
+                break
+                default:
+                    error("Unknown release quality ${params.CONFLUENT_RELEASE_QUALITY}")
+                break
+            }
+        }
+    }
+
+    def molecule_args = ""
+    if(override_config) {
+        override_config['bootstrap'] = false
+        def base_config = [
+            'provisioner': [
+                'inventory': [
+                    'group_vars': [
+                        'all': override_config
+                    ]
+                ]
+            ]
+        ]
+        echo "Overriding Ansible vars for testing with base-config:\n" + prettyPrint(toJson(override_config))
+
+        writeYaml file: "roles/confluent.test/base-config.yml", data: base_config
+
+        molecule_args = "--base-config base-config.yml"
+    }
+
     withDockerServer([uri: dockerHost()]) {
         stage('Plaintext') {
-            sh '''
-                cd roles/confluent.test
-                molecule test -s plaintext-rhel
-            '''
+            sh """
+cd roles/confluent.test
+molecule ${molecule_args} test -s plaintext-rhel
+            """
         }
     }
 }


### PR DESCRIPTION
# Description

This PR adds the ability to specify override parameters for primarily three concepts:
* A different packages repo (ie: `confluent_common_repository_baseurl`)
* A different version, older or un-released (ie `confluent_package_version`)
* And because our Debian nightly packages use an odd version format (example: `5.4.3~SNAPSHOT-1`), a switch to tell the job "what kind of" release to install (ie: `confluent_package_redhat_suffix` & `confluent_package_debian_suffix`)

We use molecule's `--base-config` to set these values to override the values in the Anisble Playbooks - I've used this config with `--debug` and have verified that the intended versions are installed.

Fixes # (issue)

N/A

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

The last two Jenkins builds used
* No parameters to simulate testing that would be done locally (PASS)
* Parameters pointing to an HTTP endpoint containing the `5.3.4` nightly builds.

**Test Configuration**:


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules