### PR TITLE
Configure additional kafka sys admins

### DIFF
--- a/roles/confluent.kafka_broker/tasks/main.yml
+++ b/roles/confluent.kafka_broker/tasks/main.yml
@@ -190,3 +190,6 @@
   when:
     - health_checks_enabled|bool
     - jolokia_enabled|bool
+
+- include_tasks: rbac_rolebindings.yml
+  when: kafka_broker_additional_system_admins|length > 0

--- a/roles/confluent.kafka_broker/tasks/rbac_rolebindings.yml
+++ b/roles/confluent.kafka_broker/tasks/rbac_rolebindings.yml
@@ -1,0 +1,26 @@
+---
+- name: RBAC Setup Tasks
+  include_tasks: ../../tasks/rbac_setup.yml
+  vars:
+    user: "{{kafka_broker_user}}"
+    group: "{{kafka_broker_group}}"
+
+- name: Grant role System Admin to Additional Kafka Broker System Admins
+  uri:
+    url: "{{mds_http_protocol}}://{{ groups['kafka_broker'][0] }}:{{mds_port}}/security/1.0/principals/User:{{item}}/roles/SystemAdmin"
+    method: POST
+    validate_certs: false
+    force_basic_auth: true
+    url_username: "{{mds_super_user}}"
+    url_password: "{{mds_super_user_password}}"
+    headers:
+      Content-Type: application/json
+    body_format: json
+    body: >
+      {
+        "clusters": {
+          "kafka-cluster": "{{kafka_cluster_id}}"
+        }
+      }
+    status_code: 204
+  loop: "{{kafka_broker_additional_system_admins}}"

--- a/roles/confluent.test/molecule/rbac-scram-custom-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/rbac-scram-custom-rhel/molecule.yml
@@ -203,6 +203,9 @@ provisioner:
         rbac_component_additional_system_admins:
           - user1
 
+        kafka_broker_additional_system_admins:
+          - user2
+
       kafka_broker:
         ldap_config: |
           ldap.java.naming.factory.initial=com.sun.jndi.ldap.LdapCtxFactory
@@ -265,6 +268,10 @@ provisioner:
             password: user1p
             uid: 9992
             guid: 92
+          - username: user2
+            password: user2p
+            uid: 9991
+            guid: 91
 
 verifier:
   name: ansible

--- a/roles/confluent.test/molecule/rbac-scram-custom-rhel/verify.yml
+++ b/roles/confluent.test/molecule/rbac-scram-custom-rhel/verify.yml
@@ -27,6 +27,40 @@
         property: transaction.state.log.min.isr
         expected_value: "2"
 
+    - name: Get Clusters associated with user1
+      uri:
+        url: https://kafka-broker1:8090/security/1.0/lookup/managed/clusters/principal/User:user1
+        validate_certs: false
+        force_basic_auth: true
+        url_username: "{{mds_super_user}}"
+        url_password: "{{mds_super_user_password}}"
+      register: clusters
+      run_once: true
+
+    - name: Assert cluster count expected
+      assert:
+        that:
+          - clusters.json|length == 4
+        fail_msg: "There should only be for clusters in {{clusters.json}}"
+        quiet: true
+
+    - name: Get Clusters associated with user2
+      uri:
+        url: https://kafka-broker1:8090/security/1.0/lookup/managed/clusters/principal/User:user2
+        validate_certs: false
+        force_basic_auth: true
+        url_username: "{{mds_super_user}}"
+        url_password: "{{mds_super_user_password}}"
+      register: clusters
+      run_once: true
+
+    - name: Assert cluster count expected
+      assert:
+        that:
+          - clusters.json|length == 1
+        fail_msg: "There should only be for clusters in {{clusters.json}}"
+        quiet: true
+
 - name: Verify - schema_registry
   hosts: schema_registry
   gather_facts: false

--- a/roles/confluent.test/molecule/rbac-scram-custom-rhel/verify.yml
+++ b/roles/confluent.test/molecule/rbac-scram-custom-rhel/verify.yml
@@ -29,7 +29,7 @@
 
     - name: Get Clusters associated with user1
       uri:
-        url: https://kafka-broker1:8090/security/1.0/lookup/managed/clusters/principal/User:user1
+        url: "https://{{groups['kafka_broker'][0]}}:8090/security/1.0/lookup/managed/clusters/principal/User:user1"
         validate_certs: false
         force_basic_auth: true
         url_username: "{{mds_super_user}}"
@@ -46,7 +46,7 @@
 
     - name: Get Clusters associated with user2
       uri:
-        url: https://kafka-broker1:8090/security/1.0/lookup/managed/clusters/principal/User:user2
+        url: "https://{{groups['kafka_broker'][0]}}:8090/security/1.0/lookup/managed/clusters/principal/User:user2"
         validate_certs: false
         force_basic_auth: true
         url_username: "{{mds_super_user}}"

--- a/roles/confluent.variables_handlers/defaults/main.yml
+++ b/roles/confluent.variables_handlers/defaults/main.yml
@@ -356,7 +356,9 @@ token_services_public_pem_file: generated_ssl_files/public.pem
 token_services_private_pem_file: generated_ssl_files/tokenKeypair.pem
 
 rbac_component_additional_system_admins: []
+kafka_broker_additional_system_admins: "{{rbac_component_additional_system_admins}}"
 schema_registry_additional_system_admins: "{{rbac_component_additional_system_admins}}"
 ksql_additional_system_admins: "{{rbac_component_additional_system_admins}}"
 kafka_connect_additional_system_admins: "{{rbac_component_additional_system_admins}}"
+# TODO remove this variable in future release, no one can be a sys admin on c3, just on the components c3 monitors
 control_center_additional_system_admins: "{{rbac_component_additional_system_admins}}"


### PR DESCRIPTION
# Description

Users in the `rbac_component_additional_system_admins` list do not get added as a kafka cluster sysadmin

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

added tests to rbac-scram-custom-rhel scenario


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Any variable changes have been validated to be backwards compatible