### PR TITLE
Force 'check if service running' tasks to run in normal mode

### DIFF
--- a/roles/confluent.kafka_broker/tasks/restart_kafka.yml
+++ b/roles/confluent.kafka_broker/tasks/restart_kafka.yml
@@ -2,6 +2,7 @@
 - name: Check if Kafka Service Running
   shell: "systemctl show -p SubState {{kafka_broker_service_name}}"
   changed_when: false
+  check_mode: false
   register: substate
 
 # All kafka_broker hosts iterate over the list of kakfa_broker hosts, each seeing the list in the same order

--- a/roles/confluent.zookeeper/tasks/restart_zookeeper.yml
+++ b/roles/confluent.zookeeper/tasks/restart_zookeeper.yml
@@ -2,6 +2,7 @@
 - name: Check if Zookeeper Service Running
   shell: "systemctl show -p SubState {{zookeeper_service_name}}"
   changed_when: false
+  check_mode: false
   register: substate
 
 # All zookeeper hosts iterate over the list of zookeeper hosts, each seeing the list in the same order


### PR DESCRIPTION
, even in check mode, to avoid uninitialized variable.

# Description

We are trying to run the playbook (all.yml) in check mode on feature branches. This does not currently work, resulting in the following error message:
```
RUNNING HANDLER [confluent.zookeeper : Restart Zookeeper Serially] *************
fatal: [myhost.mydomain]: FAILED! => 
  msg: |-
    The conditional check 'substate.stdout == 'SubState=running'' failed. The error was: error while evaluating conditional (substate.stdout == 'SubState=running'): 'dict object' has no attribute 'stdout'
  
    The error appears to be in '/builds/kafka/provisioner/cp-ansible/roles/confluent.zookeeper/tasks/restart_zookeeper.yml': line 10, column 3, but may
    be elsewhere in the file depending on the exact syntax problem.
  
    The offending line appears to be:
  
    # restart.yml tasks will only run for that host ON that host
    - name: Restart Zookeeper Serially
      ^ here
```
I think it is because shell-tasks are always skipped by Ansible in check mode. So https://github.com/confluentinc/cp-ansible/blob/f67a2c63bc10caecb17a7415c90e5cc8b36b6436/roles/confluent.zookeeper/tasks/restart_zookeeper.yml#L3 is skipped in check mode, resulting in the error message reaching https://github.com/confluentinc/cp-ansible/blob/f67a2c63bc10caecb17a7415c90e5cc8b36b6436/roles/confluent.zookeeper/tasks/restart_zookeeper.yml#L16

Equivalent code, and issue, for restart of the brokers. This PR forces the shell-tasks to run in normal mode, even in check mode. This shouldn't be problematic, since the actual shell command does not modify the system. It just checks if a service is running or not.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Run `ansible-playbook all.yml -i <inventory> --check`.

I have verified that the PR changes fixes our issues running in check mode.

**Test Configuration**:

Simple inventory with a single host provisioned as zookeeper and broker.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules