### PR TITLE
55 customize super.users kafka property with rbac

### DIFF
--- a/roles/confluent.kafka_broker/tasks/rbac.yml
+++ b/roles/confluent.kafka_broker/tasks/rbac.yml
@@ -2,10 +2,10 @@
 - name: Get Principal used on the Inter Broker Listener
   include_tasks: set_principal.yml
 
-# TODO customers might want to add to this list, so should put in defaults
+# Takes custom super.users and puts into list, without super.users set, should be the empty list []
 - name: Initialize Super Users List
   set_fact:
-    super_users: []
+    super_users: "{{ (kafka_broker.properties['super.users'] | default('')).split(';') | difference(['']) }}"
 
 - name: Add each Broker Principal to Super Users List
   set_fact:
@@ -19,6 +19,12 @@
 - name: Remove Duplicates in Super Users List
   set_fact:
     super_users: "{{ super_users | unique }}"
+
+- name: Add Super Users list to Kafka Properties
+  set_fact:
+    kafka_broker:
+      properties:
+        super.users: "{{super_users | join(';')}}"
 
 - name: Create SSL Certificate Directory
   file:

--- a/roles/confluent.kafka_broker/templates/server.properties.j2
+++ b/roles/confluent.kafka_broker/templates/server.properties.j2
@@ -122,8 +122,6 @@ confluent.metadata.server.ssl.truststore.password={{kafka_broker_truststore_stor
 authorizer.class.name=io.confluent.kafka.security.authorizer.ConfluentServerAuthorizer
 confluent.authorizer.access.rule.providers=CONFLUENT{% if mds_acls_enabled|bool %},ZK_ACL{% endif %}
 
-super.users={{super_users | join(';')}}
-
 # LDAP Configuration
 {{ldap_config}}
 

--- a/roles/confluent.test/molecule/rbac-mtls-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/rbac-mtls-rhel/molecule.yml
@@ -137,6 +137,10 @@ provisioner:
         ssl_enabled: true
         ssl_mutual_auth_enabled: true
 
+        kafka_broker:
+          properties:
+            super.users: User:dom;User:jeff
+
         rbac_enabled: true
 
         kafka_broker_custom_listeners:

--- a/roles/confluent.test/molecule/rbac-mtls-rhel/verify.yml
+++ b/roles/confluent.test/molecule/rbac-mtls-rhel/verify.yml
@@ -19,6 +19,18 @@
         property: ldap.java.naming.provider.url
         expected_value: ldap://ldap1:389
 
+    - name: Get super.users
+      shell: grep "super.users" /etc/kafka/server.properties
+      register: super_users_grep
+
+    - name: Assert super users found in server.properties
+      assert:
+        that:
+          - "'User:dom' in super_users_grep.stdout"
+          - "'User:jeff' in super_users_grep.stdout"
+        fail_msg: "Super Users property: {{super_users_grep.stdout}} does not contain User:dom and User:jeff"
+        quiet: true
+
 - name: Verify - schema_registry
   hosts: schema_registry
   gather_facts: false


### PR DESCRIPTION
# Description

super.users property can now be customized. this will append to custom super.users list with what cp-ansible thinks are the necessary super.users for rbac to function. it also removes duplicates from the list

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Added custom super.users list to one molecule scenario with a test case


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules