### PR TITLE
Transaction state log isr property default fix

### DIFF
--- a/roles/confluent.kafka_broker/defaults/main.yml
+++ b/roles/confluent.kafka_broker/defaults/main.yml
@@ -69,7 +69,7 @@ kafka_broker:
     socket.receive.buffer.bytes: 102400
     socket.request.max.bytes: 104857600
     socket.send.buffer.bytes: 102400
-    transaction.state.log.min.isr: 2
+    transaction.state.log.min.isr: "{{ [ kafka_broker_default_interal_replication_factor, 2 ] | min }}"
     transaction.state.log.replication.factor: "{{kafka_broker_default_interal_replication_factor}}"
     zookeeper.connection.timeout.ms: 18000
     confluent.license.topic.replication.factor: "{{kafka_broker_default_interal_replication_factor}}"

--- a/roles/confluent.test/molecule/rbac-scram-custom-rhel/verify.yml
+++ b/roles/confluent.test/molecule/rbac-scram-custom-rhel/verify.yml
@@ -19,6 +19,14 @@
         property: ldap.java.naming.factory.initial
         expected_value: com.sun.jndi.ldap.LdapCtxFactory
 
+    - import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: /etc/kafka/server.properties
+        property: transaction.state.log.min.isr
+        expected_value: 2
+
 - name: Verify - schema_registry
   hosts: schema_registry
   gather_facts: false


### PR DESCRIPTION
# Description

transaction.state.log.min.isr property default does not account for single or double broker kafka clusters

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Added test case to verify.yml of rbac-scram-custom-rhel
Tested manually w one broker cluster as well


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules