### PR TITLE
Feature/copyfilepermissions

### DIFF
--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -542,7 +542,7 @@ Default:  3888
 
 ### zookeeper_copy_files
 
-Use to copy files from control node to zookeeper hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to)
+Use to copy files from control node to zookeeper hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode ('default: 0640') to set directory and file permissions.
 
 Default:  []
 
@@ -662,7 +662,7 @@ Default:  8080
 
 ### kafka_broker_copy_files
 
-Use to copy files from control node to kafka hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to)
+Use to copy files from control node to kafka hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode ('default: 0640') to set directory and file permissions.
 
 Default:  []
 
@@ -814,7 +814,7 @@ Default:  8078
 
 ### schema_registry_copy_files
 
-Use to copy files from control node to schema registry hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to)
+Use to copy files from control node to schema registry hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode ('default: 0640') to set directory and file permissions.
 
 Default:  []
 
@@ -942,7 +942,7 @@ Default:  8075
 
 ### kafka_rest_copy_files
 
-Use to copy files from control node to schema registry hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to)
+Use to copy files from control node to schema registry hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode ('default: 0640') to set directory and file permissions.
 
 Default:  []
 
@@ -1086,7 +1086,7 @@ Default:  8077
 
 ### kafka_connect_copy_files
 
-Use to copy files from control node to connect hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to)
+Use to copy files from control node to connect hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode ('default: 0640') to set directory and file permissions.
 
 Default:  []
 
@@ -1254,7 +1254,7 @@ Default:  8076
 
 ### ksql_copy_files
 
-Use to copy files from control node to ksqlDB hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to)
+Use to copy files from control node to ksqlDB hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode ('default: 0640') to set directory and file permissions.
 
 Default:  []
 
@@ -1342,7 +1342,7 @@ Default:  "{{ssl_enabled}}"
 
 ### control_center_copy_files
 
-Use to copy files from control node to Control Center hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to)
+Use to copy files from control node to Control Center hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode ('default: 0640') to set directory and file permissions.
 
 Default:  []
 

--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -542,7 +542,7 @@ Default:  3888
 
 ### zookeeper_copy_files
 
-Use to copy files from control node to zookeeper hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode ('default: 0640') to set directory and file permissions.
+Use to copy files from control node to zookeeper hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode (default: '0640') to set directory and file permissions.
 
 Default:  []
 
@@ -662,7 +662,7 @@ Default:  8080
 
 ### kafka_broker_copy_files
 
-Use to copy files from control node to kafka hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode ('default: 0640') to set directory and file permissions.
+Use to copy files from control node to kafka hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode (default: '0640') to set directory and file permissions.
 
 Default:  []
 
@@ -814,7 +814,7 @@ Default:  8078
 
 ### schema_registry_copy_files
 
-Use to copy files from control node to schema registry hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode ('default: 0640') to set directory and file permissions.
+Use to copy files from control node to schema registry hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode (default: '0640') to set directory and file permissions.
 
 Default:  []
 
@@ -942,7 +942,7 @@ Default:  8075
 
 ### kafka_rest_copy_files
 
-Use to copy files from control node to schema registry hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode ('default: 0640') to set directory and file permissions.
+Use to copy files from control node to schema registry hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode (default: '0640') to set directory and file permissions.
 
 Default:  []
 
@@ -1086,7 +1086,7 @@ Default:  8077
 
 ### kafka_connect_copy_files
 
-Use to copy files from control node to connect hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode ('default: 0640') to set directory and file permissions.
+Use to copy files from control node to connect hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode (default: '0640') to set directory and file permissions.
 
 Default:  []
 
@@ -1254,7 +1254,7 @@ Default:  8076
 
 ### ksql_copy_files
 
-Use to copy files from control node to ksqlDB hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode ('default: 0640') to set directory and file permissions.
+Use to copy files from control node to ksqlDB hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode (default: '0640') to set directory and file permissions.
 
 Default:  []
 
@@ -1342,7 +1342,7 @@ Default:  "{{ssl_enabled}}"
 
 ### control_center_copy_files
 
-Use to copy files from control node to Control Center hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode ('default: 0640') to set directory and file permissions.
+Use to copy files from control node to Control Center hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode (default: '0640') to set directory and file permissions.
 
 Default:  []
 

--- a/roles/confluent.test/molecule/plaintext-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/plaintext-rhel/molecule.yml
@@ -137,6 +137,9 @@ provisioner:
         zookeeper_copy_files:
           - source_path: "roles/confluent.test/molecule/{{scenario_name}}/molecule.yml"
             destination_path: /tmp/molecule.yml
+          - source_path: "roles/confluent.test/molecule/{{scenario_name}}/molecule.yml"
+            destination_path: /tmp/molecule2.yml
+            file_mode: '0666'
 
         kafka_broker_copy_files: "{{zookeeper_copy_files}}"
         schema_registry_copy_files: "{{zookeeper_copy_files}}"

--- a/roles/confluent.test/molecule/plaintext-rhel/verify.yml
+++ b/roles/confluent.test/molecule/plaintext-rhel/verify.yml
@@ -181,6 +181,20 @@
         - "http://{{inventory_hostname}}:7770/jolokia/list"
         - "http://{{inventory_hostname}}:8079"
 
+    - name: Get stats on first copied file
+      stat:
+        path: /tmp/molecule.yml
+      register: copied_file
+
+    - name: Assert first copied file's permissions correct
+      assert:
+        that:
+          - copied_file.stat.exists
+          - copied_file.stat.gr_name == 'confluent'
+          - copied_file.stat.pw_name == 'cp-kafka'
+          - copied_file.stat.mode == '0640'
+        quiet: true
+
     - name: Get stats on second copied file
       stat:
         path: /tmp/molecule2.yml

--- a/roles/confluent.test/molecule/plaintext-rhel/verify.yml
+++ b/roles/confluent.test/molecule/plaintext-rhel/verify.yml
@@ -180,6 +180,21 @@
       with_items:
         - "http://{{inventory_hostname}}:7770/jolokia/list"
         - "http://{{inventory_hostname}}:8079"
+
+    - name: Get stats on second copied file
+      stat:
+        path: /tmp/molecule2.yml
+      register: copied_file2
+
+    - name: Assert second copied file's permissions correct
+      assert:
+        that:
+          - copied_file2.stat.exists
+          - copied_file2.stat.gr_name == 'confluent'
+          - copied_file2.stat.pw_name == 'cp-kafka'
+          - copied_file2.stat.mode == '0666'
+        quiet: true
+
 - name: Verify - kafka_broker
   hosts: kafka_broker
   gather_facts: false

--- a/roles/confluent.variables/defaults/main.yml
+++ b/roles/confluent.variables/defaults/main.yml
@@ -252,7 +252,7 @@ zookeeper_peer_port: 2888
 ### Zookeeper leader port
 zookeeper_leader_port: 3888
 
-### Use to copy files from control node to zookeeper hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode ('default: 0640') to set directory and file permissions.
+### Use to copy files from control node to zookeeper hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode (default: '0640') to set directory and file permissions.
 zookeeper_copy_files: []
 
 # User provided properties, merged into the final properties dictionary with precedence
@@ -362,7 +362,7 @@ kafka_broker_jmxexporter_port: 8080
 
 kafka_broker_jmxexporter_config_path: /opt/prometheus/kafka.yml
 
-### Use to copy files from control node to kafka hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode ('default: 0640') to set directory and file permissions.
+### Use to copy files from control node to kafka hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode (default: '0640') to set directory and file permissions.
 kafka_broker_copy_files: []
 
 ### Replication Factor for internal topics. Defaults to the minimum of the number of brokers and 3
@@ -438,7 +438,7 @@ schema_registry_jmxexporter_config_path: /opt/prometheus/schema_registry.yml
 ### Port to expose prometheus metrics. Beware of port collisions if colocating components on same host
 schema_registry_jmxexporter_port: 8078
 
-### Use to copy files from control node to schema registry hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode ('default: 0640') to set directory and file permissions.
+### Use to copy files from control node to schema registry hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode (default: '0640') to set directory and file permissions.
 schema_registry_copy_files: []
 
 ### Use to set custom schema registry properties. This variable is a dictionary. Put values true/false in quotation marks to perserve case. NOTE- kafka_broker.properties is deprecated.
@@ -506,7 +506,7 @@ kafka_rest_jmxexporter_config_path: /opt/prometheus/kafka_rest.yml
 ### Port to expose prometheus metrics. Beware of port collisions if colocating components on same host
 kafka_rest_jmxexporter_port: 8075
 
-### Use to copy files from control node to schema registry hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode ('default: 0640') to set directory and file permissions.
+### Use to copy files from control node to schema registry hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode (default: '0640') to set directory and file permissions.
 kafka_rest_copy_files: []
 
 ### Use to set custom Rest Proxy properties. This variable is a dictionary. Put values true/false in quotation marks to perserve case. NOTE- kafka_rest.properties is deprecated.
@@ -581,7 +581,7 @@ kafka_connect_jmxexporter_config_path: /opt/prometheus/kafka_connect.yml
 ### Port to expose connect prometheus metrics. Beware of port collisions if colocating components on same host
 kafka_connect_jmxexporter_port: 8077
 
-### Use to copy files from control node to connect hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode ('default: 0640') to set directory and file permissions.
+### Use to copy files from control node to connect hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode (default: '0640') to set directory and file permissions.
 kafka_connect_copy_files: []
 
 ### Connect Service Group Id. Customize when configuring multiple connect clusters in same inventory
@@ -675,7 +675,7 @@ ksql_jmxexporter_config_path: /opt/prometheus/ksql.yml
 ### Port to expose ksqlDB prometheus metrics. Beware of port collisions if colocating components on same host
 ksql_jmxexporter_port: 8076
 
-### Use to copy files from control node to ksqlDB hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode ('default: 0640') to set directory and file permissions.
+### Use to copy files from control node to ksqlDB hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode (default: '0640') to set directory and file permissions.
 ksql_copy_files: []
 
 ### Replication Factor for ksqlDB internal topics. Defaults to the minimum of the number of brokers and 3
@@ -729,7 +729,7 @@ control_center:
   # Deprecated way of providing custom properties
   properties: {}
 
-### Use to copy files from control node to Control Center hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode ('default: 0640') to set directory and file permissions.
+### Use to copy files from control node to Control Center hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode (default: '0640') to set directory and file permissions.
 control_center_copy_files: []
 
 ### Replication Factor for Control Center internal topics. Defaults to the minimum of the number of brokers and 3

--- a/roles/confluent.variables/defaults/main.yml
+++ b/roles/confluent.variables/defaults/main.yml
@@ -252,7 +252,7 @@ zookeeper_peer_port: 2888
 ### Zookeeper leader port
 zookeeper_leader_port: 3888
 
-### Use to copy files from control node to zookeeper hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to)
+### Use to copy files from control node to zookeeper hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode ('default: 0640') to set directory and file permissions.
 zookeeper_copy_files: []
 
 # User provided properties, merged into the final properties dictionary with precedence
@@ -362,7 +362,7 @@ kafka_broker_jmxexporter_port: 8080
 
 kafka_broker_jmxexporter_config_path: /opt/prometheus/kafka.yml
 
-### Use to copy files from control node to kafka hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to)
+### Use to copy files from control node to kafka hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode ('default: 0640') to set directory and file permissions.
 kafka_broker_copy_files: []
 
 ### Replication Factor for internal topics. Defaults to the minimum of the number of brokers and 3
@@ -438,7 +438,7 @@ schema_registry_jmxexporter_config_path: /opt/prometheus/schema_registry.yml
 ### Port to expose prometheus metrics. Beware of port collisions if colocating components on same host
 schema_registry_jmxexporter_port: 8078
 
-### Use to copy files from control node to schema registry hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to)
+### Use to copy files from control node to schema registry hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode ('default: 0640') to set directory and file permissions.
 schema_registry_copy_files: []
 
 ### Use to set custom schema registry properties. This variable is a dictionary. Put values true/false in quotation marks to perserve case. NOTE- kafka_broker.properties is deprecated.
@@ -506,7 +506,7 @@ kafka_rest_jmxexporter_config_path: /opt/prometheus/kafka_rest.yml
 ### Port to expose prometheus metrics. Beware of port collisions if colocating components on same host
 kafka_rest_jmxexporter_port: 8075
 
-### Use to copy files from control node to schema registry hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to)
+### Use to copy files from control node to schema registry hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode ('default: 0640') to set directory and file permissions.
 kafka_rest_copy_files: []
 
 ### Use to set custom Rest Proxy properties. This variable is a dictionary. Put values true/false in quotation marks to perserve case. NOTE- kafka_rest.properties is deprecated.
@@ -581,7 +581,7 @@ kafka_connect_jmxexporter_config_path: /opt/prometheus/kafka_connect.yml
 ### Port to expose connect prometheus metrics. Beware of port collisions if colocating components on same host
 kafka_connect_jmxexporter_port: 8077
 
-### Use to copy files from control node to connect hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to)
+### Use to copy files from control node to connect hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode ('default: 0640') to set directory and file permissions.
 kafka_connect_copy_files: []
 
 ### Connect Service Group Id. Customize when configuring multiple connect clusters in same inventory
@@ -675,7 +675,7 @@ ksql_jmxexporter_config_path: /opt/prometheus/ksql.yml
 ### Port to expose ksqlDB prometheus metrics. Beware of port collisions if colocating components on same host
 ksql_jmxexporter_port: 8076
 
-### Use to copy files from control node to ksqlDB hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to)
+### Use to copy files from control node to ksqlDB hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode ('default: 0640') to set directory and file permissions.
 ksql_copy_files: []
 
 ### Replication Factor for ksqlDB internal topics. Defaults to the minimum of the number of brokers and 3
@@ -729,7 +729,7 @@ control_center:
   # Deprecated way of providing custom properties
   properties: {}
 
-### Use to copy files from control node to Control Center hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to)
+### Use to copy files from control node to Control Center hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode ('default: 0640') to set directory and file permissions.
 control_center_copy_files: []
 
 ### Replication Factor for Control Center internal topics. Defaults to the minimum of the number of brokers and 3

--- a/tasks/copy_files.yml
+++ b/tasks/copy_files.yml
@@ -3,7 +3,7 @@
   file:
     path: "{{ item.destination_path | dirname }}"
     state: directory
-    mode: 0750
+    mode: "{{ item.directory_mode | default('0750') }}"
     owner: "{{user}}"
     group: "{{group}}"
   loop: "{{ copy_files }}"
@@ -12,7 +12,7 @@
   copy:
     src: "{{ item.source_path }}"
     dest: "{{ item.destination_path }}"
-    mode: 0640
+    mode: "{{ item.file_mode | default('0640') }}"
     owner: "{{user}}"
     group: "{{group}}"
   loop: "{{ copy_files }}"


### PR DESCRIPTION
# Description

This PR add the possibility to specify directory and file permissions when using task copy_files from Ansible host
Example:
adding this to group vars
```
        zookeeper_copy_files:
          - source_path: /full/ansible/host/path/jmx/jmx_password
            destination_path: "{{archive_config_base_path}}/etc/jmx/jmx_password"
            file_mode: '0600'
          - source_path: /full/ansible/host/path/jmx/jmx_access
            destination_path: "{{archive_config_base_path}}/etc/jmx/jmx_access"
```
will copy jmx_password on zookeeper hosts with the desired permissions. This is required because for some configuration files you will get an error if permissions are too open (e.g. `Error: Password file read access must be restricted: /opt/confluent/etc/jmx/jmx_password`).
Default values for file and directory mode are untouched so this PR will run on existing inventories without modifications.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# How Has This Been Tested?

Feature has been tested with molecule scenario archive-plain-rhel





# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] Any variable changes have been validated to be backwards compatible