### PR TITLE
Disable yamllint truthy.check-keys

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -41,5 +41,4 @@ rules:
     level: error
   truthy:
     level: error
-    ignore: |
-      *linter.yml
+    check-keys: false


### PR DESCRIPTION
# Description

Minor change of the yamllint rules. Instead of having to ignore selected files, I suggest to disable the `truthy.check-keys` rule. I think this could/should be merged into the 6.1.1-post branch, but feel free to disagree. 😉 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
