### PR TITLE
20210303 fix malformed super users #569

### DIFF
--- a/roles/confluent.kafka_broker/tasks/rbac.yml
+++ b/roles/confluent.kafka_broker/tasks/rbac.yml
@@ -24,7 +24,7 @@
 # Loop over each brokers principal and add to list
 - name: Add Each Broker's Principal to Super Users List
   set_fact:
-    super_users: "{{super_users}}  + [ 'User:{{ hostvars[item]['kafka_broker_principal'] }}' ]"
+    super_users: "{{super_users}}  + [ '{{ hostvars[item]['kafka_broker_principal'] }}' ]"
   loop: "{{ groups['kafka_broker'] }}"
 
 - name: Remove Duplicates and Convert to String

--- a/roles/confluent.kafka_broker/tasks/rbac.yml
+++ b/roles/confluent.kafka_broker/tasks/rbac.yml
@@ -1,11 +1,5 @@
 ---
-- name: Get Principal used on the Inter Broker Listener
-  include_tasks: set_principal.yml
-  vars:
-    listener: "{{kafka_broker_listeners[kafka_broker_inter_broker_listener_name]}}"
-  when: install_pattern == 'parallel'
-
-- name: Get Principal used on the Inter Broker Listener - Rolling Deployment
+- name: Get Principals used on the Inter Broker Listener
   include_tasks: set_principal.yml
   vars:
     listener: "{{kafka_broker_listeners[kafka_broker_inter_broker_listener_name]}}"
@@ -14,7 +8,13 @@
     apply:
       delegate_to: "{{item}}"
       delegate_facts: true
-  when: install_pattern == 'serial'
+  run_once: true
+
+- name: Show principals
+  debug:
+    msg: "Principal for {{item}} is  {{ hostvars[item]['kafka_broker_principal'] }}"
+  loop: "{{ groups['kafka_broker'] }}"
+  run_once: true
 
 # Take super.users property, split into list, remove empty string from list, and add in mds_super_user
 - name: Initialize Super Users List
@@ -24,7 +24,7 @@
 # Loop over each brokers principal and add to list
 - name: Add Each Broker's Principal to Super Users List
   set_fact:
-    super_users: "{{super_users}}  + [ '{{ hostvars[item]['kafka_broker_principal'] }}' ]"
+    super_users: "{{super_users}}  + [ 'User:{{ hostvars[item]['kafka_broker_principal'] }}' ]"
   loop: "{{ groups['kafka_broker'] }}"
 
 - name: Remove Duplicates and Convert to String

--- a/roles/confluent.kafka_broker/tasks/set_principal.yml
+++ b/roles/confluent.kafka_broker/tasks/set_principal.yml
@@ -1,17 +1,17 @@
 ---
 - name: Set Principal - Sasl Scram
   set_fact:
-    kafka_broker_principal: "{{ sasl_scram_users.admin.principal }}"
+    kafka_broker_principal: "User:{{ sasl_scram_users.admin.principal }}"
   when: listener['sasl_protocol'] | default(sasl_protocol) | normalize_sasl_protocol == 'SCRAM-SHA-512'
 
 - name: Set Principal - Sasl Plain
   set_fact:
-    kafka_broker_principal: "{{ sasl_plain_users.admin.principal }}"
+    kafka_broker_principal: "User:{{ sasl_plain_users.admin.principal }}"
   when: listener['sasl_protocol'] | default(sasl_protocol) | normalize_sasl_protocol == 'PLAIN'
 
 - name: Set Principal - Sasl Kerberos
   set_fact:
-    kafka_broker_principal: "{{ kerberos_kafka_broker_primary }}"
+    kafka_broker_principal: "User:{{ kerberos_kafka_broker_primary }}"
   when: listener['sasl_protocol'] | default(sasl_protocol) | normalize_sasl_protocol == 'GSSAPI'
 
 - name: Extract Common Name from Keystore - SSL Mutual Auth
@@ -37,16 +37,8 @@
 
 - name: Set Principal - SSL Mutual Auth
   set_fact:
-    kafka_broker_principal: "{{ distinguished_name_from_keystore.stdout }}"
+    kafka_broker_principal: "User:{{ distinguished_name_from_keystore.stdout }}"
   when:
     - listener['sasl_protocol'] | default(sasl_protocol) | normalize_sasl_protocol == 'none'
     - listener['ssl_enabled'] | default(ssl_enabled) | bool
     - listener['ssl_mutual_auth_enabled'] | default(ssl_mutual_auth_enabled) | bool
-
-- name: Normalize User Name
-  set_fact:
-    kafka_broker_principal: "User:{{ kafka_broker_principal }}"
-  when: kafka_broker_principal is defined
-
-- debug:
-    var: kafka_broker_principal


### PR DESCRIPTION
# Description

Using 6.1.0-post with an RBAC enabled cluster, deploying kafka brokers with the rolling strategy results in malformed super.users. As a result, broker restart fails.

Core reason is that task 'Normalize User Name' (roles/confluent.kafka_broker/tasks/set_principal.yml) performs an update on the variable 'kafka_broker_principal' but may be executed multiple times from the loop in rbac.yml and/or when executing for multiple broker hosts. 

To resolve the issue, this PR:
- Builds the correctly formed principal in each task, and removes the update step 'Normalize User Name'.
- Replaces the 2 loops in rbac.yml which call set_principal in different modes, with a single loop over all broker hosts + run_once.

Fixes # 569

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Tested against 1 ZK, 3 Broker setup
- Tested with PLAIN and mTLS interbroker replication.
- For each of the above:
-- Ran initial deployment
-- Ran parallel deployment strategy
-- Ran rolling deployment stategy
-- Validated super.users config and broker availability.

**Test Configuration**:


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Any dependent changes have been merged and published in downstream modules
- [X] Any variable changes have been validated to be backwards compatible