### PR TITLE
Replace molecule yamllint with GitHub Actions linter workflow

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,8 +1,6 @@
 ---
 name: Lint Code Base
-on:
-  - pull_request
-  - push
+on: pull_request
 jobs:
   super-lint:
     name: Lint code base
@@ -17,7 +15,6 @@ jobs:
         uses: github/super-linter@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # TODO: Uncomment to only run on files changed in PR
-          # VALIDATE_ALL_CODEBASE: false
+          VALIDATE_ALL_CODEBASE: false
           LINTER_RULES_PATH: .
           VALIDATE_YAML: true

--- a/roles/confluent.test/molecule/archive-community-plaintext-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/archive-community-plaintext-rhel/molecule.yml
@@ -99,9 +99,6 @@ provisioner:
 
 verifier:
   name: ansible
-lint: |
-  set -e
-  yamllint -c ../../.yamllint ../..
 scenario:
   test_sequence:
     - lint

--- a/roles/confluent.test/molecule/archive-plain-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/archive-plain-rhel/molecule.yml
@@ -108,9 +108,6 @@ provisioner:
 
 verifier:
   name: ansible
-lint: |
-  set -e
-  yamllint -c ../../.yamllint ../..
 scenario:
   test_sequence:
     - lint

--- a/roles/confluent.test/molecule/archive-scram-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/archive-scram-rhel/molecule.yml
@@ -115,9 +115,6 @@ provisioner:
 
 verifier:
   name: ansible
-lint: |
-  set -e
-  yamllint -c ../../.yamllint ../..
 scenario:
   test_sequence:
     - lint

--- a/roles/confluent.test/molecule/ccloud-kafka-rest/molecule.yml
+++ b/roles/confluent.test/molecule/ccloud-kafka-rest/molecule.yml
@@ -71,9 +71,6 @@ provisioner:
 
 verifier:
   name: ansible
-lint: |
-  set -e
-  yamllint -c ../../.yamllint ../..
 scenario:
   test_sequence:
     - lint

--- a/roles/confluent.test/molecule/confluent-kafka-kerberos-customcerts-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/confluent-kafka-kerberos-customcerts-rhel/molecule.yml
@@ -242,9 +242,6 @@ provisioner:
 
 verifier:
   name: ansible
-lint: |
-  set -e
-  yamllint -c ../../.yamllint ../..
 scenario:
   test_sequence:
     - lint

--- a/roles/confluent.test/molecule/cp-kafka-plain-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/cp-kafka-plain-rhel/molecule.yml
@@ -111,9 +111,6 @@ provisioner:
 
 verifier:
   name: ansible
-lint: |
-  set -e
-  yamllint -c ../../.yamllint ../..
 scenario:
   test_sequence:
     - lint

--- a/roles/confluent.test/molecule/kafka-connect-replicator-mtls-scram-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/kafka-connect-replicator-mtls-scram-rhel/molecule.yml
@@ -225,9 +225,6 @@ provisioner:
 
 verifier:
   name: ansible
-lint: |
-  set -e
-  yamllint -c ../../.yamllint ../..
 scenario:
   test_sequence:
     - lint

--- a/roles/confluent.test/molecule/kafka-connect-replicator-plain-kerberos-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/kafka-connect-replicator-plain-kerberos-rhel/molecule.yml
@@ -260,9 +260,6 @@ provisioner:
 
 verifier:
   name: ansible
-lint: |
-  set -e
-  yamllint -c ../../.yamllint ../..
 scenario:
   test_sequence:
     - lint

--- a/roles/confluent.test/molecule/kerberos-customcerts-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/kerberos-customcerts-rhel/molecule.yml
@@ -211,9 +211,6 @@ provisioner:
 
 verifier:
   name: ansible
-lint: |
-  set -e
-  yamllint -c ../../.yamllint ../..
 scenario:
   test_sequence:
     - lint

--- a/roles/confluent.test/molecule/kerberos-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/kerberos-rhel/molecule.yml
@@ -203,9 +203,6 @@ provisioner:
 
 verifier:
   name: ansible
-lint: |
-  set -e
-  yamllint -c ../../.yamllint ../..
 scenario:
   test_sequence:
     - lint

--- a/roles/confluent.test/molecule/mtls-custombundle-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/mtls-custombundle-rhel/molecule.yml
@@ -152,9 +152,6 @@ provisioner:
 
 verifier:
   name: ansible
-lint: |
-  set -e
-  yamllint -c ../../.yamllint ../..
 scenario:
   test_sequence:
     - lint

--- a/roles/confluent.test/molecule/mtls-customcerts-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/mtls-customcerts-rhel/molecule.yml
@@ -136,9 +136,6 @@ provisioner:
 
 verifier:
   name: ansible
-lint: |
-  set -e
-  yamllint -c ../../.yamllint ../..
 scenario:
   test_sequence:
     - lint

--- a/roles/confluent.test/molecule/mtls-debian/molecule.yml
+++ b/roles/confluent.test/molecule/mtls-debian/molecule.yml
@@ -154,9 +154,6 @@ provisioner:
 
 verifier:
   name: ansible
-lint: |
-  set -e
-  yamllint -c ../../.yamllint ../..
 scenario:
   test_sequence:
     - lint

--- a/roles/confluent.test/molecule/mtls-java11-debian/molecule.yml
+++ b/roles/confluent.test/molecule/mtls-java11-debian/molecule.yml
@@ -120,9 +120,6 @@ provisioner:
 
 verifier:
   name: ansible
-lint: |
-  set -e
-  yamllint -c ../../.yamllint ../..
 scenario:
   test_sequence:
     - lint

--- a/roles/confluent.test/molecule/mtls-java11-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/mtls-java11-rhel/molecule.yml
@@ -102,9 +102,6 @@ provisioner:
 
 verifier:
   name: ansible
-lint: |
-  set -e
-  yamllint -c ../../.yamllint ../..
 scenario:
   test_sequence:
     - lint

--- a/roles/confluent.test/molecule/mtls-java11-ubuntu/molecule.yml
+++ b/roles/confluent.test/molecule/mtls-java11-ubuntu/molecule.yml
@@ -120,9 +120,6 @@ provisioner:
 
 verifier:
   name: ansible
-lint: |
-  set -e
-  yamllint -c ../../.yamllint ../..
 scenario:
   test_sequence:
     - lint

--- a/roles/confluent.test/molecule/mtls-ubuntu/molecule.yml
+++ b/roles/confluent.test/molecule/mtls-ubuntu/molecule.yml
@@ -127,9 +127,6 @@ provisioner:
 
 verifier:
   name: ansible
-lint: |
-  set -e
-  yamllint -c ../../.yamllint ../..
 scenario:
   test_sequence:
     - lint

--- a/roles/confluent.test/molecule/multi-ksql-connect-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/multi-ksql-connect-rhel/molecule.yml
@@ -208,9 +208,6 @@ provisioner:
 
 verifier:
   name: ansible
-lint: |
-  set -e
-  yamllint -c ../../.yamllint ../..
 scenario:
   test_sequence:
     - lint

--- a/roles/confluent.test/molecule/plain-customcerts-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/plain-customcerts-rhel/molecule.yml
@@ -137,9 +137,6 @@ provisioner:
 
 verifier:
   name: ansible
-lint: |
-  set -e
-  yamllint -c ../../.yamllint ../..
 scenario:
   test_sequence:
     - lint

--- a/roles/confluent.test/molecule/plain-erp-tls-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/plain-erp-tls-rhel/molecule.yml
@@ -56,9 +56,6 @@ provisioner:
 
 verifier:
   name: ansible
-lint: |
-  set -e
-  yamllint -c ../../.yamllint ../..
 scenario:
   test_sequence:
     - lint

--- a/roles/confluent.test/molecule/plain-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/plain-rhel/molecule.yml
@@ -147,9 +147,6 @@ provisioner:
         control_center_log4j_root_logger: INFO, stdout, main
 verifier:
   name: ansible
-lint: |
-  set -e
-  yamllint -c ../../.yamllint ../..
 scenario:
   test_sequence:
     - lint

--- a/roles/confluent.test/molecule/plaintext-basic-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/plaintext-basic-rhel/molecule.yml
@@ -213,9 +213,6 @@ provisioner:
 
 verifier:
   name: ansible
-lint: |
-  set -e
-  yamllint -c ../../.yamllint ../..
 scenario:
   test_sequence:
     - lint

--- a/roles/confluent.test/molecule/plaintext-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/plaintext-rhel/molecule.yml
@@ -160,9 +160,6 @@ provisioner:
 
 verifier:
   name: ansible
-lint: |
-  set -e
-  yamllint -c ../../.yamllint ../..
 scenario:
   test_sequence:
     - lint

--- a/roles/confluent.test/molecule/provided-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/provided-rhel/molecule.yml
@@ -181,9 +181,6 @@ provisioner:
 
 verifier:
   name: ansible
-lint: |
-  set -e
-  yamllint -c ../../.yamllint ../..
 scenario:
   test_sequence:
     - lint

--- a/roles/confluent.test/molecule/rbac-kerberos-debian/molecule.yml
+++ b/roles/confluent.test/molecule/rbac-kerberos-debian/molecule.yml
@@ -284,9 +284,6 @@ provisioner:
             guid: 91
 verifier:
   name: ansible
-lint: |
-  set -e
-  yamllint -c ../../.yamllint ../..
 scenario:
   test_sequence:
     - lint

--- a/roles/confluent.test/molecule/rbac-mds-kerberos-debian/molecule.yml
+++ b/roles/confluent.test/molecule/rbac-mds-kerberos-debian/molecule.yml
@@ -342,9 +342,6 @@ provisioner:
 
 verifier:
   name: ansible
-lint: |
-  set -e
-  yamllint -c ../../.yamllint ../..
 scenario:
   test_sequence:
     - lint

--- a/roles/confluent.test/molecule/rbac-mds-mtls-custom-kerberos-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/rbac-mds-mtls-custom-kerberos-rhel/molecule.yml
@@ -359,9 +359,6 @@ provisioner:
 
 verifier:
   name: ansible
-lint: |
-  set -e
-  yamllint -c ../../.yamllint ../..
 scenario:
   test_sequence:
     - lint

--- a/roles/confluent.test/molecule/rbac-mds-mtls-custom-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/rbac-mds-mtls-custom-rhel/molecule.yml
@@ -320,9 +320,6 @@ provisioner:
 
 verifier:
   name: ansible
-lint: |
-  set -e
-  yamllint -c ../../.yamllint ../..
 scenario:
   test_sequence:
     - lint

--- a/roles/confluent.test/molecule/rbac-mds-plain-custom-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/rbac-mds-plain-custom-rhel/molecule.yml
@@ -317,9 +317,6 @@ provisioner:
 
 verifier:
   name: ansible
-lint: |
-  set -e
-  yamllint -c ../../.yamllint ../..
 scenario:
   test_sequence:
     - lint

--- a/roles/confluent.test/molecule/rbac-mds-scram-custom-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/rbac-mds-scram-custom-rhel/molecule.yml
@@ -314,9 +314,6 @@ provisioner:
 
 verifier:
   name: ansible
-lint: |
-  set -e
-  yamllint -c ../../.yamllint ../..
 scenario:
   test_sequence:
     - lint

--- a/roles/confluent.test/molecule/rbac-mtls-provided-ubuntu/molecule.yml
+++ b/roles/confluent.test/molecule/rbac-mtls-provided-ubuntu/molecule.yml
@@ -244,9 +244,6 @@ provisioner:
 
 verifier:
   name: ansible
-lint: |
-  set -e
-  yamllint -c ../../.yamllint ../..
 scenario:
   test_sequence:
     - lint

--- a/roles/confluent.test/molecule/rbac-mtls-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/rbac-mtls-rhel/molecule.yml
@@ -231,9 +231,6 @@ provisioner:
 
 verifier:
   name: ansible
-lint: |
-  set -e
-  yamllint -c ../../.yamllint ../..
 scenario:
   test_sequence:
     - lint

--- a/roles/confluent.test/molecule/rbac-mtls-rhel8/molecule.yml
+++ b/roles/confluent.test/molecule/rbac-mtls-rhel8/molecule.yml
@@ -206,9 +206,6 @@ provisioner:
 
 verifier:
   name: ansible
-lint: |
-  set -e
-  yamllint -c ../../.yamllint ../..
 scenario:
   test_sequence:
     - lint

--- a/roles/confluent.test/molecule/rbac-plain-provided-debian/molecule.yml
+++ b/roles/confluent.test/molecule/rbac-plain-provided-debian/molecule.yml
@@ -268,9 +268,6 @@ provisioner:
 
 verifier:
   name: ansible
-lint: |
-  set -e
-  yamllint -c ../../.yamllint ../..
 scenario:
   test_sequence:
     - lint

--- a/roles/confluent.test/molecule/rbac-scram-custom-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/rbac-scram-custom-rhel/molecule.yml
@@ -280,9 +280,6 @@ provisioner:
 
 verifier:
   name: ansible
-lint: |
-  set -e
-  yamllint -c ../../.yamllint ../..
 scenario:
   test_sequence:
     - lint

--- a/roles/confluent.test/molecule/scram-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/scram-rhel/molecule.yml
@@ -102,9 +102,6 @@ provisioner:
         mask_secrets: false
 verifier:
   name: ansible
-lint: |
-  set -e
-  yamllint -c ../../.yamllint ../..
 scenario:
   test_sequence:
     - lint

--- a/roles/confluent.test/molecule/zookeeper-digest/molecule.yml
+++ b/roles/confluent.test/molecule/zookeeper-digest/molecule.yml
@@ -103,9 +103,6 @@ provisioner:
 
 verifier:
   name: ansible
-lint: |
-  set -e
-  yamllint -c ../../.yamllint ../..
 scenario:
   test_sequence:
     - lint

--- a/roles/confluent.test/molecule/zookeeper-kerberos/molecule.yml
+++ b/roles/confluent.test/molecule/zookeeper-kerberos/molecule.yml
@@ -163,9 +163,6 @@ provisioner:
 
 verifier:
   name: ansible
-lint: |
-  set -e
-  yamllint -c ../../.yamllint ../..
 scenario:
   test_sequence:
     - lint

--- a/roles/confluent.test/molecule/zookeeper-mtls/molecule.yml
+++ b/roles/confluent.test/molecule/zookeeper-mtls/molecule.yml
@@ -160,9 +160,6 @@ provisioner:
 
 verifier:
   name: ansible
-lint: |
-  set -e
-  yamllint -c ../../.yamllint ../..
 scenario:
   test_sequence:
     - lint


### PR DESCRIPTION
# Description

This PR replaces the `yamllint` linting that is currently part of the molecule tests with a GitHub Actions workflow based on [Super-Linter](https://github.com/github/super-linter).

This addresses several enhancements:

- Makes PR `yamllint` errors available to contributors (ref https://github.com/confluentinc/cp-ansible/issues/551). Yamllint errors has been my most common mistake when filing PRs to this project, and I do not like to bug maintainers for details from the closed Jenkins build log. But still I love linting. 💘
- Will make it easy to introduce more linting in this project, as Super-Linter supports most of them. I personally think `ansible-lint` should be the first one to be added - as this will require us to maintain less details in the newly added development guide. And this has already been discussed with @domenicbove.
- Introducing GitHub Actions could be an opportunity to make this project more "community friendly". IMO running PR check pipelines on a closed Jenkins without contributor access is not very welcoming (ref https://github.com/confluentinc/cp-ansible/issues/551). 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible