### PR TITLE
Add missing changed_when to enable no-changed-when ansible-lint rule

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -5,7 +5,6 @@ skip_list:
   - risky-shell-pipe
   - command-instead-of-shell
   - command-instead-of-module
-  - no-changed-when
   - var-spacing
   - unnamed-task
   - meta-no-info

--- a/tasks/masterkey.yml
+++ b/tasks/masterkey.yml
@@ -1,6 +1,7 @@
 ---
 - name: Create Passphrase File
   shell: "openssl rand -base64 14 > /tmp/passphrase.txt"
+  changed_when: true
 
 - name: Generate Master Encryption Key and File
   shell: |
@@ -8,6 +9,7 @@
       --local-secrets-file /tmp/security.properties \
       --passphrase @/tmp/passphrase.txt | awk '/Master/{print $5}'
   register: masterkey
+  changed_when: true
 
 - name: Write Master Key to File
   copy:

--- a/upgrade_kafka_connect.yml
+++ b/upgrade_kafka_connect.yml
@@ -17,6 +17,7 @@
 
     - shell: "egrep -i 'ssl.client.auth ?= ?true' {{ kafka_connect.config_file }}"
       register: mtls_check
+      changed_when: false
       failed_when: false
 
     - name: Set MTLS Variable

--- a/upgrade_kafka_rest.yml
+++ b/upgrade_kafka_rest.yml
@@ -32,6 +32,7 @@
 
     - shell: "egrep -i 'ssl.client.auth ?= ?true' {{ kafka_rest.config_file }}"
       register: mtls_check
+      changed_when: false
       failed_when: false
 
     - name: Set MTLS Variable

--- a/upgrade_ksql.yml
+++ b/upgrade_ksql.yml
@@ -17,6 +17,7 @@
 
     - shell: "egrep -i 'ssl.client.auth ?= ?true' {{ ksql.config_file }}"
       register: mtls_check
+      changed_when: false
       failed_when: false
 
     - name: Set MTLS Variable

--- a/upgrade_schema_registry.yml
+++ b/upgrade_schema_registry.yml
@@ -34,6 +34,7 @@
 
     - shell: "egrep -i 'ssl.client.auth ?= ?true' {{ schema_registry.config_file }}"
       register: mtls_check
+      changed_when: false
       failed_when: false
 
     - name: Set MTLS Variable


### PR DESCRIPTION
# Description

Any tasks marked as changed, if nothing is changed, annoys me. Fixing the existing violations allowing us to enable the `no-changed-when` rule will ensure any future PR will have to consider this.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible