### PR TITLE
<WIP> Support for Separate Cert Stores for Control Center 

### DIFF
--- a/roles/confluent.control_center/tasks/main.yml
+++ b/roles/confluent.control_center/tasks/main.yml
@@ -58,6 +58,26 @@
     cert_path: "{{control_center_cert_path}}"
     key_path: "{{control_center_key_path}}"
   when: control_center_ssl_enabled|bool or kafka_broker_listeners[control_center_kafka_listener_name]['ssl_enabled'] | default(ssl_enabled) | bool
+  
+- include_role:
+    name: confluent.ssl
+  vars:
+    truststore_storepass: "{{control_center_rest_truststore_storepass}}"
+    truststore_path: "{{control_center_rest_truststore_path}}"
+    keystore_path: "{{control_center_rest_keystore_path}}"
+    keystore_storepass: "{{control_center_rest_keystore_storepass}}"
+    keystore_keypass: "{{control_center_rest_keystore_keypass}}"
+    service_name: control_center
+    hostnames: "{{ [inventory_hostname, ansible_fqdn] | unique }}"
+    ca_cert_path: "{{control_center_rest_ca_cert_path}}"
+    cert_path: "{{control_center_rest_cert_path}}"
+    key_path: "{{control_center_rest_key_path}}"
+    ssl_truststore_filepath: "{{ ssl_rest_truststore_filepath | default(ssl_truststore_filepath) }}"
+    ssl_keystore_filepath: "{{ ssl_rest_keystore_filepath | default(ssl_keystore_filepath) }}"
+    ssl_signed_cert_filepath: "{{ ssl_rest_signed_cert_filepath | default(ssl_signed_cert_filepath) }}"
+    ssl_key_filepath: "{{ ssl_rest_key_filepath | default(ssl_key_filepath) }}"
+    ssl_key_password: "{{ ssl_rest_key_password | default(ssl_key_password) }}"
+  when: control_center_ssl_enabled|bool AND (control_center_rest_keystore_path != control_center_keystore_path OR control_center_rest_truststore_path != control_center_truststore_path) AND (ssl_custom_certs OR ssl_provided_keystore_and_truststore) | bool
 
 - name: Configure Kerberos
   include_role:

--- a/roles/confluent.control_center/templates/control-center.properties.j2
+++ b/roles/confluent.control_center/templates/control-center.properties.j2
@@ -1,12 +1,12 @@
 # Control Center Configuration
 confluent.controlcenter.rest.listeners={{control_center_http_protocol}}://{{control_center_listener_hostname}}:{{control_center_port}}
 {% if control_center_ssl_enabled|bool %}
-confluent.controlcenter.rest.ssl.keystore.location={{control_center_keystore_path}}
-confluent.controlcenter.rest.ssl.keystore.password={{control_center_keystore_storepass}}
-confluent.controlcenter.rest.ssl.key.password={{control_center_keystore_keypass}}
+confluent.controlcenter.rest.ssl.keystore.location={{control_center_rest_keystore_path}}
+confluent.controlcenter.rest.ssl.keystore.password={{control_center_rest_keystore_storepass}}
+confluent.controlcenter.rest.ssl.key.password={{control_center_rest_keystore_keypass}}
 {% if control_center_ssl_mutual_auth_enabled|bool %}
-confluent.controlcenter.rest.ssl.truststore.location={{control_center_truststore_path}}
-confluent.controlcenter.rest.ssl.truststore.password={{control_center_truststore_storepass}}
+confluent.controlcenter.rest.ssl.truststore.location={{control_center_rest_truststore_path}}
+confluent.controlcenter.rest.ssl.truststore.password={{control_center_rest_truststore_storepass}}
 {% endif %}
 {% endif %}
 

--- a/roles/confluent.variables_handlers/defaults/main.yml
+++ b/roles/confluent.variables_handlers/defaults/main.yml
@@ -241,6 +241,7 @@ control_center_listener_hostname: "0.0.0.0"
 control_center_ssl_enabled: "{{ssl_enabled}}"
 control_center_ssl_mutual_auth_enabled: "{{ ssl_mutual_auth_enabled }}"
 control_center_http_protocol: "{{ 'https' if control_center_ssl_enabled|bool else 'http' }}"
+
 control_center_truststore_path: "/var/ssl/private/control_center.truststore.jks"
 control_center_keystore_path: "/var/ssl/private/control_center.keystore.jks"
 control_center_truststore_storepass: "{{ ssl_truststore_password if ssl_provided_keystore_and_truststore|bool else 'confluenttruststorepass'}}"
@@ -249,6 +250,16 @@ control_center_keystore_keypass: "{{ ssl_keystore_key_password if ssl_provided_k
 control_center_ca_cert_path: "/var/ssl/private/ca.crt"
 control_center_cert_path: "/var/ssl/private/control_center.crt"
 control_center_key_path: "/var/ssl/private/control_center.key"
+
+control_center_rest_truststore_path: "{{control_center_truststore_path}}"
+control_center_rest_keystore_path: "{{control_center_keystore_path}}"
+control_center_rest_truststore_storepass: "{{ control_center_truststore_storepass }}"
+control_center_rest_keystore_storepass: "{{ control_center_keystore_storepass }}"
+control_center_rest_keystore_keypass: "{{ control_center_keystore_keypass }}"
+control_center_rest_ca_cert_path: "{{control_center_ca_cert_path}}"
+control_center_rest_cert_path: "{{control_center_cert_path}}"
+control_center_rest_key_path: "{{control_center_key_path}}"
+
 control_center_kafka_listener_name: internal
 control_center:
   log4j_file: /etc/confluent-control-center/control-center_log4j.properties


### PR DESCRIPTION
# Description

Allows for a user to have separate Certs for the REST interface vs the STREAMS layer.
Default functionality is maintained, user has to opt in to gain the new functionality.  

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Currently working to test and debug with customer.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules