### PR TITLE
Fix for Kerberos listener sasl service name property

### DIFF
--- a/roles/confluent.kafka_broker/templates/listener.j2
+++ b/roles/confluent.kafka_broker/templates/listener.j2
@@ -28,6 +28,7 @@ listener.name.{{listener.value.name|lower}}.plain.sasl.jaas.config=org.apache.ka
 {% endif %}
 {% if listener['value']['sasl_protocol'] | default(sasl_protocol) | normalize_sasl_protocol == 'GSSAPI' %}
 listener.name.{{listener.value.name|lower}}.sasl.enabled.mechanisms=GSSAPI
+listener.name.{{listener.value.name|lower}}.sasl.kerberos.service.name={{kerberos_kafka_broker_primary}}
 listener.name.{{listener.value.name|lower}}.gssapi.sasl.jaas.config=com.sun.security.auth.module.Krb5LoginModule required \
   useKeyTab=true \
   storeKey=true \


### PR DESCRIPTION
# Description

Fixes the issue for when Kerberos based listener is setup with a combination of other types of listeners like OAuthBearer.
The property `sasl.kerberos.service.name` needs to exist at the listener level and not just at the global level.

Fixes # (issue)

## Type of change

- [Y] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Deployment.

**Test Configuration**:

3 ZK, 3 Broker RBAC + Kerberos setup. Conencting to kafka broker via kafka client to Kerberos listener failed. 
Adding this property resolved the issue

# Checklist:

- [Y] My code follows the style guidelines of this project
- [Y] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [Y] My changes generate no new warnings
- [NA] I have added tests that prove my fix is effective or that my feature works
- [NA] Any dependent changes have been merged and published in downstream modules
- [NA] Any variable changes have been validated to be backwards compatible