### PR TITLE
Force playbook failure on any failure

### DIFF
--- a/control_center.yml
+++ b/control_center.yml
@@ -34,6 +34,7 @@
 - name: Control Center Serial Provisioning
   hosts: control_center_serial
   serial: 1
+  any_errors_fatal: true
   gather_facts: false
   tags: control_center
   environment: "{{ proxy_env }}"

--- a/kafka_broker.yml
+++ b/kafka_broker.yml
@@ -44,6 +44,7 @@
 - name: Kafka Broker Non Controllers Provisioning
   hosts: kafka_broker_non_controller
   serial: 1
+  any_errors_fatal: true
   gather_facts: false
   tags: kafka_broker
   environment: "{{ proxy_env }}"
@@ -58,6 +59,7 @@
 
 - name: Kafka Broker Controller Provisioning
   hosts: kafka_broker_controller
+  any_errors_fatal: true
   gather_facts: false
   tags: kafka_broker
   environment: "{{ proxy_env }}"

--- a/kafka_connect.yml
+++ b/kafka_connect.yml
@@ -34,6 +34,7 @@
 - name: Kafka Connect Serial Provisioning
   hosts: kafka_connect_serial
   serial: 1
+  any_errors_fatal: true
   gather_facts: false
   tags: kafka_connect
   environment: "{{ proxy_env }}"

--- a/kafka_connect_replicator.yml
+++ b/kafka_connect_replicator.yml
@@ -34,6 +34,7 @@
 - name: Kafka Connect Replicator Serial Provisioning
   hosts: kafka_connect_replicator_serial
   serial: 1
+  any_errors_fatal: true
   gather_facts: false
   tags: kafka_connect_replicator
   environment: "{{ proxy_env }}"

--- a/kafka_rest.yml
+++ b/kafka_rest.yml
@@ -34,6 +34,7 @@
 - name: Kafka Rest Serial Provisioning
   hosts: kafka_rest_serial
   serial: 1
+  any_errors_fatal: true
   gather_facts: false
   tags: kafka_rest
   environment: "{{ proxy_env }}"

--- a/schema_registry.yml
+++ b/schema_registry.yml
@@ -3,6 +3,7 @@
   hosts: schema_registry
   # Start SR hosts serially because there is a race condition on topic creation when multiple hosts start at the same time
   serial: 1
+  any_errors_fatal: true
   gather_facts: false
   tags: schema_registry
   environment: "{{ proxy_env }}"

--- a/zookeeper.yml
+++ b/zookeeper.yml
@@ -44,6 +44,7 @@
 - name: Zookeeper Followers Provisioning
   hosts: zookeeper_follower
   serial: 1
+  any_errors_fatal: true
   gather_facts: false
   tags: zookeeper
   environment: "{{ proxy_env }}"
@@ -58,6 +59,7 @@
 
 - name: Zookeeper Leader Provisioning
   hosts: zookeeper_leader
+  any_errors_fatal: true
   gather_facts: false
   tags: zookeeper
   environment: "{{ proxy_env }}"


### PR DESCRIPTION
# Description

Getting reports that with `deployment_strategy: rolling` - and a host failure, playbook execution is continuing. Upon local testing I can't replicate

But reading the docs: https://docs.ansible.com/ansible/latest/user_guide/playbooks_error_handling.html#aborting-a-play-on-all-hosts

It says:
> By default, Ansible continues to execute tasks as long as there are hosts that have not yet failed.

So to be safe, I am adding `any_errors_fatal: true` on any rolling deployment playbooks.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Set a variable that does not work with a rolling deployment, do a rolling deployment and make sure the playbook does not continue

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible