### PR TITLE
Allow Zookeeper health check in check mode

### DIFF
--- a/roles/confluent.zookeeper/tasks/health_check.yml
+++ b/roles/confluent.zookeeper/tasks/health_check.yml
@@ -10,6 +10,7 @@
   retries: 25
   delay: 5
   changed_when: false
+  check_mode: false
   ignore_errors: true
 
 - name: Wait for Zookeeper Quorum
@@ -21,6 +22,7 @@
   retries: 25
   delay: 5
   changed_when: false
+  check_mode: false
   when: not status.failed
   ignore_errors: true
 


### PR DESCRIPTION
# Description

We are including the `health_check.yml` tasks in some custom playbooks, e.g. patching and rebooting:
```yaml
import_role:
  name: confluent.zookeeper
  tasks_from: health_check.yml
```

We prefer to run everything in check mode on feature branches in our GitOps approach. While the Kafka Broker health checks are running fine in check mode, the Zookeeper health checks are not. This PR fixes this issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Verified ok in our GitOps managed environments. Running fine both in check mode and non check mode.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible