### PR TITLE
Bugfix- only strips spaces after commas in dname

### DIFF
--- a/roles/confluent.kafka_broker/tasks/set_principal.yml
+++ b/roles/confluent.kafka_broker/tasks/set_principal.yml
@@ -19,14 +19,15 @@
   # Search lines with Entry type: "PrivateKeyEntry" and return that line and all after, ca cert is of type "trustedCertEntry"
   # Search for first "Owner" line
   # Extract DNAME from line
-  # Remove spaces
+  # Remove spaces after commas
   shell: |
     keytool -list -keystore {{kafka_broker_keystore_path}} \
         -storepass {{kafka_broker_keystore_storepass}} -v \
         | grep PrivateKeyEntry -A1000 \
         | grep Owner -m1 \
         | cut -d ":" -f2 \
-        | tr -d '[:space:]'
+        | cut -c2- \
+        | sed 's/\s*,\s*/,/g'
   register: distinguished_name_from_keystore
   when:
     - kafka_broker_listeners[kafka_broker_inter_broker_listener_name]['sasl_protocol'] | default(sasl_protocol) | normalize_sasl_protocol == 'none'

--- a/roles/confluent.test/molecule/certs-create.sh
+++ b/roles/confluent.test/molecule/certs-create.sh
@@ -65,7 +65,7 @@ for line in `sed '/^$/d' $filename`; do
       keytool -genkey -noprompt \
           -keystore $KEYSTORE_FILENAME \
           -alias $alias \
-          -dname "CN=$service,OU=QE,O=CONFLUENT,L=PaloAlto,ST=Ca,C=US" \
+          -dname "CN=$service,OU=QE IT,O=CONFLUENT,L=PaloAlto,ST=Ca,C=US" \
           -ext $EXT \
           -keyalg RSA \
           -storetype pkcs12 \

--- a/roles/confluent.test/molecule/rbac-mtls-provided-ubuntu/verify.yml
+++ b/roles/confluent.test/molecule/rbac-mtls-provided-ubuntu/verify.yml
@@ -19,6 +19,17 @@
         property: ldap.java.naming.provider.url
         expected_value: ldaps://ldap1:636
 
+    - name: Get super.users
+      shell: grep "super.users" /etc/kafka/server.properties
+      register: super_users_grep
+
+    - name: Assert full dname found in server.properties
+      assert:
+        that:
+          - "'User:CN=kafka_broker,OU=QE IT,O=CONFLUENT,L=PaloAlto,ST=Ca,C=US' in super_users_grep.stdout"
+        fail_msg: "Super Users property: {{super_users_grep.stdout}} does not contain User:CN=kafka_broker,OU=QE IT,O=CONFLUENT,L=PaloAlto,ST=Ca,C=US"
+        quiet: true
+
 - name: Verify - schema_registry
   hosts: schema_registry
   gather_facts: false


### PR DESCRIPTION
# Description

Added better logic for stripping spaces in mtls super user
Updates the test certs dname, and adds a test


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

rbac-mtls-provided-ubuntu scenario succeeds, and validates the bugfix

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules