### PR TITLE
Create Jolokia and Prom JMX exporter directories based on jar path

### DIFF
--- a/roles/confluent.common/tasks/main.yml
+++ b/roles/confluent.common/tasks/main.yml
@@ -17,7 +17,7 @@
 
 - name: Create Jolokia directory
   file:
-    path: "{{ jolokia_jar_path | name }}"
+    path: "{{ jolokia_jar_path | dirname }}"
     state: directory
     mode: 0755
   when: jolokia_enabled|bool

--- a/roles/confluent.common/tasks/main.yml
+++ b/roles/confluent.common/tasks/main.yml
@@ -17,7 +17,7 @@
 
 - name: Create Jolokia directory
   file:
-    path: /opt/jolokia
+    path: "{{ jolokia_jar_path | name }}"
     state: directory
     mode: 0755
   when: jolokia_enabled|bool
@@ -33,7 +33,7 @@
 
 - name: Create Prometheus install directory
   file:
-    path: /opt/prometheus
+    path: "{{ jmxexporter_jar_path | dirname }}"
     state: directory
     mode: 0755
   when: jmxexporter_enabled|bool


### PR DESCRIPTION
# Description

Directories to place JARs are being created with hard-coded paths. Instead jar_paths can be used to create a proper directory if variables change.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible