### PR TITLE
Added additional permission for KSQL RBAC access for interactive queries

### DIFF
--- a/roles/confluent.ksql/tasks/rbac.yml
+++ b/roles/confluent.ksql/tasks/rbac.yml
@@ -52,7 +52,7 @@
       }
     status_code: 204
 
-- name: Grant ksql user the ResourceOwner role with three resourcePatterns
+- name: Grant ksql user the ResourceOwner role with four resourcePatterns
   uri:
     url: "{{mds_bootstrap_server_urls.split(',')[0]}}/security/1.0/principals/User:{{ksql_ldap_user}}/roles/ResourceOwner/bindings"
     method: POST
@@ -85,6 +85,11 @@
             "resourceType":"Group",
             "name":"_confluent-ksql-{{ksql_final_properties['ksql.service.id']}}",
             "patternType":"PREFIXED"
+          },
+          {
+            "resourceType":"Topic",
+            "name": "_confluent-ksql-{{ksql_final_properties['ksql.service.id']}}",
+            "patternType": "LITERAL"
           }
         ]
       }
@@ -116,9 +121,9 @@
       }
     status_code: 204
 
-- name: Grant ksql user the DeveloperRead role on resourceType Subject in Schema Registry Cluster
+- name: Grant ksql user the ResourceOwnder role on resourceType Subject in Schema Registry Cluster
   uri:
-    url: "{{mds_bootstrap_server_urls.split(',')[0]}}/security/1.0/principals/User:{{ksql_ldap_user}}/roles/DeveloperRead/bindings"
+    url: "{{mds_bootstrap_server_urls.split(',')[0]}}/security/1.0/principals/User:{{ksql_ldap_user}}/roles/ResourceOwner/bindings"
     method: POST
     validate_certs: false
     force_basic_auth: true

--- a/roles/confluent.ksql/tasks/rbac.yml
+++ b/roles/confluent.ksql/tasks/rbac.yml
@@ -121,7 +121,7 @@
       }
     status_code: 204
 
-- name: Grant ksql user the ResourceOwnder role on resourceType Subject in Schema Registry Cluster
+- name: Grant ksql user the ResourceOwner role on resourceType Subject in Schema Registry Cluster
   uri:
     url: "{{mds_bootstrap_server_urls.split(',')[0]}}/security/1.0/principals/User:{{ksql_ldap_user}}/roles/ResourceOwner/bindings"
     method: POST

--- a/roles/confluent.ksql/tasks/rbac.yml
+++ b/roles/confluent.ksql/tasks/rbac.yml
@@ -72,11 +72,6 @@
         },
         "resourcePatterns": [
           {
-            "resourceType": "Topic",
-            "name": "_confluent-ksql-{{ksql_final_properties['ksql.service.id']}}_command_topic",
-            "patternType":"LITERAL"
-          },
-          {
             "resourceType":"Topic",
             "name":"{{ksql_final_properties['ksql.service.id']}}-ksql_processing_log",
             "patternType":"LITERAL"
@@ -89,7 +84,7 @@
           {
             "resourceType":"Topic",
             "name": "_confluent-ksql-{{ksql_final_properties['ksql.service.id']}}",
-            "patternType": "LITERAL"
+            "patternType": "PREFIXED"
           }
         ]
       }


### PR DESCRIPTION
# Description

This PR corrects the following:

grant ResourceOwner on _confluent-ksql-<ksql-id>  topic (currently none)

grant ResourceOwner on _confluent-ksql-<ksql-id> subject (currently DeveloperRead)

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Successfully validated against rbac-scram-custom-rhel scenario.



# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible