### PR TITLE
don't fail when control plane listener name is undefined

### DIFF
--- a/roles/confluent.variables/vars/main.yml
+++ b/roles/confluent.variables/vars/main.yml
@@ -308,7 +308,7 @@ kafka_broker_properties:
   controlplane_listener:
     enabled: "{{ kafka_broker_configure_control_plane_listener|bool and kafka_broker_configure_multiple_listeners|bool }}"
     properties:
-      control.plane.listener.name: "{{kafka_broker_listeners[kafka_broker_control_plane_listener_name]['name']|default(kafka_broker_listeners[kafka_broker_inter_broker_listener_name]['name'])}}"
+      control.plane.listener.name: "{{(kafka_broker_listeners[kafka_broker_control_plane_listener_name]|default(kafka_broker_listeners[kafka_broker_inter_broker_listener_name]))['name']}}"
   metrics_reporter:
     enabled: "{{ kafka_broker_metrics_reporter_enabled|bool }}"
     properties:


### PR DESCRIPTION
# Description

`control.plane.listener.name` assignment fails (at least with ansible 2.7) when `kafka_broker_control_plane_listener_name` defaults to `controller` but there's no listeners with this name.
This change let the `default()` call use default value instead of failing

## Type of change

Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Run playbook with inventory containing several listeners but no `controller` one

**Test Configuration**:
- ansible 2.7
- `kafka_broker_configure_control_plane_listener` = `false`
- inventory declares `kafka_broker_custom_listeners` with several listeners, but none of them named `controller`

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [N/A] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [N/A] Any dependent changes have been merged and published in downstream modules
- [N/A] Any variable changes have been validated to be backwards compatible