### PR TITLE
Fixed typo in confluent.common/tasks/main.yml joklokia_download_result -> jolokia_download_result

### DIFF
--- a/roles/confluent.common/tasks/main.yml
+++ b/roles/confluent.common/tasks/main.yml
@@ -70,8 +70,8 @@
     url: "{{ jolokia_jar_url }}"
     dest: "{{ jolokia_jar_path }}"
     mode: 0755
-  register: joklokia_download_result
-  until: joklokia_download_result is success
+  register: jolokia_download_result
+  until: jolokia_download_result is success
   retries: 5
   delay: 5
   when:


### PR DESCRIPTION
# Description
The change made is purely a cosmetic fix for the cp-ansible respository. It was discovered when I was updating the cp-ansible repository for my organization and I ran into a typo in your play. 

Fixes # (issue)
Changed the registered value, as well as the conditional value from:
joklokia_download_ressult -> jolokia_download_result

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
The changes are only cosmetic, the play "roles/confluent.common/tasks/main.yml Download Jolokia Jar" registers that jolokia have been downloaded. Ansible will not proceed with the next play until it has succeeded downloading using the "until" conditional. 

**Test Configuration**:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Any variable changes have been validated to be backwards compatible