### PR TITLE
Archive upgrade bugfix for archive installer

### DIFF
--- a/roles/confluent.kafka_broker/tasks/dynamic_groups.yml
+++ b/roles/confluent.kafka_broker/tasks/dynamic_groups.yml
@@ -1,4 +1,10 @@
 ---
+- name: Gather OS Facts
+  setup:
+    filter: ansible_os_family
+    gather_subset:
+      - '!all'
+
 - name: Load server.properties
   slurp:
     src: "{{ kafka_broker.config_file }}"
@@ -18,6 +24,19 @@
         or 'zookeeper.ssl.client.enable=true' in slurped_properties.content|b64decode
     - kafka_broker_secrets_protection_enabled|bool
 
+- name: Load override.conf - Archive Installer
+  slurp:
+    src: "{{ kafka_broker.systemd_override }}"
+  register: slurped_override
+  when: installation_method == "archive"
+
+- name: Set kafka_broker_current_version variable - Archive Installer
+  set_fact:
+    kafka_broker_current_version: "{{ (slurped_override.content|b64decode) .split('\n') |
+      select('match', '^ExecStart=' + archive_config_base_path + '/confluent-(.*)/bin/kafka-server-start ' + kafka_broker.config_file) |
+      list | first | regex_search('[0-9]+(.[0-9]+)+') }}"
+  when: installation_method == "archive"
+
 # TODO When Zookeeper is removed, use kafka-metadata-quorum script. See KIP-595
 - name: Get Controller Broker ID
   shell: >
@@ -30,6 +49,8 @@
           get /controller | grep brokerid
   args:
     executable: /bin/bash
+  vars:
+    archive_version: "{{kafka_broker_current_version | default(confluent_package_version)}}"
   register: controller_query
   run_once: true
   changed_when: false

--- a/roles/confluent.kafka_broker/tasks/dynamic_groups.yml
+++ b/roles/confluent.kafka_broker/tasks/dynamic_groups.yml
@@ -2,8 +2,6 @@
 - name: Gather OS Facts
   setup:
     filter: ansible_os_family
-    gather_subset:
-      - '!all'
 
 - name: Load server.properties
   slurp:

--- a/roles/confluent.kafka_broker/tasks/dynamic_groups.yml
+++ b/roles/confluent.kafka_broker/tasks/dynamic_groups.yml
@@ -50,7 +50,7 @@
   args:
     executable: /bin/bash
   vars:
-    archive_version: "{{kafka_broker_current_version | default(confluent_package_version)}}"
+    archive_version: "{{ kafka_broker_current_version | default(confluent_package_version) }}"
   register: controller_query
   run_once: true
   changed_when: false

--- a/roles/confluent.zookeeper/tasks/dynamic_groups.yml
+++ b/roles/confluent.zookeeper/tasks/dynamic_groups.yml
@@ -2,8 +2,6 @@
 - name: Gather OS Facts
   setup:
     filter: ansible_os_family
-    gather_subset:
-      - '!all'
 
 - name: Load override.conf - Archive Installer
   slurp:

--- a/roles/confluent.zookeeper/tasks/dynamic_groups.yml
+++ b/roles/confluent.zookeeper/tasks/dynamic_groups.yml
@@ -1,10 +1,31 @@
 ---
+- name: Gather OS Facts
+  setup:
+    filter: ansible_os_family
+    gather_subset:
+      - '!all'
+
+- name: Load override.conf - Archive Installer
+  slurp:
+    src: "{{ zookeeper.systemd_override }}"
+  register: slurped_override
+  when: installation_method == "archive"
+
+- name: Set zookeeper_current_version variable - Archive Installer
+  set_fact:
+    zookeeper_current_version: "{{ (slurped_override.content|b64decode) .split('\n') |
+      select('match', '^ExecStart=' + archive_config_base_path + '/confluent-(.*)/bin/zookeeper-server-start ' + zookeeper.config_file) |
+      list | first | regex_search('[0-9]+(.[0-9]+)+') }}"
+  when: installation_method == "archive"
+
 - name: Get Leader/Follower
   shell: >
     set -o pipefail &&
       {{ zookeeper_health_check_command }} | grep Mode
   args:
     executable: /bin/bash
+  vars:
+    archive_version: "{{ zookeeper_current_version | default(confluent_package_version) }}"
   register: leader_query
   changed_when: false
   check_mode: false

--- a/upgrade_kafka_broker_log_format.yml
+++ b/upgrade_kafka_broker_log_format.yml
@@ -16,7 +16,7 @@
         filter: ansible_os_family
         gather_subset:
           - '!all'
-          
+
     - import_role:
         name: confluent.variables
 


### PR DESCRIPTION
# Description

dynamic_groups.yml tasks fail when `installation_method: archive` and `confluent_package_version` gets switched - this is because the commands are built out of full paths that have the version built in. The solution is to first figure out what the current version is before running those commands and add a variable.

Without this essentially upgrades with `installation_method: archive` fail.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Ran zookeeper.yml and kafka_broker.yml with `confluent_package_version: 6.1.0` and then set it to 6.1.1


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible