### PR TITLE
MINOR: When Confluent Version is defined also override confluent_repo_version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,6 +51,7 @@ def job = {
 
     if(params.CONFLUENT_PACKAGE_VERSION) {
         override_config['confluent_package_version'] = params.CONFLUENT_PACKAGE_VERSION
+        override_config['confluent_repo_version'] = params.CONFLUENT_PACKAGE_VERSION.tokenize('.')[0..1].join('.')
 
         if(confluent_release_quality != 'prod') {
             // 'prod' case doesn't need anything overriden


### PR DESCRIPTION
# Description

This build failure in Jenkins reminds me that we should override `confluent_repo_version` if we're overriding the to-be-installed version.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration



**Test Configuration**:


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules