### PR TITLE
Support non-local linux Users

### DIFF
--- a/roles/confluent.control_center/tasks/main.yml
+++ b/roles/confluent.control_center/tasks/main.yml
@@ -50,11 +50,10 @@
 
 - name: Check if Control Center User Exists
   # Create user task must be skipped for non-linux users
-  shell: "getent passwd {{control_center_user}}"
-  register: user_output
+  getent:
+    database: passwd
+    key: "{{control_center_user}}"
   failed_when: false
-  changed_when: false
-  check_mode: false
 
 - name: Create Control Center User
   user:
@@ -62,7 +61,8 @@
     comment: Confluent Control Center
     system: true
     group: "{{control_center_group}}"
-  when: user_output.rc != 0
+  when: (getent_passwd|default({}))[control_center_user] is not defined
+
 
 - name: Set Control Center Data Dir permissions
   file:

--- a/roles/confluent.control_center/tasks/main.yml
+++ b/roles/confluent.control_center/tasks/main.yml
@@ -49,7 +49,7 @@
     name: "{{control_center_group}}"
 
 - name: Check if Control Center User Exists
-  # The following task fails for non-local linux users
+  # Create user task must be skipped for non-linux users
   shell: "getent passwd {{control_center_user}}"
   register: user_output
   failed_when: false

--- a/roles/confluent.control_center/tasks/main.yml
+++ b/roles/confluent.control_center/tasks/main.yml
@@ -23,7 +23,6 @@
   when: installation_method == "package"
   tags: package
 
-# Install Packages
 - name: Install the Control Center Packages
   yum:
     name: "{{ control_center_packages | product([confluent_package_redhat_suffix]) | map('join') | list }}"
@@ -45,17 +44,25 @@
   tags: package
   notify: restart control center
 
-# Configure environment
 - name: Create Control Center Group
   group:
     name: "{{control_center_group}}"
 
+- name: Check if Control Center User Exists
+  # The following task fails for non-local linux users
+  shell: "getent passwd {{control_center_user}}"
+  register: user_output
+  failed_when: false
+  changed_when: false
+  check_mode: false
+
 - name: Create Control Center User
   user:
     name: "{{control_center_user}}"
-    comment: "Control Center User"
+    comment: Confluent Control Center
     system: true
     group: "{{control_center_group}}"
+  when: user_output.rc != 0
 
 - name: Set Control Center Data Dir permissions
   file:

--- a/roles/confluent.kafka_broker/tasks/main.yml
+++ b/roles/confluent.kafka_broker/tasks/main.yml
@@ -23,7 +23,6 @@
   when: installation_method == "package"
   tags: package
 
-# Install Packages
 - name: Install the Kafka Broker Packages
   yum:
     name: "{{ kafka_broker_packages | product([confluent_package_redhat_suffix]) | map('join') | list }}"
@@ -49,12 +48,21 @@
   group:
     name: "{{kafka_broker_group}}"
 
+- name: Check if Kafka Broker User Exists
+  # The following task fails for non-local linux users
+  shell: "getent passwd {{kafka_broker_user}}"
+  register: user_output
+  failed_when: false
+  changed_when: false
+  check_mode: false
+
 - name: Kafka Broker user
   user:
     name: "{{kafka_broker_user}}"
-    comment: "Kafka User"
+    comment: Confluent Kafka
     system: true
     group: "{{kafka_broker_group}}"
+  when: user_output.rc !=0
 
 # Archive File deployments need to create SystemD service units
 # Copy the tarball's systemd service to the system

--- a/roles/confluent.kafka_broker/tasks/main.yml
+++ b/roles/confluent.kafka_broker/tasks/main.yml
@@ -49,14 +49,14 @@
     name: "{{kafka_broker_group}}"
 
 - name: Check if Kafka Broker User Exists
-  # The following task fails for non-local linux users
+  # Create user task must be skipped for non-linux users
   shell: "getent passwd {{kafka_broker_user}}"
   register: user_output
   failed_when: false
   changed_when: false
   check_mode: false
 
-- name: Kafka Broker user
+- name: Create Kafka Broker user
   user:
     name: "{{kafka_broker_user}}"
     comment: Confluent Kafka

--- a/roles/confluent.kafka_broker/tasks/main.yml
+++ b/roles/confluent.kafka_broker/tasks/main.yml
@@ -50,11 +50,10 @@
 
 - name: Check if Kafka Broker User Exists
   # Create user task must be skipped for non-linux users
-  shell: "getent passwd {{kafka_broker_user}}"
-  register: user_output
+  getent:
+    database: passwd
+    key: "{{kafka_broker_user}}"
   failed_when: false
-  changed_when: false
-  check_mode: false
 
 - name: Create Kafka Broker user
   user:
@@ -62,7 +61,7 @@
     comment: Confluent Kafka
     system: true
     group: "{{kafka_broker_group}}"
-  when: user_output.rc !=0
+  when: (getent_passwd|default({}))[kafka_broker_user] is not defined
 
 # Archive File deployments need to create SystemD service units
 # Copy the tarball's systemd service to the system

--- a/roles/confluent.kafka_connect/tasks/main.yml
+++ b/roles/confluent.kafka_connect/tasks/main.yml
@@ -23,7 +23,6 @@
   when: installation_method == "package"
   tags: package
 
-# Install Packages
 - name: Install the Kafka Connect Packages
   yum:
     name: "{{ kafka_connect_packages | product([confluent_package_redhat_suffix]) | map('join') | list }}"
@@ -45,17 +44,25 @@
   tags: package
   notify: restart connect distributed
 
-# Configure environment
-- name: Create Connect Distributed Group
+- name: Create Kafka Connect Group
   group:
     name: "{{kafka_connect_group}}"
 
-- name: Create Connect Distributed User
+- name: Check if Kafka Connect User Exists
+  # The following task fails for non-local linux users
+  shell: "getent passwd {{kafka_connect_user}}"
+  register: user_output
+  failed_when: false
+  changed_when: false
+  check_mode: false
+
+- name: Create Kafka Connect User
   user:
     name: "{{kafka_connect_user}}"
-    comment: "Connect Distributed User"
+    comment: Confluent Kafka Connect
     system: true
     group: "{{kafka_connect_group}}"
+  when: user_output.rc != 0
 
 # Archive File deployments need to create SystemD service units
 # Copy the tarball's systemd service to the system
@@ -115,7 +122,7 @@
   include_tasks: rbac.yml
   when: rbac_enabled|bool
 
-- name: Create Connect Distributed Config directory
+- name: Create Kafka Connect Config directory
   file:
     path: "{{ kafka_connect.config_file | dirname }}"
     state: directory
@@ -123,7 +130,7 @@
     owner: "{{kafka_connect_user}}"
     group: "{{kafka_connect_group}}"
 
-- name: Create Connect Distributed Config with Secrets Protection
+- name: Create Kafka Connect Config with Secrets Protection
   include_role:
     name: confluent.common
     tasks_from: secrets_protection.yml
@@ -138,7 +145,7 @@
     handler: restart connect distributed
   when: kafka_connect_secrets_protection_enabled|bool
 
-- name: Create Connect Distributed Config
+- name: Create Kafka Connect Config
   template:
     src: connect-distributed.properties.j2
     dest: "{{kafka_connect.config_file}}"
@@ -178,7 +185,7 @@
     owner: "{{kafka_connect_user}}"
     mode: 0640
 
-- name: Create Connect Distributed Jolokia Config
+- name: Create Kafka Connect Jolokia Config
   template:
     src: kafka_connect_jolokia.properties.j2
     dest: "{{kafka_connect_jolokia_config}}"

--- a/roles/confluent.kafka_connect/tasks/main.yml
+++ b/roles/confluent.kafka_connect/tasks/main.yml
@@ -49,7 +49,7 @@
     name: "{{kafka_connect_group}}"
 
 - name: Check if Kafka Connect User Exists
-  # The following task fails for non-local linux users
+  # Create user task must be skipped for non-linux users
   shell: "getent passwd {{kafka_connect_user}}"
   register: user_output
   failed_when: false

--- a/roles/confluent.kafka_connect/tasks/main.yml
+++ b/roles/confluent.kafka_connect/tasks/main.yml
@@ -50,11 +50,10 @@
 
 - name: Check if Kafka Connect User Exists
   # Create user task must be skipped for non-linux users
-  shell: "getent passwd {{kafka_connect_user}}"
-  register: user_output
+  getent:
+    database: passwd
+    key: "{{kafka_connect_user}}"
   failed_when: false
-  changed_when: false
-  check_mode: false
 
 - name: Create Kafka Connect User
   user:
@@ -62,7 +61,7 @@
     comment: Confluent Kafka Connect
     system: true
     group: "{{kafka_connect_group}}"
-  when: user_output.rc != 0
+  when: (getent_passwd|default({}))[kafka_connect_user] is not defined
 
 # Archive File deployments need to create SystemD service units
 # Copy the tarball's systemd service to the system

--- a/roles/confluent.kafka_connect_replicator/tasks/main.yml
+++ b/roles/confluent.kafka_connect_replicator/tasks/main.yml
@@ -49,7 +49,7 @@
     name: "{{kafka_connect_replicator_group}}"
 
 - name: Check if Kafka Connect Replicator User Exists
-  # The following task fails for non-local linux users
+  # Create user task must be skipped for non-linux users
   shell: "getent passwd {{kafka_connect_replicator_user}}"
   register: user_output
   failed_when: false

--- a/roles/confluent.kafka_connect_replicator/tasks/main.yml
+++ b/roles/confluent.kafka_connect_replicator/tasks/main.yml
@@ -23,7 +23,6 @@
   when: installation_method == "package"
   tags: package
 
-# Install Packages
 - name: Install the Kafka Connect Replicator Packages
   yum:
     name: "{{ kafka_connect_replicator_packages | product([confluent_package_redhat_suffix]) | map('join') | list }}"
@@ -45,17 +44,25 @@
   tags: package
   notify: Restart Kafka Connect Replicator
 
-# Configure environment
 - name: Create Kafka Connect Replicator Group
   group:
     name: "{{kafka_connect_replicator_group}}"
 
+- name: Check if Kafka Connect Replicator User Exists
+  # The following task fails for non-local linux users
+  shell: "getent passwd {{kafka_connect_replicator_user}}"
+  register: user_output
+  failed_when: false
+  changed_when: false
+  check_mode: false
+
 - name: Create Kafka Connect Replicator User
   user:
     name: "{{kafka_connect_replicator_user}}"
-    comment: "Confluent Replicator User"
+    comment: Confluent Kafka Connect Replicator
     system: true
     group: "{{kafka_connect_replicator_group}}"
+  when: user_output.rc != 0
 
 - name: Configure TLS for Kafka Connect Replicator Host
   include_role:

--- a/roles/confluent.kafka_connect_replicator/tasks/main.yml
+++ b/roles/confluent.kafka_connect_replicator/tasks/main.yml
@@ -50,11 +50,10 @@
 
 - name: Check if Kafka Connect Replicator User Exists
   # Create user task must be skipped for non-linux users
-  shell: "getent passwd {{kafka_connect_replicator_user}}"
-  register: user_output
+  getent:
+    database: passwd
+    key: "{{kafka_connect_replicator_user}}"
   failed_when: false
-  changed_when: false
-  check_mode: false
 
 - name: Create Kafka Connect Replicator User
   user:
@@ -62,7 +61,7 @@
     comment: Confluent Kafka Connect Replicator
     system: true
     group: "{{kafka_connect_replicator_group}}"
-  when: user_output.rc != 0
+  when: (getent_passwd|default({}))[kafka_connect_replicator_user] is not defined
 
 - name: Configure TLS for Kafka Connect Replicator Host
   include_role:

--- a/roles/confluent.kafka_rest/tasks/main.yml
+++ b/roles/confluent.kafka_rest/tasks/main.yml
@@ -23,7 +23,6 @@
   when: installation_method == "package"
   tags: package
 
-# Install Packages
 - name: Install the Kafka Rest Packages
   yum:
     name: "{{ kafka_rest_packages | product([confluent_package_redhat_suffix]) | map('join') | list }}"
@@ -45,21 +44,29 @@
   tags: package
   notify: restart kafka-rest
 
-# Configure environment
 - name: Create Kafka Rest Group
   group:
     name: "{{kafka_rest_group}}"
 
+- name: Check if Kafka Rest User Exists
+  # The following task fails for non-local linux users
+  shell: "getent passwd {{kafka_rest_user}}"
+  register: user_output
+  failed_when: false
+  changed_when: false
+  check_mode: false
+
 - name: Create Kafka Rest User
   user:
     name: "{{kafka_rest_user}}"
-    comment: "Kafka REST User"
+    comment: Confluent REST proxy
     system: true
     group: "{{kafka_rest_group}}"
+  when: user_output.rc != 0
 
 # Archive File deployments need to create SystemD service units
 # Copy the tarball's systemd service to the system
-- name: Copy Kafka REST Service from archive file to system
+- name: Copy Kafka Rest Service from archive file to system
   copy:
     src: "{{binary_base_path}}/lib/systemd/system/{{kafka_rest.systemd_file|basename}}"
     remote_src: true

--- a/roles/confluent.kafka_rest/tasks/main.yml
+++ b/roles/confluent.kafka_rest/tasks/main.yml
@@ -49,7 +49,7 @@
     name: "{{kafka_rest_group}}"
 
 - name: Check if Kafka Rest User Exists
-  # The following task fails for non-local linux users
+  # Create user task must be skipped for non-linux users
   shell: "getent passwd {{kafka_rest_user}}"
   register: user_output
   failed_when: false

--- a/roles/confluent.kafka_rest/tasks/main.yml
+++ b/roles/confluent.kafka_rest/tasks/main.yml
@@ -50,11 +50,10 @@
 
 - name: Check if Kafka Rest User Exists
   # Create user task must be skipped for non-linux users
-  shell: "getent passwd {{kafka_rest_user}}"
-  register: user_output
+  getent:
+    database: passwd
+    key: "{{kafka_rest_user}}"
   failed_when: false
-  changed_when: false
-  check_mode: false
 
 - name: Create Kafka Rest User
   user:
@@ -62,7 +61,7 @@
     comment: Confluent REST proxy
     system: true
     group: "{{kafka_rest_group}}"
-  when: user_output.rc != 0
+  when: (getent_passwd|default({}))[kafka_rest_user] is not defined
 
 # Archive File deployments need to create SystemD service units
 # Copy the tarball's systemd service to the system

--- a/roles/confluent.ksql/tasks/main.yml
+++ b/roles/confluent.ksql/tasks/main.yml
@@ -23,8 +23,7 @@
   when: installation_method == "package"
   tags: package
 
-# Install Packages
-- name: Install the KSQL Packages
+- name: Install the Ksql Packages
   yum:
     name: "{{ ksql_packages | product([confluent_package_redhat_suffix]) | map('join') | list }}"
     state: latest
@@ -35,7 +34,7 @@
   tags: package
   notify: restart ksql
 
-- name: Install the KSQL Packages
+- name: Install the Ksql Packages
   apt:
     name: "{{ ksql_packages | product([confluent_package_debian_suffix]) | map('join') | list }}"
   when:
@@ -45,17 +44,25 @@
   tags: package
   notify: restart ksql
 
-# Configure environment
 - name: Create Ksql Group
   group:
     name: "{{ksql_group}}"
 
+- name: Check if Ksql User Exists
+  # The following task fails for non-local linux users
+  shell: "getent passwd {{ksql_user}}"
+  register: user_output
+  failed_when: false
+  changed_when: false
+  check_mode: false
+
 - name: Create Ksql User
   user:
     name: "{{ksql_user}}"
-    comment: "Connect Distributed User"
+    comment: Confluent KSQL
     system: true
     group: "{{ksql_group}}"
+  when: user_output.rc != 0
 
 - name: Set Ksql streams dir permissions
   file:

--- a/roles/confluent.ksql/tasks/main.yml
+++ b/roles/confluent.ksql/tasks/main.yml
@@ -50,11 +50,10 @@
 
 - name: Check if Ksql User Exists
   # Create user task must be skipped for non-linux users
-  shell: "getent passwd {{ksql_user}}"
-  register: user_output
+  getent:
+    database: passwd
+    key: "{{ksql_user}}"
   failed_when: false
-  changed_when: false
-  check_mode: false
 
 - name: Create Ksql User
   user:
@@ -62,7 +61,7 @@
     comment: Confluent KSQL
     system: true
     group: "{{ksql_group}}"
-  when: user_output.rc != 0
+  when: (getent_passwd|default({}))[ksql_user] is not defined
 
 - name: Set Ksql streams dir permissions
   file:

--- a/roles/confluent.ksql/tasks/main.yml
+++ b/roles/confluent.ksql/tasks/main.yml
@@ -49,7 +49,7 @@
     name: "{{ksql_group}}"
 
 - name: Check if Ksql User Exists
-  # The following task fails for non-local linux users
+  # Create user task must be skipped for non-linux users
   shell: "getent passwd {{ksql_user}}"
   register: user_output
   failed_when: false

--- a/roles/confluent.schema_registry/tasks/main.yml
+++ b/roles/confluent.schema_registry/tasks/main.yml
@@ -45,17 +45,25 @@
   tags: package
   notify: restart schema-registry
 
-# Configure environment
 - name: Schema Registry Group
   group:
     name: "{{schema_registry_group}}"
 
+- name: Check if Schema Registry User Exists
+  # The following task fails for non-local linux users
+  shell: "getent passwd {{schema_registry_user}}"
+  register: user_output
+  failed_when: false
+  changed_when: false
+  check_mode: false
+
 - name: Schema Registry User
   user:
     name: "{{schema_registry_user}}"
-    comment: "Schema Registry User"
+    comment: Confluent Schema Registry
     system: true
     group: "{{schema_registry_group}}"
+  when: user_output.rc != 0
 
 # Archive File deployments need to create SystemD service units
 # Copy the tarball's systemd service to the system

--- a/roles/confluent.schema_registry/tasks/main.yml
+++ b/roles/confluent.schema_registry/tasks/main.yml
@@ -57,7 +57,7 @@
   changed_when: false
   check_mode: false
 
-- name: Schema Registry User
+- name: Create Schema Registry User
   user:
     name: "{{schema_registry_user}}"
     comment: Confluent Schema Registry

--- a/roles/confluent.schema_registry/tasks/main.yml
+++ b/roles/confluent.schema_registry/tasks/main.yml
@@ -50,7 +50,7 @@
     name: "{{schema_registry_group}}"
 
 - name: Check if Schema Registry User Exists
-  # The following task fails for non-local linux users
+  # Create user task must be skipped for non-linux users
   shell: "getent passwd {{schema_registry_user}}"
   register: user_output
   failed_when: false

--- a/roles/confluent.schema_registry/tasks/main.yml
+++ b/roles/confluent.schema_registry/tasks/main.yml
@@ -51,11 +51,10 @@
 
 - name: Check if Schema Registry User Exists
   # Create user task must be skipped for non-linux users
-  shell: "getent passwd {{schema_registry_user}}"
-  register: user_output
+  getent:
+    database: passwd
+    key: "{{schema_registry_user}}"
   failed_when: false
-  changed_when: false
-  check_mode: false
 
 - name: Create Schema Registry User
   user:
@@ -63,7 +62,7 @@
     comment: Confluent Schema Registry
     system: true
     group: "{{schema_registry_group}}"
-  when: user_output.rc != 0
+  when: (getent_passwd|default({}))[schema_registry_user] is not defined
 
 # Archive File deployments need to create SystemD service units
 # Copy the tarball's systemd service to the system

--- a/roles/confluent.zookeeper/tasks/main.yml
+++ b/roles/confluent.zookeeper/tasks/main.yml
@@ -50,7 +50,7 @@
     name: "{{zookeeper_group}}"
 
 - name: Check if Zookeeper User Exists
-  # The following task fails for non-local linux users
+  # Create user task must be skipped for non-linux users
   shell: "getent passwd {{zookeeper_user}}"
   register: user_output
   failed_when: false

--- a/roles/confluent.zookeeper/tasks/main.yml
+++ b/roles/confluent.zookeeper/tasks/main.yml
@@ -51,11 +51,10 @@
 
 - name: Check if Zookeeper User Exists
   # Create user task must be skipped for non-linux users
-  shell: "getent passwd {{zookeeper_user}}"
-  register: user_output
+  getent:
+    database: passwd
+    key: "{{zookeeper_user}}"
   failed_when: false
-  changed_when: false
-  check_mode: false
 
 - name: Create Zookeeper User
   user:
@@ -63,7 +62,7 @@
     comment: Confluent Kafka
     system: true
     group: "{{zookeeper_group}}"
-  when: user_output.rc !=0
+  when: (getent_passwd|default({}))[zookeeper_user] is not defined
 
 # Archive File deployments need to create SystemD service units
 # Copy the tarball's systemd service to the system

--- a/roles/confluent.zookeeper/tasks/main.yml
+++ b/roles/confluent.zookeeper/tasks/main.yml
@@ -45,17 +45,25 @@
   tags: package
   notify: restart zookeeper
 
-# Configure environment
 - name: Create Zookeeper Group
   group:
     name: "{{zookeeper_group}}"
 
+- name: Check if Zookeeper User Exists
+  # The following task fails for non-local linux users
+  shell: "getent passwd {{zookeeper_user}}"
+  register: user_output
+  failed_when: false
+  changed_when: false
+  check_mode: false
+
 - name: Create Zookeeper User
   user:
     name: "{{zookeeper_user}}"
-    comment: "Zookeeper User"
+    comment: Confluent Kafka
     system: true
     group: "{{zookeeper_group}}"
+  when: user_output.rc !=0
 
 # Archive File deployments need to create SystemD service units
 # Copy the tarball's systemd service to the system


### PR DESCRIPTION
# Description

The `Create Zookeeper User` task fails for hosts that have non local linux users. (ie users saved in active directory). Adding a simple check to see if the user exists, and skipping that task as necessary. Uses the [getent Module](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/getent_module.html) which returns a dictionary named `getent_passwd` that will have a subdictionary for the username searched. Like this:

```
ok: [schema-registry1] => {
    "getent_passwd": {
        "cp-schema-registry": [
            "x",
            "991",
            "998",
            "Confluent Schema Registry",
            "/tmp",
            "/sbin/nologin"
        ]
    }
}
```

Also updated the User comment to match that of the users that get created with package installation.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Ran this with `plain-rhel` scenario, and saw that the task gets skipped (bc the containers already have the packages installed). Also debugged the `user_output` var.


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible