### PR TITLE
fix: Support for noop "upgrade" from/to same version

### DIFF
--- a/upgrade_kafka_broker.yml
+++ b/upgrade_kafka_broker.yml
@@ -30,6 +30,11 @@
         log_message_format_version: 2.5
       when: kafka_broker_upgrade_start_version is match('5.5.*')
 
+    - set_fact:
+        inter_broker_protocol_version: 2.6
+        log_message_format_version: 2.6
+      when: kafka_broker_upgrade_start_version is match('6.0.*')
+
     - name: Set Inter-Broker Protocol Version to Current Version
       lineinfile:
         path: "{{kafka_broker.config_file}}"


### PR DESCRIPTION
# Description

I am expecting an attempt to "upgrade" from/to same version to be a noop - i.e. idempotent. This does not seem to be the case, and this PR is an attempt to fix this.

To reproduce (with reference to [Upgrade Confluent Platform with Ansible Playbooks](https://docs.confluent.io/ansible/current/ansible-upgrade.html)):

```shell
git checkout 6.0.2-post
ansible-playbook -i /path/to/hosts.yml upgrade_kafka_broker.yml -e kafka_broker_upgrade_start_version=6.0
```

Expected behavior:
- Playbook runs without errors, but no Kafka Broker hosts are upgraded.

Actualt behavior:
```log
TASK [Set Inter-Broker Protocol Version to Current Version] ********************
fatal: [<kafka_broker host>]: FAILED! => 
  msg: |-
    The task includes an option with an undefined variable. The error was: 'inter_broker_protocol_version' is undefined
  
    The error appears to be in '<path>/cp-ansible/upgrade_kafka_broker.yml': line 33, column 7, but may
    be elsewhere in the file depending on the exact syntax problem.
  
    The offending line appears to be:
  
  
        - name: Set Inter-Broker Protocol Version to Current Version
          ^ here
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Verified the expected behavior against one of our 6.0 clusters.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible