### PR TITLE
Use nightly builds in .x branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,6 +54,14 @@ def job = {
 
     if(params.CONFLUENT_PACKAGE_BASEURL) {
         override_config['confluent_common_repository_baseurl'] = params.CONFLUENT_PACKAGE_BASEURL
+    } else if (targetBranch().toString().endsWith('.x')) {
+        /* This condition imples we're in a dev (.x) branch and therefore the release in confluent_package_version
+           does not yet exist on https://packages.confluent.io so we have to query the packaging job for the last
+           successful build location (what utilities.getLastNightlyPackagingBaseURL returns). We also override the
+           confluent_package_*_suffix to an empty string so it will install the (expected) latest version */
+        override_config['confluent_common_repository_baseurl'] = utilities.getLastNightlyPackagingBaseURL(targetBranch().toString())
+        override_config['confluent_package_redhat_suffix'] = ""
+        override_config['confluent_package_debian_suffix'] = ""
     }
 
     if(params.CONFLUENT_PACKAGE_VERSION) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,7 +54,7 @@ def job = {
 
     if(params.CONFLUENT_PACKAGE_BASEURL) {
         override_config['confluent_common_repository_baseurl'] = params.CONFLUENT_PACKAGE_BASEURL
-    } else if (targetBranch().toString().matches('\d+\.\d+\.(x|\d+)')) {
+    } else if (targetBranch().toString().matches('\\d+\\.\\d+\\.(x|\\d+)')) {
         /* This condition imples we're in a dev (.x) branch and therefore the release in confluent_package_version
            does not yet exist on https://packages.confluent.io so we have to query the packaging job for the last
            successful build location (what utilities.getLastNightlyPackagingBaseURL returns). We also override the

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,7 +54,7 @@ def job = {
 
     if(params.CONFLUENT_PACKAGE_BASEURL) {
         override_config['confluent_common_repository_baseurl'] = params.CONFLUENT_PACKAGE_BASEURL
-    } else if (targetBranch().toString().endsWith('.x')) {
+    } else if (targetBranch().toString().matches('\d+\.\d+\.(x|\d+)')) {
         /* This condition imples we're in a dev (.x) branch and therefore the release in confluent_package_version
            does not yet exist on https://packages.confluent.io so we have to query the packaging job for the last
            successful build location (what utilities.getLastNightlyPackagingBaseURL returns). We also override the


### PR DESCRIPTION
# Description

The typical pattern at Confluent is to have the `.x` branches in the project repositories to be targeting the "next" versioned release. This means the releases for that "next" Confluent Platform are not yet on https://packages.confluent.io. So say if we were to bump roles/confluent.variables_handlers/defaults/main.yml to the "next" version in 5.4.x of `5.4.3`, you would get this type of error:

```
    failed: [zookeeper1] (item=confluent-common) => {"ansible_loop_var": "item", "changed": false, "item": "confluent-common", "msg": "No package matching 'confluent-common-5.4.3-1' found available, installed or updated", "rc": 126, "results": ["No package matching 'confluent-common-5.4.3-1' found available, installed or updated"]}
```

So this change aims to query the packaging job (the one that produces nightly CP artifacts), and returns the HTTP location of said artifacts to test against. This is needed before I do a bump in 5.4.x to 5.4.3.

### Summary of changes

* Users may still specify/override the baseurl location to packages.confluent.io and set a released version
* `-post` branch builds will not be affected, as we're making a conditional check that the branch matches the pattern `\d.\d.x` and only executes on a `.x` dev branch.

Fixes  

N/A

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Since this is targeting a `-post` branch for changes, the new behavior isn't executed, so check out this helper PR https://github.com/confluentinc/cp-ansible/pull/377 for the actual run that did trigger the separate code path.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules