### PR TITLE
Updates to two molecule scenarios.

### DIFF
--- a/roles/confluent.test/molecule/mtls-java11-debian/molecule.yml
+++ b/roles/confluent.test/molecule/mtls-java11-debian/molecule.yml
@@ -7,6 +7,7 @@ platforms:
     groups:
       - zookeeper
     image: geerlingguy/docker-debian9-ansible
+    dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -18,6 +19,7 @@ platforms:
     groups:
       - kafka_broker
     image: geerlingguy/docker-debian9-ansible
+    dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -29,6 +31,7 @@ platforms:
     groups:
       - kafka_broker
     image: geerlingguy/docker-debian9-ansible
+    dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -40,6 +43,7 @@ platforms:
     groups:
       - kafka_broker
     image: geerlingguy/docker-debian9-ansible
+    dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -51,6 +55,7 @@ platforms:
     groups:
       - schema_registry
     image: geerlingguy/docker-debian9-ansible
+    dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -62,6 +67,7 @@ platforms:
     groups:
       - kafka_rest
     image: geerlingguy/docker-debian9-ansible
+    dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -73,6 +79,7 @@ platforms:
     groups:
       - kafka_connect
     image: geerlingguy/docker-debian9-ansible
+    dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -84,6 +91,7 @@ platforms:
     groups:
       - ksql
     image: geerlingguy/docker-debian9-ansible
+    dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -95,6 +103,7 @@ platforms:
     groups:
       - control_center
     image: geerlingguy/docker-debian9-ansible
+    dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/roles/confluent.test/molecule/mtls-java11-ubuntu/molecule.yml
+++ b/roles/confluent.test/molecule/mtls-java11-ubuntu/molecule.yml
@@ -7,6 +7,7 @@ platforms:
     groups:
       - zookeeper
     image: geerlingguy/docker-ubuntu1804-ansible
+    dockerfile: ../Dockerfile-debian-archive.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -18,6 +19,7 @@ platforms:
     groups:
       - kafka_broker
     image: geerlingguy/docker-ubuntu1804-ansible
+    dockerfile: ../Dockerfile-debian-archive.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -29,6 +31,7 @@ platforms:
     groups:
       - kafka_broker
     image: geerlingguy/docker-ubuntu1804-ansible
+    dockerfile: ../Dockerfile-debian-archive.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -40,6 +43,7 @@ platforms:
     groups:
       - kafka_broker
     image: geerlingguy/docker-ubuntu1804-ansible
+    dockerfile: ../Dockerfile-debian-archive.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -51,6 +55,7 @@ platforms:
     groups:
       - schema_registry
     image: geerlingguy/docker-ubuntu1804-ansible
+    dockerfile: ../Dockerfile-debian-archive.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -62,6 +67,7 @@ platforms:
     groups:
       - kafka_rest
     image: geerlingguy/docker-ubuntu1804-ansible
+    dockerfile: ../Dockerfile-debian-archive.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -73,6 +79,7 @@ platforms:
     groups:
       - kafka_connect
     image: geerlingguy/docker-ubuntu1804-ansible
+    dockerfile: ../Dockerfile-debian-archive.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -84,6 +91,7 @@ platforms:
     groups:
       - ksql
     image: geerlingguy/docker-ubuntu1804-ansible
+    dockerfile: ../Dockerfile-debian-archive.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -95,6 +103,7 @@ platforms:
     groups:
       - control_center
     image: geerlingguy/docker-ubuntu1804-ansible
+    dockerfile: ../Dockerfile-debian-archive.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/roles/confluent.test/molecule/mtls-java11-ubuntu/molecule.yml
+++ b/roles/confluent.test/molecule/mtls-java11-ubuntu/molecule.yml
@@ -7,7 +7,7 @@ platforms:
     groups:
       - zookeeper
     image: geerlingguy/docker-ubuntu1804-ansible
-    dockerfile: ../Dockerfile-debian-archive.j2
+    dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -19,7 +19,7 @@ platforms:
     groups:
       - kafka_broker
     image: geerlingguy/docker-ubuntu1804-ansible
-    dockerfile: ../Dockerfile-debian-archive.j2
+    dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -31,7 +31,7 @@ platforms:
     groups:
       - kafka_broker
     image: geerlingguy/docker-ubuntu1804-ansible
-    dockerfile: ../Dockerfile-debian-archive.j2
+    dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -43,7 +43,7 @@ platforms:
     groups:
       - kafka_broker
     image: geerlingguy/docker-ubuntu1804-ansible
-    dockerfile: ../Dockerfile-debian-archive.j2
+    dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -55,7 +55,7 @@ platforms:
     groups:
       - schema_registry
     image: geerlingguy/docker-ubuntu1804-ansible
-    dockerfile: ../Dockerfile-debian-archive.j2
+    dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -67,7 +67,7 @@ platforms:
     groups:
       - kafka_rest
     image: geerlingguy/docker-ubuntu1804-ansible
-    dockerfile: ../Dockerfile-debian-archive.j2
+    dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -79,7 +79,7 @@ platforms:
     groups:
       - kafka_connect
     image: geerlingguy/docker-ubuntu1804-ansible
-    dockerfile: ../Dockerfile-debian-archive.j2
+    dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -91,7 +91,7 @@ platforms:
     groups:
       - ksql
     image: geerlingguy/docker-ubuntu1804-ansible
-    dockerfile: ../Dockerfile-debian-archive.j2
+    dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -103,7 +103,7 @@ platforms:
     groups:
       - control_center
     image: geerlingguy/docker-ubuntu1804-ansible
-    dockerfile: ../Dockerfile-debian-archive.j2
+    dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/roles/confluent.test/molecule/mtls-java11-ubuntu/molecule.yml
+++ b/roles/confluent.test/molecule/mtls-java11-ubuntu/molecule.yml
@@ -7,7 +7,7 @@ platforms:
     groups:
       - zookeeper
     image: geerlingguy/docker-ubuntu1804-ansible
-    dockerfile: ../Dockerfile-debian.j2
+    dockerfile: ../Dockerfile-ubuntu.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -19,7 +19,7 @@ platforms:
     groups:
       - kafka_broker
     image: geerlingguy/docker-ubuntu1804-ansible
-    dockerfile: ../Dockerfile-debian.j2
+    dockerfile: ../Dockerfile-ubuntu.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -31,7 +31,7 @@ platforms:
     groups:
       - kafka_broker
     image: geerlingguy/docker-ubuntu1804-ansible
-    dockerfile: ../Dockerfile-debian.j2
+    dockerfile: ../Dockerfile-ubuntu.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -43,7 +43,7 @@ platforms:
     groups:
       - kafka_broker
     image: geerlingguy/docker-ubuntu1804-ansible
-    dockerfile: ../Dockerfile-debian.j2
+    dockerfile: ../Dockerfile-ubuntu.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -55,7 +55,7 @@ platforms:
     groups:
       - schema_registry
     image: geerlingguy/docker-ubuntu1804-ansible
-    dockerfile: ../Dockerfile-debian.j2
+    dockerfile: ../Dockerfile-ubuntu.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -67,7 +67,7 @@ platforms:
     groups:
       - kafka_rest
     image: geerlingguy/docker-ubuntu1804-ansible
-    dockerfile: ../Dockerfile-debian.j2
+    dockerfile: ../Dockerfile-ubuntu.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -79,7 +79,7 @@ platforms:
     groups:
       - kafka_connect
     image: geerlingguy/docker-ubuntu1804-ansible
-    dockerfile: ../Dockerfile-debian.j2
+    dockerfile: ../Dockerfile-ubuntu.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -91,7 +91,7 @@ platforms:
     groups:
       - ksql
     image: geerlingguy/docker-ubuntu1804-ansible
-    dockerfile: ../Dockerfile-debian.j2
+    dockerfile: ../Dockerfile-ubuntu.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -103,7 +103,7 @@ platforms:
     groups:
       - control_center
     image: geerlingguy/docker-ubuntu1804-ansible
-    dockerfile: ../Dockerfile-debian.j2
+    dockerfile: ../Dockerfile-ubuntu.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro


### PR DESCRIPTION
# Description

A report from support indicated that a user was seeing failures in user and directory creation when running playbooks with CP-Kafka on ubuntu 20 and Debian 10.  We advised both are currently not supported, however validated against our latest branch of Ubuntu 18.04 and Debian 9, and confirmed that functionality works as expected.

Discovered that the two scenarios required usage of docker files, to configure OS dependencies.  This PR adds the appropriate docker files to those scenarios.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


Validated against the following molecule scenarios:

mtls-java11-debian
mtls-java11-ubuntu


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible