### PR TITLE
Cluster Registration requires MDS activation

### DIFF
--- a/roles/confluent.kafka_broker/tasks/main.yml
+++ b/roles/confluent.kafka_broker/tasks/main.yml
@@ -353,7 +353,7 @@
 
 - name: Register Cluster
   include_tasks: register_cluster.yml
-  when: kafka_broker_cluster_name|length > 0
+  when: kafka_broker_cluster_name|length > 0 and rbac_enabled|bool
 
 - name: Create RBAC Rolebindings
   include_tasks: rbac_rolebindings.yml

--- a/roles/confluent.kafka_connect/tasks/main.yml
+++ b/roles/confluent.kafka_connect/tasks/main.yml
@@ -241,7 +241,7 @@
 
 - name: Register Cluster
   include_tasks: register_cluster.yml
-  when: kafka_connect_cluster_name|length > 0
+  when: kafka_connect_cluster_name|length > 0 and rbac_enabled|bool
 
 - name: Deploy Connectors
   include_tasks: deploy_connectors.yml

--- a/roles/confluent.kafka_connect_replicator/tasks/main.yml
+++ b/roles/confluent.kafka_connect_replicator/tasks/main.yml
@@ -229,7 +229,7 @@
 
 - name: Register Cluster
   include_tasks: register_cluster.yml
-  when: kafka_connect_replicator_cluster_name|length > 0
+  when: kafka_connect_replicator_cluster_name|length > 0 and rbac_enabled|bool
 
 - name: Configure RBAC on Replicator configuration
   include_tasks: rbac_replicator.yml

--- a/roles/confluent.ksql/tasks/main.yml
+++ b/roles/confluent.ksql/tasks/main.yml
@@ -262,4 +262,4 @@
 
 - name: Register Cluster
   include_tasks: register_cluster.yml
-  when: ksql_cluster_name | length >0
+  when: ksql_cluster_name | length >0 and rbac_enabled|bool

--- a/roles/confluent.schema_registry/tasks/main.yml
+++ b/roles/confluent.schema_registry/tasks/main.yml
@@ -239,4 +239,4 @@
 
 - name: Register Cluster
   include_tasks: register_cluster.yml
-  when: schema_registry_cluster_name | length >0
+  when: schema_registry_cluster_name | length >0 and rbac_enabled|bool

--- a/roles/confluent.test/molecule/archive-plain-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/archive-plain-rhel/molecule.yml
@@ -91,6 +91,14 @@ provisioner:
   inventory:
     group_vars:
       all:
+        # Validating custom port works on ERP.
+        mds_port: 7000
+        # Validating that cluster naming is disabled when RBAC is not present.
+        kafka_broker_cluster_name: doombar
+        schema_registry_cluster_name: augustina
+        ksql_cluster_name: kolsch
+        kafka_connect_cluster_name: budvar
+
         sasl_protocol: plain
         ssl_enabled: true
         fips_enabled: true


### PR DESCRIPTION
# Description

Cluster Registry is apart of the MDS.  Customers have been confused by not running MDS and receiving errors when specifying a cluster name.

I have added an additional logic gate to prevent registrations calls from running unless MDS is enabled.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I have updated the archive-plain-rhel scenario to use register cluster names, while rbac is not enabled.  This validates that the calls are not made.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible