### PR TITLE
Missing spaces in property check in upgrade conditional

### DIFF
--- a/tasks/create_ordered_kafka_groups.yml
+++ b/tasks/create_ordered_kafka_groups.yml
@@ -25,7 +25,7 @@
 - name: Get Controller Broker ID
   shell: |
     {{ binary_base_path }}/bin/zookeeper-shell {{ groups['zookeeper'][0] }}:{{zookeeper_client_port}} \
-      {% if 'zookeeper.ssl.client.enable = true' in slurped_properties.content|b64decode %}-zk-tls-config-file {{ kafka_broker.zookeeper_tls_client_config_file if kafka_broker_secrets_protection_enabled else kafka_broker.config_file }}{% endif %} \
+      {% if 'zookeeper.ssl.client.enable = true' in slurped_properties.content|b64decode or 'zookeeper.ssl.client.enable=true' in slurped_properties.content|b64decode %}-zk-tls-config-file {{ kafka_broker.zookeeper_tls_client_config_file if kafka_broker_secrets_protection_enabled else kafka_broker.config_file }}{% endif %} \
       get /controller | grep brokerid
   register: controller_query
   run_once: true

--- a/tasks/create_ordered_kafka_groups.yml
+++ b/tasks/create_ordered_kafka_groups.yml
@@ -19,13 +19,13 @@
     owner: "{{kafka_broker_user}}"
     group: "{{kafka_broker_group}}"
   when:
-    - "'zookeeper.ssl.client.enable=true' in slurped_properties.content|b64decode"
+    - "'zookeeper.ssl.client.enable = true' in slurped_properties.content|b64decode"
     - kafka_broker_secrets_protection_enabled|bool
 
 - name: Get Controller Broker ID
   shell: |
     {{ binary_base_path }}/bin/zookeeper-shell {{ groups['zookeeper'][0] }}:{{zookeeper_client_port}} \
-      {% if 'zookeeper.ssl.client.enable=true' in slurped_properties.content|b64decode %}-zk-tls-config-file {{ kafka_broker.zookeeper_tls_client_config_file if kafka_broker_secrets_protection_enabled else kafka_broker.config_file }}{% endif %} \
+      {% if 'zookeeper.ssl.client.enable = true' in slurped_properties.content|b64decode %}-zk-tls-config-file {{ kafka_broker.zookeeper_tls_client_config_file if kafka_broker_secrets_protection_enabled else kafka_broker.config_file }}{% endif %} \
       get /controller | grep brokerid
   register: controller_query
   run_once: true

--- a/tasks/create_ordered_kafka_groups.yml
+++ b/tasks/create_ordered_kafka_groups.yml
@@ -19,7 +19,7 @@
     owner: "{{kafka_broker_user}}"
     group: "{{kafka_broker_group}}"
   when:
-    - "'zookeeper.ssl.client.enable = true' in slurped_properties.content|b64decode"
+    - "'zookeeper.ssl.client.enable = true' in slurped_properties.content|b64decode or 'zookeeper.ssl.client.enable=true' in slurped_properties.content|b64decode"
     - kafka_broker_secrets_protection_enabled|bool
 
 - name: Get Controller Broker ID


### PR DESCRIPTION
# Description

Missing spaces causing zookeeper shell connection without properties
Need to handle server.properties that has been generated with the secrets protection scripts

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Ran the install with a secrets protection enabled kafka


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible