### PR TITLE
RocksDB env var for ksqlDB

### DIFF
--- a/roles/confluent.ksql/defaults/main.yml
+++ b/roles/confluent.ksql/defaults/main.yml
@@ -11,6 +11,8 @@ ksql_java_args:
 ksql_custom_java_args: ""
 ksql_final_java_args: "{{ ksql_java_args + [ ksql_custom_java_args ] }}"
 
+ksql_rocksdb_path: ""
+
 # Empty values will not be written into override.conf
 ksql_service_overrides:
   LimitNOFILE: 100000
@@ -19,6 +21,7 @@ ksql_service_overrides:
 ksql_service_environment_overrides:
   KSQL_HEAP_OPTS: "-Xmx3g"
   KSQL_OPTS: "{{ ksql_final_java_args | java_arg_build_out }}"
+  ROCKSDB_SHAREDLIB_DIR: "{{ksql_rocksdb_path}}"
 
 ksql_default_internal_replication_factor: "{{ [ groups['kafka_broker'] | length, 3 ] | min }}"
 

--- a/roles/confluent.ksql/defaults/main.yml
+++ b/roles/confluent.ksql/defaults/main.yml
@@ -11,7 +11,7 @@ ksql_java_args:
 ksql_custom_java_args: ""
 ksql_final_java_args: "{{ ksql_java_args + [ ksql_custom_java_args ] }}"
 
-ksql_rocksdb_path: /tmp
+ksql_rocksdb_path: /tmp/ksqldb
 
 # Empty values will not be written into override.conf
 ksql_service_overrides:

--- a/roles/confluent.ksql/defaults/main.yml
+++ b/roles/confluent.ksql/defaults/main.yml
@@ -11,7 +11,7 @@ ksql_java_args:
 ksql_custom_java_args: ""
 ksql_final_java_args: "{{ ksql_java_args + [ ksql_custom_java_args ] }}"
 
-ksql_rocksdb_path: ""
+ksql_rocksdb_path: /tmp
 
 # Empty values will not be written into override.conf
 ksql_service_overrides:

--- a/roles/confluent.ksql/tasks/main.yml
+++ b/roles/confluent.ksql/tasks/main.yml
@@ -84,6 +84,23 @@
     owner: "{{ksql_user}}"
     mode: 0750
 
+- name: Create RocksDB Directory
+  file:
+    path: "{{ksql_rocksdb_path}}"
+    group: "{{ksql_group}}"
+    owner: "{{ksql_user}}"
+    mode: 0750
+    state: directory
+  when: ksql_rocksdb_path != ""
+
+- name: Set Permission to RocksDB Files
+  file:
+    path: "{{ksql_rocksdb_path}}"
+    group: "{{ksql_group}}"
+    owner: "{{ksql_user}}"
+    recurse: true
+  when: ksql_rocksdb_path != ""
+
 - name: Create Ksql log4j Config
   template:
     src: ksql-server_log4j.properties.j2

--- a/roles/confluent.ksql/tasks/main.yml
+++ b/roles/confluent.ksql/tasks/main.yml
@@ -84,13 +84,6 @@
     owner: "{{ksql_user}}"
     mode: 0750
 
-- name: Create RocksDB Directory
-  file:
-    path: "{{ksql_rocksdb_path}}"
-    mode: 0777
-    state: directory
-  when: ksql_rocksdb_path != ""
-
 - name: Create Ksql log4j Config
   template:
     src: ksql-server_log4j.properties.j2
@@ -99,6 +92,23 @@
     owner: "{{ksql_user}}"
     group: "{{ksql_group}}"
   notify: restart ksql
+
+- name: Create RocksDB Directory
+  file:
+    path: "{{ksql_rocksdb_path}}"
+    group: "{{ksql_group}}"
+    owner: "{{ksql_user}}"
+    mode: 0750
+    state: directory
+  when: ksql_rocksdb_path != ""
+
+- name: Set Permission to RocksDB Files
+  file:
+    path: "{{ksql_rocksdb_path}}"
+    group: "{{ksql_group}}"
+    owner: "{{ksql_user}}"
+    recurse: true
+  when: ksql_rocksdb_path != ""
 
 - name: Ksql Jaas Config
   template:

--- a/roles/confluent.ksql/tasks/main.yml
+++ b/roles/confluent.ksql/tasks/main.yml
@@ -87,18 +87,8 @@
 - name: Create RocksDB Directory
   file:
     path: "{{ksql_rocksdb_path}}"
-    group: "{{ksql_group}}"
-    owner: "{{ksql_user}}"
-    mode: 0750
+    mode: 0777
     state: directory
-  when: ksql_rocksdb_path != ""
-
-- name: Set Permission to RocksDB Files
-  file:
-    path: "{{ksql_rocksdb_path}}"
-    group: "{{ksql_group}}"
-    owner: "{{ksql_user}}"
-    recurse: true
   when: ksql_rocksdb_path != ""
 
 - name: Create Ksql log4j Config


### PR DESCRIPTION
# Description

Sets up directory for RocksDB on ksqldb hosts. By default uses the /tmp directory
Whatever directory set will get 777 so that any users run ksqldb queries what write on the directory

Fixes # (https://github.com/confluentinc/cp-ansible/issues/397)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Run any molecule scenario can see the directory created


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules