### PR TITLE
Add missing file permissions

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -2,7 +2,6 @@
 exclude_paths:
   - hosts_example.yml
 skip_list:
-  - risky-file-permissions
   - risky-shell-pipe
   - command-instead-of-shell
   - command-instead-of-module

--- a/roles/confluent.common/tasks/debian.yml
+++ b/roles/confluent.common/tasks/debian.yml
@@ -35,6 +35,7 @@
   copy:
     src: "{{custom_apt_repo_filepath}}"
     dest: /etc/apt/sources.list.d/custom_confluent.list
+    mode: 0644
   when: repository_configuration == 'custom'
   notify:
     - apt-get update
@@ -45,6 +46,7 @@
   copy:
     content: 'Acquire::Check-Valid-Until "0";'
     dest: /etc/apt/apt.conf.d/skip-check
+    mode: 0644
   notify:
     - debian apt-get update
   when:

--- a/roles/confluent.common/tasks/failure_handling.yml
+++ b/roles/confluent.common/tasks/failure_handling.yml
@@ -3,6 +3,7 @@
   file:
     state: directory
     path: "error_files/{{inventory_hostname}}"
+    mode: 0755
   delegate_to: localhost
   vars:
     ansible_connection: local

--- a/roles/confluent.common/tasks/redhat.yml
+++ b/roles/confluent.common/tasks/redhat.yml
@@ -31,6 +31,7 @@
   copy:
     src: "{{custom_yum_repofile_filepath}}"
     dest: /etc/yum.repos.d/custom-confluent.repo
+    mode: 0644
   register: custom_repo_result
   when: repository_configuration == 'custom'
 

--- a/roles/confluent.common/tasks/ubuntu.yml
+++ b/roles/confluent.common/tasks/ubuntu.yml
@@ -23,6 +23,7 @@
   copy:
     src: "{{custom_apt_repo_filepath}}"
     dest: /etc/apt/sources.list.d/custom_confluent.list
+    mode: 0644
   when: repository_configuration == 'custom'
   notify:
     - apt-get update
@@ -33,6 +34,7 @@
   file:
     path: /usr/share/man/man1
     state: directory
+    mode: 0755
 
 - name: Add open JDK repo
   apt_repository:

--- a/roles/confluent.control_center/tasks/main.yml
+++ b/roles/confluent.control_center/tasks/main.yml
@@ -168,6 +168,7 @@
     path: /var/log/confluent/
     owner: "{{control_center_user}}"
     group: "{{control_center_group}}"
+    mode: 0770
     state: directory
 
 - name: Create Logs Directory

--- a/tasks/masterkey.yml
+++ b/tasks/masterkey.yml
@@ -13,6 +13,7 @@
   copy:
     content: "{{ masterkey.stdout }}"
     dest: /tmp/masterkey
+    mode: 0640
 
 - name: Copy Security File Back to Ansible Host
   fetch:

--- a/tasks/upgrade_component.yml
+++ b/tasks/upgrade_component.yml
@@ -14,6 +14,7 @@
     src: "{{ item }}"
     remote_src: true
     dest: "/tmp/upgrade/{{ service_name }}/{{ item | basename }}-{{timestamp}}"
+    mode: 0640
   loop: "{{ backup_files }}"
   # Files cannot be copied because directory is not created in check mode
   ignore_errors: "{{ ansible_check_mode }}"
@@ -73,6 +74,7 @@
     dest: "{{ item }}"
     remote_src: true
     src: "/tmp/upgrade/{{ service_name }}/{{ item | basename }}-{{timestamp}}"
+    mode: 0640
   loop: "{{ restore_files }}"
   # Files cannot be copied because directory is not created in check mode
   ignore_errors: "{{ ansible_check_mode }}"

--- a/upgrade_kafka_broker.yml
+++ b/upgrade_kafka_broker.yml
@@ -202,6 +202,7 @@
         src: "{{ item }}"
         remote_src: true
         dest: "/tmp/upgrade/{{ kafka_broker_service_name }}/{{ item | basename }}-{{timestamp}}"
+        mode: 0640
       loop:
         - "{{ kafka_broker.config_file }}"
         - "{{ kafka_broker.systemd_override }}"
@@ -271,6 +272,7 @@
         dest: "{{ item }}"
         remote_src: true
         src: "/tmp/upgrade/{{ kafka_broker_service_name }}/{{ item | basename }}-{{timestamp}}"
+        mode: 0640
       loop:
         - "{{ kafka_broker.config_file }}"
         - "{{ zookeeper.config_file }}"

--- a/upgrade_ksql.yml
+++ b/upgrade_ksql.yml
@@ -73,6 +73,7 @@
         src: "{{ item }}"
         remote_src: true
         dest: "/tmp/upgrade/{{ ksql_service_name }}/{{ item | basename }}-{{timestamp}}"
+        mode: 0640
       loop:
         - "{{ ksql.config_file }}"
         - "{{ ksql.systemd_override }}"
@@ -141,6 +142,7 @@
         dest: "{{ item }}"
         remote_src: true
         src: "/tmp/upgrade/{{ ksql_service_name }}/{{ item | basename }}-{{timestamp}}"
+        mode: 0640
       loop:
         - "{{ ksql.config_file }}"
         - "{{ ksql.systemd_override }}"

--- a/upgrade_zookeeper.yml
+++ b/upgrade_zookeeper.yml
@@ -128,6 +128,7 @@
         src: "{{ item }}"
         remote_src: true
         dest: "/tmp/upgrade/{{ zookeeper_service_name }}/{{ item | basename }}-{{timestamp}}"
+        mode: 0640
       loop:
         - "{{ zookeeper.config_file }}"
         - "{{ zookeeper.systemd_override }}"
@@ -206,6 +207,7 @@
         dest: "{{ item }}"
         remote_src: true
         src: "/tmp/upgrade/{{ zookeeper_service_name }}/{{ item | basename }}-{{timestamp}}"
+        mode: 0640
       loop:
         - "{{ zookeeper.config_file }}"
         - "{{ kafka_broker.config_file }}"


### PR DESCRIPTION
to enable `risky-file-permissions` ansible-lint rule.

# Description

File permissions are now mentioned in the development guidelines. To facilitate PR review, it seems attractive to fix all missing file permissions in current codebase and enable the `risky-file-permissions` ansible-lint rule. Then at least file permissions must be set, and can be reviewed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible