### PR TITLE
Improve the file permissions on ssl files

### DIFF
--- a/roles/confluent.kafka_broker/tasks/rbac.yml
+++ b/roles/confluent.kafka_broker/tasks/rbac.yml
@@ -36,7 +36,7 @@
   copy:
     src: "{{token_services_public_pem_file}}"
     dest: "{{rbac_enabled_public_pem_path}}"
-    mode: '755'
+    mode: 0640
     owner: "{{kafka_broker_user}}"
     group: "{{kafka_broker_group}}"
 
@@ -44,6 +44,6 @@
   copy:
     src: "{{token_services_private_pem_file}}"
     dest: "{{rbac_enabled_private_pem_path}}"
-    mode: '755'
+    mode: 0640
     owner: "{{kafka_broker_user}}"
     group: "{{kafka_broker_group}}"

--- a/roles/confluent.ssl/tasks/create_keystore_and_truststore.yml
+++ b/roles/confluent.ssl/tasks/create_keystore_and_truststore.yml
@@ -33,10 +33,13 @@
   include_tasks: provided_keystore_and_truststore.yml
   when: ssl_provided_keystore_and_truststore|bool
 
-- name: Delete SSL Certificate Generation Directory
+- name: Delete SSL Certificate Generation Directory and Files
   file:
-    path: /var/ssl/private/generation
+    path: "/var/ssl/private/{{item}}"
     state: absent
+  loop:
+    - generation
+    - ca.srl
   when: delete_generation_dir|bool
 
 - set_fact:

--- a/roles/confluent.ssl/tasks/main.yml
+++ b/roles/confluent.ssl/tasks/main.yml
@@ -53,7 +53,7 @@
     path: "{{item}}"
     owner: "{{user}}"
     group: "{{group}}"
-    mode: '0644'
+    mode: 0640
   loop:
     - "{{keystore_path}}"
     - "{{truststore_path}}"

--- a/tasks/rbac_setup.yml
+++ b/tasks/rbac_setup.yml
@@ -21,6 +21,6 @@
   copy:
     src: "{{token_services_public_pem_file}}"
     dest: "{{rbac_enabled_public_pem_path}}"
-    mode: '755'
+    mode: 0640
     owner: "{{user}}"
     group: "{{group}}"


### PR DESCRIPTION
# Description

Makes sure no ssl files are world readable

This is run on a c3 host
```
[root@control-center1 /]# ls -lat /var/ssl/private
total 36
drwxr-xr-x 2 root              root      4096 Oct 13 19:04 .
-rw-r----- 1 cp-control-center confluent 4809 Oct 13 19:04 control_center.keystore.jks
-rw-r----- 1 cp-control-center confluent 1330 Oct 13 19:04 control_center.crt
-rw-r----- 1 cp-control-center confluent 1856 Oct 13 19:04 control_center.key
-rw-r----- 1 cp-control-center confluent 1218 Oct 13 19:04 control_center.truststore.jks
-rw-r----- 1 cp-control-center confluent 1310 Oct 13 19:04 ca.crt
-rw-r----- 1 cp-control-center confluent  451 Oct 13 19:00 public.pem
```

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Ran an rbac scenario with some components colocated to make sure the shared ownership onrbac pem file is ok. Did a restart of services too.


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible