### PR TITLE
define jmx config file thru variables

### DIFF
--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -548,6 +548,22 @@ Default:  8079
 
 ***
 
+### zookeeper_jmxexporter_config_source_path
+
+Path on Ansible Controller for Zookeeper jmx config file. Only necessary to set for custom config.
+
+Default:  zookeeper.yml
+
+***
+
+### zookeeper_jmxexporter_config_path
+
+Destination path for Zookeeper jmx config file
+
+Default:  /opt/prometheus/zookeeper.yml
+
+***
+
 ### zookeeper_peer_port
 
 Zookeeper peer port
@@ -713,6 +729,22 @@ Default:  "{{jmxexporter_enabled}}"
 Port to expose prometheus metrics. Beware of port collisions if colocating components on same host
 
 Default:  8080
+
+***
+
+### kafka_broker_jmxexporter_config_source_path
+
+Path on Ansible Controller for Kafka Broker jmx config file. Only necessary to set for custom config.
+
+Default:  kafka.yml
+
+***
+
+### kafka_broker_jmxexporter_config_path
+
+Destination path for Kafka Broker jmx config file
+
+Default:  /opt/prometheus/kafka.yml
 
 ***
 
@@ -884,6 +916,22 @@ Default:  "{{jmxexporter_enabled}}"
 
 ***
 
+### schema_registry_jmxexporter_config_source_path
+
+Path on Ansible Controller for Schema Registry jmx config file. Only necessary to set for custom config.
+
+Default:  schema_registry.yml
+
+***
+
+### schema_registry_jmxexporter_config_path
+
+Destination path for Schema Registry jmx config file
+
+Default:  /opt/prometheus/schema_registry.yml
+
+***
+
 ### schema_registry_jmxexporter_port
 
 Port to expose prometheus metrics. Beware of port collisions if colocating components on same host
@@ -1025,6 +1073,22 @@ Default:  "{{jolokia_password}}"
 Boolean to enable Prometheus Exporter Agent installation and configuration on Rest Proxy
 
 Default:  "{{jmxexporter_enabled}}"
+
+***
+
+### kafka_rest_jmxexporter_config_source_path
+
+Path on Ansible Controller for Rest Proxy jmx config file. Only necessary to set for custom config.
+
+Default:  kafka_rest.yml
+
+***
+
+### kafka_rest_jmxexporter_config_path
+
+Destination path for Rest Proxy jmx config file
+
+Default:  /opt/prometheus/kafka_rest.yml
 
 ***
 
@@ -1177,6 +1241,22 @@ Default:  "{{jolokia_password}}"
 Boolean to enable Prometheus Exporter Agent installation and configuration on Connect
 
 Default:  "{{jmxexporter_enabled}}"
+
+***
+
+### kafka_connect_jmxexporter_config_source_path
+
+Path on Ansible Controller for Connect jmx config file. Only necessary to set for custom config.
+
+Default:  kafka_connect.yml
+
+***
+
+### kafka_connect_jmxexporter_config_path
+
+Destination path for Connect jmx config file
+
+Default:  /opt/prometheus/kafka_connect.yml
 
 ***
 
@@ -1361,6 +1441,22 @@ Default:  "{{jolokia_password}}"
 Boolean to enable Prometheus Exporter Agent installation and configuration on ksqlDB
 
 Default:  "{{jmxexporter_enabled}}"
+
+***
+
+### ksql_jmxexporter_config_source_path
+
+Path on Ansible Controller for ksqlDB jmx config file. Only necessary to set for custom config.
+
+Default:  ksql.yml
+
+***
+
+### ksql_jmxexporter_config_path
+
+Destination path for ksqlDB jmx config file
+
+Default:  /opt/prometheus/ksql.yml
 
 ***
 

--- a/roles/confluent.kafka_broker/tasks/dynamic_groups.yml
+++ b/roles/confluent.kafka_broker/tasks/dynamic_groups.yml
@@ -25,8 +25,7 @@
       {{ binary_base_path }}/bin/zookeeper-shell {{ groups['zookeeper'][0] }}:{{ zookeeper_client_port }}
           {%- if 'zookeeper.ssl.client.enable = true' in slurped_properties.content|b64decode
                 or 'zookeeper.ssl.client.enable=true' in slurped_properties.content|b64decode %}
-            -zk-tls-config-file {{ kafka_broker.zookeeper_tls_client_config_file \
-              if kafka_broker_secrets_protection_enabled else kafka_broker.config_file }}
+            -zk-tls-config-file {{ kafka_broker.zookeeper_tls_client_config_file if kafka_broker_secrets_protection_enabled else kafka_broker.config_file }}
           {%- endif %}
           get /controller | grep brokerid
   register: controller_query

--- a/roles/confluent.kafka_broker/tasks/main.yml
+++ b/roles/confluent.kafka_broker/tasks/main.yml
@@ -250,7 +250,7 @@
 
 - name: Deploy JMX Exporter Config File
   copy:
-    src: "{{kafka_broker_jmxexporter_config_file}}"
+    src: "{{kafka_broker_jmxexporter_config_source_path}}"
     dest: "{{kafka_broker_jmxexporter_config_path}}"
     mode: 0640
     owner: "{{kafka_broker_user}}"

--- a/roles/confluent.kafka_broker/tasks/main.yml
+++ b/roles/confluent.kafka_broker/tasks/main.yml
@@ -250,7 +250,7 @@
 
 - name: Deploy JMX Exporter Config File
   copy:
-    src: "kafka.yml"
+    src: "{{kafka_broker_jmxexporter_config_file}}"
     dest: "{{kafka_broker_jmxexporter_config_path}}"
     mode: 0640
     owner: "{{kafka_broker_user}}"

--- a/roles/confluent.kafka_broker/tasks/main.yml
+++ b/roles/confluent.kafka_broker/tasks/main.yml
@@ -121,7 +121,6 @@
     that:
       - kafka_broker_final_properties['log.dirs'].split(',')[0] != "/"
     fail_msg: "Make sure datadir key is set to list of directories, NOT a string or dictionary."
-    quiet: true
 
 - name: Set Permissions on Data Dirs
   file:

--- a/roles/confluent.kafka_connect/tasks/main.yml
+++ b/roles/confluent.kafka_connect/tasks/main.yml
@@ -177,7 +177,7 @@
 
 - name: Deploy JMX Exporter Config File
   copy:
-    src: "kafka_connect.yml"
+    src: "{{kafka_connect_jmxexporter_config_source_path}}"
     dest: "{{kafka_connect_jmxexporter_config_path}}"
     mode: 0640
     owner: "{{kafka_connect_user}}"

--- a/roles/confluent.kafka_rest/tasks/main.yml
+++ b/roles/confluent.kafka_rest/tasks/main.yml
@@ -190,7 +190,7 @@
 
 - name: Deploy JMX Exporter Config File
   copy:
-    src: "kafka_rest.yml"
+    src: "{{kafka_rest_jmxexporter_config_source_path}}"
     dest: "{{kafka_rest_jmxexporter_config_path}}"
     mode: 0640
     owner: "{{kafka_rest_user}}"

--- a/roles/confluent.ksql/tasks/main.yml
+++ b/roles/confluent.ksql/tasks/main.yml
@@ -200,7 +200,7 @@
 
 - name: Deploy JMX Exporter Config File
   copy:
-    src: "ksql.yml"
+    src: "{{ksql_jmxexporter_config_source_path}}"
     dest: "{{ksql_jmxexporter_config_path}}"
     mode: 0640
     owner: "{{ksql_user}}"

--- a/roles/confluent.schema_registry/tasks/main.yml
+++ b/roles/confluent.schema_registry/tasks/main.yml
@@ -174,7 +174,7 @@
 
 - name: Deploy JMX Exporter Config File
   copy:
-    src: "schema_registry.yml"
+    src: "{{schema_registry_jmxexporter_config_source_path}}"
     dest: "{{schema_registry_jmxexporter_config_path}}"
     mode: 0640
     owner: "{{schema_registry_user}}"

--- a/roles/confluent.variables/defaults/main.yml
+++ b/roles/confluent.variables/defaults/main.yml
@@ -255,7 +255,10 @@ zookeeper_jmxexporter_enabled: "{{jmxexporter_enabled}}"
 ### Port to expose prometheus metrics. Beware of port collisions if colocating components on same host
 zookeeper_jmxexporter_port: 8079
 
+## destination path for zookeeper jmx config file
 zookeeper_jmxexporter_config_path: /opt/prometheus/zookeeper.yml
+## source file for zookeeper jmx config file
+zookeeper_jmxexporter_config_file: "zookeeper.yml"
 
 zookeeper_health_check_command: "{% if zookeeper_sasl_protocol in ['kerberos', 'digest'] %}KAFKA_OPTS='-Djava.security.auth.login.config={{zookeeper.jaas_file}}'{% endif %}
 {{ binary_base_path }}/bin/kafka-run-class
@@ -406,7 +409,10 @@ kafka_broker_jmxexporter_enabled: "{{jmxexporter_enabled}}"
 ### Port to expose prometheus metrics. Beware of port collisions if colocating components on same host
 kafka_broker_jmxexporter_port: 8080
 
+## destination path for broker jmx config file
 kafka_broker_jmxexporter_config_path: /opt/prometheus/kafka.yml
+## source file for broker jmx config file
+kafka_broker_jmxexporter_config_file: "kafka.yml"
 
 ### Use to copy files from control node to kafka hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to)
 kafka_broker_copy_files: []

--- a/roles/confluent.variables/defaults/main.yml
+++ b/roles/confluent.variables/defaults/main.yml
@@ -257,8 +257,9 @@ zookeeper_jmxexporter_port: 8079
 
 ## destination path for zookeeper jmx config file
 zookeeper_jmxexporter_config_path: /opt/prometheus/zookeeper.yml
-## source file for zookeeper jmx config file
-zookeeper_jmxexporter_config_file: "zookeeper.yml"
+
+### Path on Ansible Controller for Zookeeper jmx config file. Only necessary to set for custom config.
+zookeeper_jmxexporter_config_source_path: "zookeeper.yml"
 
 zookeeper_health_check_command: "{% if zookeeper_sasl_protocol in ['kerberos', 'digest'] %}KAFKA_OPTS='-Djava.security.auth.login.config={{zookeeper.jaas_file}}'{% endif %}
 {{ binary_base_path }}/bin/kafka-run-class
@@ -411,8 +412,8 @@ kafka_broker_jmxexporter_port: 8080
 
 ## destination path for broker jmx config file
 kafka_broker_jmxexporter_config_path: /opt/prometheus/kafka.yml
-## source file for broker jmx config file
-kafka_broker_jmxexporter_config_file: "kafka.yml"
+## Path on Ansible Controller for Kafka Broker jmx config file. Only necessary to set for custom config.
+kafka_broker_jmxexporter_config_source_path: "kafka.yml"
 
 ### Use to copy files from control node to kafka hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to)
 kafka_broker_copy_files: []

--- a/roles/confluent.variables/defaults/main.yml
+++ b/roles/confluent.variables/defaults/main.yml
@@ -255,11 +255,11 @@ zookeeper_jmxexporter_enabled: "{{jmxexporter_enabled}}"
 ### Port to expose prometheus metrics. Beware of port collisions if colocating components on same host
 zookeeper_jmxexporter_port: 8079
 
-## destination path for zookeeper jmx config file
-zookeeper_jmxexporter_config_path: /opt/prometheus/zookeeper.yml
-
 ### Path on Ansible Controller for Zookeeper jmx config file. Only necessary to set for custom config.
-zookeeper_jmxexporter_config_source_path: "zookeeper.yml"
+zookeeper_jmxexporter_config_source_path: zookeeper.yml
+
+### Destination path for Zookeeper jmx config file
+zookeeper_jmxexporter_config_path: /opt/prometheus/zookeeper.yml
 
 zookeeper_health_check_command: "{% if zookeeper_sasl_protocol in ['kerberos', 'digest'] %}KAFKA_OPTS='-Djava.security.auth.login.config={{zookeeper.jaas_file}}'{% endif %}
 {{ binary_base_path }}/bin/kafka-run-class
@@ -410,10 +410,11 @@ kafka_broker_jmxexporter_enabled: "{{jmxexporter_enabled}}"
 ### Port to expose prometheus metrics. Beware of port collisions if colocating components on same host
 kafka_broker_jmxexporter_port: 8080
 
-## destination path for broker jmx config file
+### Path on Ansible Controller for Kafka Broker jmx config file. Only necessary to set for custom config.
+kafka_broker_jmxexporter_config_source_path: kafka.yml
+
+### Destination path for Kafka Broker jmx config file
 kafka_broker_jmxexporter_config_path: /opt/prometheus/kafka.yml
-## Path on Ansible Controller for Kafka Broker jmx config file. Only necessary to set for custom config.
-kafka_broker_jmxexporter_config_source_path: "kafka.yml"
 
 ### Use to copy files from control node to kafka hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to)
 kafka_broker_copy_files: []
@@ -496,6 +497,10 @@ schema_registry_jolokia_password: "{{jolokia_password}}"
 ### Boolean to enable Prometheus Exporter Agent installation and configuration on schema registry
 schema_registry_jmxexporter_enabled: "{{jmxexporter_enabled}}"
 
+### Path on Ansible Controller for Schema Registry jmx config file. Only necessary to set for custom config.
+schema_registry_jmxexporter_config_source_path: schema_registry.yml
+
+### Destination path for Schema Registry jmx config file
 schema_registry_jmxexporter_config_path: /opt/prometheus/schema_registry.yml
 
 ### Port to expose prometheus metrics. Beware of port collisions if colocating components on same host
@@ -569,6 +574,11 @@ kafka_rest_jolokia_password: "{{jolokia_password}}"
 
 ### Boolean to enable Prometheus Exporter Agent installation and configuration on Rest Proxy
 kafka_rest_jmxexporter_enabled: "{{jmxexporter_enabled}}"
+
+### Path on Ansible Controller for Rest Proxy jmx config file. Only necessary to set for custom config.
+kafka_rest_jmxexporter_config_source_path: kafka_rest.yml
+
+### Destination path for Rest Proxy jmx config file
 kafka_rest_jmxexporter_config_path: /opt/prometheus/kafka_rest.yml
 
 ### Port to expose prometheus metrics. Beware of port collisions if colocating components on same host
@@ -647,6 +657,11 @@ kafka_connect_jolokia_password: "{{jolokia_password}}"
 
 ### Boolean to enable Prometheus Exporter Agent installation and configuration on Connect
 kafka_connect_jmxexporter_enabled: "{{jmxexporter_enabled}}"
+
+### Path on Ansible Controller for Connect jmx config file. Only necessary to set for custom config.
+kafka_connect_jmxexporter_config_source_path: kafka_connect.yml
+
+### Destination path for Connect jmx config file
 kafka_connect_jmxexporter_config_path: /opt/prometheus/kafka_connect.yml
 
 ### Port to expose connect prometheus metrics. Beware of port collisions if colocating components on same host
@@ -748,6 +763,11 @@ ksql_jolokia_password: "{{jolokia_password}}"
 
 ### Boolean to enable Prometheus Exporter Agent installation and configuration on ksqlDB
 ksql_jmxexporter_enabled: "{{jmxexporter_enabled}}"
+
+### Path on Ansible Controller for ksqlDB jmx config file. Only necessary to set for custom config.
+ksql_jmxexporter_config_source_path: ksql.yml
+
+### Destination path for ksqlDB jmx config file
 ksql_jmxexporter_config_path: /opt/prometheus/ksql.yml
 
 ### Port to expose ksqlDB prometheus metrics. Beware of port collisions if colocating components on same host

--- a/roles/confluent.zookeeper/tasks/main.yml
+++ b/roles/confluent.zookeeper/tasks/main.yml
@@ -202,7 +202,7 @@
 
 - name: Deploy JMX Exporter Config File
   copy:
-    src: "{{zookeeper_jmxexporter_config_file}}"
+    src: "{{zookeeper_jmxexporter_config_source_path}}"
     dest: "{{zookeeper_jmxexporter_config_path}}"
     mode: 0640
     owner: "{{zookeeper_user}}"

--- a/roles/confluent.zookeeper/tasks/main.yml
+++ b/roles/confluent.zookeeper/tasks/main.yml
@@ -202,7 +202,7 @@
 
 - name: Deploy JMX Exporter Config File
   copy:
-    src: "zookeeper.yml"
+    src: "{{zookeeper_jmxexporter_config_file}}"
     dest: "{{zookeeper_jmxexporter_config_path}}"
     mode: 0640
     owner: "{{zookeeper_user}}"


### PR DESCRIPTION
# Description

jmx config file is hardcoded in playbook, but confluent grafana dashboards expect onather version
This change allow user to specify an alternative file to use as source.

## Type of change

New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

run playbook with an inventory containing `kafka_broker_jmxexporter_config_file` and/or `zookeeper_jmxexporter_config_file` defined to a custom jmx config file
