### PR TITLE
Archivepath

### DIFF
--- a/roles/confluent.kafka_broker/tasks/main.yml
+++ b/roles/confluent.kafka_broker/tasks/main.yml
@@ -186,27 +186,15 @@
   when: "'GSSAPI' in kafka_broker_sasl_enabled_mechanisms or zookeeper_sasl_protocol in ['kerberos', 'digest']"
   notify: restart kafka
 
-- name: Create SCRAM Users - Standard
+- name: Create SCRAM Users
   shell: |
-    kafka-configs --zookeeper localhost:{{zookeeper_final_properties.clientPort}} --alter \
+    {{ binary_base_path }}/bin/kafka-configs --zookeeper localhost:{{zookeeper_final_properties.clientPort}} --alter \
       --add-config 'SCRAM-SHA-512=[password={{ item.value['password'] }}]' \
       --entity-type users --entity-name {{ item.value['principal'] }}
   loop: "{{ sasl_scram_users|dict2items }}"
   delegate_to: "{{ groups['zookeeper'][0] }}"
   run_once: true
-  when: "'SCRAM-SHA-512' in kafka_broker_sasl_enabled_mechanisms" and not installation_method == "archive"
-
-- name: Create SCRAM Users - Archive
-  shell: |
-    kafka-configs --zookeeper localhost:{{zookeeper_final_properties.clientPort}} --alter \
-      --add-config 'SCRAM-SHA-512=[password={{ item.value['password'] }}]' \
-      --entity-type users --entity-name {{ item.value['principal'] }}
-  loop: "{{ sasl_scram_users|dict2items }}"
-  delegate_to: "{{ groups['zookeeper'][0] }}"
-  run_once: true
-  environment:
-    PATH: "{{archive_destination_path}}/confluent-{{confluent_package_version}}/bin:{{ ansible_env.PATH }}"
-  when: "'SCRAM-SHA-512' in kafka_broker_sasl_enabled_mechanisms" and installation_method == "archive"
+  when: "'SCRAM-SHA-512' in kafka_broker_sasl_enabled_mechanisms"
 
 - name: Deploy JMX Exporter Config File
   copy:

--- a/roles/confluent.kafka_broker/tasks/main.yml
+++ b/roles/confluent.kafka_broker/tasks/main.yml
@@ -186,7 +186,7 @@
   when: "'GSSAPI' in kafka_broker_sasl_enabled_mechanisms or zookeeper_sasl_protocol in ['kerberos', 'digest']"
   notify: restart kafka
 
-- name: Create SCRAM Users
+- name: Create SCRAM Users - Standard
   shell: |
     kafka-configs --zookeeper localhost:{{zookeeper_final_properties.clientPort}} --alter \
       --add-config 'SCRAM-SHA-512=[password={{ item.value['password'] }}]' \
@@ -194,7 +194,19 @@
   loop: "{{ sasl_scram_users|dict2items }}"
   delegate_to: "{{ groups['zookeeper'][0] }}"
   run_once: true
-  when: "'SCRAM-SHA-512' in kafka_broker_sasl_enabled_mechanisms"
+  when: "'SCRAM-SHA-512' in kafka_broker_sasl_enabled_mechanisms" and not installation_method == "archive"
+
+- name: Create SCRAM Users - Archive
+  shell: |
+    kafka-configs --zookeeper localhost:{{zookeeper_final_properties.clientPort}} --alter \
+      --add-config 'SCRAM-SHA-512=[password={{ item.value['password'] }}]' \
+      --entity-type users --entity-name {{ item.value['principal'] }}
+  loop: "{{ sasl_scram_users|dict2items }}"
+  delegate_to: "{{ groups['zookeeper'][0] }}"
+  run_once: true
+  environment:
+    PATH: "{{archive_destination_path}}/confluent-{{confluent_package_version}}/bin:{{ ansible_env.PATH }}"
+  when: "'SCRAM-SHA-512' in kafka_broker_sasl_enabled_mechanisms" and installation_method == "archive"
 
 - name: Deploy JMX Exporter Config File
   copy:


### PR DESCRIPTION
# Description

When installing Confluent platform as archive and enable SCRAM, playbook fails creating scram users because kafka-configs is not in the path.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

**Test Configuration**:

OS: RHEL7
Install method: Archive
Variables to set in hosts file to reproduce the issue:
```
confluent_archive_file_remote: false
confluent_archive_file_source: "/tmp/confluent-6.0.1.tar.gz" # local path on Ansible host where you downloaded the archive
sasl_protocol: scram
```

**Proposed fix**:
Prepend the `kafka-configs` command with the `binary_base_path` internal variable because it is [declared](https://github.com/confluentinc/cp-ansible/blob/daf14ea207be4fc09f43191b154a21713bfaccca/roles/confluent.variables/vars/main.yml#L1066) to use the Confluent archive path or `/usr` by default and it can be possibly overriden as per documentation in VARIABLES.md
# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible