### PR TITLE
Updated ordered restart to support basic auth on jolokia.

### DIFF
--- a/tasks/create_ordered_kafka_groups.yml
+++ b/tasks/create_ordered_kafka_groups.yml
@@ -9,6 +9,9 @@
   uri:
     url: "{{ kafka_broker_jolokia_active_controller_url }}"
     validate_certs: false
+    force_basic_auth: true
+    url_username: "{{kafka_broker_jolokia_user}}"
+    url_password: "{{kafka_broker_jolokia_password}}"
     return_content: true
     status_code: 200
   register: active_controller_count_query


### PR DESCRIPTION
# Description

Added basic auth support to ordered restart logic in case user wishes to upgrade from one version of 5.5.x to another version of 5.5.x.

Fixes # (issue)

https://github.com/confluentinc/cp-ansible/issues/498

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Ran RBAC-MTLS-RHEL scenario and set to 5.5.0, manually upgraded to 5.5.3.


**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible