### PR TITLE
[MINOR] Adding C3 LOG4J_OPTS variable back

### DIFF
--- a/roles/confluent.control_center/defaults/main.yml
+++ b/roles/confluent.control_center/defaults/main.yml
@@ -31,6 +31,7 @@ control_center_service_environment_overrides:
   ROCKSDB_SHAREDLIB_DIR: "{{control_center_rocksdb_path}}"
   CONTROL_CENTER_HEAP_OPTS: "-Xmx6g"
   CONTROL_CENTER_OPTS: "{{ control_center_final_java_args | java_arg_build_out }}"
+  CONTROL_CENTER_LOG4J_OPTS: "{% if control_center_custom_log4j|bool %}-Dlog4j.configuration=file:{{control_center.log4j_file}}{% endif %}"
   # Remove trailing slash if there is one
   LOG_DIR: "{{ control_center_log_dir|regex_replace('\\/$', '') }}"
   CONFLUENT_SECURITY_MASTER_KEY: "{% if control_center_secrets_protection_enabled|bool %}{{secrets_protection_masterkey}}{% endif %}"


### PR DESCRIPTION
# Description

Adding `CONTROL_CENTER_LOG4J_OPTS` variable back.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible