### PR TITLE
Add Cleanup post task to destroy/cleanup resources

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -97,11 +97,13 @@ molecule ${molecule_args} test -s plaintext-rhel
 }
 
 def post = {
-    stage('Cleanup') {
-        sh """
+    withDockerServer([uri: dockerHost()]) {
+        stage('Cleanup') {
+            sh """
 cd roles/confluent.test
 molecule destroy --all --parallel || true
 """
+        }
     }
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,7 @@ def confluent_release_quality = choice(name: 'CONFLUENT_RELEASE_QUALITY',
 
 // Parameter for the molecule test scenario to run
 def molecule_scenario_name = choice(name: 'SCENARIO_NAME',
-    choices: ['plaintext-rhel', 'customcerts-rhel'],
+    choices: ['plaintext-rhel'],
     defaultValue: 'plaintext-rhel',
     description: 'The Ansible Molecule scenario name to run',
 )

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -96,4 +96,13 @@ molecule ${molecule_args} test -s plaintext-rhel
     }
 }
 
-runJob config, job
+def post = {
+    stage('Cleanup') {
+        sh """
+cd roles/confluent.test
+molecule destroy --all --parallel || true
+"""
+    }
+}
+
+runJob config, job, post


### PR DESCRIPTION
# Description

It was reported in a tools thread that there were running `molecule_local/geerlingguy/docker-centos7-ansible` Containers that were over 24 hours old. These were likely aborted jobs that never had a chance to clean up. This change adds a post-step that will execute `molecule destroy` at the end of the job irrespective of the outcome.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration



**Test Configuration**:


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules