### PR TITLE
Add initial Ansible collection meta

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,0 +1,17 @@
+---
+namespace: confluent
+name: platform
+version: 6.2.0
+readme: README.md
+authors:
+  - Confluent Ansible Community (https://github.com/confluentinc/cp-ansible)
+description: Confluent Platform Ansible Collection
+license_file: LICENSE.md
+tags:
+  - confluent
+  - kafka
+dependencies: {}
+repository: https://github.com/confluentinc/cp-ansible
+documentation: https://docs.confluent.io/ansible/current/overview.html
+homepage: https://github.com/confluentinc/cp-ansible
+issues: https://github.com/confluentinc/cp-ansible/issues

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,0 +1,2 @@
+---
+requires_ansible: ">=2.9"


### PR DESCRIPTION
Relates to https://github.com/confluentinc/cp-ansible/issues/613

This PR adds `galaxy.yml`, that fulfills the minimal requirements to use `ansible-galaxy` CLI to install the contents of cp-ansible repository as an Ansible Collection.

```script
$ ansible-galaxy collection install git+https://github.com/erikgb/cp-ansible.git,ansible-galaxy-cli
Starting galaxy collection install process
Process install dependency map
Starting collection install process
Installing 'confluent.kafka:6.2.0' to '/home/erikbo/.ansible/collections/ansible_collections/confluent/kafka'
Created collection for confluent.kafka at /home/erikbo/.ansible/collections/ansible_collections/confluent/kafka
confluent.kafka (6.2.0) was installed successfully
```

I scaffolded a new collection using ansible-galaxy

```script
$ ansible-galaxy collection init confluent.kafka
```

and used the generated galaxy.yml as a starting point. All fields and field comments are kept for the initial draft to facilitate discussions, but **should be cleaned up before merge**.

Also adding `meta/runtime.yml`, that states the [official Ansible requirement for using cp-ansible](https://docs.confluent.io/ansible/current/ansible-requirements.html#general-requirements).