### PR TITLE
Corrected confluent-server_enabled variable to correct name

### DIFF
--- a/tasks/upgrade_component.yml
+++ b/tasks/upgrade_component.yml
@@ -45,7 +45,7 @@
     state: absent
   when:
     - ansible_os_family == "Debian"
-    - not confluent-server_enabled|bool
+    - not confluent_server_enabled|bool
   # Packages will not be found in check mode because repos not changed
   ignore_errors: "{{ ansible_check_mode }}"
 

--- a/upgrade_ksql.yml
+++ b/upgrade_ksql.yml
@@ -89,7 +89,7 @@
         state: absent
       when:
         - ansible_os_family == "Debian"
-        - not confluent-server_enabled|bool
+        - not confluent_server_enabled|bool
       # Packages will not be found in check mode because repos not changed
       ignore_errors: "{{ ansible_check_mode }}"
 

--- a/upgrade_zookeeper.yml
+++ b/upgrade_zookeeper.yml
@@ -144,7 +144,7 @@
         state: absent
       when:
         - ansible_os_family == "Debian"
-        - not confluent-server_enabled|bool
+        - not confluent_server_enabled|bool
       # Packages will not be found in check mode because repos not changed
       ignore_errors: "{{ ansible_check_mode }}"
 


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Both the upgrade_zookeeper and upgrade_ksql playbooks contained the incorrect variable name for checking if confluent-server was enabled or not.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Ran rbac-scram-provided-debian-upgrade-550-current.sh

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible