### PR TITLE
Kafka Tar Upgrade Bugfix

### DIFF
--- a/upgrade_kafka_broker.yml
+++ b/upgrade_kafka_broker.yml
@@ -278,6 +278,22 @@
       # Files cannot be copied because directory is not created in check mode
       ignore_errors: "{{ ansible_check_mode }}"
 
+    - name: Copy Kafka Broker Service from Archive Directory to System
+      copy:
+        src: "{{binary_base_path}}/lib/systemd/system/{{kafka_broker.systemd_file|basename}}"
+        remote_src: true
+        dest: "{{kafka_broker.systemd_file}}"
+        mode: 0644
+        force: true
+      when: installation_method == "archive"
+
+    - name: Update Override to Use New Version
+      lineinfile:
+        path: "{{ kafka_broker.systemd_override }}"
+        line: "ExecStart={{archive_config_base_path}}/confluent-{{confluent_package_version}}/bin/kafka-server-start {{ kafka_broker.config_file }}"
+        regexp: "ExecStart={{archive_config_base_path}}/confluent-(.*)/bin/kafka-server-start {{ kafka_broker.config_file }}"
+      when: installation_method == "archive"
+
     - name: Disable Embedded Rest Proxy
       # Existing server.properties is missing configuration
       lineinfile:


### PR DESCRIPTION
# Description

Adds missing tasks that put new systemd file and update the override.conf w correct version
Without this the upgrade pulls the new tar but starts up the old version of kafka

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

ran the upgrade_kafka_broker.yml playbook and confirmed the kafka version

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible