### PR TITLE
Rest Proxy Monitoring Interceptors Bugfix

### DIFF
--- a/roles/confluent.variables/vars/main.yml
+++ b/roles/confluent.variables/vars/main.yml
@@ -891,7 +891,7 @@ kafka_rest_properties:
   monitoring_interceptor_client:
     enabled: "{{ kafka_rest_monitoring_interceptors_enabled|bool }}"
     properties: "{{ kafka_broker_listeners[kafka_rest_kafka_listener_name] | client_properties(ssl_enabled, pkcs12_enabled, ssl_mutual_auth_enabled, sasl_protocol,
-                            'confluent.monitoring.interceptor.', kafka_rest_truststore_path, kafka_rest_truststore_storepass, kafka_rest_keystore_path, kafka_rest_keystore_storepass, kafka_rest_keystore_keypass,
+                            'client.confluent.monitoring.interceptor.', kafka_rest_truststore_path, kafka_rest_truststore_storepass, kafka_rest_keystore_path, kafka_rest_keystore_storepass, kafka_rest_keystore_keypass,
                             false, sasl_plain_users.kafka_rest.principal, sasl_plain_users.kafka_rest.password, sasl_scram_users.kafka_rest.principal, sasl_scram_users.kafka_rest.password,
                             kerberos_kafka_broker_primary|default('kafka'), kafka_rest_keytab_path, kafka_rest_kerberos_principal|default('rp'),
                             false, kafka_rest_ldap_user, kafka_rest_ldap_password, mds_bootstrap_server_urls) }}"


### PR DESCRIPTION
# Description

Monitoring interceptors are not configured for the license topic in Rest Proxy. This WARN log repeats indefinitely
```
WARN [Producer clientId=confluent.monitoring.interceptor.confluent-license-consumer] Bootstrap broker ip-172-30-30-215.eu-west-1.compute.internal:9092 (id: -3 rack: null) disconnected (org.apache.kafka.clients.NetworkClient)
```

According to [the docs](https://docs.confluent.io/platform/current/kafka-rest/production-deployment/rest-proxy/config.html)
> Use the client. prefix to override the default settings of admins, consumers and producers in Confluent REST Proxy

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Ran rbac-mtls-rhel molecule scenario and validated the logs

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible