### PR TITLE
Fix internal kafka_broker role 'restart kafka' handler relative path

### DIFF
--- a/roles/confluent.kafka_broker/handlers/main.yml
+++ b/roles/confluent.kafka_broker/handlers/main.yml
@@ -1,3 +1,3 @@
 ---
 - name: restart kafka
-  include_tasks: roles/confluent.kafka_broker/tasks/restart_kafka.yml
+  include_tasks: tasks/restart_kafka.yml

--- a/upgrade_kafka_broker.yml
+++ b/upgrade_kafka_broker.yml
@@ -6,7 +6,8 @@
     kafka_broker_upgrade_start_version: "5.3"
     kafka_broker_rest_proxy_enabled: false
   handlers:
-    - import_tasks: roles/confluent.kafka_broker/handlers/main.yml
+    - name: restart kafka
+      include_tasks: roles/confluent.kafka_broker/tasks/restart_kafka.yml
   tasks:
     - import_role:
         name: confluent.variables
@@ -219,7 +220,8 @@
     upgrade_to_version: "6.0"
     kafka_broker_rest_proxy_enabled: false
   handlers:
-    - import_tasks: roles/confluent.kafka_broker/handlers/main.yml
+    - name: restart kafka
+      include_tasks: roles/confluent.kafka_broker/tasks/restart_kafka.yml
   tasks:
     - import_role:
         name: confluent.variables

--- a/upgrade_kafka_broker_log_format.yml
+++ b/upgrade_kafka_broker_log_format.yml
@@ -6,7 +6,8 @@
     kafka_broker_upgrade_end_version: "6.0"
     kafka_broker_rest_proxy_enabled: false
   handlers:
-    - import_tasks: roles/confluent.kafka_broker/handlers/main.yml
+    - name: restart kafka
+      include_tasks: roles/confluent.kafka_broker/tasks/restart_kafka.yml
   tasks:
     - import_role:
         name: confluent.variables


### PR DESCRIPTION
# Description

I am trying to use the confluent.kafka_broker role as a role dependency, and that does not work - because it results in an incorrect path. This PR corrects this, and I have verified that it solves my use case.

I think it seems odd to refer to a role-internal file using an "external" path, starting with `roles/<role-name>` - as it really limits what will actually work. The bug seems to have been introduced in this commit, https://github.com/confluentinc/cp-ansible/commit/6d50a7f09d4843bcc1e85821613a560ffa5d95f3#diff-0fec400f04957013fee20d1dfd6d96128a0e5275684c5b0d6713d546b0a67c42, and I assume that the change was done to fix another issue. Let us 🤞 that this issue won't return...

If this PR is merged, the path will be equivalent to a similar reference in https://github.com/confluentinc/cp-ansible/blob/d61b9a2426c151c779e696278d25689edc93e6cc/roles/confluent.zookeeper/handlers/main.yml#L3 making the code more consistent.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible