### PR TITLE
Omitting connect producer/consumer jaas properties only when RBAC enabled

### DIFF
--- a/roles/confluent.test/molecule/plain-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/plain-rhel/molecule.yml
@@ -100,6 +100,9 @@ provisioner:
       all:
         sasl_protocol: plain
 
+        zookeeper_custom_properties:
+          dataLogDir: /opt/zookeeper
+
         kafka_connect_confluent_hub_plugins:
           - jcustenborder/kafka-connect-spooldir:2.0.43
 

--- a/roles/confluent.test/molecule/plain-rhel/verify.yml
+++ b/roles/confluent.test/molecule/plain-rhel/verify.yml
@@ -76,6 +76,14 @@
         property: security.protocol
         expected_value: SASL_PLAINTEXT
 
+    - import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: /etc/kafka/connect-distributed.properties
+        property: producer.sasl.jaas.config
+        expected_value: 'org.apache.kafka.common.security.plain.PlainLoginModule required username="kafka_connect" password="kafka_connect-secret";'
+
     - name: Get Connectors on connect cluster1
       uri:
         url: "http://kafka-connect1:8083/connectors"

--- a/roles/confluent.variables/vars/main.yml
+++ b/roles/confluent.variables/vars/main.yml
@@ -548,14 +548,14 @@ kafka_connect_properties:
     enabled: true
     properties: "{{ kafka_broker_listeners[kafka_connect_kafka_listener_name] | client_properties(ssl_enabled, pkcs12_enabled, ssl_mutual_auth_enabled, sasl_protocol,
                             'producer.', kafka_connect_truststore_path, kafka_connect_truststore_storepass, kafka_connect_keystore_path, kafka_connect_keystore_storepass, kafka_connect_keystore_keypass,
-                            true, sasl_plain_users.kafka_connect.principal, sasl_plain_users.kafka_connect.password, sasl_scram_users.kafka_connect.principal, sasl_scram_users.kafka_connect.password,
+                            rbac_enabled, sasl_plain_users.kafka_connect.principal, sasl_plain_users.kafka_connect.password, sasl_scram_users.kafka_connect.principal, sasl_scram_users.kafka_connect.password,
                             kerberos_kafka_broker_primary|default('kafka'), kafka_connect_keytab_path, kafka_connect_kerberos_principal|default('kafka'),
                             false, kafka_connect_ldap_user, kafka_connect_ldap_password, mds_bootstrap_server_urls) }}"
   consumer:
     enabled: true
     properties: "{{ kafka_broker_listeners[kafka_connect_kafka_listener_name] | client_properties(ssl_enabled, pkcs12_enabled, ssl_mutual_auth_enabled, sasl_protocol,
                             'consumer.', kafka_connect_truststore_path, kafka_connect_truststore_storepass, kafka_connect_keystore_path, kafka_connect_keystore_storepass, kafka_connect_keystore_keypass,
-                            true, sasl_plain_users.kafka_connect.principal, sasl_plain_users.kafka_connect.password, sasl_scram_users.kafka_connect.principal, sasl_scram_users.kafka_connect.password,
+                            rbac_enabled, sasl_plain_users.kafka_connect.principal, sasl_plain_users.kafka_connect.password, sasl_scram_users.kafka_connect.principal, sasl_scram_users.kafka_connect.password,
                             kerberos_kafka_broker_primary|default('kafka'), kafka_connect_keytab_path, kafka_connect_kerberos_principal|default('kafka'),
                             false, kafka_connect_ldap_user, kafka_connect_ldap_password, mds_bootstrap_server_urls) }}"
   monitoring_interceptor:


### PR DESCRIPTION
# Description

In a non rbac deployment, we should have connect worker configured as a kafka client with these properties:  `[producer|consumer].sasl.jaas.config` 
Connectors added to the cluster will inherit these properties, but can still override those them using this: https://docs.confluent.io/current/connect/references/allconfigs.html#override-the-worker-configuration

In an rbac deployment, we will force connectors to configure their `[producer|consumer].sasl.jaas.config` properties to make sure admins are properly thinking about access and role bindings.

Also fixes broken test in scenario. The test was around the dataLogDir custom property. it was somehow left out of the molecule.yml, but tested for in the verify.yml

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Added verify task to plain-rhel scenario


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible