### PR TITLE
Minor docs mention to zk acls

### DIFF
--- a/hosts_example.yml
+++ b/hosts_example.yml
@@ -25,7 +25,7 @@ all:
     #### Zookeeper SASL Authentication ####
     ## Zookeeper can have Kerberos (GSSAPI) or Digest-MD5 SASL Authentication
     ## By default when sasl_protocol = kerberos, zookeeper will also use sasl kerberos. It can  be configured with:
-    ## When a mechanism is selected, zookeeper.set.acl=true is added to kafka's server.properties. NOTE- property not added when using mTLS, set manually with Custom Properties 
+    ## When a mechanism is selected, zookeeper.set.acl=true is added to kafka's server.properties. NOTE- property not added when using mTLS, set manually with Custom Properties
     # zookeeper_sasl_protocol: <none/kerberos/digest>
 
     #### Kerberos Configuration ####

--- a/hosts_example.yml
+++ b/hosts_example.yml
@@ -25,7 +25,7 @@ all:
     #### Zookeeper SASL Authentication ####
     ## Zookeeper can have Kerberos (GSSAPI) or Digest-MD5 SASL Authentication
     ## By default when sasl_protocol = kerberos, zookeeper will also use sasl kerberos. It can  be configured with:
-    ## When a mechanism is selected, zookeeper.set.acl=true is added to kafka's server.properties. NOTE- property not added when using mTLS, set manually with Custom Properties
+    ## When a mechanism is selected, zookeeper.set.acl=true is added to kafka's server.properties. Note: property not added when using mTLS, set manually with Custom Properties
     # zookeeper_sasl_protocol: <none/kerberos/digest>
 
     #### Kerberos Configuration ####

--- a/hosts_example.yml
+++ b/hosts_example.yml
@@ -25,6 +25,7 @@ all:
     #### Zookeeper SASL Authentication ####
     ## Zookeeper can have Kerberos (GSSAPI) or Digest-MD5 SASL Authentication
     ## By default when sasl_protocol = kerberos, zookeeper will also use sasl kerberos. It can  be configured with:
+    ## When a mechanism is selected, zookeeper.set.acl=true is added to kafka's server.properties. NOTE- property not added when using mTLS, set manually with Custom Properties 
     # zookeeper_sasl_protocol: <none/kerberos/digest>
 
     #### Kerberos Configuration ####


### PR DESCRIPTION
# Description

Zookeeper can have acls on kafka data. This is controlled with the zookeeper.set.acl kafka property. This is a docs update to mention that this property gets set for kafka->zk auth modes: sasl_digest and sasl_md5sum.... It does not get set for mTLS, because that can be error prone. Customers will need to set that manually with kafka custom properties

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Just a docs update


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules