### PR TITLE
Replicator plain kerberos fix

### DIFF
--- a/roles/confluent.test/molecule/Dockerfile.j2
+++ b/roles/confluent.test/molecule/Dockerfile.j2
@@ -19,7 +19,7 @@ RUN yum -y install java-1.8.0-openjdk \
 
 RUN echo $'[Confluent.dist]\n\
 name=Confluent repository (dist)\n\
-baseurl=https://packages.confluent.io/rpm/6.1/7\n\
+baseurl=https://packages.confluent.io/rpm/6.1/8\n\
 gpgcheck=1\n\
 gpgkey=https://packages.confluent.io/rpm/6.1/archive.key\n\
 enabled=1\n\

--- a/roles/confluent.test/molecule/Dockerfile.j2
+++ b/roles/confluent.test/molecule/Dockerfile.j2
@@ -19,7 +19,7 @@ RUN yum -y install java-1.8.0-openjdk \
 
 RUN echo $'[Confluent.dist]\n\
 name=Confluent repository (dist)\n\
-baseurl=https://packages.confluent.io/rpm/6.1/8\n\
+baseurl=https://packages.confluent.io/rpm/6.1/7\n\
 gpgcheck=1\n\
 gpgkey=https://packages.confluent.io/rpm/6.1/archive.key\n\
 enabled=1\n\

--- a/roles/confluent.test/molecule/kafka-connect-replicator-plain-kerberos-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/kafka-connect-replicator-plain-kerberos-rhel/molecule.yml
@@ -154,20 +154,6 @@ provisioner:
 
 
       mds:
-        # _sasl_plain_users: "{
-        #   'admin': {
-        #     'principal': 'admin',
-        #     'password': 'admin-secret'
-        #   },
-        #   'client': {
-        #     'principal': 'client',
-        #     'password': 'client-secret'
-        #   },
-        #   'kafka_connect_replicator': {
-        #     'principal': 'kafka_connect_replicator',
-        #     'password': 'kafka_connect_replicator-secret'
-        #   }
-        # }"
         _sasl_plain_users:
           admin:
             principal: admin

--- a/roles/confluent.test/molecule/kafka-connect-replicator-plain-kerberos-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/kafka-connect-replicator-plain-kerberos-rhel/molecule.yml
@@ -169,10 +169,10 @@ provisioner:
         #   }
         # }"
         _sasl_plain_users:
-          admin: 
+          admin:
             principal: admin
             password: admin-secret
-          client: 
+          client:
             principal: client
             password: client-secret
           kafka_connect_replicator:

--- a/roles/confluent.test/molecule/kafka-connect-replicator-plain-kerberos-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/kafka-connect-replicator-plain-kerberos-rhel/molecule.yml
@@ -154,6 +154,30 @@ provisioner:
 
 
       mds:
+        # _sasl_plain_users: "{
+        #   'admin': {
+        #     'principal': 'admin',
+        #     'password': 'admin-secret'
+        #   },
+        #   'client': {
+        #     'principal': 'client',
+        #     'password': 'client-secret'
+        #   },
+        #   'kafka_connect_replicator': {
+        #     'principal': 'kafka_connect_replicator',
+        #     'password': 'kafka_connect_replicator-secret'
+        #   }
+        # }"
+        _sasl_plain_users:
+          admin: 
+            principal: admin
+            password: admin-secret
+          client: 
+            principal: client
+            password: client-secret
+          kafka_connect_replicator:
+            principal: kafka_connect_replicator
+            password: kafka_connect_replicator-secret
         sasl_protocol: plain
         ssl_enabled: true
         ssl_custom_certs: true

--- a/upgrade_kafka_broker_log_format.yml
+++ b/upgrade_kafka_broker_log_format.yml
@@ -16,7 +16,7 @@
         filter: ansible_os_family
         gather_subset:
           - '!all'
-          
+
     - import_role:
         name: confluent.variables
 


### PR DESCRIPTION
# Description

Between 6.1.0-post and 6.1.1-post we changed the logic around sasl plain and sasl scram users, so that only the components which exist in the inventory file will have a user created.  Previously we created all default users no matter which components were defined.

With this change, it broke the kafka-connect-replicator-plain-kerberos-rhel molecule scenario due to the kafka-connect-replicator group not existing when the first MDS cluster is created.  This led to the replicator user credentials not being added to the MDS cluster, which was preventing replicator from consuming from this cluster.

By overriding the users for the mds cluster, to include the replicator user and password, we bypass this issue.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Validated kafka-connect-replicator-plain-kerberos-rhel  with the fix in place.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible