### PR TITLE
Updated RBAC URI calls to not run when using check mode

### DIFF
--- a/roles/confluent.common/tasks/rbac_setup.yml
+++ b/roles/confluent.common/tasks/rbac_setup.yml
@@ -16,7 +16,8 @@
 - name: Parse Kafka Cluster ID from json query
   set_fact:
     kafka_cluster_id: "{{ cluster_id_query.json.data[0].cluster_id }}"
-  when: cluster_id_source | default('erp') == 'erp'
+  when: (cluster_id_source | default('erp') == 'erp') and not ansible_check_mode
+
 
 # TODO this will not work for Secure ZK or Archive installation method
 - name: Get Kafka Cluster ID from Zookeeper

--- a/roles/confluent.control_center/tasks/rbac.yml
+++ b/roles/confluent.control_center/tasks/rbac.yml
@@ -26,6 +26,7 @@
       }
     status_code: 204
   loop: "{{control_center_additional_system_admins}}"
+  when: not ansible_check_mode
 
 - name: Grant role System Admin to Control Center user
   uri:
@@ -45,3 +46,4 @@
         }
       }
     status_code: 204
+  when: not ansible_check_mode

--- a/roles/confluent.kafka_broker/tasks/rbac_rolebindings.yml
+++ b/roles/confluent.kafka_broker/tasks/rbac_rolebindings.yml
@@ -26,3 +26,4 @@
       }
     status_code: 204
   loop: "{{kafka_broker_additional_system_admins}}"
+  when: not ansible_check_mode

--- a/roles/confluent.kafka_connect/tasks/rbac.yml
+++ b/roles/confluent.kafka_connect/tasks/rbac.yml
@@ -27,6 +27,7 @@
       }
     status_code: 204
   loop: "{{kafka_connect_additional_system_admins}}"
+  when: not ansible_check_mode
 
 - name: Grant role Security Admin to Connect user
   uri:
@@ -47,6 +48,7 @@
         }
       }
     status_code: 204
+  when: not ansible_check_mode
 
 - name: Grant Connect User ResourceOwner on Connect Topics and Group
   uri:
@@ -95,6 +97,7 @@
         }
       }
     status_code: 204
+  when: not ansible_check_mode
 
 - name: Grant Connect User ResourceOwner on Secret Registry Topic and Group
   uri:
@@ -128,7 +131,7 @@
         }
       }
     status_code: 204
-  when: kafka_connect_secret_registry_enabled|bool
+  when: kafka_connect_secret_registry_enabled|bool and not ansible_check_mode
 
 - name: Grant connect user the DeveloperWrite role on Monitoring Interceptor Topic
   uri:
@@ -155,4 +158,4 @@
         }]
       }
     status_code: 204
-  when: kafka_connect_monitoring_interceptors_enabled|bool
+  when: kafka_connect_monitoring_interceptors_enabled|bool and not ansible_check_mode

--- a/roles/confluent.kafka_rest/tasks/rbac.yml
+++ b/roles/confluent.kafka_rest/tasks/rbac.yml
@@ -34,6 +34,7 @@
         ]
       }
     status_code: 204
+  when: not ansible_check_mode
 
 ### Rest Proxy user is now being set as resource owner on the monitoring interceptor topic to prevent race conditions when RBAC is enabled.
 
@@ -62,4 +63,4 @@
         }]
       }
     status_code: 204
-  when: kafka_rest_monitoring_interceptors_enabled|bool
+  when: kafka_rest_monitoring_interceptors_enabled|bool and not ansible_check_mode

--- a/roles/confluent.ksql/tasks/rbac.yml
+++ b/roles/confluent.ksql/tasks/rbac.yml
@@ -31,6 +31,7 @@
       }
     status_code: 204
   loop: "{{ksql_additional_system_admins}}"
+  when: not ansible_check_mode
 
 - name: Grant ResourceOwner of KSQL Cluster on KSQL User
   uri:
@@ -57,6 +58,7 @@
         }]
       }
     status_code: 204
+  when: not ansible_check_mode
 
 - name: Grant ksql user the ResourceOwner role with four resourcePatterns
   uri:
@@ -90,6 +92,7 @@
         ]
       }
     status_code: 204
+  when: not ansible_check_mode
 
 - name: Grant ksql user the DeveloperWrite role on resourceType TransactionalId
   uri:
@@ -116,6 +119,7 @@
         }]
       }
     status_code: 204
+  when: not ansible_check_mode
 
 - name: Grant ksql user the ResourceOwner role on resourceType Subject in Schema Registry Cluster
   uri:
@@ -143,7 +147,7 @@
         }]
       }
     status_code: 204
-  when: "'schema_registry' in groups"
+  when: ("'schema_registry' in groups") and not ansible_check_mode
 
 - name: Grant ksql user the DeveloperWrite role on Monitoring Interceptor Topic
   uri:
@@ -170,7 +174,7 @@
         }]
       }
     status_code: 204
-  when: ksql_monitoring_interceptors_enabled|bool
+  when: ksql_monitoring_interceptors_enabled|bool and not ansible_check_mode
 
 - name: Grant ksql user the ResourceOwner role on the Processing Log Topic
   uri:
@@ -202,4 +206,4 @@
   loop:
     - "{{ksql_ldap_user}}"
     - "{{ksql_log4j_principal}}"
-  when: ksql_log_streaming_enabled | bool
+  when: ksql_log_streaming_enabled | bool and not ansible_check_mode

--- a/roles/confluent.schema_registry/tasks/rbac.yml
+++ b/roles/confluent.schema_registry/tasks/rbac.yml
@@ -27,6 +27,7 @@
       }
     status_code: 204
   loop: "{{schema_registry_additional_system_admins}}"
+  when: not ansible_check_mode
 
 - name: Grant Schema Registry user the role SecurityAdmin on the Schema Registry cluster
   uri:
@@ -47,6 +48,7 @@
         }
       }
     status_code: 204
+  when: not ansible_check_mode
 
 - name: Grant Schema Registry user ResourceOwner Schema Registry Group and Topic
   uri:
@@ -85,3 +87,4 @@
         ]
       }
     status_code: 204
+  when: not ansible_check_mode


### PR DESCRIPTION
# Description

Update RBAC URI calls, along with API calls to retrieve cluster_ID to not run during check mode, as they require interaction with the API which is generally not available when running check mode.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested with scenario: rbac-scram-custom-rhel

1. Run scenario rbac-scram-custom-rhel
2. Run the scenario again via cache, with --check option: 

ansible-playbook -i ~/.cache/molecule/confluent.test/rbac-scram-custom-rhel/inventory all.yml --check


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible