### PR TITLE
log.dirs Assertion

### DIFF
--- a/roles/confluent.kafka_broker/tasks/main.yml
+++ b/roles/confluent.kafka_broker/tasks/main.yml
@@ -114,14 +114,12 @@
     mode: 0750
 
 # To avoid a catastrophic user error where root directory permissions get recursively changed
-- name: Assert log.dirs property not Misconfigured
+- name: Assert log.dirs Property not Misconfigured
   assert:
     that:
       - kafka_broker_final_properties['log.dirs'].split(',')[0] != "/"
     fail_msg: "Make sure datadir key is set to list of directories, NOT a string or dictionary."
     quiet: true
-
-- fail:
 
 - name: Set Permissions on Data Dirs
   file:

--- a/roles/confluent.kafka_broker/tasks/main.yml
+++ b/roles/confluent.kafka_broker/tasks/main.yml
@@ -113,6 +113,16 @@
     state: directory
     mode: 0750
 
+# To avoid a catastrophic user error where root directory permissions get recursively changed
+- name: Assert log.dirs property not Misconfigured
+  assert:
+    that:
+      - kafka_broker_final_properties['log.dirs'].split(',')[0] != "/"
+    fail_msg: "Make sure datadir key is set to list of directories, NOT a string or dictionary."
+    quiet: true
+
+- fail:
+
 - name: Set Permissions on Data Dirs
   file:
     path: "{{item}}"

--- a/roles/confluent.test/molecule/plain-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/plain-rhel/molecule.yml
@@ -98,6 +98,11 @@ provisioner:
   inventory:
     group_vars:
       all:
+
+        kafka_broker:
+          datadir:
+            /var/lib/kafka/my-data
+
         sasl_protocol: plain
 
         kafka_connect_confluent_hub_plugins:

--- a/roles/confluent.test/molecule/plain-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/plain-rhel/molecule.yml
@@ -98,11 +98,6 @@ provisioner:
   inventory:
     group_vars:
       all:
-
-        kafka_broker:
-          datadir:
-            /var/lib/kafka/my-data
-
         sasl_protocol: plain
 
         kafka_connect_confluent_hub_plugins:


### PR DESCRIPTION
# Description

User recently misconfigured this property:
```
kafka_broker:
  datadir:
    /var/lib/kafka/my-data
```

where datadir *should be a list*. This resulted in a catastrophic reconfiguration of the VM where all files changed ownership to the kafka_broker_user. This PR validates that catastrophe will not happen!

Now this is how it will error out:
```
    TASK [confluent.kafka_broker : Assert log.dirs Property not Misconfigured] *****
fatal: [kafka-broker1]: FAILED! => {"assertion": "kafka_broker_final_properties['log.dirs'].split(',')[0] != \"/\"", "changed": false, "evaluated_to": false, "msg": "Make sure datadir key is set to list of directories, NOT a string or dictionary."}
```

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested with the misconfiguration in the description, got the error message, and the playbook stopped, without destroying the file system :)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible