### PR TITLE
Dynamic Kafka Groups should honor ZK SSL Variable

### DIFF
--- a/roles/confluent.kafka_broker/tasks/dynamic_groups.yml
+++ b/roles/confluent.kafka_broker/tasks/dynamic_groups.yml
@@ -17,9 +17,7 @@
     owner: "{{ kafka_broker_user }}"
     group: "{{ kafka_broker_group }}"
   when:
-    - >
-      'zookeeper.ssl.client.enable = true' in slurped_properties.content|b64decode
-        or 'zookeeper.ssl.client.enable=true' in slurped_properties.content|b64decode
+    - zookeeper_ssl_enabled|bool
     - kafka_broker_secrets_protection_enabled|bool
 
 - name: Load override.conf - Archive Installer
@@ -40,8 +38,7 @@
   shell: >
     set -o pipefail &&
       {{ binary_base_path }}/bin/zookeeper-shell {{ groups['zookeeper'][0] }}:{{ zookeeper_client_port }}
-          {%- if 'zookeeper.ssl.client.enable = true' in slurped_properties.content|b64decode
-                or 'zookeeper.ssl.client.enable=true' in slurped_properties.content|b64decode %}
+          {%- if zookeeper_ssl_enabled|bool %}
             -zk-tls-config-file {{ kafka_broker.zookeeper_tls_client_config_file if kafka_broker_secrets_protection_enabled else kafka_broker.config_file }}
           {%- endif %}
           get /controller | grep brokerid

--- a/roles/confluent.test/molecule/zookeeper-mtls/molecule.yml
+++ b/roles/confluent.test/molecule/zookeeper-mtls/molecule.yml
@@ -143,7 +143,22 @@ provisioner:
     converge: ../../../../all.yml
   inventory:
     group_vars:
+      # zookeeper:
+      #   zookeeper_ssl_enabled: true
+      #   zookeeper_ssl_mutual_auth_enabled: true
+      
       all:
+        deployment_strategy: rolling
+        zookeeper_custom_properties:
+          # clientPort: 2181
+          # ssl.clientAuth: none
+          sslQuorum: "false"
+
+        zookeeper_ssl_enabled: true
+        zookeeper_ssl_mutual_auth_enabled: false
+
+        mask_secrets: false
+
         scenario_name: zookeeper-mtls
 
         ssl_enabled: true
@@ -152,8 +167,7 @@ provisioner:
 
         fips_enabled: true
 
-        zookeeper_ssl_enabled: true
-        zookeeper_ssl_mutual_auth_enabled: true
+
         sasl_protocol: scram
 
         secrets_protection_enabled: true

--- a/roles/confluent.variables/vars/main.yml
+++ b/roles/confluent.variables/vars/main.yml
@@ -165,7 +165,7 @@ kafka_broker_properties:
       zookeeper.ssl.truststore.location: "{{kafka_broker_pkcs12_truststore_path}}"
       zookeeper.ssl.truststore.password: "{{kafka_broker_truststore_storepass}}"
   zk_mtls:
-    enabled: "{{ zookeeper_ssl_mutual_auth_enabled }}"
+    enabled: "{{ zookeeper_ssl_enabled and zookeeper_ssl_mutual_auth_enabled }}"
     properties:
       zookeeper.ssl.keystore.location: "{{kafka_broker_pkcs12_keystore_path}}"
       zookeeper.ssl.keystore.password: "{{kafka_broker_keystore_storepass}}"

--- a/roles/confluent.zookeeper/tasks/dynamic_groups.yml
+++ b/roles/confluent.zookeeper/tasks/dynamic_groups.yml
@@ -16,6 +16,27 @@
       list | first | regex_search('[0-9]+(.[0-9]+)+') }}"
   when: installation_method == "archive"
 
+- name: Load zookeeper.properties
+  slurp:
+    src: "{{ zookeeper.config_file }}"
+  register: slurped_properties
+
+# - debug:
+#     msg: "{{ (slurped_properties.content|b64decode).split('\n') }}"
+
+# - debug:
+#     msg: "{{ (slurped_properties.content|b64decode).split('\n') |
+#       select('match', '^ssl.clientAuth=need') }}"
+
+- name: Set Current zookeeper_ssl_enabled, Create Backup
+  set_fact:
+    zookeeper_ssl_enabled_backup: "{{ zookeeper_ssl_enabled }}"
+    zookeeper_ssl_enabled: "{{ (slurped_properties.content|b64decode).split('\n') |
+      select('match', '^ssl.clientAuth=need') | length > 0 }}"
+
+- debug:
+    msg: "{{ zookeeper_ssl_enabled }}"
+
 - name: Get Leader/Follower
   shell: >
     set -o pipefail &&
@@ -30,6 +51,13 @@
 
 - debug:
     msg: "{{ leader_query.stdout }}"
+
+- name: Restore zookeeper_ssl_enabled
+  set_fact:
+    zookeeper_ssl_enabled: "{{ zookeeper_ssl_enabled_backup }}"
+
+- debug:
+    msg: "{{ zookeeper_ssl_enabled }}"
 
 - name: "Group Hosts by Zookeeper Mode: Follower or Leader"
   group_by:


### PR DESCRIPTION
# Description

Resolves a bug where you enable/disable `zookeeper_ssl_enabled` variable and try to install kafka. In this case the server.properties will be incorrect and dynamic_groups.yml tasks fail

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration



**Test Configuration**:


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible