### PR TITLE
Connect Hub Timeout Bugfix

### DIFF
--- a/roles/confluent.kafka_connect/defaults/main.yml
+++ b/roles/confluent.kafka_connect/defaults/main.yml
@@ -31,6 +31,7 @@ kafka_connect_confluent_hub_client:
   file: "http://client.hub.confluent.io/confluent-hub-client-latest.tar.gz"
   is_remote: true
   install_dir: /etc/kafka/confluent-hub
+  timeout: 90
 kafka_connect_confluent_hub_plugins: []
 kafka_connect_confluent_hub_plugins_dest: /usr/share/java
 kafka_connect_plugins: []

--- a/roles/confluent.kafka_connect/tasks/confluent_hub.yml
+++ b/roles/confluent.kafka_connect/tasks/confluent_hub.yml
@@ -7,11 +7,24 @@
     owner: "{{kafka_connect_user}}"
     mode: 0764
 
-- name: Installing/Unarchiving Confluent Hub
-  unarchive:
+- name: Download Confluent Hub Tar
+  get_url:
+    url: "{{kafka_connect_confluent_hub_client.file}}"
+    dest: "{{kafka_connect_confluent_hub_client.install_dir}}/confluent-hub-client-latest.tar.gz"
+    timeout: "{{kafka_connect_confluent_hub_client.timeout}}"
+  when: kafka_connect_confluent_hub_client.is_remote
+
+- name: Copy Confluent Hub Tar
+  copy:
     src: "{{kafka_connect_confluent_hub_client.file}}"
+    dest: "{{kafka_connect_confluent_hub_client.install_dir}}/confluent-hub-client-latest.tar.gz"
+  when: not kafka_connect_confluent_hub_client.is_remote
+
+- name: Unarchiving Confluent Hub
+  unarchive:
+    src: "{{kafka_connect_confluent_hub_client.install_dir}}/confluent-hub-client-latest.tar.gz"
     dest: "{{kafka_connect_confluent_hub_client.install_dir}}"
-    remote_src: "{{kafka_connect_confluent_hub_client.is_remote}}"
+    remote_src: true
     creates: "{{kafka_connect_confluent_hub_client.install_dir}}/bin/confluent-hub"
 
 - name: Symlinking Confluent Hub CLI

--- a/roles/confluent.test/molecule/mtls-debian/molecule.yml
+++ b/roles/confluent.test/molecule/mtls-debian/molecule.yml
@@ -125,6 +125,9 @@ provisioner:
         ssl_enabled: true
         ssl_mutual_auth_enabled: true
 
+        kafka_connect_confluent_hub_plugins:
+          - jcustenborder/kafka-connect-spooldir:2.0.43
+
 verifier:
   name: ansible
 lint: |


### PR DESCRIPTION
# Description

Changes the splits the unarchive task into get_url (with timeout) or copy, and then unarchive
Bug this resolves is around lack of timeout on the unarchive task. The get_url task now has a configurable timeout, defaulting to 90s
 
Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Updated the mtls-debian scenario to run the connect hub tasks, and it works


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules