### PR TITLE
Connect clusters can be configured with unique connectors

### DIFF
--- a/roles/confluent.kafka_connect/tasks/main.yml
+++ b/roles/confluent.kafka_connect/tasks/main.yml
@@ -206,9 +206,24 @@
     - health_checks_enabled|bool
     - not ansible_check_mode
 
-- name: Register connector configs and remove deleted connectors
+- name: Register Kafka Connect Subgroups
+  set_fact: subgroups="{{ ((subgroups | default([])) + hostvars[item].group_names) | difference('kafka_connect') }}"
+  with_items: "{{groups['kafka_connect']}}"
+
+- name: Register connector configs and remove deleted connectors for single cluster
   kafka_connectors:
-    connect_url: "{{kafka_connect_http_protocol}}://{{groups['kafka_connect'][0]}}:{{kafka_connect_rest_port}}/connectors"
+    connect_url: "{{kafka_connect_http_protocol}}://{{inventory_hostname}}:{{kafka_connect_rest_port}}/connectors"
     active_connectors: "{{ kafka_connect_connectors }}"
-  when: kafka_connect_connectors is defined
+  when:
+    - kafka_connect_connectors is defined
+    - subgroups|length == 0
+  run_once: true
+
+- name: Register connector configs and remove deleted connectors for Multiple Clusters
+  kafka_connectors:
+    connect_url: "http{% if hostvars[groups[item][0]].kafka_connect_ssl_enabled|default(kafka_connect_ssl_enabled) %}s{% endif %}://{{ groups[item][0] }}:{{ hostvars[groups[item][0]].kafka_connect_rest_port|default(kafka_connect_rest_port) }}/connectors"
+    active_connectors: "{{ hostvars[groups[item][0]].kafka_connect_connectors }}"
+  when: hostvars[groups[item][0]].kafka_connect_connectors is defined
+  delegate_to: "{{ groups[item][0] }}"
+  loop: "{{subgroups}}"
   run_once: true

--- a/roles/confluent.test/molecule/multi-ksql-connect-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/multi-ksql-connect-rhel/molecule.yml
@@ -76,6 +76,19 @@ platforms:
     privileged: true
     networks:
       - name: confluent
+  - name: kafka-connect3
+    hostname: kafka-connect3.confluent
+    groups:
+      - kafka_connect
+      - ssl
+    image: geerlingguy/docker-centos7-ansible
+    dockerfile: ../Dockerfile.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    networks:
+      - name: confluent
   - name: ksql1
     hostname: ksql1.confluent
     groups:
@@ -150,16 +163,39 @@ provisioner:
         ssl_mutual_auth_enabled: true
 
       # connect clusters
+      ssl:
+        kafka_connect_group_id: connect-ssl
       syslog:
         kafka_connect_group_id: connect-syslog
+        # Create Connectors not working w ssl on molecule
+        kafka_connect_ssl_enabled: false
+        kafka_connect_ssl_mutual_auth_enabled: false
+        kafka_connect_connectors:
+          - name: sample-connector-1
+            config:
+              connector.class: "FileStreamSinkConnector"
+              tasks.max: "1"
+              file: "/etc/kafka/connect-distributed.properties"
+              topics: "test_topic"
       elastic:
         kafka_connect_group_id: connect-elastic
+        # Create Connectors not working w ssl
+        kafka_connect_ssl_enabled: false
+        kafka_connect_ssl_mutual_auth_enabled: false
+        kafka_connect_connectors:
+          - name: sample-connector-2
+            config:
+              connector.class: "FileStreamSinkConnector"
+              tasks.max: "1"
+              file: "/etc/kafka/connect-distributed.properties"
+              topics: "test_topic"
 
       # ksql clusters
       ks1:
         ksql_service_id: ksql1_
       ks2:
         ksql_service_id: ksql2_
+        ksql_ssl_enabled: false
 
       control_center:
         ksql_cluster_ansible_group_names:
@@ -168,6 +204,7 @@ provisioner:
         kafka_connect_cluster_ansible_group_names:
           - syslog
           - elastic
+          - ssl
 
 verifier:
   name: ansible

--- a/roles/confluent.test/molecule/multi-ksql-connect-rhel/verify.yml
+++ b/roles/confluent.test/molecule/multi-ksql-connect-rhel/verify.yml
@@ -1,5 +1,5 @@
 ---
-- name: Verify - kafka_connect
+- name: Verify - kafka_connect1
   hosts: kafka-connect1
   gather_facts: false
   tasks:
@@ -12,7 +12,21 @@
         property: group.id
         expected_value: connect-syslog
 
-- name: Verify - kafka_connect
+    - name: Get Connectors on connect cluster1
+      uri:
+        url: "http://kafka-connect1:8083/connectors"
+        status_code: 200
+        validate_certs: false
+      register: connectors
+
+    - name: Assert Connector Created
+      assert:
+        that:
+          - connectors.json[0] == "sample-connector-1"
+        fail_msg: "Connector not created"
+        quiet: true
+
+- name: Verify - kafka_connect2
   hosts: kafka-connect2
   gather_facts: false
   tasks:
@@ -24,6 +38,47 @@
         file_path: /etc/kafka/connect-distributed.properties
         property: group.id
         expected_value: connect-elastic
+
+    - name: Get Connectors on connect cluster2
+      uri:
+        url: "http://kafka-connect2:8083/connectors"
+        status_code: 200
+        validate_certs: false
+      register: connectors
+
+    - name: Assert Connector Created
+      assert:
+        that:
+          - connectors.json[0] == "sample-connector-2"
+        fail_msg: "Connector not created"
+        quiet: true
+
+- name: Verify - kafka_connect3
+  hosts: kafka-connect3
+  gather_facts: false
+  tasks:
+    - name: Check line properties file
+      import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: /etc/kafka/connect-distributed.properties
+        property: group.id
+        expected_value: connect-ssl
+
+    - name: Get Connectors on connect cluster2
+      uri:
+        url: "https://kafka-connect3:8083/connectors"
+        status_code: 200
+        validate_certs: false
+      register: connectors
+
+    - name: Assert No Connectors Created
+      assert:
+        that:
+          - connectors.json|length == 0
+        fail_msg: "Connector should not be created"
+        quiet: true
 
 - name: Verify - ksql
   hosts: ksql1
@@ -64,14 +119,32 @@
         property: confluent.controlcenter.ksql.ks1.ssl.truststore.location
         expected_value: /var/ssl/private/control_center.truststore.jks
 
-    - name: Check line multi connect line
+    - name: Check line ksql cluster2
+      import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: /etc/confluent-control-center/control-center-production.properties
+        property: confluent.controlcenter.ksql.ks2.url
+        expected_value: http://ksql2:8088,http://ksql3:8088
+
+    - name: Check line connect cluster2
       import_role:
         name: confluent.test
         tasks_from: check_property.yml
       vars:
         file_path: /etc/confluent-control-center/control-center-production.properties
         property: confluent.controlcenter.connect.connect-elastic.cluster
-        expected_value: https://kafka-connect2:8083
+        expected_value: http://kafka-connect2:8083
+
+    - name: Check line connect cluster3
+      import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: /etc/confluent-control-center/control-center-production.properties
+        property: confluent.controlcenter.connect.connect-ssl.cluster
+        expected_value: https://kafka-connect3:8083
 
     - name: Check advertised url default
       import_role:
@@ -89,4 +162,4 @@
       vars:
         file_path: /etc/confluent-control-center/control-center-production.properties
         property: confluent.controlcenter.ksql.ks2.advertised.url
-        expected_value: https://ksql2.confluent:8088,https://ksql3.confluent:8088
+        expected_value: http://ksql2.confluent:8088,http://ksql3.confluent:8088

--- a/roles/confluent.test/molecule/plain-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/plain-rhel/molecule.yml
@@ -103,6 +103,14 @@ provisioner:
         kafka_connect_confluent_hub_plugins:
           - jcustenborder/kafka-connect-spooldir:2.0.43
 
+        kafka_connect_connectors:
+          - name: sample-connector-1
+            config:
+              connector.class: "FileStreamSinkConnector"
+              tasks.max: "1"
+              file: "/etc/kafka/connect-distributed.properties"
+              topics: "test_topic"
+
 verifier:
   name: ansible
 lint: |

--- a/roles/confluent.test/molecule/plain-rhel/verify.yml
+++ b/roles/confluent.test/molecule/plain-rhel/verify.yml
@@ -55,6 +55,20 @@
         property: security.protocol
         expected_value: SASL_PLAINTEXT
 
+    - name: Get Connectors on connect cluster1
+      uri:
+        url: "http://kafka-connect1:8083/connectors"
+        status_code: 200
+        validate_certs: false
+      register: connectors
+
+    - name: Assert Connector Created
+      assert:
+        that:
+          - connectors.json[0] == "sample-connector-1"
+        fail_msg: "Connector not created"
+        quiet: true
+
 - name: Verify - ksql
   hosts: ksql
   gather_facts: false

--- a/roles/confluent.test/tasks/check_property.yml
+++ b/roles/confluent.test/tasks/check_property.yml
@@ -8,5 +8,5 @@
   assert:
     that:
       - expected_value == grep.stdout | regex_replace('^[-a-zA-Z0-9.]*[ ]?=[ ]?(.*)$', '\\1')
-    fail_msg: "Property: {{property}} set to {{ grep.stdout | regex_replace('^[-a-zA-Z0-9-.]*[ ]?=[ ]?(.*)$', '\\1') }} not {{expected_value}}"
+    fail_msg: "Property: {{property}} set to {{ grep.stdout | regex_replace('^[-a-zA-Z0-9.]*[ ]?=[ ]?(.*)$', '\\1') }} not {{expected_value}}"
     quiet: true

--- a/roles/confluent.test/tasks/check_property.yml
+++ b/roles/confluent.test/tasks/check_property.yml
@@ -7,6 +7,6 @@
 - name: Assert property set as expected
   assert:
     that:
-      - expected_value == grep.stdout | regex_replace('^[a-zA-Z.]*[ ]?=[ ]?(.*)$', '\\1')
-    fail_msg: "Property: {{property}} set to {{ grep.stdout | regex_replace('^[a-zA-Z.]*[ ]?=[ ]?(.*)$', '\\1') }} not {{expected_value}}"
+      - expected_value == grep.stdout | regex_replace('^[-a-zA-Z0-9.]*[ ]?=[ ]?(.*)$', '\\1')
+    fail_msg: "Property: {{property}} set to {{ grep.stdout | regex_replace('^[-a-zA-Z0-9-.]*[ ]?=[ ]?(.*)$', '\\1') }} not {{expected_value}}"
     quiet: true


### PR DESCRIPTION
# Description

If using the multi connect and connectors feature then you will only get connectors configured on one cluster. This resolves that as well as makes sure connect clusters can be configured separately and configured correctly in c3

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

updated the multi-ksql-connect-rhel and plain-rhel scenarios

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible