### PR TITLE
Custom extension classes on Kafka Connect role

### DIFF
--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -966,7 +966,7 @@ Default:  "{{ ssl_mutual_auth_enabled }}"
 
 ### kafka_connect_custom_rest_extension_classes
 
-Additional set of extension classes
+Additional set of Connect extension classes.
 
 Default:  []
 
@@ -2281,4 +2281,3 @@ Key Size used by keytool -genkeypair command when creating Keystores. Only used 
 Default:  2048
 
 ***
-

--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -964,11 +964,11 @@ Default:  "{{ ssl_mutual_auth_enabled }}"
 
 ***
 
-### kafka_connect_extension_classes_custom
+### kafka_connect_custom_rest_extension_classes
 
-Additional set of comma-separated extension classes
+Additional set of extension classes
 
-Default:  ""
+Default:  []
 
 ***
 

--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -964,6 +964,14 @@ Default:  "{{ ssl_mutual_auth_enabled }}"
 
 ***
 
+### kafka_connect_extension_classes_custom
+
+Additional set of comma-separated extension classes
+
+Default:  ""
+
+***
+
 ### kafka_connect_jolokia_enabled
 
 Boolean to enable Jolokia Agent installation and configuration on Connect
@@ -2070,7 +2078,7 @@ Default:  "https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaa
 
 A path reference to a local archive file or URL. By default this is the URL from Confluent's repositories. In an ansible-pull deployment this could be set to a local file such as "~/.ansible/pull/{{inventory_hostname}}/{{confluent_archive_file_name}}".
 
-Default:  "{{confluent_common_repository_baseurl}}/archive/{{confluent_repo_version}}/confluent-{{confluent_package_version}}.tar.gz"
+Default:  "{{confluent_common_repository_baseurl}}/archive/{{confluent_repo_version}}/confluent{{'' if confluent_server_enabled else '-community'}}-{{confluent_package_version}}.tar.gz"
 
 ***
 

--- a/roles/confluent.test/molecule/rbac-scram-custom-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/rbac-scram-custom-rhel/molecule.yml
@@ -146,8 +146,8 @@ platforms:
     privileged: true
     ## Commenting below to avoid port collision on jenkins server
     ## Uncomment to view c3 in browser at localhost:9021
-    # published_ports:
-    #   - "9021:9021"
+    published_ports:
+      - "9021:9021"
     networks:
       - name: confluent${BUILD_NUMBER}
 provisioner:
@@ -223,6 +223,11 @@ provisioner:
           ldap.group.member.attribute.pattern: CN=(.*),OU=rbac,DC=example,DC=com
           ldap.user.object.class: account
           confluent.balancer.enable: "true"
+
+        kafka_connect_service_environment_overrides:
+          CLASSPATH: /usr/share/java/kafka-connect-replicator/*
+        kafka_connect_extension_classes_custom: io.confluent.connect.replicator.monitoring.ReplicatorMonitoringExtension
+        kafka_connect_custom_java_args: "-Djavax.net.ssl.trustStore={{kafka_connect_truststore_path}} -Djavax.net.ssl.trustStorePassword={{kafka_connect_truststore_storepass}}"
 
       ldap_server:
         ldaps_enabled: true

--- a/roles/confluent.test/molecule/rbac-scram-custom-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/rbac-scram-custom-rhel/molecule.yml
@@ -146,8 +146,8 @@ platforms:
     privileged: true
     ## Commenting below to avoid port collision on jenkins server
     ## Uncomment to view c3 in browser at localhost:9021
-    published_ports:
-      - "9021:9021"
+    #  published_ports:
+    #    - "9021:9021"
     networks:
       - name: confluent${BUILD_NUMBER}
 provisioner:

--- a/roles/confluent.test/molecule/rbac-scram-custom-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/rbac-scram-custom-rhel/molecule.yml
@@ -226,7 +226,8 @@ provisioner:
 
         kafka_connect_service_environment_overrides:
           CLASSPATH: /usr/share/java/kafka-connect-replicator/*
-        kafka_connect_extension_classes_custom: io.confluent.connect.replicator.monitoring.ReplicatorMonitoringExtension
+        kafka_connect_custom_rest_extension_classes:
+          - io.confluent.connect.replicator.monitoring.ReplicatorMonitoringExtension
         kafka_connect_custom_java_args: "-Djavax.net.ssl.trustStore={{kafka_connect_truststore_path}} -Djavax.net.ssl.trustStorePassword={{kafka_connect_truststore_storepass}}"
 
       ldap_server:

--- a/roles/confluent.variables/defaults/main.yml
+++ b/roles/confluent.variables/defaults/main.yml
@@ -529,6 +529,10 @@ kafka_connect_key_path: "/var/ssl/private/kafka_connect.key"
 kafka_connect_export_certs: "{{kafka_connect_ssl_mutual_auth_enabled}}"
 kafka_connect_keytab_path: /etc/security/keytabs/kafka_connect.keytab
 kafka_connect_kafka_listener_name: internal
+
+### Additional extension classes to be added to 
+kafka_connect_extension_classes_custom: ""
+
 kafka_connect:
   log4j_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/kafka/connect_distributed_log4j.properties"
   # Deprecated way of providing custom properties

--- a/roles/confluent.variables/defaults/main.yml
+++ b/roles/confluent.variables/defaults/main.yml
@@ -530,8 +530,8 @@ kafka_connect_export_certs: "{{kafka_connect_ssl_mutual_auth_enabled}}"
 kafka_connect_keytab_path: /etc/security/keytabs/kafka_connect.keytab
 kafka_connect_kafka_listener_name: internal
 
-### Additional set of comma-separated extension classes
-kafka_connect_extension_classes_custom: ""
+### Additional set of extension classes
+kafka_connect_custom_rest_extension_classes: []
 
 kafka_connect:
   log4j_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/kafka/connect_distributed_log4j.properties"

--- a/roles/confluent.variables/defaults/main.yml
+++ b/roles/confluent.variables/defaults/main.yml
@@ -530,7 +530,7 @@ kafka_connect_export_certs: "{{kafka_connect_ssl_mutual_auth_enabled}}"
 kafka_connect_keytab_path: /etc/security/keytabs/kafka_connect.keytab
 kafka_connect_kafka_listener_name: internal
 
-### Additional set of extension classes
+### Additional set of Connect extension classes.
 kafka_connect_custom_rest_extension_classes: []
 
 kafka_connect:

--- a/roles/confluent.variables/defaults/main.yml
+++ b/roles/confluent.variables/defaults/main.yml
@@ -530,7 +530,7 @@ kafka_connect_export_certs: "{{kafka_connect_ssl_mutual_auth_enabled}}"
 kafka_connect_keytab_path: /etc/security/keytabs/kafka_connect.keytab
 kafka_connect_kafka_listener_name: internal
 
-### Additional extension classes to be added to 
+### Additional set of comma-separated extension classes
 kafka_connect_extension_classes_custom: ""
 
 kafka_connect:

--- a/roles/confluent.variables/vars/main.yml
+++ b/roles/confluent.variables/vars/main.yml
@@ -504,8 +504,9 @@ kafka_connect_properties:
       producer.bootstrap.servers: "{{ groups['kafka_broker'] | default(['localhost']) | join(':' + kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']|string + ',') }}:{{kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']}}"
       consumer.bootstrap.servers: "{{ groups['kafka_broker'] | default(['localhost']) | join(':' + kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']|string + ',') }}:{{kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']}}"
       confluent.license.topic: _confluent-command
-    rest_classes:
-      enabled: "{{ kafka_connect_extension_classes_custom||length > 0 }}"
+  rest_classes:
+    enabled: "{{ kafka_connect_extension_classes_custom||length > 0 }}"
+    properties:
       rest.extension.classes: "{{ kafka_connect_extension_classes_custom }}"
   ssl:
     enabled: "{{kafka_connect_ssl_enabled}}"

--- a/roles/confluent.variables/vars/main.yml
+++ b/roles/confluent.variables/vars/main.yml
@@ -504,6 +504,7 @@ kafka_connect_properties:
       producer.bootstrap.servers: "{{ groups['kafka_broker'] | default(['localhost']) | join(':' + kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']|string + ',') }}:{{kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']}}"
       consumer.bootstrap.servers: "{{ groups['kafka_broker'] | default(['localhost']) | join(':' + kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']|string + ',') }}:{{kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']}}"
       confluent.license.topic: _confluent-command
+      rest.extension.classes: "{% if kafka_connect_extension_classes_custom | length >0 %}{{ kafka_connect_extension_classes_custom }}{% endif %}"
   ssl:
     enabled: "{{kafka_connect_ssl_enabled}}"
     properties:
@@ -580,7 +581,7 @@ kafka_connect_properties:
   rbac:
     enabled: "{{rbac_enabled}}"
     properties:
-      rest.extension.classes: "io.confluent.connect.security.ConnectSecurityExtension{% if kafka_connect_secret_registry_enabled|bool %},io.confluent.connect.secretregistry.ConnectSecretRegistryExtension{% endif %}"
+      rest.extension.classes: "{% if kafka_connect_extension_classes_custom | length >0 %}{{ kafka_connect_extension_classes_custom }},{% endif %}io.confluent.connect.security.ConnectSecurityExtension{% if kafka_connect_secret_registry_enabled|bool %},io.confluent.connect.secretregistry.ConnectSecretRegistryExtension{% endif %}"
       rest.servlet.initializor.classes: io.confluent.common.security.jetty.initializer.InstallBearerOrBasicSecurityHandler
       public.key.path: "{{rbac_enabled_public_pem_path}}"
       confluent.metadata.bootstrap.server.urls: "{{mds_bootstrap_server_urls}}"

--- a/roles/confluent.variables/vars/main.yml
+++ b/roles/confluent.variables/vars/main.yml
@@ -505,7 +505,7 @@ kafka_connect_properties:
       consumer.bootstrap.servers: "{{ groups['kafka_broker'] | default(['localhost']) | join(':' + kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']|string + ',') }}:{{kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']}}"
       confluent.license.topic: _confluent-command
   rest_classes:
-    enabled: "{{ kafka_connect_extension_classes_custom||length > 0 }}"
+    enabled: "{{ kafka_connect_extension_classes_custom|length > 0 }}"
     properties:
       rest.extension.classes: "{{ kafka_connect_extension_classes_custom }}"
   ssl:

--- a/roles/confluent.variables/vars/main.yml
+++ b/roles/confluent.variables/vars/main.yml
@@ -504,7 +504,9 @@ kafka_connect_properties:
       producer.bootstrap.servers: "{{ groups['kafka_broker'] | default(['localhost']) | join(':' + kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']|string + ',') }}:{{kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']}}"
       consumer.bootstrap.servers: "{{ groups['kafka_broker'] | default(['localhost']) | join(':' + kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']|string + ',') }}:{{kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']}}"
       confluent.license.topic: _confluent-command
-      rest.extension.classes: "{% if kafka_connect_extension_classes_custom | length >0 %}{{ kafka_connect_extension_classes_custom }}{% endif %}"
+    rest_classes:
+      enabled: "{{ kafka_connect_extension_classes_custom||length > 0 }}"
+      rest.extension.classes: "{{ kafka_connect_extension_classes_custom }}"
   ssl:
     enabled: "{{kafka_connect_ssl_enabled}}"
     properties:

--- a/roles/confluent.variables/vars/main.yml
+++ b/roles/confluent.variables/vars/main.yml
@@ -475,6 +475,12 @@ kafka_connect:
 
 kafka_connect_http_protocol: "{{ 'https' if kafka_connect_ssl_enabled|bool else 'http' }}"
 
+kafka_connect_rest_extension_classes:
+  - "{% if rbac_enabled|bool %}io.confluent.connect.security.ConnectSecurityExtension{% endif %}"
+  - "{% if kafka_connect_secret_registry_enabled|bool %},io.confluent.connect.secretregistry.ConnectSecretRegistryExtension{% endif %}"
+ 
+kafka_connect_final_rest_extension_classes: "{{kafka_connect_rest_extension_classes| difference(['']) + kafka_connect_custom_rest_extension_classes.split(',')}}"
+
 kafka_connect_properties:
   defaults:
     enabled: true
@@ -505,9 +511,13 @@ kafka_connect_properties:
       consumer.bootstrap.servers: "{{ groups['kafka_broker'] | default(['localhost']) | join(':' + kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']|string + ',') }}:{{kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']}}"
       confluent.license.topic: _confluent-command
   rest_classes:
+<<<<<<< HEAD
     enabled: "{{ kafka_connect_extension_classes_custom|length > 0 }}"
+=======
+    enabled: "{{ kafka_connect_final_rest_extension_classes|length > 0 }}"
+>>>>>>> 62861ce8 (use list to organize classes)
     properties:
-      rest.extension.classes: "{{ kafka_connect_extension_classes_custom }}"
+      rest.extension.classes: "{{ kafka_connect_final_rest_extension_classes.join(',') }}"
   ssl:
     enabled: "{{kafka_connect_ssl_enabled}}"
     properties:
@@ -584,7 +594,6 @@ kafka_connect_properties:
   rbac:
     enabled: "{{rbac_enabled}}"
     properties:
-      rest.extension.classes: "{% if kafka_connect_extension_classes_custom | length >0 %}{{ kafka_connect_extension_classes_custom }},{% endif %}io.confluent.connect.security.ConnectSecurityExtension{% if kafka_connect_secret_registry_enabled|bool %},io.confluent.connect.secretregistry.ConnectSecretRegistryExtension{% endif %}"
       rest.servlet.initializor.classes: io.confluent.common.security.jetty.initializer.InstallBearerOrBasicSecurityHandler
       public.key.path: "{{rbac_enabled_public_pem_path}}"
       confluent.metadata.bootstrap.server.urls: "{{mds_bootstrap_server_urls}}"

--- a/roles/confluent.variables/vars/main.yml
+++ b/roles/confluent.variables/vars/main.yml
@@ -477,9 +477,9 @@ kafka_connect_http_protocol: "{{ 'https' if kafka_connect_ssl_enabled|bool else 
 
 kafka_connect_rest_extension_classes:
   - "{% if rbac_enabled|bool %}io.confluent.connect.security.ConnectSecurityExtension{% endif %}"
-  - "{% if kafka_connect_secret_registry_enabled|bool %},io.confluent.connect.secretregistry.ConnectSecretRegistryExtension{% endif %}"
- 
-kafka_connect_final_rest_extension_classes: "{{kafka_connect_rest_extension_classes| difference(['']) + kafka_connect_custom_rest_extension_classes.split(',')}}"
+  - "{% if kafka_connect_secret_registry_enabled|bool %}io.confluent.connect.secretregistry.ConnectSecretRegistryExtension{% endif %}"
+
+kafka_connect_final_rest_extension_classes: "{{(kafka_connect_rest_extension_classes|difference(['']) + kafka_connect_custom_rest_extension_classes) | unique}}"
 
 kafka_connect_properties:
   defaults:
@@ -511,13 +511,9 @@ kafka_connect_properties:
       consumer.bootstrap.servers: "{{ groups['kafka_broker'] | default(['localhost']) | join(':' + kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']|string + ',') }}:{{kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']}}"
       confluent.license.topic: _confluent-command
   rest_classes:
-<<<<<<< HEAD
-    enabled: "{{ kafka_connect_extension_classes_custom|length > 0 }}"
-=======
     enabled: "{{ kafka_connect_final_rest_extension_classes|length > 0 }}"
->>>>>>> 62861ce8 (use list to organize classes)
     properties:
-      rest.extension.classes: "{{ kafka_connect_final_rest_extension_classes.join(',') }}"
+      rest.extension.classes: "{{ kafka_connect_final_rest_extension_classes | join(',') }}"
   ssl:
     enabled: "{{kafka_connect_ssl_enabled}}"
     properties:


### PR DESCRIPTION
# Description

To deploy Confluent Replicator in a Connector cluster, monitoring extensions have to be added. Currently, this configuration is only modified when RBAC is enabled. 

This PR proposes a new variables to be concatenated when defined.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

**Test Configuration**: molecule/rbac-scram-custom-rhel

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible