### PR TITLE
55x cli install without curl

### DIFF
--- a/roles/confluent.common/tasks/main.yml
+++ b/roles/confluent.common/tasks/main.yml
@@ -47,11 +47,32 @@
     - jmxexporter_enabled|bool
     - not ansible_check_mode
 
-- name: Download Confluent CLI - Standard
-  shell: "curl -L https://cnfl.io/cli | sh -s -- -b {{ confluent_cli_path | dirname }}"
+# - name: Download Confluent CLI - Standard
+#   shell: "curl -L https://cnfl.io/cli | sh -s -- -b {{ confluent_cli_path | dirname }}"
+#   args:
+#     creates: "{{ confluent_cli_path }}"
+#   retries: 5
+#   when:
+#     - confluent_cli_download_enabled|bool
+#     - confluent_cli_custom_download_url is not defined
+
+- name: Download Confluent CLI Install Script - Standard
+  get_url:
+    url: https://cnfl.io/cli
+    dest: /tmp/install.sh
+    mode: 0755
+  when:
+    - confluent_cli_download_enabled|bool
+    - confluent_cli_custom_download_url is not defined
+
+- name: Install Confluent CLI - Standard
+  shell: "/tmp/install.sh -b {{ confluent_cli_path | dirname }}"
   args:
     creates: "{{ confluent_cli_path }}"
+  register: cli_download_result
+  until: cli_download_result is success
   retries: 5
+  delay: 5
   when:
     - confluent_cli_download_enabled|bool
     - confluent_cli_custom_download_url is not defined

--- a/roles/confluent.common/tasks/main.yml
+++ b/roles/confluent.common/tasks/main.yml
@@ -47,15 +47,6 @@
     - jmxexporter_enabled|bool
     - not ansible_check_mode
 
-# - name: Download Confluent CLI - Standard
-#   shell: "curl -L https://cnfl.io/cli | sh -s -- -b {{ confluent_cli_path | dirname }}"
-#   args:
-#     creates: "{{ confluent_cli_path }}"
-#   retries: 5
-#   when:
-#     - confluent_cli_download_enabled|bool
-#     - confluent_cli_custom_download_url is not defined
-
 - name: Download Confluent CLI Install Script - Standard
   get_url:
     url: https://cnfl.io/cli

--- a/roles/confluent.test/molecule/mtls-debian/molecule.yml
+++ b/roles/confluent.test/molecule/mtls-debian/molecule.yml
@@ -136,6 +136,8 @@ provisioner:
         jolokia_user: user1
         jolokia_password: pass
 
+        confluent_cli_download_enabled: true
+
 verifier:
   name: ansible
 lint: |

--- a/roles/confluent.test/molecule/mtls-debian/verify.yml
+++ b/roles/confluent.test/molecule/mtls-debian/verify.yml
@@ -180,3 +180,9 @@
         file_path: /etc/confluent-control-center/control-center-production.properties
         property: confluent.controlcenter.streams.security.protocol
         expected_value: SSL
+
+- name: Verify - CLI
+  hosts: all
+  gather_facts: false
+  tasks:
+    - shell: confluent --help


### PR DESCRIPTION
# Description

Noticing bugs trying to use curl to get the confluent cli install script, replacing curl with get_url module

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Added test to mtls-debian scenario which was not successfully installing the cli without the change


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible