### PR TITLE
Missing file permissions on ldaps cert files

### DIFF
--- a/roles/confluent.test.ldap/tasks/tls_custom_certs.yml
+++ b/roles/confluent.test.ldap/tasks/tls_custom_certs.yml
@@ -3,13 +3,16 @@
   copy:
     src: "{{ssl_ca_cert_filepath}}"
     dest: "/var/ssl/private/ldaps/{{ssl_ca_cert_filepath|basename}}"
+    mode: 0666
 
 - name: Copy Signed Cert to Host
   copy:
     src: "{{ssl_signed_cert_filepath}}"
     dest: "/var/ssl/private/ldaps/{{ssl_signed_cert_filepath|basename}}"
+    mode: 0666
 
 - name: Copy Key to Host
   copy:
     src: "{{ssl_key_filepath}}"
     dest: "/var/ssl/private/ldaps/{{ssl_key_filepath|basename}}"
+    mode: 0666


### PR DESCRIPTION
# Description

Fixes molecule ldaps start up errors

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Jenkins run will test it


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules