### PR TITLE
Zookeeper ssl improvement

### DIFF
--- a/roles/confluent.kafka_broker/tasks/main.yml
+++ b/roles/confluent.kafka_broker/tasks/main.yml
@@ -173,11 +173,11 @@
 
 - name: Create SCRAM Users
   shell: |
-    kafka-configs --zookeeper localhost:{{zookeeper_final_properties.clientPort}} --alter \
+    {{ binary_base_path }}/bin/kafka-configs {% if zookeeper_ssl_enabled|bool %}--zk-tls-config-file {{kafka_broker.config_file}}{% endif %} \
+      --zookeeper {{ groups['zookeeper'][0] }}:{{zookeeper_client_port}} --alter \
       --add-config 'SCRAM-SHA-512=[password={{ item.value['password'] }}]' \
       --entity-type users --entity-name {{ item.value['principal'] }}
   loop: "{{ sasl_scram_users|dict2items }}"
-  delegate_to: "{{ groups['zookeeper'][0] }}"
   run_once: true
   when: "'SCRAM-SHA-512' in kafka_broker_sasl_enabled_mechanisms"
 

--- a/roles/confluent.variables/defaults/main.yml
+++ b/roles/confluent.variables/defaults/main.yml
@@ -188,7 +188,8 @@ zookeeper_jmxexporter_port: 8079
 
 zookeeper_jmxexporter_config_path: /opt/prometheus/zookeeper.yml
 
-zookeeper_health_check_command: "{{ binary_base_path }}/bin/kafka-run-class
+zookeeper_health_check_command: "KAFKA_OPTS={{ zookeeper_final_java_args|java_arg_build_out }} 
+{{ binary_base_path }}/bin/kafka-run-class
 {% if zookeeper_ssl_enabled|bool %}
 -Dzookeeper.clientCnxnSocket=org.apache.zookeeper.ClientCnxnSocketNetty
 -Dzookeeper.ssl.trustStore.location={{zookeeper_truststore_path}}

--- a/roles/confluent.variables/defaults/main.yml
+++ b/roles/confluent.variables/defaults/main.yml
@@ -209,7 +209,7 @@ zookeeper_jmxexporter_port: 8079
 
 zookeeper_jmxexporter_config_path: /opt/prometheus/zookeeper.yml
 
-zookeeper_health_check_command: "KAFKA_OPTS='{{ zookeeper_final_java_args|java_arg_build_out }}'
+zookeeper_health_check_command: "KAFKA_OPTS='{{ zookeeper_service_environment_overrides.KAFKA_OPTS }}'
 {{ binary_base_path }}/bin/kafka-run-class
 {% if zookeeper_ssl_enabled|bool %}
 -Dzookeeper.clientCnxnSocket=org.apache.zookeeper.ClientCnxnSocketNetty

--- a/roles/confluent.variables/defaults/main.yml
+++ b/roles/confluent.variables/defaults/main.yml
@@ -209,7 +209,7 @@ zookeeper_jmxexporter_port: 8079
 
 zookeeper_jmxexporter_config_path: /opt/prometheus/zookeeper.yml
 
-zookeeper_health_check_command: "KAFKA_OPTS={{ zookeeper_final_java_args|java_arg_build_out }} 
+zookeeper_health_check_command: "KAFKA_OPTS={{ zookeeper_final_java_args|java_arg_build_out }}
 {{ binary_base_path }}/bin/kafka-run-class
 {% if zookeeper_ssl_enabled|bool %}
 -Dzookeeper.clientCnxnSocket=org.apache.zookeeper.ClientCnxnSocketNetty

--- a/roles/confluent.variables/defaults/main.yml
+++ b/roles/confluent.variables/defaults/main.yml
@@ -188,7 +188,17 @@ zookeeper_jmxexporter_port: 8079
 
 zookeeper_jmxexporter_config_path: /opt/prometheus/zookeeper.yml
 
-zookeeper_health_check_command: "exec 42<>/dev/tcp/127.0.0.1/{{zookeeper_final_properties.clientPort}}; echo -e 'srvr' >&42; cat <&42"
+zookeeper_health_check_command: "{{ binary_base_path }}/bin/kafka-run-class
+{% if zookeeper_ssl_enabled|bool %}
+-Dzookeeper.clientCnxnSocket=org.apache.zookeeper.ClientCnxnSocketNetty
+-Dzookeeper.ssl.trustStore.location={{zookeeper_truststore_path}}
+-Dzookeeper.ssl.trustStore.password={{zookeeper_truststore_storepass}}
+-Dzookeeper.ssl.keyStore.location={{zookeeper_keystore_path}}
+-Dzookeeper.ssl.keyStore.password={{zookeeper_keystore_storepass}}
+-Dzookeeper.client.secure=true
+{% endif %}
+org.apache.zookeeper.client.FourLetterWordMain {{inventory_hostname}} {{zookeeper_client_port}} srvr
+{% if zookeeper_ssl_enabled|bool %}true{% endif %}"
 
 zookeeper_current_node_hostname: "{{ inventory_hostname }}"
 

--- a/roles/confluent.variables/defaults/main.yml
+++ b/roles/confluent.variables/defaults/main.yml
@@ -209,7 +209,7 @@ zookeeper_jmxexporter_port: 8079
 
 zookeeper_jmxexporter_config_path: /opt/prometheus/zookeeper.yml
 
-zookeeper_health_check_command: "KAFKA_OPTS={{ zookeeper_final_java_args|java_arg_build_out }}
+zookeeper_health_check_command: "KAFKA_OPTS='{{ zookeeper_final_java_args|java_arg_build_out }}'
 {{ binary_base_path }}/bin/kafka-run-class
 {% if zookeeper_ssl_enabled|bool %}
 -Dzookeeper.clientCnxnSocket=org.apache.zookeeper.ClientCnxnSocketNetty

--- a/roles/confluent.variables/vars/main.yml
+++ b/roles/confluent.variables/vars/main.yml
@@ -27,7 +27,6 @@ zookeeper_properties:
   defaults:
     enabled: true
     properties:
-      clientPort: 2181
       maxClientCnxns: 0
       initLimit: 5
       syncLimit: 2
@@ -35,6 +34,10 @@ zookeeper_properties:
       autopurge.purgeInterval: 1
       dataDir: /var/lib/zookeeper
       admin.enableServer: "false"
+  non_secure:
+    enabled: "{{not zookeeper_ssl_enabled}}"
+    properties:
+      clientPort: "{{zookeeper_client_port}}"
   ssl:
     enabled: "{{zookeeper_ssl_enabled}}"
     properties:


### PR DESCRIPTION
# Description

Zk will only have one exposed port, 2181 for no tls encryption and 2182 for tls encryption
All clients can now use either

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Ran zookeeper-mtls and plain-rhel scenario
Todo test archive installer


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible