### PR TITLE
Added property for setting remote tmp location in ansible config.

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,6 +1,7 @@
 [defaults]
 hash_behaviour=merge
 callback_whitelist=profile_tasks
+remote_tmp=~/.ansible/tmp
 
 [ssh_connection]
 pipelining = True


### PR DESCRIPTION
# Description

This change adds the poperty to the ansible config for setting the remote tmp location for ansible to use.  It's set to ansible's default, however by being present allows the customer to easier override this, when in secure/locked down environments.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Validated with archive-plain-rhel scenario.


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible