### PR TITLE
avoid fail in check mode

### DIFF
--- a/roles/confluent.common/tasks/update_log4j.yml
+++ b/roles/confluent.common/tasks/update_log4j.yml
@@ -18,6 +18,7 @@
     grep RollingFileAppender {{log4j_file}} | cut -d '=' -f 1 | cut -d '.' -f 3
   register: appenders_grep
   changed_when: false
+  check_mode: false
 
 - name: Add Max Size Properties
   lineinfile:


### PR DESCRIPTION
# Description

With `--check` option, ansible fail on "Add Max Size Property" of cp-ansible/roles/confluent.common/tasks/update_log4j.yml
Addind `check_mode: false` on previous task (which clearly have no side effect) solves this issue

# How Has This Been Tested?

run playbook with `--check`