### PR TITLE
Support for desired state package upgrade/downgrade

### DIFF
--- a/roles/confluent.common/tasks/remove_packages.yml
+++ b/roles/confluent.common/tasks/remove_packages.yml
@@ -1,0 +1,49 @@
+---
+- name: Get Package Facts
+  package_facts:
+
+- name: Determine if Confluent Platform Package Version Will Change
+  set_fact:
+    confluent_package_version_changed: >-
+      {{ ansible_facts.packages['confluent-common'] is defined
+          and ansible_facts.packages['confluent-common'][0].version
+            not in [confluent_package_version, confluent_full_package_version] }}
+
+- name: Get installed Confluent Packages
+  set_fact:
+    confluent_packages_actual: >
+      {{ ansible_facts.packages | dict2items | map(attribute='key') | select('match', 'confluent-') | list }}
+
+- name: Determine Confluent Packages to Remove
+  set_fact:
+    confluent_packages_removed: >
+      {{ confluent_packages_actual if confluent_package_version_changed|bool else
+          confluent_packages_actual | intersect(['confluent-kafka']) if confluent_server_enabled else
+          confluent_packages_actual | intersect(['confluent-server']) }}
+
+- name: Debug Confluent Packages to Remove
+  debug:
+    msg: "{{ confluent_packages_removed }}"
+  when: confluent_packages_removed|length > 0
+
+- name: Stop Service before Removing Confluent Packages
+  systemd:
+    name: "{{ service_name }}"
+    state: stopped
+  when: confluent_packages_removed|length > 0
+
+- name: Remove Confluent Packages - Red Hat
+  yum:
+    name: "{{ confluent_packages_removed }}"
+    state: absent
+  when:
+    - ansible_os_family == "RedHat"
+    - confluent_packages_removed|length > 0
+
+- name: Remove Confluent Packages - Debian
+  apt:
+    name: "{{ confluent_packages_removed }}"
+    state: absent
+  when:
+    - ansible_os_family == "Debian"
+    - confluent_packages_removed|length > 0

--- a/roles/confluent.control_center/tasks/main.yml
+++ b/roles/confluent.control_center/tasks/main.yml
@@ -14,6 +14,15 @@
     - ansible_os_family
     - ansible_fqdn
 
+- name: Stop Service and Remove Packages on Version Change
+  include_role:
+    name: confluent.common
+    tasks_from: remove_packages.yml
+  vars:
+    service_name: "{{ control_center_service_name }}"
+  when: installation_method == "package"
+  tags: package
+
 # Install Packages
 - name: Install the Control Center Packages
   yum:

--- a/roles/confluent.kafka_broker/tasks/main.yml
+++ b/roles/confluent.kafka_broker/tasks/main.yml
@@ -14,6 +14,15 @@
     - ansible_os_family
     - ansible_fqdn
 
+- name: Stop Service and Remove Packages on Version Change
+  include_role:
+    name: confluent.common
+    tasks_from: remove_packages.yml
+  vars:
+    service_name: "{{ kafka_broker_service_name }}"
+  when: installation_method == "package"
+  tags: package
+
 # Install Packages
 - name: Install the Kafka Broker Packages
   yum:

--- a/roles/confluent.kafka_connect/tasks/main.yml
+++ b/roles/confluent.kafka_connect/tasks/main.yml
@@ -14,6 +14,15 @@
     - ansible_os_family
     - ansible_fqdn
 
+- name: Stop Service and Remove Packages on Version Change
+  include_role:
+    name: confluent.common
+    tasks_from: remove_packages.yml
+  vars:
+    service_name: "{{ kafka_connect_service_name }}"
+  when: installation_method == "package"
+  tags: package
+
 # Install Packages
 - name: Install the Kafka Connect Packages
   yum:

--- a/roles/confluent.kafka_connect_replicator/tasks/main.yml
+++ b/roles/confluent.kafka_connect_replicator/tasks/main.yml
@@ -14,6 +14,15 @@
     - ansible_os_family
     - ansible_fqdn
 
+- name: Stop Service and Remove Packages on Version Change
+  include_role:
+    name: confluent.common
+    tasks_from: remove_packages.yml
+  vars:
+    service_name: "{{ kafka_connect_replicator_service_name }}"
+  when: installation_method == "package"
+  tags: package
+
 # Install Packages
 - name: Install the Kafka Connect Replicator Packages
   yum:

--- a/roles/confluent.kafka_rest/tasks/main.yml
+++ b/roles/confluent.kafka_rest/tasks/main.yml
@@ -14,6 +14,15 @@
     - ansible_os_family
     - ansible_fqdn
 
+- name: Stop Service and Remove Packages on Version Change
+  include_role:
+    name: confluent.common
+    tasks_from: remove_packages.yml
+  vars:
+    service_name: "{{ kafka_rest_service_name }}"
+  when: installation_method == "package"
+  tags: package
+
 # Install Packages
 - name: Install the Kafka Rest Packages
   yum:

--- a/roles/confluent.ksql/tasks/main.yml
+++ b/roles/confluent.ksql/tasks/main.yml
@@ -14,6 +14,15 @@
     - ansible_os_family
     - ansible_fqdn
 
+- name: Stop Service and Remove Packages on Version Change
+  include_role:
+    name: confluent.common
+    tasks_from: remove_packages.yml
+  vars:
+    service_name: "{{ ksql_service_name }}"
+  when: installation_method == "package"
+  tags: package
+
 # Install Packages
 - name: Install the KSQL Packages
   yum:

--- a/roles/confluent.schema_registry/tasks/main.yml
+++ b/roles/confluent.schema_registry/tasks/main.yml
@@ -14,6 +14,15 @@
     - ansible_os_family
     - ansible_fqdn
 
+- name: Stop Service and Remove Packages on Version Change
+  include_role:
+    name: confluent.common
+    tasks_from: remove_packages.yml
+  vars:
+    service_name: "{{ schema_registry_service_name }}"
+  when: installation_method == "package"
+  tags: package
+
 # Install Packages
 - name: Install the Schema Registry Packages
   yum:

--- a/roles/confluent.zookeeper/tasks/main.yml
+++ b/roles/confluent.zookeeper/tasks/main.yml
@@ -14,6 +14,15 @@
     - ansible_os_family
     - ansible_fqdn
 
+- name: Stop Service and Remove Packages on Version Change
+  include_role:
+    name: confluent.common
+    tasks_from: remove_packages.yml
+  vars:
+    service_name: "{{ zookeeper_service_name }}"
+  when: installation_method == "package"
+  tags: package
+
 # Install Packages
 - name: Install the Zookeeper Packages
   yum:


### PR DESCRIPTION
# Description

The installed packages will now be checked for an eventual upgrade/downgrade of packages - including upgrading from confluent-kafka to confluent-server (and vice versa).

Obsolete packages are removed [_after stopping service_](https://github.com/confluentinc/cp-ansible/pull/607#issuecomment-805343543), and the existing desired state package install will take care of installing correct packages.

Fixes #591 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested partially in our custom playbooks upgrading from CP 5.4 to 5.5. Also tested upgrade/downgrade a few times CP 6.1.0 <-> CP 6.1.1. My test environment is colocated, and that seems worse than non colocated...

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible