### PR TITLE
Connect Plugin path for Tar Install

### DIFF
--- a/roles/confluent.test/molecule/archive-scram-rhel/verify.yml
+++ b/roles/confluent.test/molecule/archive-scram-rhel/verify.yml
@@ -18,3 +18,15 @@
           - archive.stat.gr_name == 'custom'
           - archive.stat.pw_name == 'cp-custom'
         quiet: true
+
+- name: Verify - kafka_connect
+  hosts: kafka_connect
+  gather_facts: false
+  tasks:
+    - import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: /opt/confluent/etc/kafka/connect-distributed.properties
+        property: plugin.path
+        expected_value: /opt/confluent/confluent-6.0.1/share/java,/usr/share/java

--- a/roles/confluent.variables/defaults/main.yml
+++ b/roles/confluent.variables/defaults/main.yml
@@ -594,7 +594,8 @@ kafka_connect_secret_registry_enabled: "{{rbac_enabled}}"
 kafka_connect_secret_registry_key: 39ff95832750c0090d84ddf5344583832efe91ef
 
 kafka_connect_plugins_path:
-  - /usr/share/java
+  - "{% if installation_method == 'archive' %}{{archive_destination_path}}/confluent-{{confluent_package_version}}/{% else %}/usr/{% endif %}share/java"
+
 
 kafka_connect_confluent_hub_plugins: []
 kafka_connect_confluent_hub_plugins_dest: /usr/share/java


### PR DESCRIPTION
# Description

Corrects `plugin.path` property when `installation_method: archive`
Keeps /usr/share/java in there in case additional plugins are installed

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Added test to archive-scram-rhel


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible