### PR TITLE
Zookeeper dataLogDir Configuration

### DIFF
--- a/roles/confluent.test/molecule/plain-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/plain-rhel/molecule.yml
@@ -103,6 +103,9 @@ provisioner:
         kafka_connect_confluent_hub_plugins:
           - jcustenborder/kafka-connect-spooldir:2.0.43
 
+        zookeeper_custom_properties:
+          dataLogDir: /opt/zookeeper
+
 verifier:
   name: ansible
 lint: |

--- a/roles/confluent.test/molecule/plain-rhel/verify.yml
+++ b/roles/confluent.test/molecule/plain-rhel/verify.yml
@@ -1,4 +1,25 @@
 ---
+- name: Verify - zookeeper
+  hosts: zookeeper
+  gather_facts: false
+  tasks:
+    - import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: /etc/kafka/zookeeper.properties
+        property: dataLogDir
+        expected_value: /opt/zookeeper
+
+    - import_role:
+        name: confluent.test
+        tasks_from: check_ownership.yml
+      vars:
+        file_name: log.1
+        custom_path: /opt/zookeeper/version-2/
+        group: confluent
+        user: cp-kafka
+
 - name: Verify - kafka_broker
   hosts: kafka_broker
   gather_facts: false

--- a/roles/confluent.test/tasks/check_property.yml
+++ b/roles/confluent.test/tasks/check_property.yml
@@ -7,6 +7,6 @@
 - name: Assert property set as expected
   assert:
     that:
-      - expected_value == grep.stdout | regex_replace('^[a-z.]*[ ]?=[ ]?(.*)$', '\\1')
-    fail_msg: "Property: {{property}} set to {{ grep.stdout | regex_replace('^[a-z.]*[ ]?=[ ]?(.*)$', '\\1') }} not {{expected_value}}"
+      - expected_value == grep.stdout | regex_replace('^[a-zA-Z.]*[ ]?=[ ]?(.*)$', '\\1')
+    fail_msg: "Property: {{property}} set to {{ grep.stdout | regex_replace('^[a-zA-Z.]*[ ]?=[ ]?(.*)$', '\\1') }} not {{expected_value}}"
     quiet: true

--- a/roles/confluent.zookeeper/tasks/main.yml
+++ b/roles/confluent.zookeeper/tasks/main.yml
@@ -89,7 +89,7 @@
     group: "{{zookeeper_group}}"
   when: zookeeper_copy_files | length > 0
 
-- name: Set Zookeeper dataDir ownership
+- name: Set Zookeeper Data Dir Ownership
   file:
     path: "{{zookeeper_final_properties.dataDir}}"
     owner: "{{zookeeper_user}}"
@@ -97,12 +97,29 @@
     state: directory
     mode: 0750
 
-- name: Set Ownership of Data Dir files
+- name: Set Ownership of Data Dir Files
   file:
     path: "{{zookeeper_final_properties.dataDir}}"
     owner: "{{zookeeper_user}}"
     group: "{{zookeeper_group}}"
     recurse: true
+
+- name: Set Zookeeper Transaction Log Data Dir Ownership
+  file:
+    path: "{{zookeeper_final_properties.dataLogDir}}"
+    owner: "{{zookeeper_user}}"
+    group: "{{zookeeper_group}}"
+    state: directory
+    mode: 0750
+  when: zookeeper_final_properties.dataLogDir is defined
+
+- name: Set Ownership of Transaction Log Data Dir Files
+  file:
+    path: "{{zookeeper_final_properties.dataLogDir}}"
+    owner: "{{zookeeper_user}}"
+    group: "{{zookeeper_group}}"
+    recurse: true
+  when: zookeeper_final_properties.dataLogDir is defined
 
 - name: Create Zookeeper myid File
   template:


### PR DESCRIPTION
# Description

Adds tasks to set up the dataLogDir directory on zk hosts. 
Feature off by default. Must configure

```
zookeeper_custom_properties:
  dataLogDir: /path
```

To use

Fixes # (https://github.com/confluentinc/cp-ansible/issues/214)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Added custom property to plain-rhel scenario with verify tasks
- Tested default case manually with plaintext-rhel, and viewed the tasks were skipped

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Any variable changes have been validated to be backwards compatible