### PR TITLE
Use actual parameter value, not param choice

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,7 +62,7 @@ def job = {
         override_config['confluent_package_version'] = params.CONFLUENT_PACKAGE_VERSION
         override_config['confluent_repo_version'] = params.CONFLUENT_PACKAGE_VERSION.tokenize('.')[0..1].join('.')
 
-        if(confluent_release_quality != 'prod') {
+        if(params.CONFLUENT_RELEASE_QUALITY != 'prod') {
             // 'prod' case doesn't need anything overriden
             switch(params.CONFLUENT_RELEASE_QUALITY) {
                 case "snapshot":


### PR DESCRIPTION
# Description

This is to fix a build issue: https://jenkins.confluent.io/job/confluentinc/job/cp-ansible/job/6.0.x/140/replay/diff

TL;DR: I was checking the object used to put a parameter into the Job, not the parameter's *value*.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

https://jenkins.confluent.io/job/confluentinc/job/cp-ansible/job/6.0.x/140/replay/diff



**Test Configuration**:


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules