### PR TITLE
Zookeeper kerberos primary java arg

### DIFF
--- a/roles/confluent.kafka_broker/defaults/main.yml
+++ b/roles/confluent.kafka_broker/defaults/main.yml
@@ -6,6 +6,10 @@ kafka_broker_java_args:
   - "{% if kafka_broker_jolokia_enabled|bool %}-javaagent:{{jolokia_jar_path}}=port={{kafka_broker_jolokia_port}},host=0.0.0.0{% if kafka_broker_jolokia_ssl_enabled|bool %}{{kafka_broker_jolokia_java_arg_ssl_addon}}{% endif %}{% endif %}"
   - "{% if kafka_broker_jmxexporter_enabled|bool %}-javaagent:{{jmxexporter_jar_path}}={{kafka_broker_jmxexporter_port}}:{{kafka_broker_jmxexporter_config_path}}{% endif %}"
   - "{% if kafka_broker_custom_log4j|bool %}-Dlog4j.configuration=file:{{kafka_broker.log4j_file}}{% endif %}"
+  - "{% if zookeeper_sasl_protocol == 'kerberos' and zookeeper_kerberos_primary != 'zookeeper' %}-Dzookeeper.sasl.client.username={{zookeeper_kerberos_primary}}{% endif %}"
+
+# Strip primary from the zookeeper principal on first zk host. Adds defaults for if there is not even a zookeeper group
+zookeeper_kerberos_primary: "{{ (hostvars[ groups['zookeeper'][0] | default('zookeeper') ] | default({})) ['zookeeper_kerberos_principal'] | default('zookeeper/host@EXAMPLE>COM') | regex_replace('/.*') }}"
 
 kafka_broker_custom_java_args: ""
 kafka_broker_final_java_args: "{{ kafka_broker_java_args + [ kafka_broker_custom_java_args ] }}"

--- a/roles/confluent.test/molecule/kerberos-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/kerberos-rhel/molecule.yml
@@ -74,56 +74,56 @@ platforms:
     privileged: true
     networks:
       - name: confluent
-  - name: kafka-rest1
-    hostname: kafka-rest1.confluent
-    groups:
-      - kafka_rest
-    image: geerlingguy/docker-centos7-ansible
-    dockerfile: ../Dockerfile.j2
-    command: ""
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
-    networks:
-      - name: confluent
-  - name: kafka-connect1
-    hostname: kafka-connect1.confluent
-    groups:
-      - kafka_connect
-    image: geerlingguy/docker-centos7-ansible
-    dockerfile: ../Dockerfile.j2
-    command: ""
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
-    networks:
-      - name: confluent
-  - name: ksql1
-    hostname: ksql1.confluent
-    groups:
-      - ksql
-    image: geerlingguy/docker-centos7-ansible
-    dockerfile: ../Dockerfile.j2
-    command: ""
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
-    networks:
-      - name: confluent
-  - name: control-center1
-    hostname: control-center1.confluent
-    groups:
-      - control_center
-    image: geerlingguy/docker-centos7-ansible
-    dockerfile: ../Dockerfile.j2
-    command: ""
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
-    published_ports:
-      - "9021:9021"
-    networks:
-      - name: confluent
+  # - name: kafka-rest1
+  #   hostname: kafka-rest1.confluent
+  #   groups:
+  #     - kafka_rest
+  #   image: geerlingguy/docker-centos7-ansible
+  #   dockerfile: ../Dockerfile.j2
+  #   command: ""
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  #   privileged: true
+  #   networks:
+  #     - name: confluent
+  # - name: kafka-connect1
+  #   hostname: kafka-connect1.confluent
+  #   groups:
+  #     - kafka_connect
+  #   image: geerlingguy/docker-centos7-ansible
+  #   dockerfile: ../Dockerfile.j2
+  #   command: ""
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  #   privileged: true
+  #   networks:
+  #     - name: confluent
+  # - name: ksql1
+  #   hostname: ksql1.confluent
+  #   groups:
+  #     - ksql
+  #   image: geerlingguy/docker-centos7-ansible
+  #   dockerfile: ../Dockerfile.j2
+  #   command: ""
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  #   privileged: true
+  #   networks:
+  #     - name: confluent
+  # - name: control-center1
+  #   hostname: control-center1.confluent
+  #   groups:
+  #     - control_center
+  #   image: geerlingguy/docker-centos7-ansible
+  #   dockerfile: ../Dockerfile.j2
+  #   command: ""
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  #   privileged: true
+  #   published_ports:
+  #     - "9021:9021"
+  #   networks:
+  #     - name: confluent
 provisioner:
   name: ansible
   config_options:
@@ -140,6 +140,7 @@ provisioner:
         sasl_protocol: kerberos
 
         kerberos_kafka_broker_primary: kafka
+
         kerberos:
           realm: realm.example.com
           kdc_hostname: kerberos1
@@ -147,7 +148,7 @@ provisioner:
 
       zookeeper:
         # Paths are relative to all.yml
-        zookeeper_kerberos_principal: "zookeeper/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
+        zookeeper_kerberos_principal: "zk/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
         zookeeper_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/zookeeper-{{inventory_hostname}}.keytab"
       kafka_broker:
         kafka_broker_kerberos_principal: "{{kerberos_kafka_broker_primary}}/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
@@ -175,7 +176,7 @@ provisioner:
 
         kerberos_principals:
           # Wish there was a better way to create this list, this will do for now
-          - principal: "zookeeper/zookeeper1.confluent@{{kerberos.realm | upper}}"
+          - principal: "zk/zookeeper1.confluent@{{kerberos.realm | upper}}"
             keytab_path: "keytabs/zookeeper-zookeeper1.keytab"
 
           - principal: "{{kerberos_kafka_broker_primary}}/kafka-broker1.confluent@{{kerberos.realm | upper}}"

--- a/roles/confluent.test/molecule/kerberos-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/kerberos-rhel/molecule.yml
@@ -74,56 +74,56 @@ platforms:
     privileged: true
     networks:
       - name: confluent
-  # - name: kafka-rest1
-  #   hostname: kafka-rest1.confluent
-  #   groups:
-  #     - kafka_rest
-  #   image: geerlingguy/docker-centos7-ansible
-  #   dockerfile: ../Dockerfile.j2
-  #   command: ""
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:ro
-  #   privileged: true
-  #   networks:
-  #     - name: confluent
-  # - name: kafka-connect1
-  #   hostname: kafka-connect1.confluent
-  #   groups:
-  #     - kafka_connect
-  #   image: geerlingguy/docker-centos7-ansible
-  #   dockerfile: ../Dockerfile.j2
-  #   command: ""
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:ro
-  #   privileged: true
-  #   networks:
-  #     - name: confluent
-  # - name: ksql1
-  #   hostname: ksql1.confluent
-  #   groups:
-  #     - ksql
-  #   image: geerlingguy/docker-centos7-ansible
-  #   dockerfile: ../Dockerfile.j2
-  #   command: ""
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:ro
-  #   privileged: true
-  #   networks:
-  #     - name: confluent
-  # - name: control-center1
-  #   hostname: control-center1.confluent
-  #   groups:
-  #     - control_center
-  #   image: geerlingguy/docker-centos7-ansible
-  #   dockerfile: ../Dockerfile.j2
-  #   command: ""
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:ro
-  #   privileged: true
-  #   published_ports:
-  #     - "9021:9021"
-  #   networks:
-  #     - name: confluent
+  - name: kafka-rest1
+    hostname: kafka-rest1.confluent
+    groups:
+      - kafka_rest
+    image: geerlingguy/docker-centos7-ansible
+    dockerfile: ../Dockerfile.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    networks:
+      - name: confluent
+  - name: kafka-connect1
+    hostname: kafka-connect1.confluent
+    groups:
+      - kafka_connect
+    image: geerlingguy/docker-centos7-ansible
+    dockerfile: ../Dockerfile.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    networks:
+      - name: confluent
+  - name: ksql1
+    hostname: ksql1.confluent
+    groups:
+      - ksql
+    image: geerlingguy/docker-centos7-ansible
+    dockerfile: ../Dockerfile.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    networks:
+      - name: confluent
+  - name: control-center1
+    hostname: control-center1.confluent
+    groups:
+      - control_center
+    image: geerlingguy/docker-centos7-ansible
+    dockerfile: ../Dockerfile.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    published_ports:
+      - "9021:9021"
+    networks:
+      - name: confluent
 provisioner:
   name: ansible
   config_options:


### PR DESCRIPTION
# Description

Adds `-Dzookeeper.sasl.client.username` java arg to kafka process whenever the zk kerberos primary != 'zookeeper'
Makes sure to also have defaults which will be important in the 600 branch

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Updated the kerberos-rhel scenario with new zk primary. Saw the failure, and upon adding the java arg it works


# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Any variable changes have been validated to be backwards compatible