### PR TITLE
Use list in all yum/apt package install tasks

### DIFF
--- a/roles/confluent.common/tasks/debian.yml
+++ b/roles/confluent.common/tasks/debian.yml
@@ -160,10 +160,9 @@
 
 - name: Install ca-certificates, openssl, unzip
   apt:
-    name: "{{ item }}"
-  loop:
-    - ca-certificates
-    - openssl
-    - unzip
-    - curl
+    name:
+      - ca-certificates
+      - openssl
+      - unzip
+      - curl
   tags: package

--- a/roles/confluent.common/tasks/redhat.yml
+++ b/roles/confluent.common/tasks/redhat.yml
@@ -54,8 +54,7 @@
 
 - name: Install OpenSSL and Unzip
   yum:
-    name: "{{item}}"
-  loop:
-    - openssl
-    - unzip
+    name:
+      - openssl
+      - unzip
   tags: package

--- a/roles/confluent.common/tasks/ubuntu.yml
+++ b/roles/confluent.common/tasks/ubuntu.yml
@@ -54,7 +54,4 @@
 - name: Install OpenSSL
   apt:
     name: openssl
-  loop:
-    - openssl
-    - unzip
   tags: package

--- a/roles/confluent.control_center/tasks/main.yml
+++ b/roles/confluent.control_center/tasks/main.yml
@@ -17,9 +17,8 @@
 # Install Packages
 - name: Install the Control Center Packages
   yum:
-    name: "{{item}}{{confluent_package_redhat_suffix}}"
+    name: "{{ control_center_packages | product([confluent_package_redhat_suffix]) | map('join') | list }}"
     state: latest
-  loop: "{{control_center_packages}}"
   when:
     - ansible_os_family == "RedHat"
     - installation_method == "package"
@@ -29,8 +28,7 @@
 
 - name: Install the Control Center Packages
   apt:
-    name: "{{item}}{{confluent_package_debian_suffix}}"
-  loop: "{{control_center_packages}}"
+    name: "{{ control_center_packages | product([confluent_package_debian_suffix]) | map('join') | list }}"
   when:
     - ansible_os_family == "Debian"
     - installation_method == "package"

--- a/roles/confluent.kafka_broker/tasks/main.yml
+++ b/roles/confluent.kafka_broker/tasks/main.yml
@@ -17,9 +17,8 @@
 # Install Packages
 - name: Install the Kafka Broker Packages
   yum:
-    name: "{{item}}{{confluent_package_redhat_suffix}}"
+    name: "{{ kafka_broker_packages | product([confluent_package_redhat_suffix]) | map('join') | list }}"
     state: latest
-  loop: "{{kafka_broker_packages}}"
   when:
     - ansible_os_family == "RedHat"
     - installation_method == "package"
@@ -29,8 +28,7 @@
 
 - name: Install the Kafka Broker Packages
   apt:
-    name: "{{item}}{{confluent_package_debian_suffix}}"
-  loop: "{{kafka_broker_packages}}"
+    name: "{{ kafka_broker_packages | product([confluent_package_debian_suffix]) | map('join') | list }}"
   when:
     - ansible_os_family == "Debian"
     - installation_method == "package"

--- a/roles/confluent.kafka_connect/tasks/main.yml
+++ b/roles/confluent.kafka_connect/tasks/main.yml
@@ -17,9 +17,8 @@
 # Install Packages
 - name: Install the Kafka Connect Packages
   yum:
-    name: "{{item}}{{confluent_package_redhat_suffix}}"
+    name: "{{ kafka_connect_packages | product([confluent_package_redhat_suffix]) | map('join') | list }}"
     state: latest
-  loop: "{{kafka_connect_packages}}"
   when:
     - ansible_os_family == "RedHat"
     - installation_method == "package"
@@ -29,8 +28,7 @@
 
 - name: Install the Kafka Connect Packages
   apt:
-    name: "{{item}}{{confluent_package_debian_suffix}}"
-  loop: "{{kafka_connect_packages}}"
+    name: "{{ kafka_connect_packages | product([confluent_package_debian_suffix]) | map('join') | list }}"
   when:
     - ansible_os_family == "Debian"
     - installation_method == "package"

--- a/roles/confluent.kafka_connect_replicator/tasks/main.yml
+++ b/roles/confluent.kafka_connect_replicator/tasks/main.yml
@@ -17,9 +17,8 @@
 # Install Packages
 - name: Install the Kafka Connect Replicator Packages
   yum:
-    name: "{{item}}{{confluent_package_redhat_suffix}}"
+    name: "{{ kafka_connect_replicator_packages | product([confluent_package_redhat_suffix]) | map('join') | list }}"
     state: latest
-  loop: "{{kafka_connect_replicator_packages}}"
   when:
     - ansible_os_family == "RedHat"
     - installation_method == "package"
@@ -29,8 +28,7 @@
 
 - name: Install the Kafka Connect Replicator Packages
   apt:
-    name: "{{item}}{{confluent_package_debian_suffix}}"
-  loop: "{{kafka_connect_replicator_packages}}"
+    name: "{{ kafka_connect_replicator_packages | product([confluent_package_debian_suffix]) | map('join') | list }}"
   when:
     - ansible_os_family == "Debian"
     - installation_method == "package"

--- a/roles/confluent.kafka_rest/tasks/main.yml
+++ b/roles/confluent.kafka_rest/tasks/main.yml
@@ -17,9 +17,8 @@
 # Install Packages
 - name: Install the Kafka Rest Packages
   yum:
-    name: "{{item}}{{confluent_package_redhat_suffix}}"
+    name: "{{ kafka_rest_packages | product([confluent_package_redhat_suffix]) | map('join') | list }}"
     state: latest
-  loop: "{{kafka_rest_packages}}"
   when:
     - ansible_os_family == "RedHat"
     - installation_method == "package"
@@ -29,8 +28,7 @@
 
 - name: Install the Kafka Rest Packages
   apt:
-    name: "{{item}}{{confluent_package_debian_suffix}}"
-  loop: "{{kafka_rest_packages}}"
+    name: "{{ kafka_rest_packages | product([confluent_package_debian_suffix]) | map('join') | list }}"
   when:
     - ansible_os_family == "Debian"
     - installation_method == "package"

--- a/roles/confluent.ksql/tasks/main.yml
+++ b/roles/confluent.ksql/tasks/main.yml
@@ -17,9 +17,8 @@
 # Install Packages
 - name: Install the KSQL Packages
   yum:
-    name: "{{item}}{{confluent_package_redhat_suffix}}"
+    name: "{{ ksql_packages | product([confluent_package_redhat_suffix]) | map('join') | list }}"
     state: latest
-  loop: "{{ksql_packages}}"
   when:
     - ansible_os_family == "RedHat"
     - installation_method == "package"
@@ -29,8 +28,7 @@
 
 - name: Install the KSQL Packages
   apt:
-    name: "{{item}}{{confluent_package_debian_suffix}}"
-  loop: "{{ksql_packages}}"
+    name: "{{ ksql_packages | product([confluent_package_debian_suffix]) | map('join') | list }}"
   when:
     - ansible_os_family == "Debian"
     - installation_method == "package"

--- a/roles/confluent.schema_registry/tasks/main.yml
+++ b/roles/confluent.schema_registry/tasks/main.yml
@@ -17,9 +17,8 @@
 # Install Packages
 - name: Install the Schema Registry Packages
   yum:
-    name: "{{item}}{{confluent_package_redhat_suffix}}"
+    name: "{{ schema_registry_packages | product([confluent_package_redhat_suffix]) | map('join') | list }}"
     state: latest
-  loop: "{{schema_registry_packages}}"
   when:
     - ansible_os_family == "RedHat"
     - installation_method == "package"
@@ -29,8 +28,7 @@
 
 - name: Install the Schema Registry Packages
   apt:
-    name: "{{item}}{{confluent_package_debian_suffix}}"
-  loop: "{{schema_registry_packages}}"
+    name: "{{ schema_registry_packages | product([confluent_package_debian_suffix]) | map('join') | list }}"
   when:
     - ansible_os_family == "Debian"
     - installation_method == "package"

--- a/roles/confluent.test.ldap/tasks/main.yml
+++ b/roles/confluent.test.ldap/tasks/main.yml
@@ -11,17 +11,16 @@
 
 - name: Install LDAP Server Packages
   yum:
-    name: "{{item}}"
+    name:
+      - rsyslog
+      - libselinux-python
+      - openldap
+      - openldap-servers
+      - compat-openldap
+      - openldap-clients
+      - openldap-devel
+      - nss-pam-ldapd
     state: latest
-  loop:
-    - rsyslog
-    - libselinux-python
-    - openldap
-    - openldap-servers
-    - compat-openldap
-    - openldap-clients
-    - openldap-devel
-    - nss-pam-ldapd
 
 - name: Start slapd Service
   service:

--- a/roles/confluent.test/molecule/certificates.yml
+++ b/roles/confluent.test/molecule/certificates.yml
@@ -4,22 +4,20 @@
   tasks:
     - name: Install OpenSSL Rsync and Java
       yum:
-        name: "{{item}}"
+        name:
+          - openssl
+          - rsync
+          - java-1.8.0-openjdk
         state: present
-      loop:
-        - openssl
-        - rsync
-        - java-1.8.0-openjdk
       when: ansible_os_family == "RedHat"
 
     - name: Install OpenSSL Rsync and Java
       apt:
-        name: "{{item}}"
+        name:
+          - openssl
+          - rsync
+          - openjdk-8-jdk
         state: present
-      loop:
-        - openssl
-        - rsync
-        - openjdk-8-jdk
       when: ansible_os_family == "Debian"
 
     - name: Create SSL Certificate Generation Directory

--- a/roles/confluent.test/molecule/mtls-custombundle-rhel/prepare.yml
+++ b/roles/confluent.test/molecule/mtls-custombundle-rhel/prepare.yml
@@ -4,22 +4,20 @@
   tasks:
     - name: Install OpenSSL Rsync and Java
       yum:
-        name: "{{item}}"
+        name:
+          - openssl
+          - rsync
+          - java-1.8.0-openjdk
         state: present
-      loop:
-        - openssl
-        - rsync
-        - java-1.8.0-openjdk
       when: ansible_os_family == "RedHat"
 
     - name: Install OpenSSL Rsync and Java
       apt:
-        name: "{{item}}"
+        name:
+          - openssl
+          - rsync
+          - openjdk-8-jdk
         state: present
-      loop:
-        - openssl
-        - rsync
-        - openjdk-8-jdk
       when: ansible_os_family == "Debian"
 
     - name: Create SSL Certificate Generation Directory

--- a/roles/confluent.zookeeper/tasks/main.yml
+++ b/roles/confluent.zookeeper/tasks/main.yml
@@ -17,9 +17,8 @@
 # Install Packages
 - name: Install the Zookeeper Packages
   yum:
-    name: "{{item}}{{confluent_package_redhat_suffix}}"
+    name: "{{ zookeeper_packages | product([confluent_package_redhat_suffix]) | map('join') | list }}"
     state: latest
-  loop: "{{zookeeper_packages}}"
   when:
     - ansible_os_family == "RedHat"
     - installation_method == "package"
@@ -29,8 +28,7 @@
 
 - name: Install the Zookeeper Packages
   apt:
-    name: "{{item}}{{confluent_package_debian_suffix}}"
-  loop: "{{zookeeper_packages}}"
+    name: "{{ zookeeper_packages | product([confluent_package_debian_suffix]) | map('join') | list }}"
   when:
     - ansible_os_family == "Debian"
     - installation_method == "package"

--- a/tasks/certificate_authority.yml
+++ b/tasks/certificate_authority.yml
@@ -54,21 +54,19 @@
     - name: Install OpenSSL and Rsync - RedHat
       tags: certificate_authority
       yum:
-        name: "{{item}}"
+        name:
+          - openssl
+          - rsync
         state: present
-      loop:
-        - openssl
-        - rsync
       when: ansible_os_family == "RedHat"
 
     - name: Install OpenSSL and Rsync - Debian
       tags: certificate_authority
       apt:
-        name: "{{item}}"
+        name:
+          - openssl
+          - rsync
         state: present
-      loop:
-        - openssl
-        - rsync
       when: ansible_os_family == "Debian"
 
     - name: Create SSL Certificate Generation Directory


### PR DESCRIPTION
# Description

This PR replaces all loops on package install tasks with a list of packages supplied to the `yum` and `apt` ansible modules. This should improve performance on the desired state package tasks.

I have left out the upgrade-playbooks, at least for now, as they are not idempotent (#https://github.com/confluentinc/cp-ansible/issues/588) and will typically be run just once.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible