### PR TITLE
Corrects kafka connect mtls property

### DIFF
--- a/roles/confluent.variables/vars/main.yml
+++ b/roles/confluent.variables/vars/main.yml
@@ -532,7 +532,7 @@ kafka_connect_properties:
   mtls:
     enabled: "{{ kafka_connect_ssl_mutual_auth_enabled }}"
     properties:
-      listeners.https.ssl.client.auth: "true"
+      listeners.https.ssl.client.auth: required
   sr:
     enabled: "{{ 'schema_registry' in groups }}"
     properties:


### PR DESCRIPTION
# Description

`kafka_connect_ssl_mutual_auth_enabled` was not properly setting connect properties. Only need to make the change for connect

Connect docs: show the client.auth property options as required, requested, none
https://docs.confluent.io/platform/current/kafka/encryption.html#encryption-ssl-rest

SR Docs, show this property uses boolean
https://docs.confluent.io/platform/current/schema-registry/installation/config.html#ssl-client-auth

RP Docs: show this property uses a boolean
https://docs.confluent.io/platform/current/kafka-rest/production-deployment/rest-proxy/security.html#id1

ksqldb docs show this property is a boolean:
https://docs.ksqldb.io/en/latest/operate-and-deploy/installation/server-config/security/#configuring-listener-for-ssl-encryption

Fixes # (https://github.com/confluentinc/cp-ansible/issues/703)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?




# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible