### PR TITLE
Inventory supports any component group, does not require all

### DIFF
--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -76,6 +76,14 @@ Default:  true
 
 ***
 
+### monitoring_interceptors_enabled
+
+Boolean to configure Monitoring Interceptors on ksqlDB, Rest Proxy, and Connect. Only honored if inventory also has Control Center Group
+
+Default:  true
+
+***
+
 ### installation_method
 
 The method of installation. Valid values are "package" or "archive". If "archive" is selected then services will not be installed via the use of yum or apt, but will instead be installed via expanding the target .tar.gz file from the Confluent archive into the path defined by `archive_destination_path`. Configuration files are also kept in this directory structure instead of `/etc`. SystemD service units are copied from the ardhive for each target service and overrides are created pointing at the new paths. The "package" installation method is the default behavior that utilizes yum/apt.
@@ -668,6 +676,14 @@ Default:  "{{ kafka_rest.properties }}"
 
 ***
 
+### kafka_rest_monitoring_interceptors_enabled
+
+Boolean to configure Monitoring Interceptors on Rest Proxy. Only honored if inventory also has Control Center Group
+
+Default:  "{{ monitoring_interceptors_enabled }}"
+
+***
+
 ### kafka_connect_user
 
 Only use to customize Linux User Connect Service runs with. User must exist on host.
@@ -796,6 +812,14 @@ Default:  "{{ kafka_connect.properties }}"
 
 ***
 
+### kafka_connect_monitoring_interceptors_enabled
+
+Boolean to configure Monitoring Interceptors on Connect. Only honored if inventory also has Control Center Group
+
+Default:  "{{ monitoring_interceptors_enabled }}"
+
+***
+
 ### ksql_user
 
 Only use to customize Linux User ksqlDB Service runs with. User must exist on host.
@@ -905,6 +929,14 @@ Default:  default_
 Use to set custom ksqlDB properties. This variable is a dictionary. Put values true/false in quotation marks to perserve case. NOTE- ksql.properties is deprecated.
 
 Default:  "{{ ksql.properties }}"
+
+***
+
+### ksql_monitoring_interceptors_enabled
+
+Boolean to configure Monitoring Interceptors on ksqlDB. Only honored if inventory also has Control Center Group
+
+Default:  "{{ monitoring_interceptors_enabled }}"
 
 ***
 

--- a/all.yml
+++ b/all.yml
@@ -1,24 +1,18 @@
 ---
-- name: Generate CA for Self Signed Certs
-  hosts: zookeeper[0]
-  gather_facts: false
-  tags: certificate_authority
-  tasks:
-  - import_role:
-      name: confluent.variables
-
-  - name: Create Certificate Authority and Copy to Ansible Host
-    include_tasks: tasks/certificate_authority.yml
-    when: (self_signed|bool and regenerate_ca|bool and kafka_broker_listeners | ssl_required(ssl_enabled)) or create_mds_certs|bool
-
 - name: Host Prerequisites
   hosts: zookeeper:kafka_broker:schema_registry:kafka_connect:ksql:control_center:kafka_rest
   gather_facts: false
-  tags: common
   environment: "{{ proxy_env }}"
   tasks:
+  - name: Create Certificate Authority and Copy to Ansible Host
+    include_tasks: tasks/certificate_authority.yml
+    tags: certificate_authority
+    run_once: true
+    when: (self_signed|bool and regenerate_ca|bool and kafka_broker_listeners | ssl_required(ssl_enabled)) or create_mds_certs|bool
+
   - import_role:
       name: confluent.common
+    tags: common
 
 - name: Zookeeper Provisioning
   hosts: zookeeper

--- a/roles/confluent.test/molecule/mtls-java11-debian/molecule.yml
+++ b/roles/confluent.test/molecule/mtls-java11-debian/molecule.yml
@@ -13,6 +13,28 @@ platforms:
     privileged: true
     networks:
       - name: confluent
+  - name: zookeeper2
+    hostname: zookeeper2.confluent
+    groups:
+      - zookeeper
+    image: geerlingguy/docker-debian9-ansible
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    networks:
+      - name: confluent
+  - name: zookeeper3
+    hostname: zookeeper3.confluent
+    groups:
+      - zookeeper
+    image: geerlingguy/docker-debian9-ansible
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    networks:
+      - name: confluent
   - name: kafka-broker1
     hostname: kafka-broker1.confluent
     groups:

--- a/roles/confluent.test/molecule/mtls-java11-debian/molecule.yml
+++ b/roles/confluent.test/molecule/mtls-java11-debian/molecule.yml
@@ -13,28 +13,6 @@ platforms:
     privileged: true
     networks:
       - name: confluent
-  - name: zookeeper2
-    hostname: zookeeper2.confluent
-    groups:
-      - zookeeper
-    image: geerlingguy/docker-debian9-ansible
-    command: ""
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
-    networks:
-      - name: confluent
-  - name: zookeeper3
-    hostname: zookeeper3.confluent
-    groups:
-      - zookeeper
-    image: geerlingguy/docker-debian9-ansible
-    command: ""
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
-    networks:
-      - name: confluent
   - name: kafka-broker1
     hostname: kafka-broker1.confluent
     groups:

--- a/roles/confluent.variables/defaults/main.yml
+++ b/roles/confluent.variables/defaults/main.yml
@@ -46,6 +46,9 @@ common_role_completed: false
 
 proxy_env: {}
 
+### Boolean to configure Monitoring Interceptors on ksqlDB, Rest Proxy, and Connect. Only honored if inventory also has Control Center Group
+monitoring_interceptors_enabled: true
+
 ### The method of installation. Valid values are "package" or "archive". If "archive" is selected then services will not be installed via the use of yum or apt, but will instead be installed via expanding the target .tar.gz file from the Confluent archive into the path defined by `archive_destination_path`. Configuration files are also kept in this directory structure instead of `/etc`. SystemD service units are copied from the ardhive for each target service and overrides are created pointing at the new paths. The "package" installation method is the default behavior that utilizes yum/apt.
 installation_method: "package"
 
@@ -394,6 +397,9 @@ kafka_rest_copy_files: []
 ### Use to set custom Rest Proxy properties. This variable is a dictionary. Put values true/false in quotation marks to perserve case. NOTE- kafka_rest.properties is deprecated.
 kafka_rest_custom_properties: "{{ kafka_rest.properties }}"
 
+### Boolean to configure Monitoring Interceptors on Rest Proxy. Only honored if inventory also has Control Center Group
+kafka_rest_monitoring_interceptors_enabled: "{{ monitoring_interceptors_enabled }}"
+
 
 # Kafka Connect Variables
 
@@ -476,6 +482,9 @@ kafka_connect_plugins_dest: /usr/share/java
 ### Use to set custom Connect properties. This variable is a dictionary. Put values true/false in quotation marks to perserve case. NOTE- kafka_connect.properties is deprecated.
 kafka_connect_custom_properties: "{{ kafka_connect.properties }}"
 
+### Boolean to configure Monitoring Interceptors on Connect. Only honored if inventory also has Control Center Group
+kafka_connect_monitoring_interceptors_enabled: "{{ monitoring_interceptors_enabled }}"
+
 
 
 #### KSQLDB Variables ####
@@ -537,6 +546,9 @@ ksql_service_id: default_
 
 ### Use to set custom ksqlDB properties. This variable is a dictionary. Put values true/false in quotation marks to perserve case. NOTE- ksql.properties is deprecated.
 ksql_custom_properties: "{{ ksql.properties }}"
+
+### Boolean to configure Monitoring Interceptors on ksqlDB. Only honored if inventory also has Control Center Group
+ksql_monitoring_interceptors_enabled: "{{ monitoring_interceptors_enabled }}"
 
 
 # Control Center Variables

--- a/roles/confluent.variables/defaults/main.yml
+++ b/roles/confluent.variables/defaults/main.yml
@@ -486,7 +486,6 @@ kafka_connect_custom_properties: "{{ kafka_connect.properties }}"
 kafka_connect_monitoring_interceptors_enabled: "{{ monitoring_interceptors_enabled }}"
 
 
-
 #### KSQLDB Variables ####
 
 ### Only use to customize Linux User ksqlDB Service runs with. User must exist on host.

--- a/roles/confluent.variables/vars/main.yml
+++ b/roles/confluent.variables/vars/main.yml
@@ -215,13 +215,13 @@ kafka_broker_properties:
                             plain_jaas_config, kafka_broker_keytab_path, kafka_broker_kerberos_principal|default('kafka'),
                             sasl_scram_users.admin.principal, sasl_scram_users.admin.password, rbac_enabled_public_pem_path ) }}"
   metrics_reporter:
-    enabled: "{{kafka_broker_metrics_reporter_enabled}}"
+    enabled: "{{ 'control_center' in groups and kafka_broker_metrics_reporter_enabled|bool }}"
     properties:
       metric.reporters: io.confluent.metrics.reporter.ConfluentMetricsReporter
       confluent.metrics.reporter.bootstrap.servers: "{{ groups['kafka_broker'] | default(['localhost']) | join(':' + kafka_broker_listeners[kafka_broker_inter_broker_listener_name]['port']|string + ',') }}:{{kafka_broker_listeners[kafka_broker_inter_broker_listener_name]['port']}}"
       confluent.metrics.reporter.topic.replicas: "{{kafka_broker_default_interal_replication_factor}}"
   metrics_reporter_client:
-    enabled: "{{kafka_broker_metrics_reporter_enabled}}"
+    enabled: "{{ 'control_center' in groups and kafka_broker_metrics_reporter_enabled|bool }}"
     properties: "{{ kafka_broker_listeners[kafka_broker_inter_broker_listener_name] | client_properties(ssl_enabled, pkcs12_enabled, ssl_mutual_auth_enabled, sasl_protocol,
                             'confluent.metrics.reporter.', kafka_broker_truststore_path, kafka_broker_truststore_storepass, kafka_broker_keystore_path, kafka_broker_keystore_storepass, kafka_broker_keystore_keypass,
                             false, sasl_plain_users.admin.principal, sasl_plain_users.admin.password, sasl_scram_users.admin.principal, sasl_scram_users.admin.password,
@@ -344,8 +344,6 @@ kafka_connect_properties:
     enabled: true
     properties:
       rest.port: "{{kafka_connect_rest_port}}"
-      consumer.interceptor.classes: io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor
-      producer.interceptor.classes: io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor
       config.storage.replication.factor: "{{ kafka_connect_default_internal_replication_factor }}"
       config.storage.topic: "{{kafka_connect_group_id}}-configs"
       group.id: "{{kafka_connect_group_id}}"
@@ -369,8 +367,6 @@ kafka_connect_properties:
       bootstrap.servers: "{{ groups['kafka_broker'] | default(['localhost']) | join(':' + kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']|string + ',') }}:{{kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']}}"
       producer.bootstrap.servers: "{{ groups['kafka_broker'] | default(['localhost']) | join(':' + kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']|string + ',') }}:{{kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']}}"
       consumer.bootstrap.servers: "{{ groups['kafka_broker'] | default(['localhost']) | join(':' + kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']|string + ',') }}:{{kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']}}"
-      producer.confluent.monitoring.interceptor.bootstrap.servers: "{{ groups['kafka_broker'] | default(['localhost']) | join(':' + kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']|string + ',') }}:{{kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']}}"
-      consumer.confluent.monitoring.interceptor.bootstrap.servers: "{{ groups['kafka_broker'] | default(['localhost']) | join(':' + kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']|string + ',') }}:{{kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']}}"
   ssl:
     enabled: "{{kafka_connect_ssl_enabled}}"
     properties:
@@ -422,14 +418,22 @@ kafka_connect_properties:
                             true, sasl_plain_users.kafka_connect.principal, sasl_plain_users.kafka_connect.password, sasl_scram_users.kafka_connect.principal, sasl_scram_users.kafka_connect.password,
                             kerberos_kafka_broker_primary|default('kafka'), kafka_connect_keytab_path, kafka_connect_kerberos_principal|default('kafka'),
                             kafka_connect_ldap_user, kafka_connect_ldap_password, mds_bootstrap_server_urls) }}"
-  producer_monitoring_interceptor:
+  monitoring_interceptor:
+    # TODO do we want a flag for this feature
+    enabled: "{{ 'control_center' in groups }}"
+    properties:
+      producer.confluent.monitoring.interceptor.bootstrap.servers: "{{ groups['kafka_broker'] | default(['localhost']) | join(':' + kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']|string + ',') }}:{{kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']}}"
+      consumer.confluent.monitoring.interceptor.bootstrap.servers: "{{ groups['kafka_broker'] | default(['localhost']) | join(':' + kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']|string + ',') }}:{{kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']}}"
+      consumer.interceptor.classes: io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor
+      producer.interceptor.classes: io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor
+  producer_monitoring_interceptor_client:
     enabled: true
     properties: "{{ kafka_broker_listeners[kafka_connect_kafka_listener_name] | client_properties(ssl_enabled, pkcs12_enabled, ssl_mutual_auth_enabled, sasl_protocol,
                             'producer.confluent.monitoring.interceptor.', kafka_connect_truststore_path, kafka_connect_truststore_storepass, kafka_connect_keystore_path, kafka_connect_keystore_storepass, kafka_connect_keystore_keypass,
                             false, sasl_plain_users.kafka_connect.principal, sasl_plain_users.kafka_connect.password, sasl_scram_users.kafka_connect.principal, sasl_scram_users.kafka_connect.password,
                             kerberos_kafka_broker_primary|default('kafka'), kafka_connect_keytab_path, kafka_connect_kerberos_principal|default('kafka'),
                             kafka_connect_ldap_user, kafka_connect_ldap_password, mds_bootstrap_server_urls) }}"
-  consumer_monitoring_interceptor:
+  consumer_monitoring_interceptor_client:
     enabled: true
     properties: "{{ kafka_broker_listeners[kafka_connect_kafka_listener_name] | client_properties(ssl_enabled, pkcs12_enabled, ssl_mutual_auth_enabled, sasl_protocol,
                             'consumer.confluent.monitoring.interceptor.', kafka_connect_truststore_path, kafka_connect_truststore_storepass, kafka_connect_keystore_path, kafka_connect_keystore_storepass, kafka_connect_keystore_keypass,
@@ -513,12 +517,9 @@ ksql_properties:
       ksql.streams.num.standby.replicas: 1
       ksql.streams.producer.delivery.timeout.ms: 2147483647
       ksql.streams.producer.max.block.ms: 9223372036854775807
-      producer.interceptor.classes: io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor
-      consumer.interceptor.classes: io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor
       listeners: "{{ksql_http_protocol}}://0.0.0.0:{{ksql_listener_port}}"
       bootstrap.servers: "{{ groups['kafka_broker'] | default(['localhost']) | join(':' + kafka_broker_listeners[ksql_kafka_listener_name]['port']|string + ',') }}:{{kafka_broker_listeners[ksql_kafka_listener_name]['port']}}"
       security.protocol: "{{kafka_broker_listeners[ksql_kafka_listener_name] | kafka_protocol_defaults(sasl_protocol, ssl_enabled) }}"
-      confluent.monitoring.interceptor.bootstrap.servers: "{{ groups['kafka_broker'] | default(['localhost']) | join(':' + kafka_broker_listeners[ksql_kafka_listener_name]['port']|string + ',') }}:{{kafka_broker_listeners[ksql_kafka_listener_name]['port']}}"
   ssl:
     # KSQL SSL properties shared with Kafka Broker
     enabled: "{{ kafka_broker_listeners[ksql_kafka_listener_name]['ssl_enabled']|default(ssl_enabled)|bool or ksql_ssl_enabled|bool }}"
@@ -576,7 +577,13 @@ ksql_properties:
       ksql.schema.registry.basic.auth.credentials.source: USER_INFO
       ksql.schema.registry.basic.auth.user.info: "{{ ksql_ldap_user | default('ksql') }}:{{ ksql_ldap_password | default('pass') }}"
   monitoring_interceptor:
-    # TODO only want this if c3 installed i think
+    # TODO do we want a flag for this feature
+    enabled: "{{ 'control_center' in groups }}"
+    properties:
+      producer.interceptor.classes: io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor
+      consumer.interceptor.classes: io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor
+      confluent.monitoring.interceptor.bootstrap.servers: "{{ groups['kafka_broker'] | default(['localhost']) | join(':' + kafka_broker_listeners[ksql_kafka_listener_name]['port']|string + ',') }}:{{kafka_broker_listeners[ksql_kafka_listener_name]['port']}}"
+  monitoring_interceptor_client:
     enabled: true
     properties: "{{ kafka_broker_listeners[ksql_kafka_listener_name] | client_properties(ssl_enabled, pkcs12_enabled, ssl_mutual_auth_enabled, sasl_protocol,
                             'confluent.monitoring.interceptor.', ksql_truststore_path, ksql_truststore_storepass, ksql_keystore_path, ksql_keystore_storepass, ksql_keystore_keypass,
@@ -632,13 +639,11 @@ kafka_rest_properties:
   defaults:
     enabled: true
     properties:
-      producer.interceptor.classes: io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor
-      consumer.interceptor.classes: io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor
       listeners: "{{kafka_rest_http_protocol}}://0.0.0.0:{{kafka_rest_port}}"
       host.name: "{{inventory_hostname}}"
+      # TODO this prop is buggy
       zookeeper.connect: "{{ groups['zookeeper'] | default(['localhost']) | join(':' + zookeeper_final_properties.clientPort|string + ',') }}:{{zookeeper_final_properties.clientPort}}"
       bootstrap.servers: "{{ groups['kafka_broker'] | default(['localhost']) | join(':' + kafka_broker_listeners[kafka_rest_kafka_listener_name]['port']|string + ',') }}:{{kafka_broker_listeners[kafka_rest_kafka_listener_name]['port']}}"
-      confluent.monitoring.interceptor.bootstrap.servers: "{{ groups['kafka_broker'] | default(['localhost']) | join(':' + kafka_broker_listeners[kafka_rest_kafka_listener_name]['port']|string + ',') }}:{{kafka_broker_listeners[kafka_rest_kafka_listener_name]['port']}}"
   id:
     enabled: "{{ inventory_hostname in groups.kafka_rest }}"
     properties:
@@ -679,8 +684,14 @@ kafka_rest_properties:
       schema.registry.ssl.keystore.password: "{{kafka_rest_keystore_storepass}}"
       schema.registry.ssl.key.password: "{{kafka_rest_keystore_keypass}}"
   monitoring_interceptor:
-    # TODO interceptors only if c3 on right?
-    enabled: true
+    # TODO do we want a flag for this feature
+    enabled: "{{ 'control_center' in groups }}"
+    properties:
+      producer.interceptor.classes: io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor
+      consumer.interceptor.classes: io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor
+      confluent.monitoring.interceptor.bootstrap.servers: "{{ groups['kafka_broker'] | default(['localhost']) | join(':' + kafka_broker_listeners[kafka_rest_kafka_listener_name]['port']|string + ',') }}:{{kafka_broker_listeners[kafka_rest_kafka_listener_name]['port']}}"
+  monitoring_interceptor_client:
+    enabled: "{{ 'control_center' in groups }}"
     properties: "{{ kafka_broker_listeners[kafka_rest_kafka_listener_name] | client_properties(ssl_enabled, pkcs12_enabled, ssl_mutual_auth_enabled, sasl_protocol,
                             'confluent.monitoring.interceptor.', kafka_rest_truststore_path, kafka_rest_truststore_storepass, kafka_rest_keystore_path, kafka_rest_keystore_storepass, kafka_rest_keystore_keypass,
                             false, sasl_plain_users.kafka_rest.principal, sasl_plain_users.kafka_rest.password, sasl_scram_users.kafka_rest.principal, sasl_scram_users.kafka_rest.password,

--- a/roles/confluent.variables/vars/main.yml
+++ b/roles/confluent.variables/vars/main.yml
@@ -782,11 +782,6 @@ control_center_properties:
       confluent.controlcenter.schema.registry.ssl.keystore.location: "{{control_center_keystore_path}}"
       confluent.controlcenter.schema.registry.ssl.keystore.password: "{{control_center_keystore_storepass}}"
       confluent.controlcenter.schema.registry.ssl.key.password: "{{control_center_keystore_keypass}}"
-  sr_rbac:
-    enabled: "{{ 'schema_registry' in groups and rbac_enabled|bool }}"
-    properties:
-      confluent.controlcenter.schema.registry.basic.auth.credentials.source: USER_INFO
-      confluent.controlcenter.schema.registry.basic.auth.user.info: "{{ control_center_ldap_user | default('c3') }}:{{ control_center_ldap_password | default('pass') }}"
   connect:
     enabled: "{{ 'kafka_connect' in groups }}"
     properties: "{{ kafka_connect_cluster_ansible_group_names | default(['kafka_connect']) | c3_connect_properties(groups, hostvars, kafka_connect_ssl_enabled,

--- a/roles/confluent.variables/vars/main.yml
+++ b/roles/confluent.variables/vars/main.yml
@@ -419,15 +419,14 @@ kafka_connect_properties:
                             kerberos_kafka_broker_primary|default('kafka'), kafka_connect_keytab_path, kafka_connect_kerberos_principal|default('kafka'),
                             kafka_connect_ldap_user, kafka_connect_ldap_password, mds_bootstrap_server_urls) }}"
   monitoring_interceptor:
-    # TODO do we want a flag for this feature
-    enabled: "{{ 'control_center' in groups }}"
+    enabled: "{{ 'control_center' in groups and kafka_connect_monitoring_interceptors_enabled|bool }}"
     properties:
       producer.confluent.monitoring.interceptor.bootstrap.servers: "{{ groups['kafka_broker'] | default(['localhost']) | join(':' + kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']|string + ',') }}:{{kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']}}"
       consumer.confluent.monitoring.interceptor.bootstrap.servers: "{{ groups['kafka_broker'] | default(['localhost']) | join(':' + kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']|string + ',') }}:{{kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']}}"
       consumer.interceptor.classes: io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor
       producer.interceptor.classes: io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor
   producer_monitoring_interceptor_client:
-    enabled: true
+    enabled: "{{ 'control_center' in groups and kafka_connect_monitoring_interceptors_enabled|bool }}"
     properties: "{{ kafka_broker_listeners[kafka_connect_kafka_listener_name] | client_properties(ssl_enabled, pkcs12_enabled, ssl_mutual_auth_enabled, sasl_protocol,
                             'producer.confluent.monitoring.interceptor.', kafka_connect_truststore_path, kafka_connect_truststore_storepass, kafka_connect_keystore_path, kafka_connect_keystore_storepass, kafka_connect_keystore_keypass,
                             false, sasl_plain_users.kafka_connect.principal, sasl_plain_users.kafka_connect.password, sasl_scram_users.kafka_connect.principal, sasl_scram_users.kafka_connect.password,
@@ -577,14 +576,13 @@ ksql_properties:
       ksql.schema.registry.basic.auth.credentials.source: USER_INFO
       ksql.schema.registry.basic.auth.user.info: "{{ ksql_ldap_user | default('ksql') }}:{{ ksql_ldap_password | default('pass') }}"
   monitoring_interceptor:
-    # TODO do we want a flag for this feature
-    enabled: "{{ 'control_center' in groups }}"
+    enabled: "{{ 'control_center' in groups and ksql_monitoring_interceptors_enabled|bool }}"
     properties:
       producer.interceptor.classes: io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor
       consumer.interceptor.classes: io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor
       confluent.monitoring.interceptor.bootstrap.servers: "{{ groups['kafka_broker'] | default(['localhost']) | join(':' + kafka_broker_listeners[ksql_kafka_listener_name]['port']|string + ',') }}:{{kafka_broker_listeners[ksql_kafka_listener_name]['port']}}"
   monitoring_interceptor_client:
-    enabled: true
+    enabled: "{{ 'control_center' in groups and ksql_monitoring_interceptors_enabled|bool }}"
     properties: "{{ kafka_broker_listeners[ksql_kafka_listener_name] | client_properties(ssl_enabled, pkcs12_enabled, ssl_mutual_auth_enabled, sasl_protocol,
                             'confluent.monitoring.interceptor.', ksql_truststore_path, ksql_truststore_storepass, ksql_keystore_path, ksql_keystore_storepass, ksql_keystore_keypass,
                             false, sasl_plain_users.ksql.principal, sasl_plain_users.ksql.password, sasl_scram_users.ksql.principal, sasl_scram_users.ksql.password,
@@ -641,8 +639,8 @@ kafka_rest_properties:
     properties:
       listeners: "{{kafka_rest_http_protocol}}://0.0.0.0:{{kafka_rest_port}}"
       host.name: "{{inventory_hostname}}"
-      # TODO this prop is buggy
-      zookeeper.connect: "{{ groups['zookeeper'] | default(['localhost']) | join(':' + zookeeper_final_properties.clientPort|string + ',') }}:{{zookeeper_final_properties.clientPort}}"
+      # TODO remove this prop for 600 release, hardcoding port for time being
+      zookeeper.connect: "{{ groups['zookeeper'] | default(['localhost']) | join(':2181,') }}:2181"
       bootstrap.servers: "{{ groups['kafka_broker'] | default(['localhost']) | join(':' + kafka_broker_listeners[kafka_rest_kafka_listener_name]['port']|string + ',') }}:{{kafka_broker_listeners[kafka_rest_kafka_listener_name]['port']}}"
   id:
     enabled: "{{ inventory_hostname in groups.kafka_rest }}"
@@ -684,14 +682,13 @@ kafka_rest_properties:
       schema.registry.ssl.keystore.password: "{{kafka_rest_keystore_storepass}}"
       schema.registry.ssl.key.password: "{{kafka_rest_keystore_keypass}}"
   monitoring_interceptor:
-    # TODO do we want a flag for this feature
-    enabled: "{{ 'control_center' in groups }}"
+    enabled: "{{ 'control_center' in groups and kafka_rest_monitoring_interceptors_enabled|bool }}"
     properties:
       producer.interceptor.classes: io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor
       consumer.interceptor.classes: io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor
       confluent.monitoring.interceptor.bootstrap.servers: "{{ groups['kafka_broker'] | default(['localhost']) | join(':' + kafka_broker_listeners[kafka_rest_kafka_listener_name]['port']|string + ',') }}:{{kafka_broker_listeners[kafka_rest_kafka_listener_name]['port']}}"
   monitoring_interceptor_client:
-    enabled: "{{ 'control_center' in groups }}"
+    enabled: "{{ 'control_center' in groups and kafka_rest_monitoring_interceptors_enabled|bool }}"
     properties: "{{ kafka_broker_listeners[kafka_rest_kafka_listener_name] | client_properties(ssl_enabled, pkcs12_enabled, ssl_mutual_auth_enabled, sasl_protocol,
                             'confluent.monitoring.interceptor.', kafka_rest_truststore_path, kafka_rest_truststore_storepass, kafka_rest_keystore_path, kafka_rest_keystore_storepass, kafka_rest_keystore_keypass,
                             false, sasl_plain_users.kafka_rest.principal, sasl_plain_users.kafka_rest.password, sasl_scram_users.kafka_rest.principal, sasl_scram_users.kafka_rest.password,
@@ -708,7 +705,6 @@ kafka_rest_properties:
       confluent.metadata.server.urls.max.age.ms: 60000
       confluent.metadata.basic.auth.user.info: "{{kafka_rest_ldap_user | default('rest') }}:{{kafka_rest_ldap_password | default('pass')}}"
       confluent.metadata.http.auth.credentials.provider: BASIC
-
   rbac_external_client:
     enabled: "{{rbac_enabled and external_mds_enabled and mds_ssl_enabled }}"
     properties:

--- a/roles/confluent.variables/vars/main.yml
+++ b/roles/confluent.variables/vars/main.yml
@@ -433,7 +433,7 @@ kafka_connect_properties:
                             kerberos_kafka_broker_primary|default('kafka'), kafka_connect_keytab_path, kafka_connect_kerberos_principal|default('kafka'),
                             kafka_connect_ldap_user, kafka_connect_ldap_password, mds_bootstrap_server_urls) }}"
   consumer_monitoring_interceptor_client:
-    enabled: true
+    enabled: "{{ 'control_center' in groups and kafka_connect_monitoring_interceptors_enabled|bool }}"
     properties: "{{ kafka_broker_listeners[kafka_connect_kafka_listener_name] | client_properties(ssl_enabled, pkcs12_enabled, ssl_mutual_auth_enabled, sasl_protocol,
                             'consumer.confluent.monitoring.interceptor.', kafka_connect_truststore_path, kafka_connect_truststore_storepass, kafka_connect_keystore_path, kafka_connect_keystore_storepass, kafka_connect_keystore_keypass,
                             false, sasl_plain_users.kafka_connect.principal, sasl_plain_users.kafka_connect.password, sasl_scram_users.kafka_connect.principal, sasl_scram_users.kafka_connect.password,

--- a/tasks/certificate_authority.yml
+++ b/tasks/certificate_authority.yml
@@ -1,4 +1,7 @@
 ---
+- import_role:
+    name: confluent.variables
+
 - name: Gather OS Facts
   setup:
     filter: ansible_os_family


### PR DESCRIPTION
# Description

- Should be able to configure kafka_rest (or any other component group) alone. Useful for connecting component to ccloud kafka instance. 
- Adds flag for monitoring interceptors, now disableable
- Removes unnecessary c3 rbac props 

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Reviewed logs of mtls scenario, made sure the certificate authority tasks did in fact only run once.
Everything else gets validated on any scenario run


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules