### PR TITLE
MINOR: Add .yamllint to ignore document-start in base-config.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.pyc
 *.idea
 generated_ssl_files/
+*base-config.yml

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,43 @@
+---
+# Based on ansible-lint config
+extends: default
+
+rules:
+  braces:
+    max-spaces-inside: 1
+    level: error
+  brackets:
+    max-spaces-inside: 1
+    level: error
+  colons:
+    max-spaces-after: -1
+    level: error
+  commas:
+    max-spaces-after: -1
+    level: error
+  comments: disable
+  comments-indentation: disable
+  document-start:
+    ignore: |
+      roles/confluent.test/base-config.yml
+    present: true
+    level: error
+  empty-lines:
+    max: 3
+    level: error
+  hyphens:
+    level: error
+  indentation:
+    spaces: 2
+    indent-sequences: consistent
+  key-duplicates:
+    level: error
+  line-length: disable
+  new-line-at-end-of-file:
+    level: error
+  new-lines:
+    type: unix
+  trailing-spaces:
+    level: error
+  truthy:
+    level: error


### PR DESCRIPTION
# Description

The Jenkins job that writes the YAML file doesn't write a YAML document-start `---`, which trips up the `yamllint`-er:

```
14:23:21  yamllint -c ../../.yamllint ../..[0m
14:23:24  ../../roles/confluent.test/base-config.yml
14:23:24    1:1       error    missing document start "---"  (document-start)
14:23:24  
14:23:24  [31mERROR: Lint failed: Command 'set -e
```

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration



**Test Configuration**:


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules