### PR TITLE
Convert systemctl shell tasks to module

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -4,7 +4,6 @@ exclude_paths:
 skip_list:
   - risky-shell-pipe
   - command-instead-of-shell
-  - command-instead-of-module
   - var-spacing
   - unnamed-task
   - meta-no-info

--- a/control_center.yml
+++ b/control_center.yml
@@ -8,18 +8,16 @@
     - import_role:
         name: confluent.variables
 
-    - name: Check if Control Center Service Running
-      shell: "systemctl show -p SubState {{control_center_service_name}}"
-      changed_when: false
-      # On some SELinux enabled hosts this command will error out, handled in next set_fact task
-      failed_when: false
-      check_mode: false
-      register: substate
+    - name: Populate service facts
+      service_facts:
 
-    - set_fact:
-        install_pattern: "{{ 'parallel' if substate.stdout != 'SubState=running' or substate.rc == 1 or control_center_deployment_strategy == 'parallel' else 'serial' }}"
+    - name: Determine Installation Pattern - Parallel or Serial
+      set_fact:
+        install_pattern: "{{ 'parallel' if service_state != 'running' or control_center_deployment_strategy == 'parallel' else 'serial' }}"
+      vars:
+        service_state: "{{ ansible_facts.services[control_center_service_name + '.service'].state | default('unknown') }}"
 
-    - name: "Group Hosts by Installation Pattern: Parallel or Serial"
+    - name: Group Hosts by Installation Pattern
       group_by:
         key: control_center_{{install_pattern}}
       changed_when: false

--- a/kafka_broker.yml
+++ b/kafka_broker.yml
@@ -8,18 +8,16 @@
     - import_role:
         name: confluent.variables
 
-    - name: Check if Kafka Service Running
-      shell: "systemctl show -p SubState {{kafka_broker_service_name}}"
-      changed_when: false
-      # On some SELinux enabled hosts this command will error out, handled in next set_fact task
-      failed_when: false
-      check_mode: false
-      register: substate
+    - name: Populate service facts
+      service_facts:
 
-    - set_fact:
-        install_pattern: "{{ 'parallel' if substate.stdout != 'SubState=running' or substate.rc == 1 or kafka_broker_deployment_strategy == 'parallel' else 'serial' }}"
+    - name: Determine Installation Pattern - Parallel or Serial
+      set_fact:
+        install_pattern: "{{ 'parallel' if service_state != 'running' or kafka_broker_deployment_strategy == 'parallel' else 'serial' }}"
+      vars:
+        service_state: "{{ ansible_facts.services[kafka_broker_service_name + '.service'].state | default('unknown') }}"
 
-    - name: "Group Hosts by Installation Pattern: Parallel or Serial"
+    - name: Group Hosts by Installation Pattern
       group_by:
         key: kafka_broker_{{install_pattern}}
       changed_when: false

--- a/kafka_connect.yml
+++ b/kafka_connect.yml
@@ -8,18 +8,16 @@
     - import_role:
         name: confluent.variables
 
-    - name: Check if Kafka Connect Service Running
-      shell: "systemctl show -p SubState {{kafka_connect_service_name}}"
-      changed_when: false
-      # On some SELinux enabled hosts this command will error out, handled in next set_fact task
-      failed_when: false
-      check_mode: false
-      register: substate
+    - name: Populate service facts
+      service_facts:
 
-    - set_fact:
-        install_pattern: "{{ 'parallel' if substate.stdout != 'SubState=running' or substate.rc == 1 or kafka_connect_deployment_strategy == 'parallel' else 'serial' }}"
+    - name: Determine Installation Pattern - Parallel or Serial
+      set_fact:
+        install_pattern: "{{ 'parallel' if service_state != 'running' or kafka_connect_deployment_strategy == 'parallel' else 'serial' }}"
+      vars:
+        service_state: "{{ ansible_facts.services[kafka_connect_service_name + '.service'].state | default('unknown') }}"
 
-    - name: "Group Hosts by Installation Pattern: Parallel or Serial"
+    - name: Group Hosts by Installation Pattern
       group_by:
         key: kafka_connect_{{install_pattern}}
       changed_when: false

--- a/kafka_connect_replicator.yml
+++ b/kafka_connect_replicator.yml
@@ -8,18 +8,16 @@
     - import_role:
         name: confluent.variables
 
-    - name: Check if Kafka Connect Replicator Service Running
-      shell: "systemctl show -p SubState {{kafka_connect_replicator_service_name}}"
-      changed_when: false
-      # On some SELinux enabled hosts this command will error out, handled in next set_fact task
-      failed_when: false
-      check_mode: false
-      register: substate
+    - name: Populate service facts
+      service_facts:
 
-    - set_fact:
-        install_pattern: "{{ 'parallel' if substate.stdout != 'SubState=running' or substate.rc == 1 or kafka_connect_replicator_deployment_strategy == 'parallel' else 'serial' }}"
+    - name: Determine Installation Pattern - Parallel or Serial
+      set_fact:
+        install_pattern: "{{ 'parallel' if service_state != 'running' or kafka_connect_replicator_deployment_strategy == 'parallel' else 'serial' }}"
+      vars:
+        service_state: "{{ ansible_facts.services[kafka_connect_replicator_service_name + '.service'].state | default('unknown') }}"
 
-    - name: "Group Hosts by Installation Pattern: Parallel or Serial"
+    - name: Group Hosts by Installation Pattern
       group_by:
         key: kafka_connect_replicator_{{install_pattern}}
       changed_when: false

--- a/kafka_rest.yml
+++ b/kafka_rest.yml
@@ -8,18 +8,16 @@
     - import_role:
         name: confluent.variables
 
-    - name: Check if Kafka Rest Service Running
-      shell: "systemctl show -p SubState {{kafka_rest_service_name}}"
-      changed_when: false
-      # On some SELinux enabled hosts this command will error out, handled in next set_fact task
-      failed_when: false
-      check_mode: false
-      register: substate
+    - name: Populate service facts
+      service_facts:
 
-    - set_fact:
-        install_pattern: "{{ 'parallel' if substate.stdout != 'SubState=running' or substate.rc == 1 or kafka_rest_deployment_strategy == 'parallel' else 'serial' }}"
+    - name: Determine Installation Pattern - Parallel or Serial
+      set_fact:
+        install_pattern: "{{ 'parallel' if service_state != 'running' or kafka_rest_deployment_strategy == 'parallel' else 'serial' }}"
+      vars:
+        service_state: "{{ ansible_facts.services[kafka_rest_service_name + '.service'].state | default('unknown') }}"
 
-    - name: "Group Hosts by Installation Pattern: Parallel or Serial"
+    - name: Group Hosts by Installation Pattern
       group_by:
         key: kafka_rest_{{install_pattern}}
       changed_when: false

--- a/ksql.yml
+++ b/ksql.yml
@@ -8,18 +8,16 @@
     - import_role:
         name: confluent.variables
 
-    - name: Check if KSQL Service Running
-      shell: "systemctl show -p SubState {{ksql_service_name}}"
-      changed_when: false
-      # On some SELinux enabled hosts this command will error out, handled in next set_fact task
-      failed_when: false
-      check_mode: false
-      register: substate
+    - name: Populate service facts
+      service_facts:
 
-    - set_fact:
-        install_pattern: "{{ 'parallel' if substate.stdout != 'SubState=running' or substate.rc == 1 or ksql_deployment_strategy == 'parallel' else 'serial' }}"
+    - name: Determine Installation Pattern - Parallel or Serial
+      set_fact:
+        install_pattern: "{{ 'parallel' if service_state != 'running' or ksql_deployment_strategy == 'parallel' else 'serial' }}"
+      vars:
+        service_state: "{{ ansible_facts.services[ksql_service_name + '.service'].state | default('unknown') }}"
 
-    - name: "Group Hosts by Installation Pattern: Parallel or Serial"
+    - name: Group Hosts by Installation Pattern
       group_by:
         key: ksql_{{install_pattern}}
       changed_when: false

--- a/zookeeper.yml
+++ b/zookeeper.yml
@@ -8,18 +8,16 @@
     - import_role:
         name: confluent.variables
 
-    - name: Check if Zookeeper Service Running
-      shell: "systemctl show -p SubState {{zookeeper_service_name}}"
-      changed_when: false
-      # On some SELinux enabled hosts this command will error out, handled in next set_fact task
-      failed_when: false
-      check_mode: false
-      register: substate
+    - name: Populate service facts
+      service_facts:
 
-    - set_fact:
-        install_pattern: "{{ 'parallel' if substate.stdout != 'SubState=running' or substate.rc == 1 or zookeeper_deployment_strategy == 'parallel' else 'serial' }}"
+    - name: Determine Installation Pattern - Parallel or Serial
+      set_fact:
+        install_pattern: "{{ 'parallel' if service_state != 'running' or zookeeper_deployment_strategy == 'parallel' else 'serial' }}"
+      vars:
+        service_state: "{{ ansible_facts.services[zookeeper_service_name + '.service'].state | default('unknown') }}"
 
-    - name: "Group Hosts by Installation Pattern: Parallel or Serial"
+    - name: Group Hosts by Installation Pattern
       group_by:
         key: zookeeper_{{install_pattern}}
       changed_when: false


### PR DESCRIPTION
and enable `command-instead-of-module` ansible-lint rules.

# Description

Removing more rules from the ansible-lint skip list could improve code quality over time.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible