### PR TITLE
kafka kerberos primary variable deprecation

### DIFF
--- a/hosts_example.yml
+++ b/hosts_example.yml
@@ -31,7 +31,6 @@ all:
 
     #### Kerberos Configuration ####
     ## Applicable when sasl_protocol is kerberos
-    # kerberos_kafka_broker_primary: <Name of the primary set on the kafka brokers' principal eg. kafka>
     ## REQUIRED: Under each host set keytab file path and principal name, see below
     # kerberos_configure: <Boolean for ansible to install kerberos packages and configure this file: /etc/krb5.conf, defaults to true>
     # kerberos:

--- a/roles/confluent.test/molecule/confluent-kafka-kerberos-customcerts-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/confluent-kafka-kerberos-customcerts-rhel/molecule.yml
@@ -172,7 +172,6 @@ provisioner:
 
         sasl_protocol: kerberos
 
-        kerberos_kafka_broker_primary: kafka
         kerberos:
           realm: realm.example.com
           kdc_hostname: kerberos1
@@ -183,7 +182,7 @@ provisioner:
         zookeeper_kerberos_principal: "zookeeper/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
         zookeeper_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/zookeeper-{{inventory_hostname}}.keytab"
       kafka_broker:
-        kafka_broker_kerberos_principal: "{{kerberos_kafka_broker_primary}}/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
+        kafka_broker_kerberos_principal: "kafka/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
         kafka_broker_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/kafka_broker-{{inventory_hostname}}.keytab"
       schema_registry:
         schema_registry_kerberos_principal: "schema_registry/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
@@ -217,13 +216,13 @@ provisioner:
           - principal: "zookeeper/zookeeper3.confluent@{{kerberos.realm | upper}}"
             keytab_path: "keytabs/zookeeper-zookeeper3.keytab"
 
-          - principal: "{{kerberos_kafka_broker_primary}}/kafka-broker1.confluent@{{kerberos.realm | upper}}"
+          - principal: "kafka/kafka-broker1.confluent@{{kerberos.realm | upper}}"
             keytab_path: "keytabs/kafka_broker-kafka-broker1.keytab"
 
-          - principal: "{{kerberos_kafka_broker_primary}}/kafka-broker2.confluent@{{kerberos.realm | upper}}"
+          - principal: "kafka/kafka-broker2.confluent@{{kerberos.realm | upper}}"
             keytab_path: "keytabs/kafka_broker-kafka-broker2.keytab"
 
-          - principal: "{{kerberos_kafka_broker_primary}}/kafka-broker3.confluent@{{kerberos.realm | upper}}"
+          - principal: "kafka/kafka-broker3.confluent@{{kerberos.realm | upper}}"
             keytab_path: "keytabs/kafka_broker-kafka-broker3.keytab"
 
           - principal: "schema_registry/schema-registry1.confluent@{{kerberos.realm | upper}}"

--- a/roles/confluent.test/molecule/kerberos-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/kerberos-rhel/molecule.yml
@@ -139,8 +139,6 @@ provisioner:
 
         sasl_protocol: kerberos
 
-        kerberos_kafka_broker_primary: kafka
-
         kerberos:
           realm: realm.example.com
           kdc_hostname: kerberos1
@@ -151,7 +149,7 @@ provisioner:
         zookeeper_kerberos_principal: "zk/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
         zookeeper_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/zookeeper-{{inventory_hostname}}.keytab"
       kafka_broker:
-        kafka_broker_kerberos_principal: "{{kerberos_kafka_broker_primary}}/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
+        kafka_broker_kerberos_principal: "kafka-a/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
         kafka_broker_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/kafka_broker-{{inventory_hostname}}.keytab"
       schema_registry:
         schema_registry_kerberos_principal: "schema_registry/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
@@ -179,13 +177,13 @@ provisioner:
           - principal: "zk/zookeeper1.confluent@{{kerberos.realm | upper}}"
             keytab_path: "keytabs/zookeeper-zookeeper1.keytab"
 
-          - principal: "{{kerberos_kafka_broker_primary}}/kafka-broker1.confluent@{{kerberos.realm | upper}}"
+          - principal: "kafka-a/kafka-broker1.confluent@{{kerberos.realm | upper}}"
             keytab_path: "keytabs/kafka_broker-kafka-broker1.keytab"
 
-          - principal: "{{kerberos_kafka_broker_primary}}/kafka-broker2.confluent@{{kerberos.realm | upper}}"
+          - principal: "kafka-a/kafka-broker2.confluent@{{kerberos.realm | upper}}"
             keytab_path: "keytabs/kafka_broker-kafka-broker2.keytab"
 
-          - principal: "{{kerberos_kafka_broker_primary}}/kafka-broker3.confluent@{{kerberos.realm | upper}}"
+          - principal: "kafka-a/kafka-broker3.confluent@{{kerberos.realm | upper}}"
             keytab_path: "keytabs/kafka_broker-kafka-broker3.keytab"
 
           - principal: "schema_registry/schema-registry1.confluent@{{kerberos.realm | upper}}"

--- a/roles/confluent.test/molecule/kerberos-rhel/verify.yml
+++ b/roles/confluent.test/molecule/kerberos-rhel/verify.yml
@@ -11,6 +11,14 @@
         property: sasl.enabled.mechanisms
         expected_value: GSSAPI
 
+    - import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: /etc/kafka/server.properties
+        property: sasl.kerberos.service.name
+        expected_value: kafka-a
+
 - name: Verify - schema_registry
   hosts: schema_registry
   gather_facts: false
@@ -22,6 +30,14 @@
         file_path: /etc/schema-registry/schema-registry.properties
         property: kafkastore.security.protocol
         expected_value: SASL_PLAINTEXT
+
+    - import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: /etc/schema-registry/schema-registry.properties
+        property: kafkastore.sasl.kerberos.service.name
+        expected_value: kafka-a
 
 - name: Verify - kafka_connect
   hosts: kafka_connect
@@ -35,6 +51,14 @@
         property: security.protocol
         expected_value: SASL_PLAINTEXT
 
+    - import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: /etc/kafka/connect-distributed.properties
+        property: sasl.kerberos.service.name
+        expected_value: kafka-a
+
 - name: Verify - kafka_rest
   hosts: kafka_rest
   gather_facts: false
@@ -46,6 +70,14 @@
         file_path: /etc/kafka-rest/kafka-rest.properties
         property: client.security.protocol
         expected_value: SASL_PLAINTEXT
+
+    - import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: /etc/kafka-rest/kafka-rest.properties
+        property: client.sasl.kerberos.service.name
+        expected_value: kafka-a
 
 - name: Verify - ksql
   hosts: ksql
@@ -59,6 +91,14 @@
         property: security.protocol
         expected_value: SASL_PLAINTEXT
 
+    - import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: /etc/ksqldb/ksql-server.properties
+        property: sasl.kerberos.service.name
+        expected_value: kafka-a
+
 - name: Verify - control_center
   hosts: control_center
   gather_facts: false
@@ -70,3 +110,11 @@
         file_path: /etc/confluent-control-center/control-center-production.properties
         property: confluent.controlcenter.streams.security.protocol
         expected_value: SASL_PLAINTEXT
+
+    - import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: /etc/confluent-control-center/control-center-production.properties
+        property: confluent.controlcenter.streams.sasl.kerberos.service.name
+        expected_value: kafka-a

--- a/roles/confluent.variables/defaults/main.yml
+++ b/roles/confluent.variables/defaults/main.yml
@@ -41,6 +41,10 @@ custom_log4j: true
 ### Boolean to configure Kerberos krb5.conf file, must also set kerberos.realm, keberos.kdc_hostname, kerberos.admin_hostname, where kerberos is a dictionary
 kerberos_configure: true
 
+# Deprecated variable now that primary can be pulled from kafka_broker_kerberos_principal
+kerberos_kafka_broker_primary: "{{ (hostvars[ groups['kafka_broker'][0] | default('kafka') ] | default({})) ['kafka_broker_kerberos_principal'] | default('kafka/host@EXAMPLE>COM') | regex_replace('/.*') }}"
+
+
 # TODO document the rest of the kerberos variables, also admin_hostname should default to kdc_hostname
 
 open_file_limit: 500000

--- a/roles/confluent.variables/vars/main.yml
+++ b/roles/confluent.variables/vars/main.yml
@@ -156,7 +156,7 @@ kafka_broker_properties:
   sasl_gssapi:
     enabled: "{{ 'GSSAPI' in kafka_broker_sasl_enabled_mechanisms }}"
     properties:
-      sasl.kerberos.service.name: "{{kerberos_kafka_broker_primary | default('kafka')}}"
+      sasl.kerberos.service.name: "{{kerberos_kafka_broker_primary}}"
   zk_ssl:
     enabled: "{{ zookeeper_ssl_enabled }}"
     properties:
@@ -247,7 +247,7 @@ kafka_broker_properties:
     properties: "{{ mds_broker_listener | client_properties(ssl_enabled, pkcs12_enabled, ssl_mutual_auth_enabled, sasl_protocol,
                             'confluent.metadata.', kafka_broker_truststore_path, kafka_broker_truststore_storepass, kafka_broker_keystore_path, kafka_broker_keystore_storepass, kafka_broker_keystore_keypass,
                             false, sasl_plain_users.admin.principal, sasl_plain_users.admin.password, sasl_scram_users.admin.principal, sasl_scram_users.admin.password,
-                            kerberos_kafka_broker_primary|default('kafka'), kafka_broker_keytab_path, kafka_broker_kerberos_principal|default('kafka'),
+                            kerberos_kafka_broker_primary, kafka_broker_keytab_path, kafka_broker_kerberos_principal|default('kafka'),
                             false, 'user', 'pass', mds_bootstrap_server_urls) }}"
   embedded_rest_proxy:
     # Do not need duplicating confluent.metadata.server and confluent.http.server config, rely on mds configs when kafka is the mds
@@ -280,7 +280,7 @@ kafka_broker_properties:
     properties: "{{ kafka_broker_listeners['internal'] | client_properties(ssl_enabled, pkcs12_enabled, ssl_mutual_auth_enabled, sasl_protocol,
                             'kafka.rest.client.', kafka_broker_truststore_path, kafka_broker_truststore_storepass, kafka_broker_keystore_path, kafka_broker_keystore_storepass, kafka_broker_keystore_keypass,
                             false, sasl_plain_users.admin.principal, sasl_plain_users.admin.password, sasl_scram_users.admin.principal, sasl_scram_users.admin.password,
-                            kerberos_kafka_broker_primary|default('kafka'), kafka_broker_keytab_path, kafka_broker_kerberos_principal|default('kafka'),
+                            kerberos_kafka_broker_primary, kafka_broker_keytab_path, kafka_broker_kerberos_principal|default('kafka'),
                             true, kafka_broker_ldap_user, kafka_broker_ldap_password, mds_bootstrap_server_urls) }}"
   embedded_rest_proxy_rbac:
     enabled: "{{ kafka_broker_rest_proxy_enabled and rbac_enabled }}"
@@ -300,7 +300,7 @@ kafka_broker_properties:
     enabled: true
     properties: "{{ kafka_broker_listeners | listener_properties(ssl_enabled, pkcs12_enabled, ssl_mutual_auth_enabled, sasl_protocol,
                             kafka_broker_truststore_path, kafka_broker_truststore_storepass, kafka_broker_keystore_path, kafka_broker_keystore_storepass, kafka_broker_keystore_keypass,
-                            plain_jaas_config, kafka_broker_keytab_path, kafka_broker_kerberos_principal|default('kafka'), kerberos_kafka_broker_primary|default('kafka'),
+                            plain_jaas_config, kafka_broker_keytab_path, kafka_broker_kerberos_principal|default('kafka'), kerberos_kafka_broker_primary,
                             sasl_scram_users.admin.principal, sasl_scram_users.admin.password, rbac_enabled_public_pem_path ) }}"
   metrics_reporter:
     enabled: "{{ kafka_broker_metrics_reporter_enabled|bool }}"
@@ -313,7 +313,7 @@ kafka_broker_properties:
     properties: "{{ kafka_broker_listeners[kafka_broker_inter_broker_listener_name] | client_properties(ssl_enabled, pkcs12_enabled, ssl_mutual_auth_enabled, sasl_protocol,
                             'confluent.metrics.reporter.', kafka_broker_truststore_path, kafka_broker_truststore_storepass, kafka_broker_keystore_path, kafka_broker_keystore_storepass, kafka_broker_keystore_keypass,
                             false, sasl_plain_users.admin.principal, sasl_plain_users.admin.password, sasl_scram_users.admin.principal, sasl_scram_users.admin.password,
-                            kerberos_kafka_broker_primary|default('kafka'), kafka_broker_keytab_path, kafka_broker_kerberos_principal|default('kafka'),
+                            kerberos_kafka_broker_primary, kafka_broker_keytab_path, kafka_broker_kerberos_principal|default('kafka'),
                             false, kafka_broker_ldap_user, kafka_broker_ldap_password, mds_bootstrap_server_urls) }}"
   telemetry:
     enabled: "{{kafka_broker_telemetry_enabled}}"
@@ -404,7 +404,7 @@ schema_registry_properties:
     properties: "{{ kafka_broker_listeners[schema_registry_kafka_listener_name] | client_properties(ssl_enabled, pkcs12_enabled, ssl_mutual_auth_enabled, sasl_protocol,
                             'kafkastore.', schema_registry_truststore_path, schema_registry_truststore_storepass, schema_registry_keystore_path, schema_registry_keystore_storepass, schema_registry_keystore_keypass,
                             false, sasl_plain_users.schema_registry.principal, sasl_plain_users.schema_registry.password, sasl_scram_users.schema_registry.principal, sasl_scram_users.schema_registry.password,
-                            kerberos_kafka_broker_primary|default('kafka'), schema_registry_keytab_path, schema_registry_kerberos_principal|default('kafka'),
+                            kerberos_kafka_broker_primary, schema_registry_keytab_path, schema_registry_kerberos_principal|default('kafka'),
                             false, schema_registry_ldap_user, schema_registry_ldap_password, mds_bootstrap_server_urls) }}"
   rbac:
     enabled: "{{rbac_enabled}}"
@@ -542,21 +542,21 @@ kafka_connect_properties:
     properties: "{{ kafka_broker_listeners[kafka_connect_kafka_listener_name] | client_properties(ssl_enabled, pkcs12_enabled, ssl_mutual_auth_enabled, sasl_protocol,
                             '', kafka_connect_truststore_path, kafka_connect_truststore_storepass, kafka_connect_keystore_path, kafka_connect_keystore_storepass, kafka_connect_keystore_keypass,
                             false, sasl_plain_users.kafka_connect.principal, sasl_plain_users.kafka_connect.password, sasl_scram_users.kafka_connect.principal, sasl_scram_users.kafka_connect.password,
-                            kerberos_kafka_broker_primary|default('kafka'), kafka_connect_keytab_path, kafka_connect_kerberos_principal|default('kafka'),
+                            kerberos_kafka_broker_primary, kafka_connect_keytab_path, kafka_connect_kerberos_principal|default('kafka'),
                             false, kafka_connect_ldap_user, kafka_connect_ldap_password, mds_bootstrap_server_urls) }}"
   producer:
     enabled: true
     properties: "{{ kafka_broker_listeners[kafka_connect_kafka_listener_name] | client_properties(ssl_enabled, pkcs12_enabled, ssl_mutual_auth_enabled, sasl_protocol,
                             'producer.', kafka_connect_truststore_path, kafka_connect_truststore_storepass, kafka_connect_keystore_path, kafka_connect_keystore_storepass, kafka_connect_keystore_keypass,
                             rbac_enabled, sasl_plain_users.kafka_connect.principal, sasl_plain_users.kafka_connect.password, sasl_scram_users.kafka_connect.principal, sasl_scram_users.kafka_connect.password,
-                            kerberos_kafka_broker_primary|default('kafka'), kafka_connect_keytab_path, kafka_connect_kerberos_principal|default('kafka'),
+                            kerberos_kafka_broker_primary, kafka_connect_keytab_path, kafka_connect_kerberos_principal|default('kafka'),
                             false, kafka_connect_ldap_user, kafka_connect_ldap_password, mds_bootstrap_server_urls) }}"
   consumer:
     enabled: true
     properties: "{{ kafka_broker_listeners[kafka_connect_kafka_listener_name] | client_properties(ssl_enabled, pkcs12_enabled, ssl_mutual_auth_enabled, sasl_protocol,
                             'consumer.', kafka_connect_truststore_path, kafka_connect_truststore_storepass, kafka_connect_keystore_path, kafka_connect_keystore_storepass, kafka_connect_keystore_keypass,
                             rbac_enabled, sasl_plain_users.kafka_connect.principal, sasl_plain_users.kafka_connect.password, sasl_scram_users.kafka_connect.principal, sasl_scram_users.kafka_connect.password,
-                            kerberos_kafka_broker_primary|default('kafka'), kafka_connect_keytab_path, kafka_connect_kerberos_principal|default('kafka'),
+                            kerberos_kafka_broker_primary, kafka_connect_keytab_path, kafka_connect_kerberos_principal|default('kafka'),
                             false, kafka_connect_ldap_user, kafka_connect_ldap_password, mds_bootstrap_server_urls) }}"
   monitoring_interceptor:
     enabled: "{{ kafka_connect_monitoring_interceptors_enabled|bool }}"
@@ -571,14 +571,14 @@ kafka_connect_properties:
     properties: "{{ kafka_broker_listeners[kafka_connect_kafka_listener_name] | client_properties(ssl_enabled, pkcs12_enabled, ssl_mutual_auth_enabled, sasl_protocol,
                             'producer.confluent.monitoring.interceptor.', kafka_connect_truststore_path, kafka_connect_truststore_storepass, kafka_connect_keystore_path, kafka_connect_keystore_storepass, kafka_connect_keystore_keypass,
                             false, sasl_plain_users.kafka_connect.principal, sasl_plain_users.kafka_connect.password, sasl_scram_users.kafka_connect.principal, sasl_scram_users.kafka_connect.password,
-                            kerberos_kafka_broker_primary|default('kafka'), kafka_connect_keytab_path, kafka_connect_kerberos_principal|default('kafka'),
+                            kerberos_kafka_broker_primary, kafka_connect_keytab_path, kafka_connect_kerberos_principal|default('kafka'),
                             false, kafka_connect_ldap_user, kafka_connect_ldap_password, mds_bootstrap_server_urls) }}"
   consumer_monitoring_interceptor_client:
     enabled: "{{ kafka_connect_monitoring_interceptors_enabled|bool }}"
     properties: "{{ kafka_broker_listeners[kafka_connect_kafka_listener_name] | client_properties(ssl_enabled, pkcs12_enabled, ssl_mutual_auth_enabled, sasl_protocol,
                             'consumer.confluent.monitoring.interceptor.', kafka_connect_truststore_path, kafka_connect_truststore_storepass, kafka_connect_keystore_path, kafka_connect_keystore_storepass, kafka_connect_keystore_keypass,
                             false, sasl_plain_users.kafka_connect.principal, sasl_plain_users.kafka_connect.password, sasl_scram_users.kafka_connect.principal, sasl_scram_users.kafka_connect.password,
-                            kerberos_kafka_broker_primary|default('kafka'), kafka_connect_keytab_path, kafka_connect_kerberos_principal|default('kafka'),
+                            kerberos_kafka_broker_primary, kafka_connect_keytab_path, kafka_connect_kerberos_principal|default('kafka'),
                             false, kafka_connect_ldap_user, kafka_connect_ldap_password, mds_bootstrap_server_urls) }}"
   rbac:
     enabled: "{{rbac_enabled}}"
@@ -614,7 +614,7 @@ kafka_connect_properties:
     properties: "{{ kafka_broker_listeners[kafka_connect_kafka_listener_name] | client_properties(ssl_enabled, pkcs12_enabled, ssl_mutual_auth_enabled, sasl_protocol,
                             'config.providers.secret.param.kafkastore.', kafka_connect_truststore_path, kafka_connect_truststore_storepass, kafka_connect_keystore_path, kafka_connect_keystore_storepass, kafka_connect_keystore_keypass,
                             false, sasl_plain_users.kafka_connect.principal, sasl_plain_users.kafka_connect.password, sasl_scram_users.kafka_connect.principal, sasl_scram_users.kafka_connect.password,
-                            kerberos_kafka_broker_primary|default('kafka'), kafka_connect_keytab_path, kafka_connect_kerberos_principal|default('kafka'),
+                            kerberos_kafka_broker_primary, kafka_connect_keytab_path, kafka_connect_kerberos_principal|default('kafka'),
                             false, kafka_connect_ldap_user, kafka_connect_ldap_password, mds_bootstrap_server_urls) }}"
   telemetry:
     enabled: "{{kafka_connect_telemetry_enabled}}"
@@ -722,7 +722,7 @@ ksql_properties:
     enabled: "{{ kafka_broker_listeners[ksql_kafka_listener_name]['sasl_protocol'] | default(sasl_protocol) | normalize_sasl_protocol == 'GSSAPI' }}"
     properties:
       sasl.mechanism: GSSAPI
-      sasl.kerberos.service.name: "{{kerberos_kafka_broker_primary | default('kafka')}}"
+      sasl.kerberos.service.name: "{{kerberos_kafka_broker_primary}}"
       sasl.jaas.config: |-
         com.sun.security.auth.module.Krb5LoginModule required useKeyTab=true storeKey=true keyTab="{{ksql_keytab_path}}" principal="{{ksql_kerberos_principal | default('ksql')}}";
   kafka_sasl_oauth:
@@ -761,7 +761,7 @@ ksql_properties:
     properties: "{{ kafka_broker_listeners[ksql_kafka_listener_name] | client_properties(ssl_enabled, pkcs12_enabled, ssl_mutual_auth_enabled, sasl_protocol,
                             'confluent.monitoring.interceptor.', ksql_truststore_path, ksql_truststore_storepass, ksql_keystore_path, ksql_keystore_storepass, ksql_keystore_keypass,
                             false, sasl_plain_users.ksql.principal, sasl_plain_users.ksql.password, sasl_scram_users.ksql.principal, sasl_scram_users.ksql.password,
-                            kerberos_kafka_broker_primary|default('kafka'), ksql_keytab_path, ksql_kerberos_principal|default('ksql'),
+                            kerberos_kafka_broker_primary, ksql_keytab_path, ksql_kerberos_principal|default('ksql'),
                             false, ksql_ldap_user, ksql_ldap_password, mds_bootstrap_server_urls) }}"
   rbac:
     enabled: "{{rbac_enabled}}"
@@ -863,7 +863,7 @@ kafka_rest_properties:
     properties: "{{ kafka_broker_listeners[kafka_rest_kafka_listener_name] | client_properties(ssl_enabled, pkcs12_enabled, ssl_mutual_auth_enabled, sasl_protocol,
                             'client.', kafka_rest_truststore_path, kafka_rest_truststore_storepass, kafka_rest_keystore_path, kafka_rest_keystore_storepass, kafka_rest_keystore_keypass,
                             false, sasl_plain_users.kafka_rest.principal, sasl_plain_users.kafka_rest.password, sasl_scram_users.kafka_rest.principal, sasl_scram_users.kafka_rest.password,
-                            kerberos_kafka_broker_primary|default('kafka'), kafka_rest_keytab_path, kafka_rest_kerberos_principal|default('rp'),
+                            kerberos_kafka_broker_primary, kafka_rest_keytab_path, kafka_rest_kerberos_principal|default('rp'),
                             false, kafka_rest_ldap_user, kafka_rest_ldap_password, mds_bootstrap_server_urls) }}"
   kafka_client_password_protection:
     # Edge case for RP only- 'client' prefix not honored by secrets protection
@@ -895,7 +895,7 @@ kafka_rest_properties:
     properties: "{{ kafka_broker_listeners[kafka_rest_kafka_listener_name] | client_properties(ssl_enabled, pkcs12_enabled, ssl_mutual_auth_enabled, sasl_protocol,
                             'confluent.monitoring.interceptor.', kafka_rest_truststore_path, kafka_rest_truststore_storepass, kafka_rest_keystore_path, kafka_rest_keystore_storepass, kafka_rest_keystore_keypass,
                             false, sasl_plain_users.kafka_rest.principal, sasl_plain_users.kafka_rest.password, sasl_scram_users.kafka_rest.principal, sasl_scram_users.kafka_rest.password,
-                            kerberos_kafka_broker_primary|default('kafka'), kafka_rest_keytab_path, kafka_rest_kerberos_principal|default('rp'),
+                            kerberos_kafka_broker_primary, kafka_rest_keytab_path, kafka_rest_kerberos_principal|default('rp'),
                             false, kafka_rest_ldap_user, kafka_rest_ldap_password, mds_bootstrap_server_urls) }}"
   rbac:
     enabled: "{{rbac_enabled}}"
@@ -996,7 +996,7 @@ control_center_properties:
     properties: "{{ kafka_broker_listeners[control_center_kafka_listener_name] | client_properties(ssl_enabled, pkcs12_enabled, ssl_mutual_auth_enabled, sasl_protocol,
                             'confluent.controlcenter.streams.', control_center_truststore_path, control_center_truststore_storepass, control_center_keystore_path, control_center_keystore_storepass, control_center_keystore_keypass,
                             false, sasl_plain_users.control_center.principal, sasl_plain_users.control_center.password, sasl_scram_users.control_center.principal, sasl_scram_users.control_center.password,
-                            kerberos_kafka_broker_primary|default('kafka'), control_center_keytab_path, control_center_kerberos_principal|default('c3'),
+                            kerberos_kafka_broker_primary, control_center_keytab_path, control_center_kerberos_principal|default('c3'),
                             false, control_center_ldap_user, control_center_ldap_password, mds_bootstrap_server_urls) }}"
   sr:
     enabled: "{{ 'schema_registry' in groups }}"

--- a/sample_inventories/rbac_centralized_mds_kerberos_custom_certs_example.yml
+++ b/sample_inventories/rbac_centralized_mds_kerberos_custom_certs_example.yml
@@ -22,7 +22,6 @@ all:
 
     ## Kerberos Configuration
     sasl_protocol: kerberos
-    kerberos_kafka_broker_primary: kafka
     kerberos:
       realm: confluent.example.com
       kdc_hostname: ip-10-0-0-10.eu-west-2.compute.internal

--- a/sample_inventories/rbac_kerberos_custom_certs_example.yml
+++ b/sample_inventories/rbac_kerberos_custom_certs_example.yml
@@ -22,7 +22,6 @@ all:
 
     ## Kerberos Configuration
     sasl_protocol: kerberos
-    kerberos_kafka_broker_primary: kafka
     kerberos:
       realm: confluent.example.com
       kdc_hostname: ip-10-0-0-10.eu-west-2.compute.internal


### PR DESCRIPTION
# Description

The `kerberos_kafka_broker_primary` variable is not necessary since it can be pulled out of the `kafka_broker_kerberos_principal` variable

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Updated kerberos-rhel scenario to use non default primary value, added verify tasks


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible