### PR TITLE
Add test for ksql tls v1.2

### DIFF
--- a/roles/confluent.test/molecule/rbac-mtls-rhel/verify.yml
+++ b/roles/confluent.test/molecule/rbac-mtls-rhel/verify.yml
@@ -44,41 +44,19 @@
         fail_msg: "Super Users property: {{super_users_grep.stdout}} does not contain User:dom and User:jeff"
         quiet: true
 
-    - import_role:
+    - include_role:
         name: confluent.test
         tasks_from: check_tls_version.yml
       vars:
-        service_port: 8090
+        service_port: "{{item}}"
         service_ca: /var/ssl/private/ca.crt
         service_cert: /var/ssl/private/kafka_broker.crt
         service_key: /var/ssl/private/kafka_broker.key
-
-    - import_role:
-        name: confluent.test
-        tasks_from: check_tls_version.yml
-      vars:
-        service_port: 9091
-        service_ca: /var/ssl/private/ca.crt
-        service_cert: /var/ssl/private/kafka_broker.crt
-        service_key: /var/ssl/private/kafka_broker.key
-
-    - import_role:
-        name: confluent.test
-        tasks_from: check_tls_version.yml
-      vars:
-        service_port: 9092
-        service_ca: /var/ssl/private/ca.crt
-        service_cert: /var/ssl/private/kafka_broker.crt
-        service_key: /var/ssl/private/kafka_broker.key
-
-    - import_role:
-        name: confluent.test
-        tasks_from: check_tls_version.yml
-      vars:
-        service_port: 9093
-        service_ca: /var/ssl/private/ca.crt
-        service_cert: /var/ssl/private/kafka_broker.crt
-        service_key: /var/ssl/private/kafka_broker.key
+      loop:
+        - 8090
+        - 9091
+        - 9092
+        - 9093
 
 - name: Verify - schema_registry
   hosts: schema_registry
@@ -244,8 +222,15 @@
         file_path: /etc/ksqldb/ksql-server.properties
         property: public.key.path
         expected_value: /var/ssl/private/public.pem
-    # TODO:  KSQL Currently still supports older TLS versions, and as of 6.0.0 does not have way to override to TLS 1.2 or later.
-    # Will have to update this in the future when this is corrected.
+
+    - import_role:
+        name: confluent.test
+        tasks_from: check_tls_version.yml
+      vars:
+        service_port: 8088
+        service_ca: /var/ssl/private/ca.crt
+        service_cert: /var/ssl/private/kafka_connect.crt
+        service_key: /var/ssl/private/kafka_connect.key
 
 - name: Verify - control_center
   hosts: control_center


### PR DESCRIPTION
# Description

Added verify task to in rbac-mtls-rhel
It appears tlsv1.2 is turned on by default for ksql in 6.0.1

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?


rbac-mtls-rhel suceeds

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible