### PR TITLE
limit users creation to enabled components

### DIFF
--- a/roles/confluent.variables_handlers/defaults/main.yml
+++ b/roles/confluent.variables_handlers/defaults/main.yml
@@ -253,7 +253,17 @@ control_center_kafka_listener_name: internal
 control_center:
   log4j_file: /etc/confluent-control-center/control-center_log4j.properties
 
-sasl_scram_users:
+kafka_broker_required_sasl_scram_users:
+  admin: true
+  client: true
+  kafka_connect: "{{ groups['kafka_connect'] | length > 0 }}"
+  control_center: "{{ groups['control_center'] | length > 0 }}"
+  kafka_rest:  "{{ groups['kafka_rest'] | length > 0 }}"
+  ksql:  "{{ groups['ksql'] | length > 0 }}"
+  schema_registry:  "{{ groups['schema_registry'] | length > 0 }}"
+  kafka_connect_replicator:  "{{ groups['kafka_connect_replicator'] | length > 0 }}"
+
+default_sasl_scram_users:
   admin:
     principal: admin
     password: admin-secret
@@ -276,7 +286,19 @@ sasl_scram_users:
     principal: schema_registry
     password: schema_registry-secret
 
-sasl_plain_users:
+sasl_scram_users: {}
+
+kafka_broker_required_sasl_plain_users:
+  admin: true
+  client: true
+  kafka_connect: "{{ groups['kafka_connect'] | length > 0 }}"
+  control_center: "{{ groups['control_center'] | length > 0 }}"
+  kafka_rest:  "{{ groups['kafka_rest'] | length > 0 }}"
+  ksql:  "{{ groups['ksql'] | length > 0 }}"
+  schema_registry:  "{{ groups['schema_registry'] | length > 0 }}"
+  kafka_connect_replicator:  "{{ groups['kafka_connect_replicator'] | length > 0 }}"
+
+default_sasl_plain_users:
   admin:
     principal: admin
     password: admin-secret
@@ -298,6 +320,8 @@ sasl_plain_users:
   schema_registry:
     principal: schema_registry
     password: schema_registry-secret
+
+sasl_plain_users: {}
 
 zookeeper_digest_users:
   admin:

--- a/roles/confluent.variables_handlers/tasks/main.yml
+++ b/roles/confluent.variables_handlers/tasks/main.yml
@@ -1,0 +1,21 @@
+- name: define default sasl users list
+  set_fact:
+    sasl_scram_users: "{{ sasl_scram_users | combine({ item.key: default_sasl_scram_users[item.key] }) }}"
+  with_dict: "{{ kafka_broker_required_sasl_scram_users }}"
+  when: item.value
+
+- name: add custom sasl users
+  set_fact:
+    sasl_scram_users: "{{ sasl_scram_users | combine(kafka_broker_custom_sasl_scram_users) }}"
+  when: kafka_broker_custom_sasl_scram_users is defined
+
+- name: define default plain users list
+  set_fact:
+    sasl_plain_users: "{{ sasl_plain_users | combine({ item.key: default_sasl_plain_users[item.key] }) }}"
+  with_dict: "{{ kafka_broker_required_sasl_plain_users }}"
+  when: item.value
+
+- name: add custom plain users
+  set_fact:
+    sasl_plain_users: "{{ sasl_plain_users | combine(kafka_broker_custom_sasl_plain_users) }}"
+  when: kafka_broker_custom_sasl_plain_users is defined


### PR DESCRIPTION
# Description

Playbook creates scram and/or plain credentials for every component (connect, schema registry, replicator, ksql ...) even if those components are not enabled.
This may imply default credentials to be defined, which is a possible security breach

This PR use new variables `kafka_broker_required_sasl_scram_users` and `kafka_broker_required_sasl_plain_users` where each entry is set to true/false to indicate if this user must be created or not.

User may overide some entries of those variables (for example, if you are using kafka connect, but install it from another source, you may force user creation, event if kafka connect is disabled in playbook.

Then, user may define `kafka_broker_custom_sasl_scram_users` and/or `kafka_broker_custom_sasl_plain_users` variable to add custom users during installation.
It's also possible to override default credentials by this way.

This PR is on 5.5.2 branch, but should be applied to newer branches also

## Type of change

New feature, **with breaking change** : inventory where sasl_plain_user and/or sasl_scram_user is overridden must rename these variable as `kafka_broker_custom_sasl_scram_users` and `kafka_broker_custom_sasl_plain_users`

The breaking change may be worked around by replacing all occurences of `sasl_scram/plain_users` in playbook by another variable (`computed_sasl_scram_users` for example).
