### PR TITLE
MINOR: Disable Build Reporting when using parameters

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,6 +59,10 @@ def job = {
                 case "snapshot":
                     override_config['confluent_package_redhat_suffix'] = "-${params.CONFLUENT_PACKAGE_VERSION}-0.1.SNAPSHOT"
                     override_config['confluent_package_debian_suffix'] = "=${params.CONFLUENT_PACKAGE_VERSION}~SNAPSHOT-1"
+
+                    // Disable reporting for nightly builds
+                    config.testbreakReporting = false
+                    config.slackChannel = null
                 break
                 default:
                     error("Unknown release quality ${params.CONFLUENT_RELEASE_QUALITY}")
@@ -84,10 +88,6 @@ def job = {
         writeYaml file: "roles/confluent.test/base-config.yml", data: base_config
 
         molecule_args = "--base-config base-config.yml"
-
-        // Disable reporting when (possibly incorrect) parameters are defined
-        config.testbreakReporting = false
-        config.slackChannel = null
     }
 
     withDockerServer([uri: dockerHost()]) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,6 +84,10 @@ def job = {
         writeYaml file: "roles/confluent.test/base-config.yml", data: base_config
 
         molecule_args = "--base-config base-config.yml"
+
+        // Disable reporting when (possibly incorrect) parameters are defined
+        config.testbreakReporting = false
+        config.slackChannel = null
     }
 
     withDockerServer([uri: dockerHost()]) {


### PR DESCRIPTION
# Description

This change disables job reporting to Slack and Confluent's Test Break system when parameters are specified, as they may be incorrect that cause build failures.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration



**Test Configuration**:


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules