### PR TITLE
Updated verify to call health checks for broker from correct location.

### DIFF
--- a/roles/confluent.test/molecule/custom-user-plaintext-rhel/verify.yml
+++ b/roles/confluent.test/molecule/custom-user-plaintext-rhel/verify.yml
@@ -39,8 +39,9 @@
         name: "{{kafka_broker_service_name}}"
         state: restarted
 
-    - name: Wait for Under Replicated Partitions on Broker
-      include_tasks: ../../../../tasks/wait_for_urp.yml
+    - import_role:
+        name: confluent.kafka_broker
+        tasks_from: health_check.yml
 
     - import_role:
         name: confluent.test


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

Verify for custom-user-plaintext-rhel scenario was calling health checks for the broker restart from the wrong location, due to a change in the 6.0.0 release.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Tested by running custom-user-plaintext-rhel scenario with verify.

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible