### PR TITLE
Added quotes around alias variable to allow for spaces in cert alias.

### DIFF
--- a/roles/confluent.ssl/tasks/provided_keystore_and_truststore.yml
+++ b/roles/confluent.ssl/tasks/provided_keystore_and_truststore.yml
@@ -7,7 +7,7 @@
 - name: Export CA Cert from Truststore
   shell: |
     keytool -exportcert -rfc \
-      -alias {{ssl_truststore_ca_cert_alias}} \
+      -alias "{{ssl_truststore_ca_cert_alias}}" \
       -storepass {{truststore_storepass}}  \
       -file {{ca_cert_path}} \
       -keystore {{truststore_path}}


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Minor changes which adds quotes around the export alias of the CA cert when it is exported from a provided trust store, to factor in spacing in the alias.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Validated with the following scenario:

rbac-mtls-provided-ubuntu

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible