### PR TITLE
define jmx config file thru variables

### DIFF
--- a/roles/confluent.kafka_broker/tasks/main.yml
+++ b/roles/confluent.kafka_broker/tasks/main.yml
@@ -128,7 +128,7 @@
 
 - name: Deploy JMX Exporter Config File
   copy:
-    src: "kafka.yml"
+    src: "{{kafka_broker_jmxexporter_config_file}}"
     dest: "{{kafka_broker_jmxexporter_config_path}}"
     mode: 0640
     owner: "{{kafka_broker_user}}"

--- a/roles/confluent.variables_handlers/defaults/main.yml
+++ b/roles/confluent.variables_handlers/defaults/main.yml
@@ -84,7 +84,10 @@ zookeeper_jolokia_enabled: "{{jolokia_enabled}}"
 zookeeper_jolokia_port: 7770
 
 zookeeper_jmxexporter_enabled: "{{jmxexporter_enabled}}"
+## destination path for zookeeper jmx config file
 zookeeper_jmxexporter_config_path: /opt/prometheus/zookeeper.yml
+## source file for zookeeper jmx config file
+zookeeper_jmxexporter_config_file: "zookeeper.yml"
 zookeeper_jmxexporter_port: 8079
 
 zookeeper_health_check_command: "exec 42<>/dev/tcp/127.0.0.1/{{zookeeper.properties.clientPort}}; echo -e 'srvr' >&42; cat <&42"
@@ -137,7 +140,10 @@ kafka_broker_jolokia_urp_url: "{{ 'https' if kafka_broker_jolokia_ssl_enabled|bo
 kafka_broker_jolokia_active_controller_url: "{{ 'https' if kafka_broker_jolokia_ssl_enabled|bool else 'http' }}://{{inventory_hostname}}:{{kafka_broker_jolokia_port}}/jolokia/read/kafka.controller:type=KafkaController,name=ActiveControllerCount"
 
 kafka_broker_jmxexporter_enabled: "{{jmxexporter_enabled}}"
+## destination path for broker jmx config file
 kafka_broker_jmxexporter_config_path: /opt/prometheus/kafka.yml
+## source file for broker jmx config file
+kafka_broker_jmxexporter_config_file: "kafka.yml"
 kafka_broker_jmxexporter_port: 8080
 
 # Schema Registry Variables

--- a/roles/confluent.zookeeper/tasks/main.yml
+++ b/roles/confluent.zookeeper/tasks/main.yml
@@ -115,7 +115,7 @@
 
 - name: Deploy JMX Exporter Config File
   copy:
-    src: "zookeeper.yml"
+    src: "{{zookeeper_jmxexporter_config_file}}"
     dest: "{{zookeeper_jmxexporter_config_path}}"
     mode: 0640
     owner: "{{zookeeper_user}}"


### PR DESCRIPTION
# Description

jmx config file is hardcoded in playbook, but confluent grafana dashboards expect onather version
This change allow user to specify an alternative file to use as source.

This PR his on 5.5.2 branch, but should be applied to newer branches also

## Type of change

New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

run playbook with an inventory containing `kafka_broker_jmxexporter_config_file` and/or `zookeeper_jmxexporter_config_file` defined to a custom jmx config file
