### PR TITLE
log4j bugs with archive installer

### DIFF
--- a/roles/confluent.control_center/defaults/main.yml
+++ b/roles/confluent.control_center/defaults/main.yml
@@ -27,7 +27,7 @@ control_center_service_environment_overrides:
   CONTROL_CENTER_OPTS: "{{ control_center_final_java_args | java_arg_build_out }}"
   CONTROL_CENTER_LOG4J_OPTS: "{% if control_center_custom_log4j|bool %}-Dlog4j.configuration=file:{{control_center.log4j_file}}{% endif %}"
   CONFLUENT_SECURITY_MASTER_KEY: "{% if control_center_secrets_protection_enabled|bool %}{{secrets_protection_masterkey}}{% endif %}"
-  LOG_DIR: "{{control_center.appender_log_path}}"
+  LOG_DIR: "{% if control_center_custom_log4j|bool %}{{control_center.appender_log_path}}{% endif %}"
 
 control_center:
   appender_log_path: /var/log/confluent/control-center/

--- a/roles/confluent.kafka_broker/defaults/main.yml
+++ b/roles/confluent.kafka_broker/defaults/main.yml
@@ -9,7 +9,6 @@ kafka_broker_java_args:
   - "{% if 'GSSAPI' in kafka_broker_sasl_enabled_mechanisms or zookeeper_sasl_protocol in ['kerberos', 'digest'] %}-Djava.security.auth.login.config={{kafka_broker.jaas_file}}{% endif %}"
   - "{% if kafka_broker_jolokia_enabled|bool %}-javaagent:{{jolokia_jar_path}}=config={{kafka_broker_jolokia_config}}{% endif %}"
   - "{% if kafka_broker_jmxexporter_enabled|bool %}-javaagent:{{jmxexporter_jar_path}}={{kafka_broker_jmxexporter_port}}:{{kafka_broker_jmxexporter_config_path}}{% endif %}"
-  - "{% if kafka_broker_custom_log4j|bool %}-Dlog4j.configuration=file:{{kafka_broker.log4j_file}}{% endif %}"
   - "{% if zookeeper_sasl_protocol == 'kerberos' and zookeeper_kerberos_primary != 'zookeeper' %}-Dzookeeper.sasl.client.username={{zookeeper_kerberos_primary}}{% endif %}"
 
 # Strip primary from the zookeeper principal on first zk host. Adds defaults for if there is not even a zookeeper group
@@ -29,6 +28,8 @@ kafka_broker_service_overrides:
 kafka_broker_service_environment_overrides:
   KAFKA_HEAP_OPTS: "-Xms6g -Xmx6g -XX:MetaspaceSize=96m -XX:+UseG1GC -XX:MaxGCPauseMillis=20 -XX:InitiatingHeapOccupancyPercent=35 -XX:G1HeapRegionSize=16M -XX:MinMetaspaceFreeRatio=50 -XX:MaxMetaspaceFreeRatio=80"
   KAFKA_OPTS: "{{ kafka_broker_final_java_args | java_arg_build_out }}"
+  KAFKA_LOG4J_OPTS: "{% if kafka_broker_custom_log4j|bool %}-Dlog4j.configuration=file:{{kafka_broker.log4j_file}}{% endif %}"
+  LOG_DIR: "{% if kafka_broker_custom_log4j|bool %}{{kafka_broker.appender_log_path}}{% endif %}"
   CONFLUENT_SECURITY_MASTER_KEY: "{% if kafka_broker_secrets_protection_enabled|bool %}{{secrets_protection_masterkey}}{% endif %}"
 
 kafka_broker_sysctl:

--- a/roles/confluent.kafka_connect/defaults/main.yml
+++ b/roles/confluent.kafka_connect/defaults/main.yml
@@ -7,7 +7,6 @@ kafka_connect_custom_log4j: "{{ custom_log4j }}"
 kafka_connect_java_args:
   - "{% if kafka_connect_ssl_enabled|bool %}-Djdk.tls.ephemeralDHKeySize=2048{% endif %}"
   - "{% if kafka_connect_jolokia_enabled|bool %}-javaagent:{{jolokia_jar_path}}=config={{kafka_connect_jolokia_config}}{% endif %}"
-  - "{% if kafka_connect_custom_log4j|bool %}-Dlog4j.configuration=file:{{kafka_connect.log4j_file}}{% endif %}"
   - "{% if kafka_connect_jmxexporter_enabled|bool %}-javaagent:{{jmxexporter_jar_path}}={{kafka_connect_jmxexporter_port}}:{{kafka_connect_jmxexporter_config_path}}{% endif %}"
 
 ### Custom Java Args to add to the Connect Process
@@ -25,6 +24,8 @@ kafka_connect_service_overrides:
 kafka_connect_service_environment_overrides:
   KAFKA_HEAP_OPTS: "-Xms256M -Xmx2G"
   KAFKA_OPTS: "{{ kafka_connect_final_java_args | java_arg_build_out }}"
+  LOG_DIR: "{% if kafka_connect_custom_log4j|bool %}{{kafka_connect.appender_log_path}}{% endif %}"
+  KAFKA_LOG4J_OPTS: "{% if kafka_connect_custom_log4j|bool %}-Dlog4j.configuration=file:{{kafka_connect.log4j_file}}{% endif %}"
   CONFLUENT_SECURITY_MASTER_KEY: "{% if kafka_connect_secrets_protection_enabled|bool %}{{secrets_protection_masterkey}}{% endif %}"
 
 kafka_connect:

--- a/roles/confluent.kafka_rest/defaults/main.yml
+++ b/roles/confluent.kafka_rest/defaults/main.yml
@@ -7,7 +7,6 @@ kafka_rest_custom_log4j: "{{ custom_log4j }}"
 kafka_rest_java_args:
   - "{% if kafka_rest_ssl_enabled|bool %}-Djdk.tls.ephemeralDHKeySize=2048{% endif %}"
   - "{% if kafka_rest_jolokia_enabled|bool %}-javaagent:{{jolokia_jar_path}}=config={{kafka_rest_jolokia_config}}{% endif %}"
-  - "{% if kafka_rest_custom_log4j|bool %}-Dlog4j.configuration=file:{{kafka_rest.log4j_file}}{% endif %}"
   - "{% if kafka_rest_jmxexporter_enabled|bool %}-javaagent:{{jmxexporter_jar_path}}={{kafka_rest_jmxexporter_port}}:{{kafka_rest_jmxexporter_config_path}}{% endif %}"
 
 ### Custom Java Args to add to the Rest Proxy Process
@@ -22,7 +21,8 @@ kafka_rest_service_overrides:
   ExecStart: "{% if installation_method == 'archive' %}{{ kafka_rest.server_start_file }} {{ kafka_rest.config_file }}{% endif %}"
 
 kafka_rest_service_environment_overrides:
-  LOG_DIR: "{{kafka_rest.appender_log_path}}"
+  LOG_DIR: "{% if kafka_rest_custom_log4j|bool %}{{kafka_rest.appender_log_path}}{% endif %}"
+  KAFKAREST_LOG4J_OPTS: "{% if kafka_rest_custom_log4j|bool %}-Dlog4j.configuration=file:{{kafka_rest.log4j_file}}{% endif %}"
   KAFKAREST_HEAP_OPTS: "-Xms1g -Xmx1g -XX:MetaspaceSize=96m -XX:+UseG1GC -XX:MaxGCPauseMillis=20 -XX:InitiatingHeapOccupancyPercent=35 -XX:G1HeapRegionSize=16M -XX:MinMetaspaceFreeRatio=50 -XX:MaxMetaspaceFreeRatio=80"
   KAFKAREST_OPTS: "{{ kafka_rest_final_java_args | java_arg_build_out }}"
   CONFLUENT_SECURITY_MASTER_KEY: "{% if kafka_rest_secrets_protection_enabled|bool %}{{secrets_protection_masterkey}}{% endif %}"

--- a/roles/confluent.ksql/defaults/main.yml
+++ b/roles/confluent.ksql/defaults/main.yml
@@ -7,7 +7,6 @@ ksql_custom_log4j: "{{ custom_log4j }}"
 ksql_java_args:
   - "{% if ksql_ssl_enabled|bool %}-Djdk.tls.ephemeralDHKeySize=2048{% endif %}"
   - "{% if ksql_jolokia_enabled|bool %}-javaagent:{{jolokia_jar_path}}=config={{ksql_jolokia_config}}{% endif %}"
-  - "{% if ksql_custom_log4j|bool %}-Dlog4j.configuration=file:{{ksql.log4j_file}}{% endif %}"
   - "{% if ksql_jmxexporter_enabled|bool %}-javaagent:{{jmxexporter_jar_path}}={{ksql_jmxexporter_port}}:{{ksql_jmxexporter_config_path}}{% endif %}"
 
 ### Custom Java Args to add to the ksqlDB Process
@@ -29,7 +28,8 @@ ksql_service_environment_overrides:
   KSQL_HEAP_OPTS: "-Xmx3g"
   KSQL_OPTS: "{{ ksql_final_java_args | java_arg_build_out }}"
   CONFLUENT_SECURITY_MASTER_KEY: "{% if ksql_secrets_protection_enabled|bool %}{{secrets_protection_masterkey}}{% endif %}"
-  LOG_DIR: "{{ksql.appender_log_path}}"
+  KSQL_LOG4J_OPTS: "{% if ksql_custom_log4j|bool %}-Dlog4j.configuration=file:{{ksql.log4j_file}}{% endif %}"
+  LOG_DIR: "{% if ksql_custom_log4j|bool %}{{ksql.appender_log_path}}{% endif %}"
   ROCKSDB_SHAREDLIB_DIR: "{{ksql_rocksdb_path}}"
 
 ksql:

--- a/roles/confluent.schema_registry/defaults/main.yml
+++ b/roles/confluent.schema_registry/defaults/main.yml
@@ -7,7 +7,6 @@ schema_registry_custom_log4j: "{{ custom_log4j }}"
 schema_registry_java_args:
   - "{% if schema_registry_ssl_enabled|bool %}-Djdk.tls.ephemeralDHKeySize=2048{% endif %}"
   - "{% if schema_registry_jolokia_enabled|bool %}-javaagent:{{jolokia_jar_path}}=config={{schema_registry_jolokia_config}}{% endif %}"
-  - "{% if schema_registry_custom_log4j|bool %}-Dlog4j.configuration=file:{{schema_registry.log4j_file}}{% endif %}"
   - "{% if schema_registry_jmxexporter_enabled|bool %}-javaagent:{{jmxexporter_jar_path}}={{schema_registry_jmxexporter_port}}:{{schema_registry_jmxexporter_config_path}}{% endif %}"
 
 ### Custom Java Args to add to the Schema Registry Process
@@ -26,7 +25,8 @@ schema_registry_service_environment_overrides:
   SCHEMA_REGISTRY_HEAP_OPTS: "-Xms1g -Xmx1g -XX:MetaspaceSize=96m -XX:+UseG1GC -XX:MaxGCPauseMillis=20 -XX:InitiatingHeapOccupancyPercent=35 -XX:G1HeapRegionSize=16M -XX:MinMetaspaceFreeRatio=50 -XX:MaxMetaspaceFreeRatio=80"
   SCHEMA_REGISTRY_OPTS: "{{ schema_registry_final_java_args | java_arg_build_out }}"
   CONFLUENT_SECURITY_MASTER_KEY: "{% if schema_registry_secrets_protection_enabled|bool %}{{secrets_protection_masterkey}}{% endif %}"
-  LOG_DIR: "{{schema_registry.appender_log_path}}"
+  SCHEMA_REGISTRY_LOG4J_OPTS: "{% if schema_registry_custom_log4j|bool %}-Dlog4j.configuration=file:{{schema_registry.log4j_file}}{% endif %}"
+  LOG_DIR: "{% if schema_registry_custom_log4j|bool %}{{schema_registry.appender_log_path}}{% endif %}"
 
 schema_registry:
   appender_log_path: /var/log/confluent/schema-registry/

--- a/roles/confluent.test/molecule/archive-plain-rhel/verify.yml
+++ b/roles/confluent.test/molecule/archive-plain-rhel/verify.yml
@@ -70,3 +70,11 @@
         file_path: /opt/confluent/etc/confluent-control-center/control-center-production.properties
         property: confluent.controlcenter.streams.security.protocol
         expected_value: SASL_PLAINTEXT
+
+- name: Verify log4j Configuration
+  hosts: all
+  gather_facts: false
+  tasks:
+    - import_role:
+        name: confluent.test
+        tasks_from: check_log4j.yml

--- a/roles/confluent.test/tasks/check_log4j.yml
+++ b/roles/confluent.test/tasks/check_log4j.yml
@@ -1,0 +1,17 @@
+---
+- name: Get Component Process Command
+  shell: |
+    ps -aux | grep {{ process_search_string | default('confluent') }} | xargs -n 1
+  register: process_grep
+  changed_when: false
+
+- name: Filter out log4j java args
+  set_fact:
+    log4j_grep: "{{ process_grep.stdout_lines | select('match', '-Dlog4j.configuration.*') | list }}"
+
+- name: Assert only 1 log4j java arg
+  assert:
+    that:
+      - log4j_grep|length == 1
+    fail_msg: There should only be one log4j java arg
+    quiet: true

--- a/roles/confluent.variables/defaults/main.yml
+++ b/roles/confluent.variables/defaults/main.yml
@@ -187,7 +187,7 @@ zookeeper_jolokia_port: 7770
 zookeeper_jolokia_ssl_enabled: "{{ zookeeper_ssl_enabled }}"
 
 ### Path on Zookeeper host for Jolokia Configuration file
-zookeeper_jolokia_config: /etc/kafka/zookeeper_jolokia.properties
+zookeeper_jolokia_config: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/kafka/zookeeper_jolokia.properties"
 
 ### Authentication Mode for Zookeeper's Jolokia Agent. Possible values: none, basic. If selecting basic, you must set zookeeper_jolokia_user and zookeeper_jolokia_password
 zookeeper_jolokia_auth_mode: "{{jolokia_auth_mode}}"
@@ -293,7 +293,7 @@ kafka_broker_jolokia_port: 7771
 kafka_broker_jolokia_ssl_enabled: "{{ ssl_enabled }}"
 
 ### Path on Kafka host for Jolokia Configuration file
-kafka_broker_jolokia_config: /etc/kafka/kafka_jolokia.properties
+kafka_broker_jolokia_config: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/kafka/kafka_jolokia.properties"
 
 ### Authentication Mode for Kafka's Jolokia Agent. Possible values: none, basic. If selecting basic, you must set kafka_broker_jolokia_user and kafka_broker_jolokia_password
 kafka_broker_jolokia_auth_mode: "{{jolokia_auth_mode}}"
@@ -374,7 +374,7 @@ schema_registry_jolokia_port: 7772
 schema_registry_jolokia_ssl_enabled: "{{ schema_registry_ssl_enabled }}"
 
 ### Path on Schema Registry host for Jolokia Configuration file
-schema_registry_jolokia_config: /etc/schema-registry/schema_registry_jolokia.properties
+schema_registry_jolokia_config: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/schema-registry/schema_registry_jolokia.properties"
 
 ### Authentication Mode for Schema Registry's Jolokia Agent. Possible values: none, basic. If selecting basic, you must set schema_registry_jolokia_user and schema_registry_jolokia_password
 schema_registry_jolokia_auth_mode: "{{jolokia_auth_mode}}"
@@ -442,7 +442,7 @@ kafka_rest_jolokia_port: 7775
 kafka_rest_jolokia_ssl_enabled: "{{ kafka_rest_ssl_enabled }}"
 
 ### Path on Rest Proxy host for Jolokia Configuration file
-kafka_rest_jolokia_config: /etc/kafka-rest/kafka_rest_jolokia.properties
+kafka_rest_jolokia_config: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/kafka-rest/kafka_rest_jolokia.properties"
 
 ### Authentication Mode for Rest Proxy's Jolokia Agent. Possible values: none, basic. If selecting basic, you must set schema_registry_jolokia_user and schema_registry_jolokia_password
 kafka_rest_jolokia_auth_mode: "{{jolokia_auth_mode}}"
@@ -512,7 +512,7 @@ kafka_connect_jolokia_port: 7773
 kafka_connect_jolokia_ssl_enabled: "{{ kafka_connect_ssl_enabled }}"
 
 ### Path on Connect host for Jolokia Configuration file
-kafka_connect_jolokia_config: /etc/kafka/kafka_connect_jolokia.properties
+kafka_connect_jolokia_config: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/kafka/kafka_connect_jolokia.properties"
 
 ### Authentication Mode for Connect's Jolokia Agent. Possible values: none, basic. If selecting basic, you must set schema_registry_jolokia_user and schema_registry_jolokia_password
 kafka_connect_jolokia_auth_mode: "{{jolokia_auth_mode}}"
@@ -603,7 +603,7 @@ ksql_jolokia_port: 7774
 ksql_jolokia_ssl_enabled: "{{ ksql_ssl_enabled }}"
 
 ### Path on ksqlDB host for Jolokia Configuration file
-ksql_jolokia_config: "{{(confluent_package_version is version('5.5.0', '>=')) | ternary('/etc/ksqldb/ksql_jolokia.properties' , '/etc/ksql/ksql_jolokia.properties')}}"
+ksql_jolokia_config: "{{ archive_config_base_path if installation_method == 'archive' else '' }}{{(confluent_package_version is version('5.5.0', '>=')) | ternary('/etc/ksqldb/ksql_jolokia.properties' , '/etc/ksql/ksql_jolokia.properties')}}"
 
 ### Authentication Mode for ksqlDB's Jolokia Agent. Possible values: none, basic. If selecting basic, you must set schema_registry_jolokia_user and schema_registry_jolokia_password
 ksql_jolokia_auth_mode: "{{jolokia_auth_mode}}"

--- a/roles/confluent.zookeeper/defaults/main.yml
+++ b/roles/confluent.zookeeper/defaults/main.yml
@@ -8,7 +8,6 @@ zookeeper_java_args:
   - "{% if zookeeper_ssl_enabled|bool %}-Djdk.tls.ephemeralDHKeySize=2048{% endif %}"
   - "{% if zookeeper_sasl_protocol in ['kerberos', 'digest'] %}-Djava.security.auth.login.config={{zookeeper.jaas_file}}{% endif %}"
   - "{% if zookeeper_jolokia_enabled|bool %}-javaagent:{{jolokia_jar_path}}=config={{zookeeper_jolokia_config}}{% endif %}"
-  - "{% if zookeeper_custom_log4j|bool %}-Dlog4j.configuration=file:{{zookeeper.log4j_file}}{% endif %}"
   - "{% if zookeeper_jmxexporter_enabled|bool %}-javaagent:{{jmxexporter_jar_path}}={{zookeeper_jmxexporter_port}}:{{zookeeper_jmxexporter_config_path}}{% endif %}"
 
 ### Custom Java Args to add to the Zookeeper Process
@@ -25,6 +24,8 @@ zookeeper_service_overrides:
 zookeeper_service_environment_overrides:
   KAFKA_HEAP_OPTS: "-Xmx1g"
   KAFKA_OPTS: "{{ zookeeper_final_java_args | java_arg_build_out }}"
+  KAFKA_LOG4J_OPTS: "{% if zookeeper_custom_log4j|bool %}-Dlog4j.configuration=file:{{zookeeper.log4j_file}}{% endif %}"
+  LOG_DIR: "{% if zookeeper_custom_log4j|bool %}{{zookeeper.log_path}}{% endif %}"
 
 zookeeper:
   log_path: /var/log/kafka/


### PR DESCRIPTION
# Description

When there are multiple log4j args in the java processes and you use the archive installer, then our components fail to start up because the component process can't write the log files as defined in the out of the box log4j conf. They do not have permissions to write the logs. By using the correct env vars, we get rid of the extra args

Also fixes an archive installer bug w the jolokia config file path

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Added verification task to archive installer scenario


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible