### PR TITLE
Override confluent repo version in dev

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,14 +52,17 @@ def job = {
 
     def override_config = [:]
 
+    def branch_name = targetBranch().toString()
+
     if(params.CONFLUENT_PACKAGE_BASEURL) {
         override_config['confluent_common_repository_baseurl'] = params.CONFLUENT_PACKAGE_BASEURL
-    } else if (targetBranch().toString().matches('\\d+\\.\\d+\\.(x|\\d+)') || targetBranch().toString().equals('master')) {
-        /* This condition imples we're in a dev (.x) or master branch and therefore the release in confluent_package_version
+    } else if (branch_name.matches('\\d+\\.\\d+\\.(x|\\d+)')) {
+        /* This condition imples we're in a dev (.x) branch and therefore the release in confluent_package_version
            does not yet exist on https://packages.confluent.io so we have to query the packaging job for the last
            successful build location (what utilities.getLastNightlyPackagingBaseURL returns). We also override the
            confluent_package_*_suffix to an empty string so it will install the (expected) latest version */
-        override_config['confluent_common_repository_baseurl'] = utilities.getLastNightlyPackagingBaseURL(targetBranch().toString())
+        override_config['confluent_common_repository_baseurl'] = utilities.getLastNightlyPackagingBaseURL(branch_name)
+        override_config['confluent_repo_version'] = branch_name.tokenize('.')[0..1].join('.')
         override_config['confluent_package_redhat_suffix'] = ""
         override_config['confluent_package_debian_suffix'] = ""
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,8 +54,8 @@ def job = {
 
     if(params.CONFLUENT_PACKAGE_BASEURL) {
         override_config['confluent_common_repository_baseurl'] = params.CONFLUENT_PACKAGE_BASEURL
-    } else if (targetBranch().toString().matches('\\d+\\.\\d+\\.(x|\\d+)')) {
-        /* This condition imples we're in a dev (.x) branch and therefore the release in confluent_package_version
+    } else if (targetBranch().toString().matches('\\d+\\.\\d+\\.(x|\\d+)') || targetBranch().toString().equals('master')) {
+        /* This condition imples we're in a dev (.x) or master branch and therefore the release in confluent_package_version
            does not yet exist on https://packages.confluent.io so we have to query the packaging job for the last
            successful build location (what utilities.getLastNightlyPackagingBaseURL returns). We also override the
            confluent_package_*_suffix to an empty string so it will install the (expected) latest version */


### PR DESCRIPTION
# Description

In the 6.0.x branch, because `confluent_repo_version` is still set to 5.5, we get incorrect HTTP paths. Eg (in a 6.0.x Jenkins build):

```
17:21:36  [31mfatal: [control-center154]: FAILED! => {"attempts": 10, "changed": false, "msg": "Failure talking to yum: failure: repodata/repomd.xml from Confluent: [Errno 256] No more mirrors to try.\n${BASEURL}/rpm/5.5/repodata/repomd.xml: [Errno 14] HTTPS Error 404 - Not Found"}[0m
```

When the 6.0.x Job queries the packaging job for the location if the nightly build. Luckily we can deduce what `confluent_repo_version` *should* be from the branch name, hence this override.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Did a replay with this change-of-sorts:

https://jenkins.confluent.io/job/confluentinc/job/cp-ansible/job/6.0.x/55/replay/diff

The job may have failed, but for a different reason I'm fixing.

**Test Configuration**:


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules