### PR TITLE
Add default value for kafka_broker_sysctl.vm.max_map_count

### DIFF
--- a/roles/confluent.kafka_broker/defaults/main.yml
+++ b/roles/confluent.kafka_broker/defaults/main.yml
@@ -51,6 +51,7 @@ kafka_broker_sysctl:
   vm.swappiness: 1
   vm.dirty_background_ratio: 5
   vm.dirty_ratio: 80
+  vm.max_map_count: 262144
 
 kafka_broker_sysctl_file: /etc/sysctl.conf
 


### PR DESCRIPTION
# Description

In lack of progress on #536, I am suggesting to add our configuration of `vm.max_map_count` as the default value in the dict variable `kafka_broker_sysctl`. Ref.  Confluent's [production deployment docs](https://docs.confluent.io/platform/current/kafka/deployment.html#file-descriptors-and-mmap).

Since the variable is a dictionary, we have to repeat all the other default keys/values - which have sensible default values. I would like to avoid that. 😄 

Fixes #536 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Running fine in all our environments - including production.

**Test Configuration**:

RHEL 7 and RHEL 8 running CP 5.4, 5.5, 6.0 and 6.1.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible