### PR TITLE
60 colocated upgrade bugfix

### DIFF
--- a/roles/confluent.test/molecule/scram-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/scram-rhel/molecule.yml
@@ -2,24 +2,51 @@
 driver:
   name: docker
 platforms:
-  - name: zookeeper1
-    hostname: zookeeper1.confluent
+  # - name: zookeeper1
+  #   hostname: zookeeper1.confluent
+  #   groups:
+  #     - zookeeper
+  #   image: geerlingguy/docker-centos7-ansible
+  #   # dockerfile: ../Dockerfile.j2
+  #   command: ""
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  #   privileged: true
+  #   networks:
+  #     - name: confluent
+  - name: kafka-broker1
+    hostname: kafka-broker1.confluent
     groups:
+      - kafka_broker
       - zookeeper
     image: geerlingguy/docker-centos7-ansible
-    dockerfile: ../Dockerfile.j2
+    # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
     networks:
       - name: confluent
-  - name: kafka-broker1
-    hostname: kafka-broker1.confluent
+  - name: kafka-broker2
+    hostname: kafka-broker2.confluent
     groups:
       - kafka_broker
+      - zookeeper
     image: geerlingguy/docker-centos7-ansible
-    dockerfile: ../Dockerfile.j2
+    # dockerfile: ../Dockerfile.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    networks:
+      - name: confluent
+  - name: kafka-broker3
+    hostname: kafka-broker3.confluent
+    groups:
+      - kafka_broker
+      - zookeeper
+    image: geerlingguy/docker-centos7-ansible
+    # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -31,55 +58,55 @@ platforms:
     groups:
       - schema_registry
     image: geerlingguy/docker-centos7-ansible
-    dockerfile: ../Dockerfile.j2
+    # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
     networks:
       - name: confluent
-  - name: kafka-rest1
-    hostname: kafka-rest1.confluent
-    groups:
-      - kafka_rest
-    image: geerlingguy/docker-centos7-ansible
-    dockerfile: ../Dockerfile.j2
-    command: ""
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
-    networks:
-      - name: confluent
-  - name: kafka-connect1
-    hostname: kafka-connect1.confluent
-    groups:
-      - kafka_connect
-    image: geerlingguy/docker-centos7-ansible
-    dockerfile: ../Dockerfile.j2
-    command: ""
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
-    networks:
-      - name: confluent
-  - name: ksql1
-    hostname: ksql1.confluent
-    groups:
-      - ksql
-    image: geerlingguy/docker-centos7-ansible
-    dockerfile: ../Dockerfile.j2
-    command: ""
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
-    networks:
-      - name: confluent
+  # - name: kafka-rest1
+  #   hostname: kafka-rest1.confluent
+  #   groups:
+  #     - kafka_rest
+  #   image: geerlingguy/docker-centos7-ansible
+  #   # dockerfile: ../Dockerfile.j2
+  #   command: ""
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  #   privileged: true
+  #   networks:
+  #     - name: confluent
+  # - name: kafka-connect1
+  #   hostname: kafka-connect1.confluent
+  #   groups:
+  #     - kafka_connect
+  #   image: geerlingguy/docker-centos7-ansible
+  #   # dockerfile: ../Dockerfile.j2
+  #   command: ""
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  #   privileged: true
+  #   networks:
+  #     - name: confluent
+  # - name: ksql1
+  #   hostname: ksql1.confluent
+  #   groups:
+  #     - ksql
+  #   image: geerlingguy/docker-centos7-ansible
+  #   # dockerfile: ../Dockerfile.j2
+  #   command: ""
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  #   privileged: true
+  #   networks:
+  #     - name: confluent
   - name: control-center1
     hostname: control-center1.confluent
     groups:
       - control_center
     image: geerlingguy/docker-centos7-ansible
-    dockerfile: ../Dockerfile.j2
+    # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -98,7 +125,8 @@ provisioner:
   inventory:
     group_vars:
       all:
-        sasl_protocol: scram
+        # sasl_protocol: scram
+        confluent_server_enabled: false
 verifier:
   name: ansible
 lint: |

--- a/roles/confluent.test/molecule/scram-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/scram-rhel/molecule.yml
@@ -2,51 +2,24 @@
 driver:
   name: docker
 platforms:
-  # - name: zookeeper1
-  #   hostname: zookeeper1.confluent
-  #   groups:
-  #     - zookeeper
-  #   image: geerlingguy/docker-centos7-ansible
-  #   # dockerfile: ../Dockerfile.j2
-  #   command: ""
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:ro
-  #   privileged: true
-  #   networks:
-  #     - name: confluent
+  - name: zookeeper1
+    hostname: zookeeper1.confluent
+    groups:
+      - zookeeper
+    image: geerlingguy/docker-centos7-ansible
+    dockerfile: ../Dockerfile.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    networks:
+      - name: confluent
   - name: kafka-broker1
     hostname: kafka-broker1.confluent
     groups:
       - kafka_broker
-      - zookeeper
     image: geerlingguy/docker-centos7-ansible
-    # dockerfile: ../Dockerfile.j2
-    command: ""
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
-    networks:
-      - name: confluent
-  - name: kafka-broker2
-    hostname: kafka-broker2.confluent
-    groups:
-      - kafka_broker
-      - zookeeper
-    image: geerlingguy/docker-centos7-ansible
-    # dockerfile: ../Dockerfile.j2
-    command: ""
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
-    networks:
-      - name: confluent
-  - name: kafka-broker3
-    hostname: kafka-broker3.confluent
-    groups:
-      - kafka_broker
-      - zookeeper
-    image: geerlingguy/docker-centos7-ansible
-    # dockerfile: ../Dockerfile.j2
+    dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -58,55 +31,55 @@ platforms:
     groups:
       - schema_registry
     image: geerlingguy/docker-centos7-ansible
-    # dockerfile: ../Dockerfile.j2
+    dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
     networks:
       - name: confluent
-  # - name: kafka-rest1
-  #   hostname: kafka-rest1.confluent
-  #   groups:
-  #     - kafka_rest
-  #   image: geerlingguy/docker-centos7-ansible
-  #   # dockerfile: ../Dockerfile.j2
-  #   command: ""
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:ro
-  #   privileged: true
-  #   networks:
-  #     - name: confluent
-  # - name: kafka-connect1
-  #   hostname: kafka-connect1.confluent
-  #   groups:
-  #     - kafka_connect
-  #   image: geerlingguy/docker-centos7-ansible
-  #   # dockerfile: ../Dockerfile.j2
-  #   command: ""
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:ro
-  #   privileged: true
-  #   networks:
-  #     - name: confluent
-  # - name: ksql1
-  #   hostname: ksql1.confluent
-  #   groups:
-  #     - ksql
-  #   image: geerlingguy/docker-centos7-ansible
-  #   # dockerfile: ../Dockerfile.j2
-  #   command: ""
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:ro
-  #   privileged: true
-  #   networks:
-  #     - name: confluent
+  - name: kafka-rest1
+    hostname: kafka-rest1.confluent
+    groups:
+      - kafka_rest
+    image: geerlingguy/docker-centos7-ansible
+    dockerfile: ../Dockerfile.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    networks:
+      - name: confluent
+  - name: kafka-connect1
+    hostname: kafka-connect1.confluent
+    groups:
+      - kafka_connect
+    image: geerlingguy/docker-centos7-ansible
+    dockerfile: ../Dockerfile.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    networks:
+      - name: confluent
+  - name: ksql1
+    hostname: ksql1.confluent
+    groups:
+      - ksql
+    image: geerlingguy/docker-centos7-ansible
+    dockerfile: ../Dockerfile.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    networks:
+      - name: confluent
   - name: control-center1
     hostname: control-center1.confluent
     groups:
       - control_center
     image: geerlingguy/docker-centos7-ansible
-    # dockerfile: ../Dockerfile.j2
+    dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -125,8 +98,7 @@ provisioner:
   inventory:
     group_vars:
       all:
-        # sasl_protocol: scram
-        confluent_server_enabled: false
+        sasl_protocol: scram
 verifier:
   name: ansible
 lint: |

--- a/roles/confluent.test/upgrade_testing/cp-kafka-plain-rhel-upgrade-550-current.sh
+++ b/roles/confluent.test/upgrade_testing/cp-kafka-plain-rhel-upgrade-550-current.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+set -e
+
+## Variables
+
+export SCENARIO_NAME=cp-kafka-plain-rhel
+export START_BRANCH=5.5.0-post
+export START_UPGRADE_VERSION=5.5
+
+echo "Call upgrade script"
+sh ./upgrade.sh

--- a/tasks/set_confluent_server_enabled.yml
+++ b/tasks/set_confluent_server_enabled.yml
@@ -9,4 +9,12 @@
 
 - set_fact:
     confluent_server_enabled: false
-  when: ansible_facts.packages['confluent-kafka-2.12'] is defined
+  when: ansible_facts.packages['confluent-kafka-2.12'] is defined or ansible_facts.packages['confluent-kafka'] is defined
+
+- set_fact:
+    confluent_kafka_upgraded: true
+  when: ansible_facts.packages['confluent-kafka'] is defined
+
+- set_fact:
+    confluent_kafka_upgraded: false
+  when: ansible_facts.packages['confluent-kafka'] is not defined

--- a/upgrade_kafka_broker.yml
+++ b/upgrade_kafka_broker.yml
@@ -78,7 +78,7 @@
         kafka_broker_current_version: "{{ ansible_facts.packages['confluent-kafka'][0]['version'] }}"
       when: not confluent_server_enabled|bool and confluent_kafka_upgraded|bool
 
-    - name: Set Current Package Version
+    - name: Set Current Package Version of confluent-server
       set_fact:
         confluent_security_current_version: "{{ ansible_facts.packages['confluent-security'][0]['version'] }}"
 

--- a/upgrade_kafka_broker.yml
+++ b/upgrade_kafka_broker.yml
@@ -73,6 +73,15 @@
         kafka_broker_current_version: "{{ ansible_facts.packages['confluent-kafka-2.12'][0]['version'] }}"
       when: not confluent_server_enabled|bool
 
+    - name: Set Current Package Version
+      set_fact:
+        confluent_security_current_version: "{{ ansible_facts.packages['confluent-security'][0]['version'] }}"
+
+    # On colocated zk/kafka hosts, the kafka package will already be upgraded, need to check confluent-server as well
+    - name: Set Current Package Version
+      set_fact:
+        kafka_broker_current_version: "{{ [kafka_broker_current_version, confluent_security_current_version] | min }}"
+
     - debug:
         msg: "Current version: {{kafka_broker_current_version}}   Upgrade to version: {{confluent_package_version}}"
 

--- a/upgrade_kafka_broker.yml
+++ b/upgrade_kafka_broker.yml
@@ -78,7 +78,7 @@
         kafka_broker_current_version: "{{ ansible_facts.packages['confluent-kafka'][0]['version'] }}"
       when: not confluent_server_enabled|bool and confluent_kafka_upgraded|bool
 
-    - name: Set Current Package Version of confluent-server
+    - name: Set Current Package Version of confluent-security
       set_fact:
         confluent_security_current_version: "{{ ansible_facts.packages['confluent-security'][0]['version'] }}"
 

--- a/upgrade_kafka_broker.yml
+++ b/upgrade_kafka_broker.yml
@@ -63,15 +63,20 @@
         controller_group: controller
         non_controller_group: non_controllers
 
-    - name: Set Current Package Version
+    - name: Set Current Package Version of confluent-server
       set_fact:
         kafka_broker_current_version: "{{ ansible_facts.packages['confluent-server'][0]['version'] }}"
       when: confluent_server_enabled|bool
 
-    - name: Set Current Package Version
+    - name: Set Current Package Version of confluent-kafka-2.12
       set_fact:
         kafka_broker_current_version: "{{ ansible_facts.packages['confluent-kafka-2.12'][0]['version'] }}"
-      when: not confluent_server_enabled|bool
+      when: not confluent_server_enabled|bool and not confluent_kafka_upgraded|bool
+
+    - name: Set Current Package Version of confluent-kafka
+      set_fact:
+        kafka_broker_current_version: "{{ ansible_facts.packages['confluent-kafka'][0]['version'] }}"
+      when: not confluent_server_enabled|bool and confluent_kafka_upgraded|bool
 
     - name: Set Current Package Version
       set_fact:

--- a/upgrade_zookeeper.yml
+++ b/upgrade_zookeeper.yml
@@ -31,17 +31,30 @@
 
     - set_fact:
         confluent_server_enabled: false
-      when: ansible_facts.packages['confluent-kafka-2.12'] is defined
+      when: ansible_facts.packages['confluent-kafka-2.12'] is defined or ansible_facts.packages['confluent-kafka'] is defined
 
-    - name: Set Current Package Version
+    - set_fact:
+        confluent_kafka_upgraded: true
+      when: ansible_facts.packages['confluent-kafka'] is defined
+
+    - set_fact:
+        confluent_kafka_upgraded: false
+      when: ansible_facts.packages['confluent-kafka'] is not defined
+
+    - name: Set Current Package Version of confluent-server
       set_fact:
         zookeeper_current_version: "{{ ansible_facts.packages['confluent-server'][0]['version'] }}"
       when: confluent_server_enabled|bool
 
-    - name: Set Current Package Version
+    - name: Set Current Package Version of confluent-kafka-2.12
       set_fact:
         zookeeper_current_version: "{{ ansible_facts.packages['confluent-kafka-2.12'][0]['version'] }}"
-      when: not confluent_server_enabled|bool
+      when: not confluent_server_enabled|bool and not confluent_kafka_upgraded|bool
+
+    - name: Set Current Package Version of confluent-kafka
+      set_fact:
+        zookeeper_current_version: "{{ ansible_facts.packages['confluent-kafka'][0]['version'] }}"
+      when: not confluent_server_enabled|bool and confluent_kafka_upgraded|bool
 
     - debug:
         msg: "Current version: {{zookeeper_current_version}}   Upgrade to version: {{confluent_package_version}}"


### PR DESCRIPTION
# Description

Adds logic to the upgrade_kafka_broker.yml playbook to handle colocated zk and kafka, which when you upgrade in that configuration the kafka package will be upgraded during the zk upgrade and in the case of confluent-kafka-2.12, the package even switches names.

Fixes # (https://github.com/confluentinc/cp-ansible/issues/423)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Manually tested plaintext 3 node zk colocated w 3 node kafka upgrade
Both confluent_server_enabled: true/false

Ran the install, zk upgrade and kafka upgrade

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible