### PR TITLE
Ignore errors for package install tasks in check mode

### DIFF
--- a/roles/confluent.control_center/tasks/main.yml
+++ b/roles/confluent.control_center/tasks/main.yml
@@ -23,6 +23,7 @@
   when:
     - ansible_os_family == "RedHat"
     - installation_method == "package"
+  ignore_errors: "{{ ansible_check_mode }}"
   tags: package
 
 - name: Install the Control Center Packages
@@ -32,6 +33,7 @@
   when:
     - ansible_os_family == "Debian"
     - installation_method == "package"
+  ignore_errors: "{{ ansible_check_mode }}"
   tags: package
 
 # Configure environment

--- a/roles/confluent.kafka_broker/tasks/main.yml
+++ b/roles/confluent.kafka_broker/tasks/main.yml
@@ -22,6 +22,7 @@
   when:
     - ansible_os_family == "RedHat"
     - installation_method == "package"
+  ignore_errors: "{{ ansible_check_mode }}"
   tags: package
 
 - name: Install the Kafka Broker Packages
@@ -31,6 +32,7 @@
   when:
     - ansible_os_family == "Debian"
     - installation_method == "package"
+  ignore_errors: "{{ ansible_check_mode }}"
   tags: package
 
 - name: Kafka Broker group

--- a/roles/confluent.kafka_connect/tasks/main.yml
+++ b/roles/confluent.kafka_connect/tasks/main.yml
@@ -23,6 +23,7 @@
   when:
     - ansible_os_family == "RedHat"
     - installation_method == "package"
+  ignore_errors: "{{ ansible_check_mode }}"
   tags: package
 
 - name: Install the Kafka Connect Packages
@@ -32,6 +33,7 @@
   when:
     - ansible_os_family == "Debian"
     - installation_method == "package"
+  ignore_errors: "{{ ansible_check_mode }}"
   tags: package
 
 # Configure environment

--- a/roles/confluent.kafka_connect_replicator/tasks/main.yml
+++ b/roles/confluent.kafka_connect_replicator/tasks/main.yml
@@ -23,6 +23,7 @@
   when:
     - ansible_os_family == "RedHat"
     - installation_method == "package"
+  ignore_errors: "{{ ansible_check_mode }}"
   tags: package
 
 - name: Install the Kafka Connect Replicator Packages
@@ -32,6 +33,7 @@
   when:
     - ansible_os_family == "Debian"
     - installation_method == "package"
+  ignore_errors: "{{ ansible_check_mode }}"
   tags: package
 
 # Configure environment

--- a/roles/confluent.kafka_rest/tasks/main.yml
+++ b/roles/confluent.kafka_rest/tasks/main.yml
@@ -23,6 +23,7 @@
   when:
     - ansible_os_family == "RedHat"
     - installation_method == "package"
+  ignore_errors: "{{ ansible_check_mode }}"
   tags: package
 
 - name: Install the Kafka Rest Packages
@@ -32,6 +33,7 @@
   when:
     - ansible_os_family == "Debian"
     - installation_method == "package"
+  ignore_errors: "{{ ansible_check_mode }}"
   tags: package
 
 # Configure environment

--- a/roles/confluent.ksql/tasks/main.yml
+++ b/roles/confluent.ksql/tasks/main.yml
@@ -23,6 +23,7 @@
   when:
     - ansible_os_family == "RedHat"
     - installation_method == "package"
+  ignore_errors: "{{ ansible_check_mode }}"
   tags: package
 
 - name: Install the KSQL Packages
@@ -32,6 +33,7 @@
   when:
     - ansible_os_family == "Debian"
     - installation_method == "package"
+  ignore_errors: "{{ ansible_check_mode }}"
   tags: package
 
 # Configure environment

--- a/roles/confluent.schema_registry/tasks/main.yml
+++ b/roles/confluent.schema_registry/tasks/main.yml
@@ -23,6 +23,7 @@
   when:
     - ansible_os_family == "RedHat"
     - installation_method == "package"
+  ignore_errors: "{{ ansible_check_mode }}"
   tags: package
 
 - name: Install the Schema Registry Packages
@@ -32,6 +33,7 @@
   when:
     - ansible_os_family == "Debian"
     - installation_method == "package"
+  ignore_errors: "{{ ansible_check_mode }}"
   tags: package
 
 # Configure environment

--- a/roles/confluent.zookeeper/tasks/main.yml
+++ b/roles/confluent.zookeeper/tasks/main.yml
@@ -22,6 +22,7 @@
   when:
     - ansible_os_family == "RedHat"
     - installation_method == "package"
+  ignore_errors: "{{ ansible_check_mode }}"
   tags: package
 
 - name: Install the Zookeeper Packages
@@ -31,6 +32,7 @@
   when:
     - ansible_os_family == "Debian"
     - installation_method == "package"
+  ignore_errors: "{{ ansible_check_mode }}"
   tags: package
 
 # Configure environment


### PR DESCRIPTION
# Description

This PR allows package install tasks to fail in check mode. This should give better support for desired state upgrades, ref. #591.

We prefer to run all desired state playbooks in check mode before we apply changes to a system, typically `ansible-playbook --check --diff <playbook>`. This allows us to QA the changes that will be applied - before running the playbook "for real". Not all Ansible modules supports diff mode, but this has proven to be a very useful technique.

When switching to a new version branch of cp-ansible as part of an upgrade, the package install tasks are currently failing in check mode - because the package repository hasn't been updated yet. This PR fixes this, and I hope this is an acceptable change.

Fixes # (#591)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested that this fixes our check mode issue.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible