### PR TITLE
Allow for customization of the Unit section of systemd service files

### DIFF
--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -2120,6 +2120,30 @@ Default:  ""
 
 ***
 
+### control_center_service_overrides
+
+Overrides to the Service Section of Control Center Systemd File. This variable is a dictionary.
+
+Default: 
+
+***
+
+### control_center_service_environment_overrides
+
+Environment Variables to be added to the Control Center Service. This variable is a dictionary.
+
+Default: 
+
+***
+
+### control_center_service_unit_overrides
+
+Overrides to the Unit Section of Control Center Systemd File. This variable is a dictionary.
+
+Default: 
+
+***
+
 # confluent.kafka_broker
 
 Below are the supported variables for the role confluent.kafka_broker
@@ -2139,6 +2163,30 @@ Default:  "{{ custom_log4j }}"
 Custom Java Args to add to the Kafka Process
 
 Default:  ""
+
+***
+
+### kafka_broker_service_overrides
+
+Overrides to the Service Section of Kafka Systemd File. This variable is a dictionary.
+
+Default: 
+
+***
+
+### kafka_broker_service_environment_overrides
+
+Environment Variables to be added to the Kafka Service. This variable is a dictionary.
+
+Default: 
+
+***
+
+### kafka_broker_service_unit_overrides
+
+Overrides to the Unit Section of Kafka Systemd File. This variable is a dictionary.
+
+Default: 
 
 ***
 
@@ -2164,6 +2212,30 @@ Default:  ""
 
 ***
 
+### kafka_connect_service_overrides
+
+Overrides to the Service Section of Connect Systemd File. This variable is a dictionary.
+
+Default: 
+
+***
+
+### kafka_connect_service_environment_overrides
+
+Environment Variables to be added to the Connect Service. This variable is a dictionary.
+
+Default: 
+
+***
+
+### kafka_connect_service_unit_overrides
+
+Overrides to the Unit Section of Connect Systemd File. This variable is a dictionary.
+
+Default: 
+
+***
+
 # confluent.kafka_rest
 
 Below are the supported variables for the role confluent.kafka_rest
@@ -2183,6 +2255,30 @@ Default:  "{{ custom_log4j }}"
 Custom Java Args to add to the Rest Proxy Process
 
 Default:  ""
+
+***
+
+### kafka_rest_service_overrides
+
+Overrides to the Service Section of Rest Proxy Systemd File. This variable is a dictionary.
+
+Default: 
+
+***
+
+### kafka_rest_service_environment_overrides
+
+Environment Variables to be added to the Rest Proxy Service. This variable is a dictionary.
+
+Default: 
+
+***
+
+### kafka_rest_service_unit_overrides
+
+Overrides to the Unit Section of Rest Proxy Systemd File. This variable is a dictionary.
+
+Default: 
 
 ***
 
@@ -2216,6 +2312,30 @@ Default:  /tmp/ksqldb
 
 ***
 
+### ksql_service_overrides
+
+Overrides to the Service Section of ksqlDB Systemd File. This variable is a dictionary.
+
+Default: 
+
+***
+
+### ksql_service_environment_overrides
+
+Environment Variables to be added to the ksqlDB Service. This variable is a dictionary.
+
+Default: 
+
+***
+
+### ksql_service_unit_overrides
+
+Overrides to the Unit Section of ksqlDB Systemd File. This variable is a dictionary.
+
+Default: 
+
+***
+
 # confluent.schema_registry
 
 Below are the supported variables for the role confluent.schema_registry
@@ -2235,6 +2355,30 @@ Default:  "{{ custom_log4j }}"
 Custom Java Args to add to the Schema Registry Process
 
 Default:  ""
+
+***
+
+### schema_registry_service_overrides
+
+Overrides to the Service Section of Schema Registry Systemd File. This variable is a dictionary.
+
+Default: 
+
+***
+
+### schema_registry_service_environment_overrides
+
+Environment Variables to be added to the Schema Registry Service. This variable is a dictionary.
+
+Default: 
+
+***
+
+### schema_registry_service_unit_overrides
+
+Overrides to the Unit Section of Schema Registry Systemd File. This variable is a dictionary.
+
+Default: 
 
 ***
 
@@ -2260,6 +2404,30 @@ Default:  ""
 
 ***
 
+### zookeeper_service_overrides
+
+Overrides to the Service Section of Zookeeper Systemd File. This variable is a dictionary.
+
+Default: 
+
+***
+
+### zookeeper_service_environment_overrides
+
+Environment Variables to be added to the Zookeeper Service. This variable is a dictionary.
+
+Default: 
+
+***
+
+### zookeeper_service_unit_overrides
+
+Overrides to the Unit Section of Zookeeper Systemd File. This variable is a dictionary.
+
+Default: 
+
+***
+
 # confluent.ssl
 
 Below are the supported variables for the role confluent.ssl
@@ -2281,3 +2449,4 @@ Key Size used by keytool -genkeypair command when creating Keystores. Only used 
 Default:  2048
 
 ***
+

--- a/roles/confluent.control_center/defaults/main.yml
+++ b/roles/confluent.control_center/defaults/main.yml
@@ -15,7 +15,7 @@ control_center_final_java_args: "{{ control_center_java_args + [ control_center_
 ### Full Path to the RocksDB Data Directory. If left as empty string, cp-ansible will not configure RocksDB
 control_center_rocksdb_path: ""
 
-# For following dictionaries, Key/Value Pairs of with empty values will not be written into override.conf
+# For following dictionaries, Key/Value Pairs with empty values will not be written into override.conf
 
 ### Overrides to the Service Section of Control Center Systemd File. This variable is a dictionary.
 control_center_service_overrides:

--- a/roles/confluent.control_center/defaults/main.yml
+++ b/roles/confluent.control_center/defaults/main.yml
@@ -15,12 +15,15 @@ control_center_final_java_args: "{{ control_center_java_args + [ control_center_
 ### Full Path to the RocksDB Data Directory. If left as empty string, cp-ansible will not configure RocksDB
 control_center_rocksdb_path: ""
 
-# Empty values will not be written into override.conf
+# For following dictionaries, Key/Value Pairs of with empty values will not be written into override.conf
+
+### Overrides to the Service Section of Control Center Systemd File. This variable is a dictionary.
 control_center_service_overrides:
   User: "{{ control_center_user if control_center_user != control_center_default_user else '' }}"
   Group: "{{ control_center_group if control_center_group != control_center_default_group else '' }}"
   ExecStart: "{% if installation_method == 'archive' %}{{ control_center.server_start_file }} {{ control_center.config_file }}{% endif %}"
 
+### Environment Variables to be added to the Control Center Service. This variable is a dictionary.
 control_center_service_environment_overrides:
   ROCKSDB_SHAREDLIB_DIR: "{{control_center_rocksdb_path}}"
   CONTROL_CENTER_HEAP_OPTS: "-Xmx6g"
@@ -28,6 +31,9 @@ control_center_service_environment_overrides:
   CONTROL_CENTER_LOG4J_OPTS: "{% if control_center_custom_log4j|bool %}-Dlog4j.configuration=file:{{control_center.log4j_file}}{% endif %}"
   CONFLUENT_SECURITY_MASTER_KEY: "{% if control_center_secrets_protection_enabled|bool %}{{secrets_protection_masterkey}}{% endif %}"
   LOG_DIR: "{% if control_center_custom_log4j|bool %}{{control_center.appender_log_path}}{% endif %}"
+
+### Overrides to the Unit Section of Control Center Systemd File. This variable is a dictionary.
+control_center_service_unit_overrides:
 
 control_center:
   appender_log_path: /var/log/confluent/control-center/

--- a/roles/confluent.control_center/templates/override.conf.j2
+++ b/roles/confluent.control_center/templates/override.conf.j2
@@ -1,3 +1,12 @@
+{% if control_center_service_unit_overrides %}
+[Unit]
+{% for key, value in control_center_service_unit_overrides.items() %}
+{% if value %}
+{{key}}={{value}}
+{% endif %}
+{% endfor %}
+
+{% endif %}
 [Service]
 {% for key, value in control_center_service_overrides.items() %}
 {% if value %}

--- a/roles/confluent.kafka_broker/defaults/main.yml
+++ b/roles/confluent.kafka_broker/defaults/main.yml
@@ -19,7 +19,7 @@ kafka_broker_custom_java_args: ""
 
 kafka_broker_final_java_args: "{{ kafka_broker_java_args + [ kafka_broker_custom_java_args ] }}"
 
-# For following dictionaries, Key/Value Pairs of with empty values will not be written into override.conf
+# For following dictionaries, Key/Value Pairs with empty values will not be written into override.conf
 
 ### Overrides to the Service Section of Kafka Systemd File. This variable is a dictionary.
 kafka_broker_service_overrides:

--- a/roles/confluent.kafka_broker/defaults/main.yml
+++ b/roles/confluent.kafka_broker/defaults/main.yml
@@ -19,18 +19,24 @@ kafka_broker_custom_java_args: ""
 
 kafka_broker_final_java_args: "{{ kafka_broker_java_args + [ kafka_broker_custom_java_args ] }}"
 
-# Key/Value Pairs with empty values will not be written into override.conf
+# For following dictionaries, Key/Value Pairs of with empty values will not be written into override.conf
+
+### Overrides to the Service Section of Kafka Systemd File. This variable is a dictionary.
 kafka_broker_service_overrides:
   User: "{{ kafka_broker_user if kafka_broker_user != kafka_broker_default_user else '' }}"
   Group: "{{ kafka_broker_group if kafka_broker_group != kafka_broker_default_group else '' }}"
   ExecStart: "{% if installation_method == 'archive' %}{{ kafka_broker.server_start_file }} {{ kafka_broker.config_file }}{% endif %}"
 
+### Environment Variables to be added to the Kafka Service. This variable is a dictionary.
 kafka_broker_service_environment_overrides:
   KAFKA_HEAP_OPTS: "-Xms6g -Xmx6g -XX:MetaspaceSize=96m -XX:+UseG1GC -XX:MaxGCPauseMillis=20 -XX:InitiatingHeapOccupancyPercent=35 -XX:G1HeapRegionSize=16M -XX:MinMetaspaceFreeRatio=50 -XX:MaxMetaspaceFreeRatio=80"
   KAFKA_OPTS: "{{ kafka_broker_final_java_args | java_arg_build_out }}"
   KAFKA_LOG4J_OPTS: "{% if kafka_broker_custom_log4j|bool %}-Dlog4j.configuration=file:{{kafka_broker.log4j_file}}{% endif %}"
   LOG_DIR: "{% if kafka_broker_custom_log4j|bool %}{{kafka_broker.appender_log_path}}{% endif %}"
   CONFLUENT_SECURITY_MASTER_KEY: "{% if kafka_broker_secrets_protection_enabled|bool %}{{secrets_protection_masterkey}}{% endif %}"
+
+### Overrides to the Unit Section of Kafka Systemd File. This variable is a dictionary.
+kafka_broker_service_unit_overrides:
 
 kafka_broker_sysctl:
   vm.swappiness: 1

--- a/roles/confluent.kafka_broker/templates/override.conf.j2
+++ b/roles/confluent.kafka_broker/templates/override.conf.j2
@@ -1,3 +1,12 @@
+{% if kafka_broker_service_unit_overrides %}
+[Unit]
+{% for key, value in kafka_broker_service_unit_overrides.items() %}
+{% if value %}
+{{key}}={{value}}
+{% endif %}
+{% endfor %}
+
+{% endif %}
 [Service]
 {% for key, value in kafka_broker_service_overrides.items() %}
 {% if value %}

--- a/roles/confluent.kafka_connect/defaults/main.yml
+++ b/roles/confluent.kafka_connect/defaults/main.yml
@@ -14,19 +14,25 @@ kafka_connect_custom_java_args: ""
 
 kafka_connect_final_java_args: "{{ kafka_connect_java_args + [ kafka_connect_custom_java_args ] }}"
 
-# Key/Value Pairs with empty values will not be written into override.conf
+# For following dictionaries, Key/Value Pairs of with empty values will not be written into override.conf
+
+### Overrides to the Service Section of Connect Systemd File. This variable is a dictionary.
 kafka_connect_service_overrides:
   LimitNOFILE: 100000
   User: "{{ kafka_connect_user if kafka_connect_user != kafka_connect_default_user else '' }}"
   Group: "{{ kafka_connect_group if kafka_connect_group != kafka_connect_default_group else '' }}"
   ExecStart: "{% if installation_method == 'archive' %}{{ kafka_connect.server_start_file }} {{ kafka_connect.config_file }}{% endif %}"
 
+### Environment Variables to be added to the Connect Service. This variable is a dictionary.
 kafka_connect_service_environment_overrides:
   KAFKA_HEAP_OPTS: "-Xms256M -Xmx2G"
   KAFKA_OPTS: "{{ kafka_connect_final_java_args | java_arg_build_out }}"
   LOG_DIR: "{% if kafka_connect_custom_log4j|bool %}{{kafka_connect.appender_log_path}}{% endif %}"
   KAFKA_LOG4J_OPTS: "{% if kafka_connect_custom_log4j|bool %}-Dlog4j.configuration=file:{{kafka_connect.log4j_file}}{% endif %}"
   CONFLUENT_SECURITY_MASTER_KEY: "{% if kafka_connect_secrets_protection_enabled|bool %}{{secrets_protection_masterkey}}{% endif %}"
+
+### Overrides to the Unit Section of Connect Systemd File. This variable is a dictionary.
+kafka_connect_service_unit_overrides:
 
 kafka_connect:
   appender_log_path: /var/log/kafka/

--- a/roles/confluent.kafka_connect/defaults/main.yml
+++ b/roles/confluent.kafka_connect/defaults/main.yml
@@ -14,7 +14,7 @@ kafka_connect_custom_java_args: ""
 
 kafka_connect_final_java_args: "{{ kafka_connect_java_args + [ kafka_connect_custom_java_args ] }}"
 
-# For following dictionaries, Key/Value Pairs of with empty values will not be written into override.conf
+# For following dictionaries, Key/Value Pairs with empty values will not be written into override.conf
 
 ### Overrides to the Service Section of Connect Systemd File. This variable is a dictionary.
 kafka_connect_service_overrides:

--- a/roles/confluent.kafka_connect/templates/override.conf.j2
+++ b/roles/confluent.kafka_connect/templates/override.conf.j2
@@ -1,3 +1,12 @@
+{% if kafka_connect_service_unit_overrides %}
+[Unit]
+{% for key, value in kafka_connect_service_unit_overrides.items() %}
+{% if value %}
+{{key}}={{value}}
+{% endif %}
+{% endfor %}
+
+{% endif %}
 [Service]
 {% for key, value in kafka_connect_service_overrides.items() %}
 {% if value %}

--- a/roles/confluent.kafka_rest/defaults/main.yml
+++ b/roles/confluent.kafka_rest/defaults/main.yml
@@ -14,18 +14,24 @@ kafka_rest_custom_java_args: ""
 
 kafka_rest_final_java_args: "{{ kafka_rest_java_args + [ kafka_rest_custom_java_args ] }}"
 
-# Key/Value Pairs with empty values will not be written into override.conf
+# For following dictionaries, Key/Value Pairs of with empty values will not be written into override.conf
+
+### Overrides to the Service Section of Rest Proxy Systemd File. This variable is a dictionary.
 kafka_rest_service_overrides:
   User: "{{ kafka_rest_user if kafka_rest_user != kafka_rest_default_user else '' }}"
   Group: "{{ kafka_rest_group if kafka_rest_group != kafka_rest_default_group else '' }}"
   ExecStart: "{% if installation_method == 'archive' %}{{ kafka_rest.server_start_file }} {{ kafka_rest.config_file }}{% endif %}"
 
+### Environment Variables to be added to the Rest Proxy Service. This variable is a dictionary.
 kafka_rest_service_environment_overrides:
   LOG_DIR: "{% if kafka_rest_custom_log4j|bool %}{{kafka_rest.appender_log_path}}{% endif %}"
   KAFKAREST_LOG4J_OPTS: "{% if kafka_rest_custom_log4j|bool %}-Dlog4j.configuration=file:{{kafka_rest.log4j_file}}{% endif %}"
   KAFKAREST_HEAP_OPTS: "-Xms1g -Xmx1g -XX:MetaspaceSize=96m -XX:+UseG1GC -XX:MaxGCPauseMillis=20 -XX:InitiatingHeapOccupancyPercent=35 -XX:G1HeapRegionSize=16M -XX:MinMetaspaceFreeRatio=50 -XX:MaxMetaspaceFreeRatio=80"
   KAFKAREST_OPTS: "{{ kafka_rest_final_java_args | java_arg_build_out }}"
   CONFLUENT_SECURITY_MASTER_KEY: "{% if kafka_rest_secrets_protection_enabled|bool %}{{secrets_protection_masterkey}}{% endif %}"
+
+### Overrides to the Unit Section of Rest Proxy Systemd File. This variable is a dictionary.
+kafka_rest_service_unit_overrides:
 
 kafka_rest:
   appender_log_path: /var/log/rest-proxy/

--- a/roles/confluent.kafka_rest/defaults/main.yml
+++ b/roles/confluent.kafka_rest/defaults/main.yml
@@ -14,7 +14,7 @@ kafka_rest_custom_java_args: ""
 
 kafka_rest_final_java_args: "{{ kafka_rest_java_args + [ kafka_rest_custom_java_args ] }}"
 
-# For following dictionaries, Key/Value Pairs of with empty values will not be written into override.conf
+# For following dictionaries, Key/Value Pairs with empty values will not be written into override.conf
 
 ### Overrides to the Service Section of Rest Proxy Systemd File. This variable is a dictionary.
 kafka_rest_service_overrides:

--- a/roles/confluent.kafka_rest/templates/override.conf.j2
+++ b/roles/confluent.kafka_rest/templates/override.conf.j2
@@ -1,3 +1,12 @@
+{% if kafka_rest_service_unit_overrides %}
+[Unit]
+{% for key, value in kafka_rest_service_unit_overrides.items() %}
+{% if value %}
+{{key}}={{value}}
+{% endif %}
+{% endfor %}
+
+{% endif %}
 [Service]
 {% for key, value in kafka_rest_service_overrides.items() %}
 {% if value %}

--- a/roles/confluent.ksql/defaults/main.yml
+++ b/roles/confluent.ksql/defaults/main.yml
@@ -17,7 +17,7 @@ ksql_final_java_args: "{{ ksql_java_args + [ ksql_custom_java_args ] }}"
 ### Full Path to the RocksDB Data Directory. If set as empty string, cp-ansible will not configure RocksDB
 ksql_rocksdb_path: /tmp/ksqldb
 
-# For following dictionaries, Key/Value Pairs of with empty values will not be written into override.conf
+# For following dictionaries, Key/Value Pairs with empty values will not be written into override.conf
 
 ### Overrides to the Service Section of ksqlDB Systemd File. This variable is a dictionary.
 ksql_service_overrides:

--- a/roles/confluent.ksql/defaults/main.yml
+++ b/roles/confluent.ksql/defaults/main.yml
@@ -17,13 +17,16 @@ ksql_final_java_args: "{{ ksql_java_args + [ ksql_custom_java_args ] }}"
 ### Full Path to the RocksDB Data Directory. If set as empty string, cp-ansible will not configure RocksDB
 ksql_rocksdb_path: /tmp/ksqldb
 
-# Key/Value Pairs with empty values will not be written into override.conf
+# For following dictionaries, Key/Value Pairs of with empty values will not be written into override.conf
+
+### Overrides to the Service Section of ksqlDB Systemd File. This variable is a dictionary.
 ksql_service_overrides:
   LimitNOFILE: 100000
   User: "{{ ksql_user if ksql_user != ksql_default_user else '' }}"
   Group: "{{ ksql_group if ksql_group != ksql_default_group else '' }}"
   ExecStart: "{% if installation_method == 'archive' %}{{ ksql.server_start_file }} {{ ksql.config_file }}{% endif %}"
 
+### Environment Variables to be added to the ksqlDB Service. This variable is a dictionary.
 ksql_service_environment_overrides:
   KSQL_HEAP_OPTS: "-Xmx3g"
   KSQL_OPTS: "{{ ksql_final_java_args | java_arg_build_out }}"
@@ -31,6 +34,9 @@ ksql_service_environment_overrides:
   KSQL_LOG4J_OPTS: "{% if ksql_custom_log4j|bool %}-Dlog4j.configuration=file:{{ksql.log4j_file}}{% endif %}"
   LOG_DIR: "{% if ksql_custom_log4j|bool %}{{ksql.appender_log_path}}{% endif %}"
   ROCKSDB_SHAREDLIB_DIR: "{{ksql_rocksdb_path}}"
+
+### Overrides to the Unit Section of ksqlDB Systemd File. This variable is a dictionary.
+ksql_service_unit_overrides:
 
 ksql:
   appender_log_path: /var/log/confluent/ksql/

--- a/roles/confluent.ksql/templates/override.conf.j2
+++ b/roles/confluent.ksql/templates/override.conf.j2
@@ -1,3 +1,12 @@
+{% if ksql_service_unit_overrides %}
+[Unit]
+{% for key, value in ksql_service_unit_overrides.items() %}
+{% if value %}
+{{key}}={{value}}
+{% endif %}
+{% endfor %}
+
+{% endif %}
 [Service]
 {% for key, value in ksql_service_overrides.items() %}
 {% if value %}

--- a/roles/confluent.schema_registry/defaults/main.yml
+++ b/roles/confluent.schema_registry/defaults/main.yml
@@ -14,7 +14,7 @@ schema_registry_custom_java_args: ""
 
 schema_registry_final_java_args: "{{ schema_registry_java_args + [ schema_registry_custom_java_args ] }}"
 
-# For following dictionaries, Key/Value Pairs of with empty values will not be written into override.conf
+# For following dictionaries, Key/Value Pairs with empty values will not be written into override.conf
 
 ### Overrides to the Service Section of Schema Registry Systemd File. This variable is a dictionary.
 schema_registry_service_overrides:

--- a/roles/confluent.schema_registry/defaults/main.yml
+++ b/roles/confluent.schema_registry/defaults/main.yml
@@ -14,19 +14,25 @@ schema_registry_custom_java_args: ""
 
 schema_registry_final_java_args: "{{ schema_registry_java_args + [ schema_registry_custom_java_args ] }}"
 
-# Key/Value Pairs with empty values will not be written into override.conf
+# For following dictionaries, Key/Value Pairs of with empty values will not be written into override.conf
+
+### Overrides to the Service Section of Schema Registry Systemd File. This variable is a dictionary.
 schema_registry_service_overrides:
   LimitNOFILE: 100000
   User: "{{ schema_registry_user if schema_registry_user != schema_registry_default_user else '' }}"
   Group: "{{ schema_registry_group if schema_registry_group != schema_registry_default_group else '' }}"
   ExecStart: "{% if installation_method == 'archive' %}{{ schema_registry.server_start_file }} {{ schema_registry.config_file }}{% endif %}"
 
+### Environment Variables to be added to the Schema Registry Service. This variable is a dictionary.
 schema_registry_service_environment_overrides:
   SCHEMA_REGISTRY_HEAP_OPTS: "-Xms1g -Xmx1g -XX:MetaspaceSize=96m -XX:+UseG1GC -XX:MaxGCPauseMillis=20 -XX:InitiatingHeapOccupancyPercent=35 -XX:G1HeapRegionSize=16M -XX:MinMetaspaceFreeRatio=50 -XX:MaxMetaspaceFreeRatio=80"
   SCHEMA_REGISTRY_OPTS: "{{ schema_registry_final_java_args | java_arg_build_out }}"
   CONFLUENT_SECURITY_MASTER_KEY: "{% if schema_registry_secrets_protection_enabled|bool %}{{secrets_protection_masterkey}}{% endif %}"
   SCHEMA_REGISTRY_LOG4J_OPTS: "{% if schema_registry_custom_log4j|bool %}-Dlog4j.configuration=file:{{schema_registry.log4j_file}}{% endif %}"
   LOG_DIR: "{% if schema_registry_custom_log4j|bool %}{{schema_registry.appender_log_path}}{% endif %}"
+
+### Overrides to the Unit Section of Schema Registry Systemd File. This variable is a dictionary.
+schema_registry_service_unit_overrides:
 
 schema_registry:
   appender_log_path: /var/log/confluent/schema-registry/

--- a/roles/confluent.schema_registry/templates/override.conf.j2
+++ b/roles/confluent.schema_registry/templates/override.conf.j2
@@ -1,3 +1,12 @@
+{% if schema_registry_service_unit_overrides %}
+[Unit]
+{% for key, value in schema_registry_service_unit_overrides.items() %}
+{% if value %}
+{{key}}={{value}}
+{% endif %}
+{% endfor %}
+
+{% endif %}
 [Service]
 {% for key, value in schema_registry_service_overrides.items() %}
 {% if value %}

--- a/roles/confluent.test/molecule/plain-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/plain-rhel/molecule.yml
@@ -111,6 +111,24 @@ provisioner:
               file: "/etc/kafka/connect-distributed.properties"
               topics: "test_topic"
 
+        zookeeper_service_unit_overrides:
+          Description: Custom Zookeeper description
+
+        kafka_broker_service_unit_overrides:
+          Description: Custom Kafka description
+
+        kafka_connect_service_unit_overrides:
+          Description: Custom Connect description
+
+        kafka_rest_service_unit_overrides:
+          Description: Custom Rest Proxy description
+
+        ksql_service_unit_overrides:
+          Description: Custom KSQLDB description
+
+        control_center_service_unit_overrides:
+          Description: Custom C3 description
+
 verifier:
   name: ansible
 lint: |

--- a/roles/confluent.test/molecule/plain-rhel/verify.yml
+++ b/roles/confluent.test/molecule/plain-rhel/verify.yml
@@ -1,4 +1,14 @@
 ---
+- name: Verify - zookeeper
+  hosts: zookeeper
+  gather_facts: false
+  tasks:
+    - name: Check Updated Service Description
+      shell: systemctl status confluent-zookeeper
+      register: systemctl_status
+      failed_when: "'Custom Zookeeper description' not in systemctl_status.stdout_lines[0]"
+      changed_when: false
+
 - name: Verify - kafka_broker
   hosts: kafka_broker
   gather_facts: false

--- a/roles/confluent.test/molecule/plain-rhel/verify.yml
+++ b/roles/confluent.test/molecule/plain-rhel/verify.yml
@@ -19,6 +19,12 @@
         property: transaction.state.log.min.isr
         expected_value: "1"
 
+    - name: Check Updated Service Description
+      shell: systemctl status confluent-server
+      register: systemctl_status
+      failed_when: "'Custom Kafka description' not in systemctl_status.stdout_lines[0]"
+      changed_when: false
+
 - name: Verify - schema_registry
   hosts: schema_registry
   gather_facts: false
@@ -30,6 +36,12 @@
         file_path: /etc/schema-registry/schema-registry.properties
         property: kafkastore.security.protocol
         expected_value: SASL_PLAINTEXT
+
+    - name: Check Original Service Description
+      shell: systemctl status confluent-schema-registry
+      register: systemctl_status
+      failed_when: "'RESTful Avro schema registry for Apache Kafka' not in systemctl_status.stdout_lines[0]"
+      changed_when: false
 
 - name: Verify - kafka_rest
   hosts: kafka_rest
@@ -43,6 +55,12 @@
         property: client.security.protocol
         expected_value: SASL_PLAINTEXT
 
+    - name: Check Updated Service Description
+      shell: systemctl status confluent-kafka-rest
+      register: systemctl_status
+      failed_when: "'Custom Rest Proxy description' not in systemctl_status.stdout_lines[0]"
+      changed_when: false
+
 - name: Verify - kafka_connect
   hosts: kafka_connect
   gather_facts: false
@@ -54,6 +72,12 @@
         file_path: /etc/kafka/connect-distributed.properties
         property: security.protocol
         expected_value: SASL_PLAINTEXT
+
+    - name: Check Updated Service Description
+      shell: systemctl status confluent-kafka-connect
+      register: systemctl_status
+      failed_when: "'Custom Connect description' not in systemctl_status.stdout_lines[0]"
+      changed_when: false
 
     - name: Get Connectors on connect cluster1
       uri:
@@ -81,6 +105,12 @@
         property: security.protocol
         expected_value: SASL_PLAINTEXT
 
+    - name: Check Updated Service Description
+      shell: systemctl status confluent-ksqldb
+      register: systemctl_status
+      failed_when: "'Custom KSQLDB description' not in systemctl_status.stdout_lines[0]"
+      changed_when: false
+
 - name: Verify - control_center
   hosts: control_center
   gather_facts: false
@@ -92,3 +122,9 @@
         file_path: /etc/confluent-control-center/control-center-production.properties
         property: confluent.controlcenter.streams.security.protocol
         expected_value: SASL_PLAINTEXT
+
+    - name: Check Updated Service Description
+      shell: systemctl status confluent-control-center
+      register: systemctl_status
+      failed_when: "'Custom C3 description' not in systemctl_status.stdout_lines[0]"
+      changed_when: false

--- a/roles/confluent.zookeeper/defaults/main.yml
+++ b/roles/confluent.zookeeper/defaults/main.yml
@@ -15,7 +15,7 @@ zookeeper_custom_java_args: ""
 
 zookeeper_final_java_args: "{{ zookeeper_java_args + [ zookeeper_custom_java_args ] }}"
 
-# For following dictionaries, Key/Value Pairs of with empty values will not be written into override.conf
+# For following dictionaries, Key/Value Pairs with empty values will not be written into override.conf
 
 ### Overrides to the Service Section of Zookeeper Systemd File. This variable is a dictionary.
 zookeeper_service_overrides:

--- a/roles/confluent.zookeeper/defaults/main.yml
+++ b/roles/confluent.zookeeper/defaults/main.yml
@@ -15,17 +15,23 @@ zookeeper_custom_java_args: ""
 
 zookeeper_final_java_args: "{{ zookeeper_java_args + [ zookeeper_custom_java_args ] }}"
 
-# Key/Value Pairs with empty values will not be written into override.conf
+# For following dictionaries, Key/Value Pairs of with empty values will not be written into override.conf
+
+### Overrides to the Service Section of Zookeeper Systemd File. This variable is a dictionary.
 zookeeper_service_overrides:
   User: "{{ zookeeper_user if zookeeper_user != zookeeper_default_user else '' }}"
   Group: "{{ zookeeper_group if zookeeper_group != zookeeper_default_group else '' }}"
   ExecStart: "{% if installation_method == 'archive' %}{{ zookeeper.server_start_file }} {{ zookeeper.config_file }}{% endif %}"
 
+### Environment Variables to be added to the Zookeeper Service. This variable is a dictionary.
 zookeeper_service_environment_overrides:
   KAFKA_HEAP_OPTS: "-Xmx1g"
   KAFKA_OPTS: "{{ zookeeper_final_java_args | java_arg_build_out }}"
   KAFKA_LOG4J_OPTS: "{% if zookeeper_custom_log4j|bool %}-Dlog4j.configuration=file:{{zookeeper.log4j_file}}{% endif %}"
   LOG_DIR: "{% if zookeeper_custom_log4j|bool %}{{zookeeper.log_path}}{% endif %}"
+
+### Overrides to the Unit Section of Zookeeper Systemd File. This variable is a dictionary.
+zookeeper_service_unit_overrides:
 
 zookeeper:
   log_path: /var/log/kafka/

--- a/roles/confluent.zookeeper/templates/override.conf.j2
+++ b/roles/confluent.zookeeper/templates/override.conf.j2
@@ -1,3 +1,12 @@
+{% if zookeeper_service_unit_overrides %}
+[Unit]
+{% for key, value in zookeeper_service_unit_overrides.items() %}
+{% if value %}
+{{key}}={{value}}
+{% endif %}
+{% endfor %}
+
+{% endif %}
 [Service]
 {% for key, value in zookeeper_service_overrides.items() %}
 {% if value %}


### PR DESCRIPTION
# Description

Introduces new variables for each component to customize systemd unit section. Feature not used on most installs.
Improved docs around other override.conf dictionaries

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

added test to plain-rhel


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible