### PR TITLE
Updated RBAC permissions for Connect to add Connect user as ResourceOwner

### DIFF
--- a/roles/confluent.kafka_connect/tasks/rbac.yml
+++ b/roles/confluent.kafka_connect/tasks/rbac.yml
@@ -82,6 +82,11 @@
                 "resourceType":"Topic",
                 "name":"{{kafka_connect_final_properties['status.storage.topic']}}",
                 "patternType":"LITERAL"
+              },
+              {
+                "resourceType":"Topic",
+                "name":"{{kafka_connect_final_properties['confluent.license.topic']}}",
+                "patternType":"LITERAL"
               }
             ]
           }

--- a/roles/confluent.variables/vars/main.yml
+++ b/roles/confluent.variables/vars/main.yml
@@ -496,6 +496,7 @@ kafka_connect_properties:
       bootstrap.servers: "{{ groups['kafka_broker'] | default(['localhost']) | join(':' + kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']|string + ',') }}:{{kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']}}"
       producer.bootstrap.servers: "{{ groups['kafka_broker'] | default(['localhost']) | join(':' + kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']|string + ',') }}:{{kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']}}"
       consumer.bootstrap.servers: "{{ groups['kafka_broker'] | default(['localhost']) | join(':' + kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']|string + ',') }}:{{kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']}}"
+      confluent.license.topic: _confluent-license
   ssl:
     enabled: "{{kafka_connect_ssl_enabled}}"
     properties:

--- a/roles/confluent.variables/vars/main.yml
+++ b/roles/confluent.variables/vars/main.yml
@@ -496,7 +496,7 @@ kafka_connect_properties:
       bootstrap.servers: "{{ groups['kafka_broker'] | default(['localhost']) | join(':' + kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']|string + ',') }}:{{kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']}}"
       producer.bootstrap.servers: "{{ groups['kafka_broker'] | default(['localhost']) | join(':' + kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']|string + ',') }}:{{kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']}}"
       consumer.bootstrap.servers: "{{ groups['kafka_broker'] | default(['localhost']) | join(':' + kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']|string + ',') }}:{{kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']}}"
-      confluent.license.topic: _confluent-license
+      confluent.license.topic: _confluent-command
   ssl:
     enabled: "{{kafka_connect_ssl_enabled}}"
     properties:


### PR DESCRIPTION

# Description

Proprietary Connectors for Confluent Platform require access to the licensing Topic in order to Operate.  This is accessed by the Connect user to validate the Connector is allowed to run.  

While we do document this on individual proprietary connectors, it's actually a setup step at the Connect Framework level, and not the Connector level and thus should be setup by default by CP-Ansible.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

I have validated by running with the rbac-kerberos-debian scenario and validated with the Kafka Connect team.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible