### PR TITLE
Jenkins bugfix for zk hostname verification

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ import static groovy.json.JsonOutput.*
 
 /* These are variables that can be used to test an un-released version of the Confluent Platform that resides at
  * a different HTTPS Endpoint other than `https://packages.confluent.io`. You do not need to specify *any* of them
- * for normal testing purposes, and are purely here for Confluent Inc's usage only. 
+ * for normal testing purposes, and are purely here for Confluent Inc's usage only.
  */
 
 // The version to install, set to the "next" version to test the "next" version.
@@ -51,6 +51,9 @@ def job = {
     }
 
     def override_config = [:]
+
+    // ansible_fqdn within certs does not match the FQDN that zookeeper verifies
+    override_config['zookeeper_custom_java_args'] = '-Dzookeeper.ssl.hostnameVerification=false -Dzookeeper.ssl.quorum.hostnameVerification=false'
 
     def branch_name = targetBranch().toString()
 


### PR DESCRIPTION
# Description

During jenkins run, ZK hostname verification failing in multi zookeeper deployment:
```
zookeeper3210.confluent210 zookeeper-server-start[1341]: Caused by: javax.net.ssl.SSLPeerUnverifiedException: Certificate for <zookeeper1210.confluent210> doesn't match any of the subject alternative names: [zookeeper1210, zookeeper1210.confluent]
```

This is not true when running locally, so as a quick fix, this adds zookeeper java args to the jenkinsfile to disable

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Jenkins job must complete successfully


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible