### PR TITLE
ANSI-721 - ZK Digest Auth Mode fix + variable rename

### DIFF
--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -452,6 +452,22 @@ Default:  "{{ssl_enabled}}"
 
 ***
 
+### zookeeper_ssl_mutual_auth_enabled
+
+Deprecated- Boolean to enable mTLS Authentication on Zookeeper (Server to Server and Client to Server). Configures kafka to authenticate with mTLS.
+
+Default:  "{{ssl_mutual_auth_enabled}}"
+
+***
+
+### zookeeper_sasl_protocol
+
+Deprecated- SASL Mechanism for Zookeeper Server to Server and Server to Client Authentication. Options are none, kerberos, digest. Server to server auth only working for digest-md5
+
+Default:  "{{sasl_protocol if sasl_protocol == 'kerberos' else 'none'}}"
+
+***
+
 ### zookeeper_quorum_authentication_type
 
 Authentication to put on ZK Server to Server connections. Available options: [mtls, digest].

--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -452,27 +452,27 @@ Default:  "{{ssl_enabled}}"
 
 ***
 
-### zookeeper_ssl_mutual_auth_enabled
+### zookeeper_quorum_authentication_type
 
-Boolean to enable mTLS Authentication on Zookeeper (Server to Server and Client to Server). Configures kafka to authenticate with mTLS.
+Authentication to put on ZK Server to Server connections. Available options: [mtls, digest].
 
-Default:  "{{ssl_mutual_auth_enabled}}"
+Default:  "{{ 'mtls' if zookeeper_ssl_enabled and zookeeper_ssl_mutual_auth_enabled else zookeeper_sasl_protocol }}"
+
+***
+
+### zookeeper_client_authentication_type
+
+Authentication to put on ZK Client to Server connections. This is Kafka's connection to ZK. Available options: [mtls, digest, kerberos].
+
+Default:  "{{ 'mtls' if zookeeper_ssl_enabled and zookeeper_ssl_mutual_auth_enabled else zookeeper_sasl_protocol }}"
 
 ***
 
 ### zookeeper_client_port
 
-Port for Kafka to Zookeeper connections. NOTE- 2181 will be configured for zk health checks
+Port for Kafka to Zookeeper connections
 
 Default:  "{{'2182' if zookeeper_ssl_enabled|bool else '2181'}}"
-
-***
-
-### zookeeper_sasl_protocol
-
-SASL Mechanism for Zookeeper Server to Server and Server to Client Authentication. Options are none, kerberos, digest. Server to server auth only working for digest-md5
-
-Default:  "{{sasl_protocol if sasl_protocol == 'kerberos' else 'none'}}"
 
 ***
 

--- a/roles/confluent.kafka_broker/defaults/main.yml
+++ b/roles/confluent.kafka_broker/defaults/main.yml
@@ -9,10 +9,10 @@ kafka_broker_log4j_root_logger: "INFO, stdout, kafkaAppender"
 
 kafka_broker_java_args:
   - "{% if kafka_broker_listeners | ssl_required(ssl_enabled) | bool %}-Djdk.tls.ephemeralDHKeySize=2048{% endif %}"
-  - "{% if 'GSSAPI' in kafka_broker_sasl_enabled_mechanisms or zookeeper_sasl_protocol in ['kerberos', 'digest'] %}-Djava.security.auth.login.config={{kafka_broker.jaas_file}}{% endif %}"
+  - "{% if 'GSSAPI' in kafka_broker_sasl_enabled_mechanisms or zookeeper_client_authentication_type in ['kerberos', 'digest'] %}-Djava.security.auth.login.config={{kafka_broker.jaas_file}}{% endif %}"
   - "{% if kafka_broker_jolokia_enabled|bool %}-javaagent:{{jolokia_jar_path}}=config={{kafka_broker_jolokia_config}}{% endif %}"
   - "{% if kafka_broker_jmxexporter_enabled|bool %}-javaagent:{{jmxexporter_jar_path}}={{kafka_broker_jmxexporter_port}}:{{kafka_broker_jmxexporter_config_path}}{% endif %}"
-  - "{% if zookeeper_sasl_protocol == 'kerberos' and zookeeper_kerberos_primary != 'zookeeper' %}-Dzookeeper.sasl.client.username={{zookeeper_kerberos_primary}}{% endif %}"
+  - "{% if zookeeper_client_authentication_type == 'kerberos' and zookeeper_kerberos_primary != 'zookeeper' %}-Dzookeeper.sasl.client.username={{zookeeper_kerberos_primary}}{% endif %}"
 
 # Strip primary from the zookeeper principal on first zk host. Adds defaults for if there is not even a zookeeper group
 zookeeper_kerberos_primary: "{{ (hostvars[ groups['zookeeper'][0] | default('zookeeper') ] | default({})) ['zookeeper_kerberos_principal'] | default('zookeeper/host@EXAMPLE>COM') | regex_replace('/.*') }}"

--- a/roles/confluent.kafka_broker/tasks/main.yml
+++ b/roles/confluent.kafka_broker/tasks/main.yml
@@ -95,7 +95,7 @@
     kerberos_keytab_path: "{{kafka_broker_kerberos_keytab_path}}"
     kerberos_keytab_destination_path: "{{kafka_broker_keytab_path}}"
     kerberos_handler: "restart kafka"
-  when: "'GSSAPI' in kafka_broker_sasl_enabled_mechanisms or zookeeper_sasl_protocol == 'kerberos' or mds_broker_listener.sasl_protocol =='kerberos'"
+  when: "'GSSAPI' in kafka_broker_sasl_enabled_mechanisms or zookeeper_client_authentication_type == 'kerberos' or mds_broker_listener.sasl_protocol =='kerberos'"
 
 - name: Copy Custom Kafka Files
   include_role:

--- a/roles/confluent.kafka_broker/templates/kafka_server_jaas.conf.j2
+++ b/roles/confluent.kafka_broker/templates/kafka_server_jaas.conf.j2
@@ -7,7 +7,7 @@ KafkaServer {
     principal="{{kafka_broker_kerberos_principal}}";
 };
 {% endif %}
-{% if zookeeper_sasl_protocol == 'kerberos' %}
+{% if zookeeper_client_authentication_type == 'kerberos' %}
 
 Client {
     com.sun.security.auth.module.Krb5LoginModule required
@@ -17,7 +17,7 @@ Client {
     principal="{{kafka_broker_kerberos_principal}}";
 };
 {% endif %}
-{% if zookeeper_sasl_protocol == 'digest' %}
+{% if zookeeper_client_authentication_type == 'digest' %}
 
 Client {
        org.apache.zookeeper.server.auth.DigestLoginModule required

--- a/roles/confluent.test/molecule/zookeeper-kerberos/molecule.yml
+++ b/roles/confluent.test/molecule/zookeeper-kerberos/molecule.yml
@@ -124,6 +124,7 @@ provisioner:
         # Paths are relative to all.yml
         zookeeper_kerberos_principal: "zookeeper/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
         zookeeper_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/zookeeper-{{inventory_hostname}}.keytab"
+
       kafka_broker:
         kafka_broker_kerberos_principal: "{{kerberos_kafka_broker_primary}}/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
         kafka_broker_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/kafka_broker-{{inventory_hostname}}.keytab"

--- a/roles/confluent.variables/defaults/main.yml
+++ b/roles/confluent.variables/defaults/main.yml
@@ -201,10 +201,10 @@ zookeeper_group: "{{zookeeper_default_group}}"
 ### Boolean to configure zookeeper with TLS Encryption. Also manages Java Keystore creation
 zookeeper_ssl_enabled: "{{ssl_enabled}}"
 
-# Deprecated- Boolean to enable mTLS Authentication on Zookeeper (Server to Server and Client to Server). Configures kafka to authenticate with mTLS.
+### Deprecated- Boolean to enable mTLS Authentication on Zookeeper (Server to Server and Client to Server). Configures kafka to authenticate with mTLS.
 zookeeper_ssl_mutual_auth_enabled: "{{ssl_mutual_auth_enabled}}"
 
-# Deprecated- SASL Mechanism for Zookeeper Server to Server and Server to Client Authentication. Options are none, kerberos, digest. Server to server auth only working for digest-md5
+### Deprecated- SASL Mechanism for Zookeeper Server to Server and Server to Client Authentication. Options are none, kerberos, digest. Server to server auth only working for digest-md5
 zookeeper_sasl_protocol: "{{sasl_protocol if sasl_protocol == 'kerberos' else 'none'}}"
 
 ### Authentication to put on ZK Server to Server connections. Available options: [mtls, digest].
@@ -227,7 +227,7 @@ zookeeper_keystore_keypass: "{{ ssl_keystore_key_password if ssl_provided_keysto
 zookeeper_ca_cert_path: "/var/ssl/private/ca.crt"
 zookeeper_cert_path: "/var/ssl/private/zookeeper.crt"
 zookeeper_key_path: "/var/ssl/private/zookeeper.key"
-zookeeper_export_certs: "{{zookeeper_ssl_mutual_auth_enabled}}"
+zookeeper_export_certs: "{{ True if zookeeper_client_authentication_type == 'mtls' or zookeeper_quorum_authentication_type == 'mtls' else False }}"
 zookeeper_keytab_path: /etc/security/keytabs/zookeeper.keytab
 
 zookeeper:
@@ -266,8 +266,7 @@ zookeeper_jmxexporter_port: 8079
 
 zookeeper_jmxexporter_config_path: /opt/prometheus/zookeeper.yml
 
-zookeeper_health_check_command: "{% if zookeeper_sasl_protocol in ['kerberos', 'digest'] %}KAFKA_OPTS='-Djava.security.auth.login.config={{zookeeper.jaas_file}}'{% endif %}
-{{ binary_base_path }}/bin/kafka-run-class
+zookeeper_health_check_command: "{{ binary_base_path }}/bin/kafka-run-class
 {% if zookeeper_ssl_enabled|bool %}
 -Dzookeeper.clientCnxnSocket=org.apache.zookeeper.ClientCnxnSocketNetty
 -Dzookeeper.ssl.trustStore.location={{zookeeper_truststore_path}}

--- a/roles/confluent.variables/defaults/main.yml
+++ b/roles/confluent.variables/defaults/main.yml
@@ -201,14 +201,20 @@ zookeeper_group: "{{zookeeper_default_group}}"
 ### Boolean to configure zookeeper with TLS Encryption. Also manages Java Keystore creation
 zookeeper_ssl_enabled: "{{ssl_enabled}}"
 
-### Boolean to enable mTLS Authentication on Zookeeper (Server to Server and Client to Server). Configures kafka to authenticate with mTLS.
+# Deprecated- Boolean to enable mTLS Authentication on Zookeeper (Server to Server and Client to Server). Configures kafka to authenticate with mTLS.
 zookeeper_ssl_mutual_auth_enabled: "{{ssl_mutual_auth_enabled}}"
 
-### Port for Kafka to Zookeeper connections. NOTE- 2181 will be configured for zk health checks
-zookeeper_client_port: "{{'2182' if zookeeper_ssl_enabled|bool else '2181'}}"
-
-### SASL Mechanism for Zookeeper Server to Server and Server to Client Authentication. Options are none, kerberos, digest. Server to server auth only working for digest-md5
+# Deprecated- SASL Mechanism for Zookeeper Server to Server and Server to Client Authentication. Options are none, kerberos, digest. Server to server auth only working for digest-md5
 zookeeper_sasl_protocol: "{{sasl_protocol if sasl_protocol == 'kerberos' else 'none'}}"
+
+### Authentication to put on ZK Server to Server connections. Available options: [mtls, digest].
+zookeeper_quorum_authentication_type: "{{ 'mtls' if zookeeper_ssl_enabled and zookeeper_ssl_mutual_auth_enabled else zookeeper_sasl_protocol }}"
+
+### Authentication to put on ZK Client to Server connections. This is Kafka's connection to ZK. Available options: [mtls, digest, kerberos].
+zookeeper_client_authentication_type: "{{ 'mtls' if zookeeper_ssl_enabled and zookeeper_ssl_mutual_auth_enabled else zookeeper_sasl_protocol }}"
+
+### Port for Kafka to Zookeeper connections
+zookeeper_client_port: "{{'2182' if zookeeper_ssl_enabled|bool else '2181'}}"
 
 ### Set this variable to customize the directory that Zookeeper writes log files to. Default location is /var/log/kafka. NOTE- zookeeper.log_path is deprecated.
 zookeeper_log_dir: "{{zookeeper.log_path}}"

--- a/roles/confluent.variables/vars/main.yml
+++ b/roles/confluent.variables/vars/main.yml
@@ -189,13 +189,11 @@ kafka_broker_properties:
       zookeeper.ssl.truststore.location: "{{kafka_broker_pkcs12_truststore_path}}"
       zookeeper.ssl.truststore.password: "{{kafka_broker_truststore_storepass}}"
   zk_mtls:
-    # enabled: "{{ zookeeper_ssl_mutual_auth_enabled }}"
     enabled: "{{ zookeeper_client_authentication_type == 'mtls' }}"
     properties:
       zookeeper.ssl.keystore.location: "{{kafka_broker_pkcs12_keystore_path}}"
       zookeeper.ssl.keystore.password: "{{kafka_broker_keystore_storepass}}"
   zk_acls:
-    # enabled: "{{ zookeeper_sasl_protocol in ['kerberos', 'digest'] }}"
     enabled: "{{ zookeeper_client_authentication_type in ['kerberos', 'digest'] }}"
     properties:
       zookeeper.set.acl: 'true'

--- a/roles/confluent.variables/vars/main.yml
+++ b/roles/confluent.variables/vars/main.yml
@@ -35,11 +35,11 @@ zookeeper_properties:
       dataDir: /var/lib/zookeeper
       admin.enableServer: "false"
   non_secure:
-    enabled: "{{not zookeeper_ssl_enabled}}"
+    enabled: "{{ not zookeeper_ssl_enabled }}"
     properties:
       clientPort: "{{zookeeper_client_port}}"
-  ssl:
-    enabled: "{{zookeeper_ssl_enabled}}"
+  client_ssl:
+    enabled: "{{ zookeeper_ssl_enabled }}"
     properties:
       secureClientPort: "{{zookeeper_client_port}}"
       serverCnxnFactory: org.apache.zookeeper.server.NettyServerCnxnFactory
@@ -48,21 +48,32 @@ zookeeper_properties:
       ssl.keyStore.password: "{{zookeeper_keystore_storepass}}"
       ssl.trustStore.location: "{{zookeeper_truststore_path}}"
       ssl.trustStore.password: "{{zookeeper_truststore_storepass}}"
+      ssl.clientAuth: "{{ 'need' if zookeeper_client_authentication_type == 'mtls' else 'none' }}"
+  client_sasl:
+    enabled: "{{ zookeeper_client_authentication_type in ['kerberos', 'digest'] or zookeeper_quorum_authentication_type == 'digest'}}"
+    properties:
+      authProvider.sasl: org.apache.zookeeper.server.auth.SASLAuthenticationProvider
+  client_sasl_kerberos:
+    enabled: "{{ zookeeper_client_authentication_type == 'kerberos' }}"
+    properties:
+      kerberos.removeHostFromPrincipal: 'true'
+      kerberos.removeRealmFromPrincipal: 'true'
+  quorum_ssl:
+    enabled: "{{ zookeeper_quorum_authentication_type == 'mtls' }}"
+    properties:
       sslQuorum: "true"
       ssl.quorum.keyStore.location: "{{zookeeper_keystore_path}}"
       ssl.quorum.keyStore.password: "{{zookeeper_keystore_storepass}}"
       ssl.quorum.trustStore.location: "{{zookeeper_truststore_path}}"
       ssl.quorum.trustStore.password: "{{zookeeper_truststore_storepass}}"
-      ssl.clientAuth: "{{ 'need' if zookeeper_ssl_mutual_auth_enabled|bool else 'none' }}"
-  sasl:
-    enabled: "{{ zookeeper_sasl_protocol in ['kerberos', 'digest'] }}"
+  quorum_sasl:
+    enabled: "{{ zookeeper_quorum_authentication_type == 'digest' }}"
     properties:
-      authProvider.sasl: org.apache.zookeeper.server.auth.SASLAuthenticationProvider
-  sasl_kerberos:
-    enabled: "{{ zookeeper_sasl_protocol == 'kerberos' }}"
-    properties:
-      kerberos.removeHostFromPrincipal: 'true'
-      kerberos.removeRealmFromPrincipal: 'true'
+      quorum.auth.enableSasl: true
+      quorum.auth.learnerRequireSasl: true
+      quorum.auth.serverRequireSasl: true
+      quorum.auth.learner.saslLoginContext: QuorumLearner
+      quorum.auth.server.saslLoginContext: QuorumServer
   servers:
     enabled: true
     properties: "{{ zookeeper_servers | split_to_dict }}"
@@ -178,12 +189,14 @@ kafka_broker_properties:
       zookeeper.ssl.truststore.location: "{{kafka_broker_pkcs12_truststore_path}}"
       zookeeper.ssl.truststore.password: "{{kafka_broker_truststore_storepass}}"
   zk_mtls:
-    enabled: "{{ zookeeper_ssl_mutual_auth_enabled }}"
+    # enabled: "{{ zookeeper_ssl_mutual_auth_enabled }}"
+    enabled: "{{ zookeeper_client_authentication_type == 'mtls' }}"
     properties:
       zookeeper.ssl.keystore.location: "{{kafka_broker_pkcs12_keystore_path}}"
       zookeeper.ssl.keystore.password: "{{kafka_broker_keystore_storepass}}"
   zk_acls:
-    enabled: "{{ zookeeper_sasl_protocol in ['kerberos', 'digest'] }}"
+    # enabled: "{{ zookeeper_sasl_protocol in ['kerberos', 'digest'] }}"
+    enabled: "{{ zookeeper_client_authentication_type in ['kerberos', 'digest'] }}"
     properties:
       zookeeper.set.acl: 'true'
   sr:

--- a/roles/confluent.zookeeper/defaults/main.yml
+++ b/roles/confluent.zookeeper/defaults/main.yml
@@ -9,7 +9,7 @@ zookeeper_log4j_root_logger: INFO, stdout, zkAppender
 
 zookeeper_java_args:
   - "{% if zookeeper_ssl_enabled|bool %}-Djdk.tls.ephemeralDHKeySize=2048{% endif %}"
-  - "{% if zookeeper_sasl_protocol in ['kerberos', 'digest'] %}-Djava.security.auth.login.config={{zookeeper.jaas_file}}{% endif %}"
+  - "{% if zookeeper_client_authentication_type in ['kerberos', 'digest'] or zookeeper_quorum_authentication_type in ['kerberos', 'digest'] %}-Djava.security.auth.login.config={{zookeeper.jaas_file}}{% endif %}"
   - "{% if zookeeper_jolokia_enabled|bool %}-javaagent:{{jolokia_jar_path}}=config={{zookeeper_jolokia_config}}{% endif %}"
   - "{% if zookeeper_jmxexporter_enabled|bool %}-javaagent:{{jmxexporter_jar_path}}={{zookeeper_jmxexporter_port}}:{{zookeeper_jmxexporter_config_path}}{% endif %}"
 

--- a/roles/confluent.zookeeper/tasks/main.yml
+++ b/roles/confluent.zookeeper/tasks/main.yml
@@ -84,7 +84,7 @@
     kerberos_keytab_path: "{{zookeeper_kerberos_keytab_path}}"
     kerberos_keytab_destination_path: "{{zookeeper_keytab_path}}"
     kerberos_handler: "restart zookeeper"
-  when: zookeeper_sasl_protocol == 'kerberos'
+  when: zookeeper_client_authentication_type == 'kerberos'
 
 - name: Copy Custom Zookeeper Files
   include_role:
@@ -197,7 +197,7 @@
     mode: 0640
     owner: "{{zookeeper_user}}"
     group: "{{zookeeper_group}}"
-  when: zookeeper_sasl_protocol in ['kerberos', 'digest']
+  when: zookeeper_client_authentication_type in ['kerberos', 'digest'] or zookeeper_quorum_authentication_type in ['kerberos', 'digest']
   notify: restart zookeeper
 
 - name: Deploy JMX Exporter Config File

--- a/roles/confluent.zookeeper/templates/zookeeper_jaas.conf.j2
+++ b/roles/confluent.zookeeper/templates/zookeeper_jaas.conf.j2
@@ -1,4 +1,4 @@
-{% if zookeeper_sasl_protocol == 'kerberos' %}
+{% if zookeeper_client_authentication_type == 'kerberos' %}
 Server {
     com.sun.security.auth.module.Krb5LoginModule required
     useKeyTab=true
@@ -7,8 +7,9 @@ Server {
     useTicketCache=false
     principal="{{zookeeper_kerberos_principal}}";
 };
+
 {% endif %}
-{% if zookeeper_sasl_protocol == 'digest' %}
+{% if zookeeper_client_authentication_type == 'digest' %}
 Server {
     org.apache.zookeeper.server.auth.DigestLoginModule required
 {% for user in zookeeper_digest_users|dict2items %}
@@ -17,12 +18,11 @@ Server {
 {% endfor %}
 };
 
+{% endif %}
+{% if zookeeper_quorum_authentication_type == 'digest' %}
 QuorumServer {
     org.apache.zookeeper.server.auth.DigestLoginModule required
-{% for user in zookeeper_digest_users|dict2items %}
-    user_{{ user['value']['principal'] }}="{{ user['value']['password'] }}"{% if loop.index == loop|length %};{% endif %}
-
-{% endfor %}
+    user_{{zookeeper_digest_users.admin.principal}}="{{zookeeper_digest_users.admin.password}}";
 };
 
 QuorumLearner {


### PR DESCRIPTION
# Description

- Fixes bug that actually enforces digest auth for server to server auth. 
- Creates two new variables `zookeeper_quorum_authentication_type` and `zookeeper_client_authentication_type` - before it was unclear what auth was applied to client vs quorum connections

ZK Docs: https://cwiki.apache.org/confluence/display/ZOOKEEPER/Server-Server+mutual+authentication

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Reran zk-kerberos and zk-digest scenarios


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible