### PR TITLE
More 6.1.x Bugfixes

### DIFF
--- a/control_center.yml
+++ b/control_center.yml
@@ -11,11 +11,13 @@
     - name: Check if Kafka Service Running
       shell: "systemctl show -p SubState {{control_center_service_name}}"
       changed_when: false
+      # On some SELinux enabled hosts this command will error out, handled in next set_fact task
+      failed_when: false
       check_mode: false
       register: substate
 
     - set_fact:
-        install_pattern: "{{ 'parallel' if substate.stdout != 'SubState=running' or control_center_deployment_strategy == 'parallel' else 'serial' }}"
+        install_pattern: "{{ 'parallel' if substate.stdout != 'SubState=running' or substate.rc == 1 or control_center_deployment_strategy == 'parallel' else 'serial' }}"
 
     - name: "Group Hosts by Installation Pattern: Parallel or Serial"
       group_by:

--- a/kafka_broker.yml
+++ b/kafka_broker.yml
@@ -11,11 +11,13 @@
     - name: Check if Kafka Service Running
       shell: "systemctl show -p SubState {{kafka_broker_service_name}}"
       changed_when: false
+      # On some SELinux enabled hosts this command will error out, handled in next set_fact task
+      failed_when: false
       check_mode: false
       register: substate
 
     - set_fact:
-        install_pattern: "{{ 'parallel' if substate.stdout != 'SubState=running' or kafka_broker_deployment_strategy == 'parallel' else 'serial' }}"
+        install_pattern: "{{ 'parallel' if substate.stdout != 'SubState=running' or substate.rc == 1 or kafka_broker_deployment_strategy == 'parallel' else 'serial' }}"
 
     - name: "Group Hosts by Installation Pattern: Parallel or Serial"
       group_by:

--- a/kafka_connect.yml
+++ b/kafka_connect.yml
@@ -11,11 +11,13 @@
     - name: Check if Kafka Service Running
       shell: "systemctl show -p SubState {{kafka_connect_service_name}}"
       changed_when: false
+      # On some SELinux enabled hosts this command will error out, handled in next set_fact task
+      failed_when: false
       check_mode: false
       register: substate
 
     - set_fact:
-        install_pattern: "{{ 'parallel' if substate.stdout != 'SubState=running' or kafka_connect_deployment_strategy == 'parallel' else 'serial' }}"
+        install_pattern: "{{ 'parallel' if substate.stdout != 'SubState=running' or substate.rc == 1 or kafka_connect_deployment_strategy == 'parallel' else 'serial' }}"
 
     - name: "Group Hosts by Installation Pattern: Parallel or Serial"
       group_by:

--- a/kafka_connect_replicator.yml
+++ b/kafka_connect_replicator.yml
@@ -11,11 +11,13 @@
     - name: Check if Kafka Service Running
       shell: "systemctl show -p SubState {{kafka_connect_replicator_service_name}}"
       changed_when: false
+      # On some SELinux enabled hosts this command will error out, handled in next set_fact task
+      failed_when: false
       check_mode: false
       register: substate
 
     - set_fact:
-        install_pattern: "{{ 'parallel' if substate.stdout != 'SubState=running' or kafka_connect_replicator_deployment_strategy == 'parallel' else 'serial' }}"
+        install_pattern: "{{ 'parallel' if substate.stdout != 'SubState=running' or substate.rc == 1 or kafka_connect_replicator_deployment_strategy == 'parallel' else 'serial' }}"
 
     - name: "Group Hosts by Installation Pattern: Parallel or Serial"
       group_by:

--- a/kafka_rest.yml
+++ b/kafka_rest.yml
@@ -11,11 +11,13 @@
     - name: Check if Kafka Service Running
       shell: "systemctl show -p SubState {{kafka_rest_service_name}}"
       changed_when: false
+      # On some SELinux enabled hosts this command will error out, handled in next set_fact task
+      failed_when: false
       check_mode: false
       register: substate
 
     - set_fact:
-        install_pattern: "{{ 'parallel' if substate.stdout != 'SubState=running' or kafka_rest_deployment_strategy == 'parallel' else 'serial' }}"
+        install_pattern: "{{ 'parallel' if substate.stdout != 'SubState=running' or substate.rc == 1 or kafka_rest_deployment_strategy == 'parallel' else 'serial' }}"
 
     - name: "Group Hosts by Installation Pattern: Parallel or Serial"
       group_by:

--- a/ksql.yml
+++ b/ksql.yml
@@ -11,11 +11,13 @@
     - name: Check if Kafka Service Running
       shell: "systemctl show -p SubState {{ksql_service_name}}"
       changed_when: false
+      # On some SELinux enabled hosts this command will error out, handled in next set_fact task
+      failed_when: false
       check_mode: false
       register: substate
 
     - set_fact:
-        install_pattern: "{{ 'parallel' if substate.stdout != 'SubState=running' or ksql_deployment_strategy == 'parallel' else 'serial' }}"
+        install_pattern: "{{ 'parallel' if substate.stdout != 'SubState=running' or substate.rc == 1 or ksql_deployment_strategy == 'parallel' else 'serial' }}"
 
     - name: "Group Hosts by Installation Pattern: Parallel or Serial"
       group_by:

--- a/roles/confluent.control_center/defaults/main.yml
+++ b/roles/confluent.control_center/defaults/main.yml
@@ -26,7 +26,7 @@ control_center_service_environment_overrides:
   CONTROL_CENTER_HEAP_OPTS: "-Xmx6g"
   CONTROL_CENTER_OPTS: "{{ control_center_final_java_args | java_arg_build_out }}"
   # Remove trailing slash if there is one
-  LOG_DIR: "{{ control_center_log_dir|regex_replace('\\/$', '') if control_center_log_dir|regex_replace('\\/$', '') != control_center_default_log_dir else '' }}"
+  LOG_DIR: "{{ control_center_log_dir|regex_replace('\\/$', '') }}"
   CONFLUENT_SECURITY_MASTER_KEY: "{% if control_center_secrets_protection_enabled|bool %}{{secrets_protection_masterkey}}{% endif %}"
 
 ### Overrides to the Unit Section of Control Center Systemd File. This variable is a dictionary.

--- a/roles/confluent.kafka_broker/defaults/main.yml
+++ b/roles/confluent.kafka_broker/defaults/main.yml
@@ -32,7 +32,7 @@ kafka_broker_service_environment_overrides:
   KAFKA_HEAP_OPTS: "-Xms6g -Xmx6g -XX:MetaspaceSize=96m -XX:+UseG1GC -XX:MaxGCPauseMillis=20 -XX:InitiatingHeapOccupancyPercent=35 -XX:G1HeapRegionSize=16M -XX:MinMetaspaceFreeRatio=50 -XX:MaxMetaspaceFreeRatio=80"
   KAFKA_OPTS: "{{ kafka_broker_final_java_args | java_arg_build_out }}"
   # Remove trailing slash if there is one
-  LOG_DIR: "{{ kafka_broker_log_dir|regex_replace('\\/$', '') if kafka_broker_log_dir|regex_replace('\\/$', '') != kafka_broker_default_log_dir else '' }}"
+  LOG_DIR: "{{ kafka_broker_log_dir|regex_replace('\\/$', '') }}"
   CONFLUENT_SECURITY_MASTER_KEY: "{% if kafka_broker_secrets_protection_enabled|bool %}{{secrets_protection_masterkey}}{% endif %}"
 
 ### Overrides to the Unit Section of Kafka Systemd File. This variable is a dictionary.

--- a/roles/confluent.kafka_connect/defaults/main.yml
+++ b/roles/confluent.kafka_connect/defaults/main.yml
@@ -28,7 +28,7 @@ kafka_connect_service_environment_overrides:
   KAFKA_HEAP_OPTS: "-Xms256M -Xmx2G"
   KAFKA_OPTS: "{{ kafka_connect_final_java_args | java_arg_build_out }}"
   # Remove trailing slash if there is one
-  LOG_DIR: "{{ kafka_connect_log_dir|regex_replace('\\/$', '') if kafka_connect_log_dir|regex_replace('\\/$', '') != kafka_connect_default_log_dir else '' }}"
+  LOG_DIR: "{{ kafka_connect_log_dir|regex_replace('\\/$', '') }}"
   CONFLUENT_SECURITY_MASTER_KEY: "{% if kafka_connect_secrets_protection_enabled|bool %}{{secrets_protection_masterkey}}{% endif %}"
 
 ### Overrides to the Unit Section of Connect Systemd File. This variable is a dictionary.

--- a/roles/confluent.kafka_rest/defaults/main.yml
+++ b/roles/confluent.kafka_rest/defaults/main.yml
@@ -24,7 +24,7 @@ kafka_rest_service_environment_overrides:
   KAFKAREST_HEAP_OPTS: "-Xms1g -Xmx1g -XX:MetaspaceSize=96m -XX:+UseG1GC -XX:MaxGCPauseMillis=20 -XX:InitiatingHeapOccupancyPercent=35 -XX:G1HeapRegionSize=16M -XX:MinMetaspaceFreeRatio=50 -XX:MaxMetaspaceFreeRatio=80"
   KAFKAREST_OPTS: "{{ kafka_rest_final_java_args | java_arg_build_out }}"
   # Remove trailing slash if there is one
-  LOG_DIR: "{{ kafka_rest_log_dir|regex_replace('\\/$', '') if kafka_rest_log_dir|regex_replace('\\/$', '') != kafka_rest_default_log_dir else '' }}"
+  LOG_DIR: "{{ kafka_rest_log_dir|regex_replace('\\/$', '') }}"
   CONFLUENT_SECURITY_MASTER_KEY: "{% if kafka_rest_secrets_protection_enabled|bool %}{{secrets_protection_masterkey}}{% endif %}"
 
 ### Overrides to the Unit Section of Rest Proxy Systemd File. This variable is a dictionary.

--- a/roles/confluent.ksql/defaults/main.yml
+++ b/roles/confluent.ksql/defaults/main.yml
@@ -32,7 +32,7 @@ ksql_service_environment_overrides:
   KSQL_OPTS: "{{ ksql_final_java_args | java_arg_build_out }}"
   KSQL_LOG4J_OPTS: "{% if ksql_custom_log4j|bool %}-Dlog4j.configuration=file:{{ ksql.log4j_file }}{% endif %}"
   # Remove trailing slash if there is one
-  LOG_DIR: "{{ ksql_log_dir|regex_replace('\\/$', '') if ksql_log_dir|regex_replace('\\/$', '') != ksql_default_log_dir else '' }}"
+  LOG_DIR: "{{ ksql_log_dir|regex_replace('\\/$', '') }}"
   CONFLUENT_SECURITY_MASTER_KEY: "{% if ksql_secrets_protection_enabled|bool %}{{secrets_protection_masterkey}}{% endif %}"
   ROCKSDB_SHAREDLIB_DIR: "{{ksql_rocksdb_path}}"
 

--- a/roles/confluent.ksql/tasks/rbac.yml
+++ b/roles/confluent.ksql/tasks/rbac.yml
@@ -198,7 +198,7 @@
         "resourcePatterns": [
           {
             "resourceType":"Topic",
-            "name":"{{ksql.properties['ksql.service.id']}}processing_log",
+            "name":"{{ksql_final_properties['ksql.service.id']}}processing_log",
             "patternType":"LITERAL"
           }
         ]

--- a/roles/confluent.ksql/templates/ksql-server_log4j.properties.j2
+++ b/roles/confluent.ksql/templates/ksql-server_log4j.properties.j2
@@ -82,7 +82,7 @@ log4j.appender.kafka_appender.ClientJaasConf=org.apache.kafka.common.security.sc
 log4j.appender.kafka_appender.SaslMechanism=GSSAPI
 log4j.appender.kafka_appender.SaslKerberosServiceName={{kerberos_kafka_broker_primary}}
 log4j.appender.kafka_appender.clientJaasConf=com.sun.security.auth.module.Krb5LoginModule required \
-   useKeyTab=true storeKey=true keyTab="{{kerberos.keytab_dir}}/{{ksql_kerberos_keytab_path | basename}}" \
+   useKeyTab=true storeKey=true keyTab="{{ksql_keytab_path}}" \
    principal="{{ksql_kerberos_principal}}" serviceName="{{kerberos_kafka_broker_primary}}";
 {% endif %}
 {% endif %}

--- a/roles/confluent.schema_registry/defaults/main.yml
+++ b/roles/confluent.schema_registry/defaults/main.yml
@@ -25,7 +25,7 @@ schema_registry_service_environment_overrides:
   SCHEMA_REGISTRY_HEAP_OPTS: "-Xms1g -Xmx1g -XX:MetaspaceSize=96m -XX:+UseG1GC -XX:MaxGCPauseMillis=20 -XX:InitiatingHeapOccupancyPercent=35 -XX:G1HeapRegionSize=16M -XX:MinMetaspaceFreeRatio=50 -XX:MaxMetaspaceFreeRatio=80"
   SCHEMA_REGISTRY_OPTS: "{{ schema_registry_final_java_args | java_arg_build_out }}"
   # Remove trailing slash if there is one
-  LOG_DIR: "{{ schema_registry_log_dir|regex_replace('\\/$', '') if schema_registry_log_dir|regex_replace('\\/$', '') != schema_registry_default_log_dir else '' }}"
+  LOG_DIR: "{{ schema_registry_log_dir|regex_replace('\\/$', '') }}"
   CONFLUENT_SECURITY_MASTER_KEY: "{% if schema_registry_secrets_protection_enabled|bool %}{{secrets_protection_masterkey}}{% endif %}"
 
 ### Overrides to the Unit Section of Schema Registry Systemd File. This variable is a dictionary.

--- a/roles/confluent.test/molecule/confluent-kafka-kerberos-customcerts-rhel/verify.yml
+++ b/roles/confluent.test/molecule/confluent-kafka-kerberos-customcerts-rhel/verify.yml
@@ -15,7 +15,7 @@
         name: confluent.test
         tasks_from: check_package.yml
       vars:
-        package_name: confluent-kafka-2.12.noarch
+        package_name: confluent-kafka.noarch
 
 - name: Verify - schema_registry
   hosts: schema_registry
@@ -33,7 +33,7 @@
         name: confluent.test
         tasks_from: check_package.yml
       vars:
-        package_name: confluent-kafka-2.12.noarch
+        package_name: confluent-kafka.noarch
 
 - name: Verify - kafka_connect
   hosts: kafka_connect
@@ -51,7 +51,7 @@
         name: confluent.test
         tasks_from: check_package.yml
       vars:
-        package_name: confluent-kafka-2.12.noarch
+        package_name: confluent-kafka.noarch
 
 - name: Verify - kafka_rest
   hosts: kafka_rest
@@ -69,7 +69,7 @@
         name: confluent.test
         tasks_from: check_package.yml
       vars:
-        package_name: confluent-kafka-2.12.noarch
+        package_name: confluent-kafka.noarch
 
 - name: Verify - ksql
   hosts: ksql
@@ -87,7 +87,7 @@
         name: confluent.test
         tasks_from: check_package.yml
       vars:
-        package_name: confluent-kafka-2.12.noarch
+        package_name: confluent-kafka.noarch
 
 - name: Verify - control_center
   hosts: control_center
@@ -105,4 +105,4 @@
         name: confluent.test
         tasks_from: check_package.yml
       vars:
-        package_name: confluent-kafka-2.12.noarch
+        package_name: confluent-kafka.noarch

--- a/roles/confluent.test/molecule/plain-erp-tls-rhel/verify.yml
+++ b/roles/confluent.test/molecule/plain-erp-tls-rhel/verify.yml
@@ -16,7 +16,7 @@
         tasks_from: check_property.yml
       vars:
         file_path: /etc/kafka/server.properties
-        property: confluent.metadata.server.listeners
+        property: confluent.http.server.listeners
         expected_value: https://0.0.0.0:8090
 
 - name: Verify - control_center

--- a/roles/confluent.variables/vars/main.yml
+++ b/roles/confluent.variables/vars/main.yml
@@ -348,8 +348,7 @@ kafka_broker_properties:
     enabled: "{{audit_logs_destination_enabled and rbac_enabled}}"
     properties:
       confluent.security.event.logger.exporter.kafka.bootstrap.servers: "{{audit_logs_destination_bootstrap_servers}}"
-      # TODO Change this to false with the 610 release
-      confluent.security.event.logger.exporter.kafka.topic.create: 'true'
+      confluent.security.event.logger.exporter.kafka.topic.create: 'false'
   audit_logs_destination_client:
     enabled: "{{audit_logs_destination_enabled and rbac_enabled}}"
     properties: "{{ audit_logs_destination_listener | client_properties(ssl_enabled, pkcs12_enabled, ssl_mutual_auth_enabled, sasl_protocol,

--- a/roles/confluent.variables/vars/main.yml
+++ b/roles/confluent.variables/vars/main.yml
@@ -439,7 +439,7 @@ schema_registry_properties:
   mtls:
     enabled: "{{ schema_registry_ssl_mutual_auth_enabled }}"
     properties:
-      ssl.client.auth: true
+      ssl.client.auth: 'true'
   kafka_client:
     enabled: true
     properties: "{{ kafka_broker_listeners[schema_registry_kafka_listener_name] | client_properties(ssl_enabled, pkcs12_enabled, ssl_mutual_auth_enabled, sasl_protocol,

--- a/roles/confluent.zookeeper/defaults/main.yml
+++ b/roles/confluent.zookeeper/defaults/main.yml
@@ -28,7 +28,8 @@ zookeeper_service_environment_overrides:
   KAFKA_HEAP_OPTS: "-Xmx1g"
   KAFKA_OPTS: "{{ zookeeper_final_java_args | java_arg_build_out }}"
   KAFKA_LOG4J_OPTS: "{% if zookeeper_custom_log4j|bool %}-Dlog4j.configuration=file:{{zookeeper.log4j_file}}{% endif %}"
-  LOG_DIR: "{% if zookeeper_custom_log4j|bool %}{{zookeeper.log_path}}{% endif %}"
+  # Remove trailing slash if there is one
+  LOG_DIR: "{{ zookeeper_log_dir|regex_replace('\\/$', '') }}"
 
 ### Overrides to the Unit Section of Zookeeper Systemd File. This variable is a dictionary.
 zookeeper_service_unit_overrides:

--- a/zookeeper.yml
+++ b/zookeeper.yml
@@ -11,11 +11,13 @@
     - name: Check if Zookeeper Service Running
       shell: "systemctl show -p SubState {{zookeeper_service_name}}"
       changed_when: false
+      # On some SELinux enabled hosts this command will error out, handled in next set_fact task
+      failed_when: false
       check_mode: false
       register: substate
 
     - set_fact:
-        install_pattern: "{{ 'parallel' if substate.stdout != 'SubState=running' or zookeeper_deployment_strategy == 'parallel' else 'serial' }}"
+        install_pattern: "{{ 'parallel' if substate.stdout != 'SubState=running' or substate.rc == 1 or zookeeper_deployment_strategy == 'parallel' else 'serial' }}"
 
     - name: "Group Hosts by Installation Pattern: Parallel or Serial"
       group_by:


### PR DESCRIPTION
# Description

- Tar install failing kafka start up with:
```
Feb 03 05:32:21 kafka-broker1.confluent systemd[1]: Started Apache Kafka - broker.
Feb 03 05:32:21 kafka-broker1.confluent kafka-server-start[5062]: mkdir: cannot create directory ‘/opt/confluent/confluent-6.1.0/bin/../logs’: Permission denied
```
By making sure `LOG_DIR` env var is always set, these logs get written to the correct location

- Package name updated from confluent-kafka-2.12 to confluent-kafka - This fix should be backported
- Admin api property changed `confluent.metadata.server.listeners` - > `confluent.http.server.listeners` - This may need to be backported
- On some SELinux enabled hosts where you remove the packages, rerunning the install will error out with
```
TASK [Check if Zookeeper Service Running] **************************************************************************************************************************************************************************************************
Wednesday 03 February 2021  10:45:52 -0700 (0:00:01.050)       0:01:02.216 ****
fatal: [ip-172-31-35-217.us-west-2.compute.internal]: FAILED! => {"changed": false, "cmd": "systemctl show -p SubState confluent-zookeeper", "delta": "0:00:00.009357", "end": "2021-02-03 17:45:52.875072", "msg": "non-zero return code", "rc": 1, "start": "2021-02-03 17:45:52.865715", "stderr": "Failed to get properties: Access denied", "stderr_lines": ["Failed to get properties: Access denied"], "stdout": "", "stdout_lines": []}
```
By updating saying failed_when false and adding a rc=1 or condition we handle this case. All in all, parallel deployment strategy should be the fallback

- ksql log processing using 55x variables, updating to current, this fix needs to be backported
- updates `confluent.security.event.logger.exporter.kafka.topic.create` to false as suggested by audit logs team, tested against 610 packages
- Put sr mtls property 'true' in single quotes to preserve case, or else it shows up as True in prop files which is against our standard

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This resolve 6 broken testing scenarios


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible