### PR TITLE
Metrics reporter logic improvement

### DIFF
--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -2073,3 +2073,4 @@ Key Size used by keytool -genkeypair command when creating Keystores. Only used 
 Default:  2048
 
 ***
+

--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -566,7 +566,7 @@ Default:  "{{ [ groups['kafka_broker'] | default(['localhost']) | length, 3 ] | 
 
 ### kafka_broker_metrics_reporter_enabled
 
-Boolean to enable the metrics reporter. Defaults to true if Control Center in inventory. Enable if you wish to have monitoring inceptors to report to a centralized monitoring cluster.
+Boolean to enable the kafka's metrics reporter. Defaults to true if Control Center in inventory. Enable if you wish to have metrics reported to a centralized monitoring cluster.
 
 Default:  "{{ 'control_center' in groups }}"
 

--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -102,7 +102,7 @@ Default:  true
 
 ### monitoring_interceptors_enabled
 
-Boolean to configure Monitoring Interceptors on ksqlDB, Rest Proxy, and Connect. Defaults to true if Control Center in inventory. Enable if you wish to have monitoring inceptors to report to a centralized monitoring cluster.
+Boolean to configure Monitoring Interceptors on ksqlDB, Rest Proxy, and Connect. Defaults to true if Control Center in inventory. Enable if you wish to have monitoring interceptors to report to a centralized monitoring cluster.
 
 Default:  "{{ 'control_center' in groups }}"
 
@@ -2073,4 +2073,3 @@ Key Size used by keytool -genkeypair command when creating Keystores. Only used 
 Default:  2048
 
 ***
-

--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -102,9 +102,9 @@ Default:  true
 
 ### monitoring_interceptors_enabled
 
-Boolean to configure Monitoring Interceptors on ksqlDB, Rest Proxy, and Connect. Only honored if inventory also has Control Center Group
+Boolean to configure Monitoring Interceptors on ksqlDB, Rest Proxy, and Connect. Defaults to true if Control Center in inventory. May still want to enable.
 
-Default:  true
+Default:  "{{ 'control_center' in groups }}"
 
 ***
 
@@ -566,9 +566,9 @@ Default:  "{{ [ groups['kafka_broker'] | default(['localhost']) | length, 3 ] | 
 
 ### kafka_broker_metrics_reporter_enabled
 
-Boolean to enable the metrics reporter
+Boolean to enable the metrics reporter. Defaults to true if Control Center in inventory. May still want to enable.
 
-Default:  true
+Default:  "{{ 'control_center' in groups }}"
 
 ***
 
@@ -846,7 +846,7 @@ Default:  "{{ kafka_rest.properties }}"
 
 ### kafka_rest_monitoring_interceptors_enabled
 
-Boolean to configure Monitoring Interceptors on Rest Proxy. Only honored if inventory also has Control Center Group
+Boolean to configure Monitoring Interceptors on Rest Proxy.
 
 Default:  "{{ monitoring_interceptors_enabled }}"
 
@@ -1014,7 +1014,7 @@ Default:  "{{ kafka_connect.properties }}"
 
 ### kafka_connect_monitoring_interceptors_enabled
 
-Boolean to configure Monitoring Interceptors on Connect. Only honored if inventory also has Control Center Group
+Boolean to configure Monitoring Interceptors on Connect.
 
 Default:  "{{ monitoring_interceptors_enabled }}"
 
@@ -1166,7 +1166,7 @@ Default:  "{{ ksql.properties }}"
 
 ### ksql_monitoring_interceptors_enabled
 
-Boolean to configure Monitoring Interceptors on ksqlDB. Only honored if inventory also has Control Center Group
+Boolean to configure Monitoring Interceptors on ksqlDB.
 
 Default:  "{{ monitoring_interceptors_enabled }}"
 

--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -102,7 +102,7 @@ Default:  true
 
 ### monitoring_interceptors_enabled
 
-Boolean to configure Monitoring Interceptors on ksqlDB, Rest Proxy, and Connect. Defaults to true if Control Center in inventory. May still want to enable.
+Boolean to configure Monitoring Interceptors on ksqlDB, Rest Proxy, and Connect. Defaults to true if Control Center in inventory. Enable if you wish to have monitoring inceptors to report to a centralized monitoring cluster.
 
 Default:  "{{ 'control_center' in groups }}"
 
@@ -566,7 +566,7 @@ Default:  "{{ [ groups['kafka_broker'] | default(['localhost']) | length, 3 ] | 
 
 ### kafka_broker_metrics_reporter_enabled
 
-Boolean to enable the metrics reporter. Defaults to true if Control Center in inventory. May still want to enable.
+Boolean to enable the metrics reporter. Defaults to true if Control Center in inventory. Enable if you wish to have monitoring inceptors to report to a centralized monitoring cluster.
 
 Default:  "{{ 'control_center' in groups }}"
 

--- a/roles/confluent.kafka_connect/tasks/rbac.yml
+++ b/roles/confluent.kafka_connect/tasks/rbac.yml
@@ -148,4 +148,4 @@
         }]
       }
     status_code: 204
-  when: "'control_center' in groups and kafka_connect_monitoring_interceptors_enabled|bool"
+  when: kafka_connect_monitoring_interceptors_enabled|bool

--- a/roles/confluent.kafka_rest/tasks/rbac.yml
+++ b/roles/confluent.kafka_rest/tasks/rbac.yml
@@ -58,4 +58,4 @@
         }]
       }
     status_code: 204
-  when: "'control_center' in groups and kafka_rest_monitoring_interceptors_enabled|bool"
+  when: kafka_rest_monitoring_interceptors_enabled|bool

--- a/roles/confluent.ksql/tasks/rbac.yml
+++ b/roles/confluent.ksql/tasks/rbac.yml
@@ -169,4 +169,4 @@
         }]
       }
     status_code: 204
-  when: "'control_center' in groups and ksql_monitoring_interceptors_enabled|bool"
+  when: ksql_monitoring_interceptors_enabled|bool

--- a/roles/confluent.test/molecule/rbac-scram-provided-debian/molecule.yml
+++ b/roles/confluent.test/molecule/rbac-scram-provided-debian/molecule.yml
@@ -134,20 +134,21 @@ platforms:
     privileged: true
     networks:
       - name: confluent
-  - name: control-center1
-    hostname: control-center1.confluent
-    groups:
-      - control_center
-    image: geerlingguy/docker-debian9-ansible
-    dockerfile: ../Dockerfile-debian.j2
-    command: ""
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
-    published_ports:
-      - "9021:9021"
-    networks:
-      - name: confluent
+  # Testing metrics reporter logic when c3 not in inventory
+  # - name: control-center1
+  #   hostname: control-center1.confluent
+  #   groups:
+  #     - control_center
+  #   image: geerlingguy/docker-debian9-ansible
+  #   dockerfile: ../Dockerfile-debian.j2
+  #   command: ""
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:ro
+  #   privileged: true
+  #   published_ports:
+  #     - "9021:9021"
+  #   networks:
+  #     - name: confluent
 provisioner:
   name: ansible
   config_options:
@@ -214,6 +215,9 @@ provisioner:
           ldap.group.name.attribute: cn
           ldap.group.member.attribute.pattern: CN=(.*),OU=rbac,DC=example,DC=com
           ldap.user.object.class: account
+
+        kafka_broker_metrics_reporter_enabled: true
+        monitoring_interceptors_enabled: true
 
       ldap_server:
         ldaps_enabled: false

--- a/roles/confluent.test/molecule/rbac-scram-provided-debian/verify.yml
+++ b/roles/confluent.test/molecule/rbac-scram-provided-debian/verify.yml
@@ -1,4 +1,16 @@
 ---
+- name: Verify - kafka_broker
+  hosts: kafka_broker
+  gather_facts: false
+  tasks:
+    - import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: /etc/kafka/server.properties
+        property: metric.reporters
+        expected_value: io.confluent.metrics.reporter.ConfluentMetricsReporter
+
 - name: Verify - schema_registry
   hosts: schema_registry
   gather_facts: false
@@ -23,6 +35,14 @@
         property: ssl.truststore.location
         expected_value: /var/ssl/private/kafka_rest.truststore.jks
 
+    - import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: /etc/kafka-rest/kafka-rest.properties
+        property: producer.interceptor.classes
+        expected_value: io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor
+
 - name: Verify - kafka_connect
   hosts: kafka_connect
   gather_facts: false
@@ -34,6 +54,14 @@
         file_path: /etc/kafka/connect-distributed.properties
         property: ssl.truststore.location
         expected_value: /var/ssl/private/kafka_connect.truststore.jks
+
+    - import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: /etc/kafka/connect-distributed.properties
+        property: producer.interceptor.classes
+        expected_value: io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor
 
 - name: Verify - ksql
   hosts: ksql
@@ -47,15 +75,10 @@
         property: ssl.truststore.location
         expected_value: /var/ssl/private/ksql.truststore.jks
 
-
-- name: Verify - control_center
-  hosts: control_center
-  gather_facts: false
-  tasks:
     - import_role:
         name: confluent.test
         tasks_from: check_property.yml
       vars:
-        file_path: /etc/confluent-control-center/control-center-production.properties
-        property: confluent.controlcenter.streams.ssl.truststore.location
-        expected_value: /var/ssl/private/control_center.truststore.jks
+        file_path: /etc/ksqldb/ksql-server.properties
+        property: producer.interceptor.classes
+        expected_value: io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor

--- a/roles/confluent.variables/defaults/main.yml
+++ b/roles/confluent.variables/defaults/main.yml
@@ -55,7 +55,7 @@ common_role_completed: false
 
 proxy_env: {}
 
-### Boolean to configure Monitoring Interceptors on ksqlDB, Rest Proxy, and Connect. Defaults to true if Control Center in inventory. May still want to enable.
+### Boolean to configure Monitoring Interceptors on ksqlDB, Rest Proxy, and Connect. Defaults to true if Control Center in inventory. Enable if you wish to have monitoring inceptors to report to a centralized monitoring cluster.
 monitoring_interceptors_enabled: "{{ 'control_center' in groups }}"
 
 ### The method of installation. Valid values are "package" or "archive". If "archive" is selected then services will not be installed via the use of yum or apt, but will instead be installed via expanding the target .tar.gz file from the Confluent archive into the path defined by `archive_destination_path`. Configuration files are also kept in this directory structure instead of `/etc`. SystemD service units are copied from the ardhive for each target service and overrides are created pointing at the new paths. The "package" installation method is the default behavior that utilizes yum/apt.

--- a/roles/confluent.variables/defaults/main.yml
+++ b/roles/confluent.variables/defaults/main.yml
@@ -324,7 +324,7 @@ kafka_broker_copy_files: []
 ### Replication Factor for internal topics. Defaults to the minimum of the number of brokers and 3
 kafka_broker_default_internal_replication_factor: "{{ [ groups['kafka_broker'] | default(['localhost']) | length, 3 ] | min }}"
 
-### Boolean to enable the metrics reporter. Defaults to true if Control Center in inventory. May still want to enable.
+### Boolean to enable the metrics reporter. Defaults to true if Control Center in inventory. Enable if you wish to have monitoring inceptors to report to a centralized monitoring cluster.
 kafka_broker_metrics_reporter_enabled: "{{ 'control_center' in groups }}"
 
 ### Use to set custom kafka properties. This variable is a dictionary. Put values true/false in quotation marks to perserve case. NOTE- kafka_broker.properties is deprecated.

--- a/roles/confluent.variables/defaults/main.yml
+++ b/roles/confluent.variables/defaults/main.yml
@@ -55,7 +55,7 @@ common_role_completed: false
 
 proxy_env: {}
 
-### Boolean to configure Monitoring Interceptors on ksqlDB, Rest Proxy, and Connect. Defaults to true if Control Center in inventory. Enable if you wish to have monitoring inceptors to report to a centralized monitoring cluster.
+### Boolean to configure Monitoring Interceptors on ksqlDB, Rest Proxy, and Connect. Defaults to true if Control Center in inventory. Enable if you wish to have monitoring interceptors to report to a centralized monitoring cluster.
 monitoring_interceptors_enabled: "{{ 'control_center' in groups }}"
 
 ### The method of installation. Valid values are "package" or "archive". If "archive" is selected then services will not be installed via the use of yum or apt, but will instead be installed via expanding the target .tar.gz file from the Confluent archive into the path defined by `archive_destination_path`. Configuration files are also kept in this directory structure instead of `/etc`. SystemD service units are copied from the ardhive for each target service and overrides are created pointing at the new paths. The "package" installation method is the default behavior that utilizes yum/apt.
@@ -324,7 +324,7 @@ kafka_broker_copy_files: []
 ### Replication Factor for internal topics. Defaults to the minimum of the number of brokers and 3
 kafka_broker_default_internal_replication_factor: "{{ [ groups['kafka_broker'] | default(['localhost']) | length, 3 ] | min }}"
 
-### Boolean to enable the metrics reporter. Defaults to true if Control Center in inventory. Enable if you wish to have monitoring inceptors to report to a centralized monitoring cluster.
+### Boolean to enable the kafka's metrics reporter. Defaults to true if Control Center in inventory. Enable if you wish to have metrics reported to a centralized monitoring cluster.
 kafka_broker_metrics_reporter_enabled: "{{ 'control_center' in groups }}"
 
 ### Use to set custom kafka properties. This variable is a dictionary. Put values true/false in quotation marks to perserve case. NOTE- kafka_broker.properties is deprecated.

--- a/roles/confluent.variables/defaults/main.yml
+++ b/roles/confluent.variables/defaults/main.yml
@@ -55,8 +55,8 @@ common_role_completed: false
 
 proxy_env: {}
 
-### Boolean to configure Monitoring Interceptors on ksqlDB, Rest Proxy, and Connect. Only honored if inventory also has Control Center Group
-monitoring_interceptors_enabled: true
+### Boolean to configure Monitoring Interceptors on ksqlDB, Rest Proxy, and Connect. Defaults to true if Control Center in inventory. May still want to enable.
+monitoring_interceptors_enabled: "{{ 'control_center' in groups }}"
 
 ### The method of installation. Valid values are "package" or "archive". If "archive" is selected then services will not be installed via the use of yum or apt, but will instead be installed via expanding the target .tar.gz file from the Confluent archive into the path defined by `archive_destination_path`. Configuration files are also kept in this directory structure instead of `/etc`. SystemD service units are copied from the ardhive for each target service and overrides are created pointing at the new paths. The "package" installation method is the default behavior that utilizes yum/apt.
 installation_method: "package"
@@ -324,8 +324,8 @@ kafka_broker_copy_files: []
 ### Replication Factor for internal topics. Defaults to the minimum of the number of brokers and 3
 kafka_broker_default_internal_replication_factor: "{{ [ groups['kafka_broker'] | default(['localhost']) | length, 3 ] | min }}"
 
-### Boolean to enable the metrics reporter
-kafka_broker_metrics_reporter_enabled: true
+### Boolean to enable the metrics reporter. Defaults to true if Control Center in inventory. May still want to enable.
+kafka_broker_metrics_reporter_enabled: "{{ 'control_center' in groups }}"
 
 ### Use to set custom kafka properties. This variable is a dictionary. Put values true/false in quotation marks to perserve case. NOTE- kafka_broker.properties is deprecated.
 kafka_broker_custom_properties: "{{ kafka_broker.properties }}"
@@ -466,7 +466,7 @@ kafka_rest_copy_files: []
 ### Use to set custom Rest Proxy properties. This variable is a dictionary. Put values true/false in quotation marks to perserve case. NOTE- kafka_rest.properties is deprecated.
 kafka_rest_custom_properties: "{{ kafka_rest.properties }}"
 
-### Boolean to configure Monitoring Interceptors on Rest Proxy. Only honored if inventory also has Control Center Group
+### Boolean to configure Monitoring Interceptors on Rest Proxy.
 kafka_rest_monitoring_interceptors_enabled: "{{ monitoring_interceptors_enabled }}"
 
 
@@ -557,7 +557,7 @@ kafka_connect_plugins_dest: /usr/share/java
 ### Use to set custom Connect properties. This variable is a dictionary. Put values true/false in quotation marks to perserve case. NOTE- kafka_connect.properties is deprecated.
 kafka_connect_custom_properties: "{{ kafka_connect.properties }}"
 
-### Boolean to configure Monitoring Interceptors on Connect. Only honored if inventory also has Control Center Group
+### Boolean to configure Monitoring Interceptors on Connect.
 kafka_connect_monitoring_interceptors_enabled: "{{ monitoring_interceptors_enabled }}"
 
 
@@ -633,7 +633,7 @@ ksql_service_id: default_
 ### Use to set custom ksqlDB properties. This variable is a dictionary. Put values true/false in quotation marks to perserve case. NOTE- ksql.properties is deprecated.
 ksql_custom_properties: "{{ ksql.properties }}"
 
-### Boolean to configure Monitoring Interceptors on ksqlDB. Only honored if inventory also has Control Center Group
+### Boolean to configure Monitoring Interceptors on ksqlDB.
 ksql_monitoring_interceptors_enabled: "{{ monitoring_interceptors_enabled }}"
 
 

--- a/roles/confluent.variables/vars/main.yml
+++ b/roles/confluent.variables/vars/main.yml
@@ -296,13 +296,13 @@ kafka_broker_properties:
                             plain_jaas_config, kafka_broker_keytab_path, kafka_broker_kerberos_principal|default('kafka'), kerberos_kafka_broker_primary|default('kafka'),
                             sasl_scram_users.admin.principal, sasl_scram_users.admin.password, rbac_enabled_public_pem_path ) }}"
   metrics_reporter:
-    enabled: "{{ 'control_center' in groups and kafka_broker_metrics_reporter_enabled|bool }}"
+    enabled: "{{ kafka_broker_metrics_reporter_enabled|bool }}"
     properties:
       metric.reporters: io.confluent.metrics.reporter.ConfluentMetricsReporter
       confluent.metrics.reporter.bootstrap.servers: "{{ groups['kafka_broker'] | default(['localhost']) | join(':' + kafka_broker_listeners[kafka_broker_inter_broker_listener_name]['port']|string + ',') }}:{{kafka_broker_listeners[kafka_broker_inter_broker_listener_name]['port']}}"
       confluent.metrics.reporter.topic.replicas: "{{kafka_broker_default_internal_replication_factor}}"
   metrics_reporter_client:
-    enabled: "{{ 'control_center' in groups and kafka_broker_metrics_reporter_enabled|bool }}"
+    enabled: "{{ kafka_broker_metrics_reporter_enabled|bool }}"
     properties: "{{ kafka_broker_listeners[kafka_broker_inter_broker_listener_name] | client_properties(ssl_enabled, pkcs12_enabled, ssl_mutual_auth_enabled, sasl_protocol,
                             'confluent.metrics.reporter.', kafka_broker_truststore_path, kafka_broker_truststore_storepass, kafka_broker_keystore_path, kafka_broker_keystore_storepass, kafka_broker_keystore_keypass,
                             false, sasl_plain_users.admin.principal, sasl_plain_users.admin.password, sasl_scram_users.admin.principal, sasl_scram_users.admin.password,
@@ -548,7 +548,7 @@ kafka_connect_properties:
                             kerberos_kafka_broker_primary|default('kafka'), kafka_connect_keytab_path, kafka_connect_kerberos_principal|default('kafka'),
                             false, kafka_connect_ldap_user, kafka_connect_ldap_password, mds_bootstrap_server_urls) }}"
   monitoring_interceptor:
-    enabled: "{{ 'control_center' in groups and kafka_connect_monitoring_interceptors_enabled|bool }}"
+    enabled: "{{ kafka_connect_monitoring_interceptors_enabled|bool }}"
     properties:
       confluent.monitoring.interceptor.topic: _confluent-monitoring
       producer.confluent.monitoring.interceptor.bootstrap.servers: "{{ groups['kafka_broker'] | default(['localhost']) | join(':' + kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']|string + ',') }}:{{kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']}}"
@@ -556,14 +556,14 @@ kafka_connect_properties:
       consumer.interceptor.classes: io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor
       producer.interceptor.classes: io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor
   producer_monitoring_interceptor_client:
-    enabled: "{{ 'control_center' in groups and kafka_connect_monitoring_interceptors_enabled|bool }}"
+    enabled: "{{ kafka_connect_monitoring_interceptors_enabled|bool }}"
     properties: "{{ kafka_broker_listeners[kafka_connect_kafka_listener_name] | client_properties(ssl_enabled, pkcs12_enabled, ssl_mutual_auth_enabled, sasl_protocol,
                             'producer.confluent.monitoring.interceptor.', kafka_connect_truststore_path, kafka_connect_truststore_storepass, kafka_connect_keystore_path, kafka_connect_keystore_storepass, kafka_connect_keystore_keypass,
                             false, sasl_plain_users.kafka_connect.principal, sasl_plain_users.kafka_connect.password, sasl_scram_users.kafka_connect.principal, sasl_scram_users.kafka_connect.password,
                             kerberos_kafka_broker_primary|default('kafka'), kafka_connect_keytab_path, kafka_connect_kerberos_principal|default('kafka'),
                             false, kafka_connect_ldap_user, kafka_connect_ldap_password, mds_bootstrap_server_urls) }}"
   consumer_monitoring_interceptor_client:
-    enabled: "{{ 'control_center' in groups and kafka_connect_monitoring_interceptors_enabled|bool }}"
+    enabled: "{{ kafka_connect_monitoring_interceptors_enabled|bool }}"
     properties: "{{ kafka_broker_listeners[kafka_connect_kafka_listener_name] | client_properties(ssl_enabled, pkcs12_enabled, ssl_mutual_auth_enabled, sasl_protocol,
                             'consumer.confluent.monitoring.interceptor.', kafka_connect_truststore_path, kafka_connect_truststore_storepass, kafka_connect_keystore_path, kafka_connect_keystore_storepass, kafka_connect_keystore_keypass,
                             false, sasl_plain_users.kafka_connect.principal, sasl_plain_users.kafka_connect.password, sasl_scram_users.kafka_connect.principal, sasl_scram_users.kafka_connect.password,
@@ -737,14 +737,14 @@ ksql_properties:
       ksql.schema.registry.basic.auth.credentials.source: USER_INFO
       ksql.schema.registry.basic.auth.user.info: "{{ ksql_ldap_user | default('ksql') }}:{{ ksql_ldap_password | default('pass') }}"
   monitoring_interceptor:
-    enabled: "{{ 'control_center' in groups and ksql_monitoring_interceptors_enabled|bool }}"
+    enabled: "{{ ksql_monitoring_interceptors_enabled|bool }}"
     properties:
       confluent.monitoring.interceptor.topic: _confluent-monitoring
       producer.interceptor.classes: io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor
       consumer.interceptor.classes: io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor
       confluent.monitoring.interceptor.bootstrap.servers: "{{ groups['kafka_broker'] | default(['localhost']) | join(':' + kafka_broker_listeners[ksql_kafka_listener_name]['port']|string + ',') }}:{{kafka_broker_listeners[ksql_kafka_listener_name]['port']}}"
   monitoring_interceptor_client:
-    enabled: "{{ 'control_center' in groups and ksql_monitoring_interceptors_enabled|bool }}"
+    enabled: "{{ ksql_monitoring_interceptors_enabled|bool }}"
     properties: "{{ kafka_broker_listeners[ksql_kafka_listener_name] | client_properties(ssl_enabled, pkcs12_enabled, ssl_mutual_auth_enabled, sasl_protocol,
                             'confluent.monitoring.interceptor.', ksql_truststore_path, ksql_truststore_storepass, ksql_keystore_path, ksql_keystore_storepass, ksql_keystore_keypass,
                             false, sasl_plain_users.ksql.principal, sasl_plain_users.ksql.password, sasl_scram_users.ksql.principal, sasl_scram_users.ksql.password,
@@ -869,14 +869,14 @@ kafka_rest_properties:
       schema.registry.ssl.keystore.password: "{{kafka_rest_keystore_storepass}}"
       schema.registry.ssl.key.password: "{{kafka_rest_keystore_keypass}}"
   monitoring_interceptor:
-    enabled: "{{ 'control_center' in groups and kafka_rest_monitoring_interceptors_enabled|bool }}"
+    enabled: "{{ kafka_rest_monitoring_interceptors_enabled|bool }}"
     properties:
       confluent.monitoring.interceptor.topic: _confluent-monitoring
       producer.interceptor.classes: io.confluent.monitoring.clients.interceptor.MonitoringProducerInterceptor
       consumer.interceptor.classes: io.confluent.monitoring.clients.interceptor.MonitoringConsumerInterceptor
       confluent.monitoring.interceptor.bootstrap.servers: "{{ groups['kafka_broker'] | default(['localhost']) | join(':' + kafka_broker_listeners[kafka_rest_kafka_listener_name]['port']|string + ',') }}:{{kafka_broker_listeners[kafka_rest_kafka_listener_name]['port']}}"
   monitoring_interceptor_client:
-    enabled: "{{ 'control_center' in groups and kafka_rest_monitoring_interceptors_enabled|bool }}"
+    enabled: "{{ kafka_rest_monitoring_interceptors_enabled|bool }}"
     properties: "{{ kafka_broker_listeners[kafka_rest_kafka_listener_name] | client_properties(ssl_enabled, pkcs12_enabled, ssl_mutual_auth_enabled, sasl_protocol,
                             'confluent.monitoring.interceptor.', kafka_rest_truststore_path, kafka_rest_truststore_storepass, kafka_rest_keystore_path, kafka_rest_keystore_storepass, kafka_rest_keystore_keypass,
                             false, sasl_plain_users.kafka_rest.principal, sasl_plain_users.kafka_rest.password, sasl_scram_users.kafka_rest.principal, sasl_scram_users.kafka_rest.password,


### PR DESCRIPTION
# Description

Now metrics reporter/ monitoring interceptors can be configured even if c3 not in inventory file. Now can make use of these vars
```
        kafka_broker_metrics_reporter_enabled: true
        monitoring_interceptors_enabled: true
```

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Removed c3 container from rbac-scram-provided-debian and added vars to test the functionality


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible