### PR TITLE
Corrected location of secrets_protection.yml for each component.

### DIFF
--- a/roles/confluent.control_center/tasks/main.yml
+++ b/roles/confluent.control_center/tasks/main.yml
@@ -128,7 +128,9 @@
     group: "{{control_center_group}}"
 
 - name: Create Control Center Config with Secrets Protection
-  include_tasks: ../../tasks/secrets_protection.yml
+  include_role:
+    name: confluent.common
+    tasks_from: secrets_protection.yml
   vars:
     encrypt_passwords: "{{ control_center_secrets_protection_encrypt_passwords }}"
     properties: "{{ control_center_secrets_protection_encrypt_properties }}"

--- a/roles/confluent.kafka_broker/tasks/main.yml
+++ b/roles/confluent.kafka_broker/tasks/main.yml
@@ -149,7 +149,9 @@
     group: "{{kafka_broker_group}}"
 
 - name: Create Kafka Broker Config with Secrets Protection
-  include_tasks: ../../tasks/secrets_protection.yml
+  include_role:
+    name: confluent.common
+    tasks_from: secrets_protection.yml
   vars:
     encrypt_passwords: "{{ kafka_broker_secrets_protection_encrypt_passwords }}"
     properties: "{{ kafka_broker_secrets_protection_encrypt_properties }}"

--- a/roles/confluent.kafka_connect/tasks/main.yml
+++ b/roles/confluent.kafka_connect/tasks/main.yml
@@ -113,7 +113,9 @@
     group: "{{kafka_connect_group}}"
 
 - name: Create Connect Distributed Config with Secrets Protection
-  include_tasks: ../../tasks/secrets_protection.yml
+  include_role:
+    name: confluent.common
+    tasks_from: secrets_protection.yml
   vars:
     encrypt_passwords: "{{ kafka_connect_secrets_protection_encrypt_passwords }}"
     properties: "{{ kafka_connect_secrets_protection_encrypt_properties }}"

--- a/roles/confluent.kafka_rest/tasks/main.yml
+++ b/roles/confluent.kafka_rest/tasks/main.yml
@@ -129,7 +129,9 @@
     group: "{{kafka_rest_group}}"
 
 - name: Create Kafka Rest Config with Secrets Protection
-  include_tasks: ../../tasks/secrets_protection.yml
+  include_role:
+    name: confluent.common
+    tasks_from: secrets_protection.yml
   vars:
     encrypt_passwords: "{{ kafka_rest_secrets_protection_encrypt_passwords }}"
     properties: "{{ kafka_rest_secrets_protection_encrypt_properties }}"

--- a/roles/confluent.ksql/tasks/main.yml
+++ b/roles/confluent.ksql/tasks/main.yml
@@ -121,7 +121,9 @@
     group: "{{ksql_group}}"
 
 - name: Create Ksql Config with Secrets Protection
-  include_tasks: ../../tasks/secrets_protection.yml
+  include_role:
+    name: confluent.common
+    tasks_from: secrets_protection.yml
   vars:
     encrypt_passwords: "{{ ksql_secrets_protection_encrypt_passwords }}"
     properties: "{{ ksql_secrets_protection_encrypt_properties }}"

--- a/roles/confluent.schema_registry/tasks/main.yml
+++ b/roles/confluent.schema_registry/tasks/main.yml
@@ -113,7 +113,9 @@
     group: "{{schema_registry_group}}"
 
 - name: Create Schema Registry Config with Secrets Protection
-  include_tasks: ../../tasks/secrets_protection.yml
+  include_role:
+    name: confluent.common
+    tasks_from: secrets_protection.yml
   vars:
     encrypt_passwords: "{{ schema_registry_secrets_protection_encrypt_passwords }}"
     properties: "{{ schema_registry_secrets_protection_encrypt_properties }}"


### PR DESCRIPTION
# Description

The 6.1.x branch contains an incorrect task reference statement for the secrets_protection file.  It was trying to pull the file from the root of the project, instead of importing it from the common role.

This patch corrects the location.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Successfully validated with the rbac-plain-provided-debian molecule scenario, which implements secrets protection.


**Test Configuration**:

See rbac-plain-provided-debian role.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible