### PR TITLE
Fix GHA linting issues

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -15,8 +15,10 @@ jobs:
         uses: github/super-linter@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VALIDATE_ALL_CODEBASE: false
+          # Must validate all codebase to make ansible-lint work
+          VALIDATE_ALL_CODEBASE: true
           LINTER_RULES_PATH: .
           VALIDATE_YAML: true
+          YAML_CONFIG_FILE: .yamllint
           VALIDATE_ANSIBLE: true
           ANSIBLE_DIRECTORY: .


### PR DESCRIPTION
# Description

It seems like the first round of introducing GHA Ansible lint was done a bit too fast. It turns out that in order to get Super-Linter to trigger ansible-lint, the whole codebase needs to be included. 👎 In addition, a bug introduced in the same PR falls back to the default yamllint rules, and not the configuration in this project. This PR fixes both.

I think Super-Linter is not "that" super, so I am planning on filing another PR soon, replacing it with:

- https://github.com/marketplace/actions/yamllint-github-action
- https://github.com/marketplace/actions/ansible-lint

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible