### PR TITLE
set log4j root logger thru variable

### DIFF
--- a/roles/confluent.kafka_broker/templates/kafka_server_log4j.properties.j2
+++ b/roles/confluent.kafka_broker/templates/kafka_server_log4j.properties.j2
@@ -16,7 +16,7 @@
 # Unspecified loggers and loggers with additivity=true output to server.log and stdout
 # Note that INFO only applies to unspecified loggers, the log level of the child logger is used otherwise
 
-log4j.rootLogger=INFO, stdout, kafkaAppender
+log4j.rootLogger={{ kafka_broker_root_logger }}
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout

--- a/roles/confluent.variables_handlers/defaults/main.yml
+++ b/roles/confluent.variables_handlers/defaults/main.yml
@@ -80,6 +80,9 @@ zookeeper:
   log4j_file: /etc/kafka/zookeeper_log4j.properties
   jaas_file: /etc/kafka/zookeeper_jaas.conf
 
+### log4j root logger string
+zookeeper_root_logger: "INFO, stdout, zkAppender"
+
 zookeeper_jolokia_enabled: "{{jolokia_enabled}}"
 zookeeper_jolokia_port: 7770
 
@@ -126,6 +129,9 @@ kafka_broker_key_path: "/var/ssl/private/kafka_broker.key"
 kafka_broker:
   log4j_file: /etc/kafka/kafka_server_log4j.properties
   jaas_file: /etc/kafka/kafka_server_jaas.conf
+
+### log4j root logger string
+kafka_broker_root_logger: "INFO, stdout, kafkaAppender"
 
 kafka_broker_schema_validation_enabled: false
 

--- a/roles/confluent.zookeeper/templates/zookeeper_log4j.properties.j2
+++ b/roles/confluent.zookeeper/templates/zookeeper_log4j.properties.j2
@@ -14,16 +14,15 @@
 # limitations under the License.
 
 
-log4j.rootLogger=INFO, stdout, zkAppender
+log4j.rootLogger={{ zookeeper_root_logger }}
 
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n
 
- 
-log4j.appender.zkAppender=org.apache.log4j.RollingFileAppender 
-log4j.appender.zkAppender.File={{zookeeper.log_path}}{{zookeeper.log_name}} 
-log4j.appender.zkAppender.layout=org.apache.log4j.PatternLayout 
+log4j.appender.zkAppender=org.apache.log4j.RollingFileAppender
+log4j.appender.zkAppender.File={{zookeeper.log_path}}{{zookeeper.log_name}}
+log4j.appender.zkAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.zkAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
 log4j.appender.zkAppender.Append=true
 log4j.appender.zkAppender.MaxBackupIndex={{zookeeper.max_log_files}}


### PR DESCRIPTION
# Description

Use a variable to set log4j root logger, allowing user to customize it, for example to send logs only to files and not to stdout.

## Type of change

New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

set `kafka_broker_root_logger: "INFO, kafkaAppender"` in inventory to see the difference in log4j config