### PR TITLE
Updated rbac topic permissions for rest proxy to be resource owner.

### DIFF
--- a/roles/confluent.kafka_rest/tasks/rbac.yml
+++ b/roles/confluent.kafka_rest/tasks/rbac.yml
@@ -35,9 +35,11 @@
       }
     status_code: 204
 
-- name: Grant Rest Proxy user the DeveloperWrite role on Monitoring Interceptor Topic
+### Rest Proxy user is now being set as resource owner on the monitoring interceptor topic to prevent race conditions when RBAC is enabled.
+
+- name: Grant Rest Proxy user ResouceOwnder on the Monitoring Interceptor Topic
   uri:
-    url: "{{mds_bootstrap_server_urls.split(',')[0]}}/security/1.0/principals/User:{{kafka_rest_ldap_user}}/roles/DeveloperWrite/bindings"
+    url: "{{mds_bootstrap_server_urls.split(',')[0]}}/security/1.0/principals/User:{{kafka_rest_ldap_user}}/roles/ResourceOwner/bindings"
     method: POST
     validate_certs: false
     force_basic_auth: true


### PR DESCRIPTION

# Description

Updated rbac topic permissions for rest proxy to be resource owner on monitoring interceptor to allow the automated creation of the monitoring interceptor topic when C3 is not present and to prevent race conditions leading to functionality issues.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration



**Test Configuration**:

Validated with rbac-kerberos-debian scenario.  Specifically confirmed that denials for the rest proxy user no longer occur when the cluster is stood up due to race conditions and also when C3 is not present.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible