### PR TITLE
[MINOR] Docs: Add comment about regenerate keystore/truststore

### DIFF
--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -246,7 +246,7 @@ Default:  true
 
 ### regenerate_keystore_and_truststore
 
-Boolean to have reruns of all.yml recreate Keystores
+Boolean to have reruns of all.yml recreate Keystores. Consider disabling this once installation is completed, as this triggers restarts.
 
 Default:  true
 

--- a/hosts_example.yml
+++ b/hosts_example.yml
@@ -55,6 +55,7 @@ all:
     # ssl_signed_cert_filepath: "/tmp/certs/{{inventory_hostname}}-signed.crt" # Can be a full chain of certs
     # ssl_key_filepath: "/tmp/certs/{{inventory_hostname}}-key.pem"
     # ssl_key_password: <password for key for each host, will be inputting in the form -passin pass:{{ssl_key_password}} >
+    # regenerate_keystore_and_truststore: true # Set to false once installation is finished to avoid triggering restarts.
     ## Option 2: Custom Keystores and Truststores
     ## CP-Ansible can move keystores/truststores to their corresponding hosts and configure the components to use them. Set These vars
     # ssl_provided_keystore_and_truststore: true

--- a/roles/confluent.variables/defaults/main.yml
+++ b/roles/confluent.variables/defaults/main.yml
@@ -116,7 +116,7 @@ ssl_self_signed_ca_password: capassword123
 ### Boolean to have reruns of all.yml regenerate the certificate authority used for self signed certs
 regenerate_ca: true
 
-### Boolean to have reruns of all.yml recreate Keystores
+### Boolean to have reruns of all.yml recreate Keystores. Consider disabling this once installation is completed, as this triggers restarts.
 regenerate_keystore_and_truststore: true
 
 certs_updated: false


### PR DESCRIPTION
As regeneration of keystore/truststore triggers restarts, this can be explicitly stated on the docs and example.