### PR TITLE
Add ansible-lint to linter GHA workflow

### DIFF
--- a/.ansible-lint.yml
+++ b/.ansible-lint.yml
@@ -1,0 +1,21 @@
+---
+exclude_paths:
+  - hosts_example.yml
+skip_list:
+  - risky-file-permissions
+  - risky-shell-pipe
+  - command-instead-of-shell
+  - command-instead-of-module
+  - no-changed-when
+  - var-spacing
+  - unnamed-task
+  - meta-no-info
+  - meta-no-tags
+  - role-name
+  - package-latest
+  - empty-string-compare
+  - yaml
+  - no-handler
+warn_list:
+  # FIXME: ERROR! couldn't resolve module/action 'sysctl'. This often indicates a misspelling, missing collection, or incorrect module path.
+  - syntax-check

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -18,3 +18,5 @@ jobs:
           VALIDATE_ALL_CODEBASE: false
           LINTER_RULES_PATH: .
           VALIDATE_YAML: true
+          VALIDATE_ANSIBLE: true
+          ANSIBLE_DIRECTORY: .

--- a/DEVELOPMENT_GUIDE.md
+++ b/DEVELOPMENT_GUIDE.md
@@ -14,7 +14,9 @@ The following document will be a reference guide to coding standards of cp-ansib
 
 [Testing](#testing)
 
-[Branching Model](#branding-model)
+[Linting](#linting)
+
+[Branching Model](#branching-model)
 
 ## Roles
 Each Confluent component has its own role, with the name `confluent.<component_name>`. Within that role, `main.yml` is the entrypoint of all tasks run when the role is invoked. Here are a few tasks and coding standards associated with them:
@@ -205,6 +207,23 @@ If you add a security feature to one component, like a schema registry authentic
 ## Testing
 
 Refer to our [How to test guide](HOW_TO_TEST.md) for how to set up Molecule testing on your development machine. We run all scenarios within `roles/confluent.test/molecule/` before each release. When developing a new feature, we ask that you add a test case in molecule. You may be inclined to make a new scenario to test it, but please consider adding your feature test to an existing scenario to save time/resources during our release testing.
+
+## Linting
+
+All Yaml files in CP-Ansible will get run through a linter during our build process.
+Pull requests with linting errors will not be accepted.
+
+We are currently using [Super-Linter](https://github.com/github/super-linter), but that is subject to change.
+They are providing a description on
+[how run Super-Linter locally](https://github.com/github/super-linter/blob/master/docs/run-linter-locally.md)
+to test your branch of code.
+
+To test/check manually, without using Super-Linter, you can run:
+
+```shell
+yamllimt .
+ansible-lint -c .ansible-lint.yml
+```
 
 ## Branching Model
 


### PR DESCRIPTION
# Description

Add `ansible-lint` to the linter GitHub Actions workflow. The initial ansible-lint configuration is **very** loose, since it is configured to pass with the existing codebase, and should be thightened over time.

Ansible-lint will lift the general code quality (opinionated), support PR review and avoid writing ALL details in the newly added developer guidelines.

The config file currently has the .yml extension, which is not the ansible-lint default. I have filed https://github.com/github/super-linter/pull/1424 to be able to name the file according to the ansible-lint default (`.ansible-lint`). But until that fix is available in a release, you'll have to run `ansible-lint -c .ansible-lint.yml` to check locally.

Also fixed a minor bug in the dev guide TOC.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible