### PR TITLE
611 Upgrade Bugfixes

### DIFF
--- a/roles/confluent.common/tasks/rbac_setup.yml
+++ b/roles/confluent.common/tasks/rbac_setup.yml
@@ -18,6 +18,7 @@
     kafka_cluster_id: "{{ cluster_id_query.json.data[0].cluster_id }}"
   when: cluster_id_source | default('erp') == 'erp'
 
+# TODO this will not work for Secure ZK or Archive installation method
 - name: Get Kafka Cluster ID from Zookeeper
   shell: /usr/bin/zookeeper-shell localhost:2181 get /cluster/id | grep version
   delegate_to: "{{ groups['zookeeper'][0] }}"

--- a/upgrade_kafka_broker_log_format.yml
+++ b/upgrade_kafka_broker_log_format.yml
@@ -10,6 +10,13 @@
     - name: restart kafka
       include_tasks: roles/confluent.kafka_broker/tasks/restart_and_wait.yml
   tasks:
+    - name: Gather OS Facts
+      setup:
+        # Only gathers items in list, filters out the rest
+        filter: ansible_os_family
+        gather_subset:
+          - '!all'
+          
     - import_role:
         name: confluent.variables
 

--- a/upgrade_kafka_rest.yml
+++ b/upgrade_kafka_rest.yml
@@ -4,12 +4,18 @@
   gather_facts: false
   environment: "{{ proxy_env }}"
   tasks:
+    - name: Gather OS Facts
+      setup:
+        # Only gathers items in list, filters out the rest
+        filter: ansible_os_family
+        gather_subset:
+          - '!all'
+
     - name: Kafka Rest Role Bindings
       import_role:
         name: confluent.kafka_rest
         tasks_from: rbac.yml
       vars:
-        cluster_id_source: zookeeper
         copy_certs: false
       run_once: true
       when: rbac_enabled|bool

--- a/upgrade_schema_registry.yml
+++ b/upgrade_schema_registry.yml
@@ -4,12 +4,18 @@
   gather_facts: false
   environment: "{{ proxy_env }}"
   tasks:
+    - name: Gather OS Facts
+      setup:
+        # Only gathers items in list, filters out the rest
+        filter: ansible_os_family
+        gather_subset:
+          - '!all'
+
     - name: Schema Registry Role Bindings
       import_role:
         name: confluent.schema_registry
         tasks_from: rbac.yml
       vars:
-        cluster_id_source: zookeeper
         copy_certs: false
       run_once: true
       when: rbac_enabled|bool

--- a/upgrade_zookeeper.yml
+++ b/upgrade_zookeeper.yml
@@ -141,15 +141,6 @@
         name: "{{ zookeeper_service_name }}"
         state: stopped
 
-    - name: Wait for Zookeeper Status on Another Zookeeper Node
-      import_role:
-        name: confluent.zookeeper
-        tasks_from: health_check.yml
-      delegate_to: "{{ groups['zookeeper'] | difference([inventory_hostname]) | first }}"
-      vars:
-        zookeeper_health_check_host: "{{ groups['zookeeper'] | difference([inventory_hostname]) | first }}"
-      when: not ansible_check_mode
-
     - name: Configure Repositories
       import_role:
         name: confluent.common


### PR DESCRIPTION
# Description

When `installation_method: archive`:
- The path to the zookeeper shell binary is hard to keep track of on all of the ZK hosts (because they may or may not be upgraded at this point and the path has a version number built in) -> removed the task that checks quorum after one host is shut down. We do not do that for kafka, wont do it with ZK
- zookeeper-shell command for getting the kafka cluster id has non secure port (2181) hardcoded and the binary path will not work for archive install. Fortunately in the case of creating role bindings, we can assume the MDS is running and can request the kafka cluster ID from the Admin API. In the future, can update the get cluster id code from ZK to match `roles/confluent.kafka_broker/tasks/dynamic_groups.yml`.
- Gathers `ansible_os_family` fact in all upgrade playbooks, this is necessary in our variable build out in higher branches

*Note*: Targeting 6.1.1-post because the upgrade playbooks are fully broken for archive installed cluster. Cannot wait for next patch. 
 
Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Ran upgrade_schema_registry.yml, upgrade_zookeeper.yml, and upgrade_kafka_rest.yml on an rbac install archive installed 6.0.0 cluster

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible