### PR TITLE
removing the ansible fully qualified module name

### DIFF
--- a/roles/confluent.common/tasks/remove_packages.yml
+++ b/roles/confluent.common/tasks/remove_packages.yml
@@ -30,7 +30,7 @@
 ### - ansible_facts.services[service_name + '.service'] is defined
 
 - name: Get Service Facts
-  ansible.builtin.service_facts:
+  service_facts:
 
 - name: Stop Service before Removing Confluent Packages
   systemd:


### PR DESCRIPTION
# Description

fully qualified module name is not compatible with ansible 2.7, error from customer: 

```

TASK [Stop Service and Remove Packages on Version Change] ******************************************************************************************************************************************************
task path: /etc/ansible/standalone/cp-ansible-6.2.0-post/roles/confluent.zookeeper/tasks/main.yml:17
Monday 21 June 2021  11:59:39 -0700 (0:00:00.980)       0:01:36.965 ***********
ERROR! no action detected in task. This often indicates a misspelled module name, or incorrect module path.
The error appears to have been in '/etc/ansible/standalone/cp-ansible-6.2.0-post/roles/confluent.common/tasks/remove_packages.yml': line 32, column 3, but may
be elsewhere in the file depending on the exact syntax problem.
The offending line appears to be:
```

on ansible 2.7

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Validated by customer


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible