### PR TITLE
Set correct rights on unpacked files and unify umask entries

### DIFF
--- a/roles/confluent.kafka_connect/tasks/confluent_hub.yml
+++ b/roles/confluent.kafka_connect/tasks/confluent_hub.yml
@@ -5,7 +5,7 @@
     state: directory
     group: "{{kafka_connect_group}}"
     owner: "{{kafka_connect_user}}"
-    mode: '764'
+    mode: 0764
 
 - name: Installing/Unarchiving Confluent Hub
   unarchive:

--- a/roles/confluent.kafka_connect/tasks/connectors.yml
+++ b/roles/confluent.kafka_connect/tasks/connectors.yml
@@ -5,7 +5,7 @@
     state: directory
     group: "{{kafka_connect_group}}"
     owner: "{{kafka_connect_user}}"
-    mode: '764'
+    mode: 0764
   when: item != '/usr/share/java'
   with_items: "{{ kafka_connect.properties['plugin.path'].split(',') }}"
 
@@ -13,6 +13,9 @@
   unarchive:
     src: "{{item}}"
     dest: "{{kafka_connect_plugins_dest}}"
+    group: "{{kafka_connect_group}}"
+    owner: "{{kafka_connect_user}}"
+    mode: 0755
     remote_src: false
   with_items: "{{kafka_connect_plugins}}"
   when: kafka_connect_plugins|length > 0
@@ -22,6 +25,9 @@
   unarchive:
     src: "{{item}}"
     dest: "{{kafka_connect_plugins_dest}}"
+    group: "{{kafka_connect_group}}"
+    owner: "{{kafka_connect_user}}"
+    mode: 0755
     remote_src: true
   with_items: "{{kafka_connect_plugins_remote}}"
   when: kafka_connect_plugins_remote|length > 0


### PR DESCRIPTION
# Description
Setting 0755 permission explicitly on all unarchived connector plugins.

Fixes #366 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration



**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules