### PR TITLE
Fix ansible-lint config: skip experimental rule

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -11,3 +11,5 @@ skip_list:
   - package-latest
   - empty-string-compare
   - no-handler
+  - no-log-password
+


### PR DESCRIPTION
# Description

This updates the ansible-lint config to skip a [disputed](https://github.com/ansible-community/ansible-lint/discussions/1589) experimental rule that is already "violated" in our code base.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Ran `ansible-lint -c .ansible-lint -qq --force-color *.yml` locally without errors.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible