### PR TITLE
Adds logic to set the mtls var during component upgrades

### DIFF
--- a/upgrade_kafka_connect.yml
+++ b/upgrade_kafka_connect.yml
@@ -7,6 +7,14 @@
     - import_role:
         name: confluent.variables_handlers
 
+    - shell: "egrep 'ssl.client.auth ?= ?true' {{ kafka_connect.config_file }}"
+      register: mtls_check
+      failed_when: false
+
+    - name: Set MTLS Variable
+      set_fact:
+        kafka_connect_ssl_mutual_auth_enabled: "{{ true if mtls_check.rc == 0 else false}}"
+
     - name: Get Package Facts
       package_facts:
         manager: auto

--- a/upgrade_kafka_rest.yml
+++ b/upgrade_kafka_rest.yml
@@ -7,6 +7,14 @@
     - import_role:
         name: confluent.variables_handlers
 
+    - shell: "egrep 'ssl.client.auth ?= ?true' {{ kafka_rest.config_file }}"
+      register: mtls_check
+      failed_when: false
+
+    - name: Set MTLS Variable
+      set_fact:
+        kafka_rest_ssl_mutual_auth_enabled: "{{ true if mtls_check.rc == 0 else false}}"
+
     - name: Get Package Facts
       package_facts:
         manager: auto

--- a/upgrade_schema_registry.yml
+++ b/upgrade_schema_registry.yml
@@ -9,6 +9,14 @@
     - import_role:
         name: confluent.variables_handlers
 
+    - shell: "egrep 'ssl.client.auth ?= ?true' {{ schema_registry.config_file }}"
+      register: mtls_check
+      failed_when: false
+
+    - name: Set MTLS Variable
+      set_fact:
+        schema_registry_ssl_mutual_auth_enabled: "{{ true if mtls_check.rc == 0 else false}}"
+
     - name: Get Package Facts
       package_facts:
         manager: auto


### PR DESCRIPTION
# Description

For SR, connect, and RP in 540 their mtls vars dont actually turn on mtls in their properties. And so in 5.5.0 when the upgrade happens it attempts to check an mtls endpoint.

There is no ksql 5.4.x -> 5.5.x playbook, but we may still want this piece of logic in the 5.5.1-post branch to be safe.

There is no mtls on c3

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Ran the mtls-debian scenario in 5.4.0-post and then upgraded using this branch

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible