### PR TITLE
Force 'count certificates in ca cert' tasks to run in normal mode eve…

### DIFF
--- a/roles/confluent.ssl/tasks/custom_certs.yml
+++ b/roles/confluent.ssl/tasks/custom_certs.yml
@@ -28,6 +28,7 @@
 - name: Count Certificates in Ca Cert
   shell: |
     grep -c "END CERTIFICATE" {{ca_cert_path}}
+  check_mode: false
   register: ca_cert_count_grep
 
 - name: Set the Certificate Count Var


### PR DESCRIPTION
…n in check mode, to avoid uninitialized variable.

# Description

See https://github.com/confluentinc/cp-ansible/pull/405#issue-489409121 for background and additional details.

We are currently on the 6.0.0-post branch, so I would appreciate if you could "upmerge" the changes if/when this PR is accepted. The selected target branch (5.5.0-post) is based on feedback from @JumaX in https://github.com/confluentinc/cp-ansible/pull/405#issuecomment-706076769.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Run `ansible-playbook all.yml -i <inventory> --check`.

I have verified that the PR changes fixes our issues running in check mode.

**Test Configuration**:

Inventory with three hosts provisioned as zookeeper and broker - with SSL/TLS enabled.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible