### PR TITLE
Path needs to accommodate for tar install

### DIFF
--- a/roles/confluent.kafka_broker/tasks/health_check.yml
+++ b/roles/confluent.kafka_broker/tasks/health_check.yml
@@ -1,7 +1,7 @@
 ---
 - name: Get Topics with UnderReplicatedPartitions
   shell: |
-    kafka-topics --bootstrap-server {{inventory_hostname}}:{{kafka_broker_listeners[kafka_broker_inter_broker_listener_name]['port']}} \
+    {{ binary_base_path }}/bin/kafka-topics --bootstrap-server {{inventory_hostname}}:{{kafka_broker_listeners[kafka_broker_inter_broker_listener_name]['port']}} \
       --describe --under-replicated-partitions --command-config {{kafka_broker.client_config_file}}
   register: topics
   # stdout_lines will have topics with URPs and stderr has WARN and ERROR level logs

--- a/roles/confluent.test/molecule/mtls-custombundle-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/mtls-custombundle-rhel/molecule.yml
@@ -133,7 +133,6 @@ provisioner:
         secrets_protection_security_file: "roles/confluent.test/molecule/{{scenario_name}}/security.properties"
         kafka_broker_secrets_protection_encrypt_properties: [advertised.listeners, broker.id]
         schema_registry_secrets_protection_encrypt_properties: [ssl.keystore.location]
-        ksql_secrets_protection_enabled: false
         kafka_rest_secrets_protection_encrypt_passwords: false
         kafka_rest_secrets_protection_encrypt_properties: [listeners, bootstrap.servers]
 

--- a/roles/confluent.test/molecule/mtls-custombundle-rhel/verify.yml
+++ b/roles/confluent.test/molecule/mtls-custombundle-rhel/verify.yml
@@ -104,14 +104,14 @@
         property: ssl.keystore.location
         expected_value: /var/ssl/private/ksql.keystore.jks
 
-    - name: Secrets Protection Disabled for KSQL, property should be unmasked
+    - name: Secrets Protection Test
       import_role:
         name: confluent.test
         tasks_from: check_property.yml
       vars:
         file_path: /etc/ksqldb/ksql-server.properties
         property: ssl.truststore.password
-        expected_value: confluenttruststorepass
+        expected_value: ${securepass:/var/ssl/private/security.properties:ksql-server.properties/ssl.truststore.password}
 
 - name: Verify - control_center
   hosts: control_center

--- a/roles/confluent.test/molecule/mtls-custombundle-rhel/verify.yml
+++ b/roles/confluent.test/molecule/mtls-custombundle-rhel/verify.yml
@@ -104,6 +104,15 @@
         property: ssl.keystore.location
         expected_value: /var/ssl/private/ksql.keystore.jks
 
+    - name: Secrets Protection Disabled for KSQL, property should be unmasked
+      import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: /etc/ksqldb/ksql-server.properties
+        property: ssl.truststore.password
+        expected_value: confluenttruststorepass
+
 - name: Verify - control_center
   hosts: control_center
   gather_facts: false

--- a/roles/confluent.test/molecule/mtls-customcerts-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/mtls-customcerts-rhel/molecule.yml
@@ -125,8 +125,6 @@ provisioner:
       all:
         scenario_name: mtls-customcerts-rhel
 
-        confluent_server_enabled: false
-
         ssl_enabled: true
         ssl_mutual_auth_enabled: true
 


### PR DESCRIPTION
# Description

- Kafka Health check uses full path for kafka-topics command to support both package and tar installation
- mtls-custom-bundle testing scenario now passing, verify tasks did not match the variables getting set
- mtls-custom-certs testing scenario now passing, there was a confluent-server test

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

archive-plain-rhel 
and rbac-scram-custom-rhel scenario should test both install modes


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible