### PR TITLE
Updated hosts_example to remove deprecated datadir variable

### DIFF
--- a/hosts_example.yml
+++ b/hosts_example.yml
@@ -271,10 +271,10 @@ kafka_broker:
   #   ## To configure Kafka to run as a custom user, uncomment below
   #   kafka_broker_user: custom-user
   #   kafka_broker_group: custom-group
-  #   
+  #
   #   # To update data log location use custom properties:
   #   # By default the log directory is /var/lib/kafka/data
-  #   
+  #
   #    kafka_broker_custom_properties:
   #      log.dirs: dir1,dir2
   #

--- a/hosts_example.yml
+++ b/hosts_example.yml
@@ -271,11 +271,6 @@ kafka_broker:
   #   ## To configure Kafka to run as a custom user, uncomment below
   #   kafka_broker_user: custom-user
   #   kafka_broker_group: custom-group
-  #   # To update the log.dirs property within the kafka server.properties, uncomment below
-  #   # By default the log directory is /var/lib/kafka/data
-  #   kafka_broker:
-  #     datadir:
-  #       - /var/lib/kafka/my-data
   #
   #   ## To enabled Self Balancing Kafka Brokers, uncomment the below lines
   #   kafka_broker_custom_properties:

--- a/hosts_example.yml
+++ b/hosts_example.yml
@@ -271,6 +271,12 @@ kafka_broker:
   #   ## To configure Kafka to run as a custom user, uncomment below
   #   kafka_broker_user: custom-user
   #   kafka_broker_group: custom-group
+  #   
+  #   # To update data log location use custom properties:
+  #   # By default the log directory is /var/lib/kafka/data
+  #   
+  #    kafka_broker_custom_properties:
+  #      log.dirs: dir1,dir2
   #
   #   ## To enabled Self Balancing Kafka Brokers, uncomment the below lines
   #   kafka_broker_custom_properties:

--- a/roles/confluent.test/molecule/archive-plain-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/archive-plain-rhel/molecule.yml
@@ -98,6 +98,9 @@ provisioner:
         kafka_connect_confluent_hub_plugins:
           - jcustenborder/kafka-connect-spooldir:2.0.43
 
+        kafka_broker_custom_properties:
+          log.dirs: /tmp/logs1,/tmp/logs2
+
         zookeeper_log_dir: /zk/logs
         kafka_broker_log_dir: /kafka/logs/
         schema_registry_log_dir: /sr/logs

--- a/roles/confluent.test/molecule/archive-plain-rhel/verify.yml
+++ b/roles/confluent.test/molecule/archive-plain-rhel/verify.yml
@@ -19,6 +19,14 @@
         property: security.providers
         expected_value: io.confluent.kafka.security.fips.provider.BcFipsProviderCreator,io.confluent.kafka.security.fips.provider.BcFipsJsseProviderCreator
 
+    - import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: /opt/confluent/etc/kafka/server.properties
+        property: log.dirs
+        expected_value: /tmp/logs1,/tmp/logs2
+
 - name: Verify - schema_registry
   hosts: schema_registry
   gather_facts: false

--- a/roles/confluent.variables/defaults/main.yml
+++ b/roles/confluent.variables/defaults/main.yml
@@ -399,7 +399,8 @@ kafka_broker:
   appender_log_path: "{{kafka_broker_default_log_dir}}"
   # Deprecated way of providing custom properties
   properties: {}
-  # Deprecated way of setting kafkas log.dirs property
+  # Deprecated way of setting kafkas log.dirs property, use kafka_broker_custom_properties:
+  # log.dirs: dir1,dir2
   datadir:
     - /var/lib/kafka/data
 


### PR DESCRIPTION
# Description

Updated hosts_example to remove deprecated datadir variable.  All log location overrides should be handled via custom broker properties:

kafka_broker_custom_properties:
  log.dirs: dir1,dir2

Fixes # (issue)

https://github.com/confluentinc/cp-ansible/issues/690

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration



**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible