### PR TITLE
Encrypt kafka client

### DIFF
--- a/roles/confluent.kafka_broker/defaults/main.yml
+++ b/roles/confluent.kafka_broker/defaults/main.yml
@@ -59,3 +59,5 @@ kafka_broker_sysctl_file: /etc/sysctl.conf
 kafka_broker_health_check_delay: 20
 
 kafka_broker_secrets_protection_file: "{{ ssl_file_dir_final }}/kafka-broker-security.properties"
+
+kafka_broker_client_secrets_protection_file: "{{ ssl_file_dir_final }}/kafka-broker-client-security.properties"

--- a/roles/confluent.kafka_broker/tasks/health_check.yml
+++ b/roles/confluent.kafka_broker/tasks/health_check.yml
@@ -15,8 +15,10 @@
 
 - name: Get Topics with UnderReplicatedPartitions with Secrets Protection enabled
   shell: |
-    set CONFLUENT_SECURITY_MASTER_KEY={{ secrets_protection_masterkey }}|{{ binary_base_path }}/bin/kafka-topics --bootstrap-server {{inventory_hostname}}:{{kafka_broker_listeners[kafka_broker_inter_broker_listener_name]['port']}} \
+    {{ binary_base_path }}/bin/kafka-topics --bootstrap-server {{inventory_hostname}}:{{kafka_broker_listeners[kafka_broker_inter_broker_listener_name]['port']}} \
       --describe --under-replicated-partitions --command-config {{kafka_broker.client_config_file}}
+  environment:
+    CONFLUENT_SECURITY_MASTER_KEY: "{{ secrets_protection_masterkey }}"
   register: topics
   # stdout_lines will have topics with URPs and stderr has WARN and ERROR level logs
   until: topics.stdout_lines|length == 0 and 'ERROR' not in topics.stderr

--- a/roles/confluent.kafka_broker/tasks/health_check.yml
+++ b/roles/confluent.kafka_broker/tasks/health_check.yml
@@ -15,7 +15,7 @@
 
 - name: Get Topics with UnderReplicatedPartitions with Secrets Protection enabled
   shell: |
-    CONFLUENT_SECURITY_MASTER_KEY|{{ binary_base_path }}/bin/kafka-topics --bootstrap-server {{inventory_hostname}}:{{kafka_broker_listeners[kafka_broker_inter_broker_listener_name]['port']}} \
+    set CONFLUENT_SECURITY_MASTER_KEY={{ secrets_protection_masterkey }}|{{ binary_base_path }}/bin/kafka-topics --bootstrap-server {{inventory_hostname}}:{{kafka_broker_listeners[kafka_broker_inter_broker_listener_name]['port']}} \
       --describe --under-replicated-partitions --command-config {{kafka_broker.client_config_file}}
   register: topics
   # stdout_lines will have topics with URPs and stderr has WARN and ERROR level logs
@@ -26,7 +26,6 @@
   changed_when: false
   check_mode: false
   when: kafka_broker_client_secrets_protection_enabled|bool
-
 
 - name: Wait for Metadata Service to start
   uri:

--- a/roles/confluent.kafka_broker/tasks/health_check.yml
+++ b/roles/confluent.kafka_broker/tasks/health_check.yml
@@ -11,6 +11,22 @@
   ignore_errors: true
   changed_when: false
   check_mode: false
+  when: not kafka_broker_client_secrets_protection_enabled|bool
+
+- name: Get Topics with UnderReplicatedPartitions with Secrets Protection enabled
+  shell: |
+    CONFLUENT_SECURITY_MASTER_KEY|{{ binary_base_path }}/bin/kafka-topics --bootstrap-server {{inventory_hostname}}:{{kafka_broker_listeners[kafka_broker_inter_broker_listener_name]['port']}} \
+      --describe --under-replicated-partitions --command-config {{kafka_broker.client_config_file}}
+  register: topics
+  # stdout_lines will have topics with URPs and stderr has WARN and ERROR level logs
+  until: topics.stdout_lines|length == 0 and 'ERROR' not in topics.stderr
+  retries: 15
+  delay: 5
+  ignore_errors: true
+  changed_when: false
+  check_mode: false
+  when: kafka_broker_client_secrets_protection_enabled|bool
+
 
 - name: Wait for Metadata Service to start
   uri:

--- a/roles/confluent.kafka_broker/tasks/main.yml
+++ b/roles/confluent.kafka_broker/tasks/main.yml
@@ -191,6 +191,21 @@
   notify: restart kafka
   when: not kafka_broker_secrets_protection_enabled|bool
 
+- name: Create Kafka Broker Client Config with Secrets Protection
+  include_role:
+    name: confluent.common
+    tasks_from: secrets_protection.yml
+  vars:
+    final_properties: "{{ kafka_broker_client_properties }}"
+    encrypt_passwords: "{{ kafka_broker_client_secrets_protection_encrypt_passwords }}"
+    encrypt_properties: "{{ kafka_broker_client_secrets_protection_encrypt_properties }}"
+    config_path: "{{ kafka_broker.client_config_file}}"
+    secrets_file: "{{ kafka_broker_secrets_protection_file }}"
+    secrets_file_owner: "{{ kafka_broker_user }}"
+    secrets_file_group: "{{ kafka_broker_group }}"
+    handler: restart kafka
+  when: kafka_broker_client_secrets_protection_enabled|bool
+
 - name: Create Kafka Broker Client Config
   template:
     src: client.properties.j2
@@ -198,6 +213,7 @@
     mode: 0640
     owner: "{{kafka_broker_user}}"
     group: "{{kafka_broker_group}}"
+  when: not kafka_broker_client_secrets_protection_enabled|bool
 
 # Zookeeper shell cannot read server.properties if secrets protection is enabled. Keeping a separate file.
 - name: Create Zookeeper TLS Client Config

--- a/roles/confluent.kafka_broker/tasks/main.yml
+++ b/roles/confluent.kafka_broker/tasks/main.yml
@@ -200,7 +200,7 @@
     encrypt_passwords: "{{ kafka_broker_client_secrets_protection_encrypt_passwords }}"
     encrypt_properties: "{{ kafka_broker_client_secrets_protection_encrypt_properties }}"
     config_path: "{{ kafka_broker.client_config_file}}"
-    secrets_file: "{{ kafka_broker_secrets_protection_file }}"
+    secrets_file: "{{ kafka_broker_client_secrets_protection_file }}"
     secrets_file_owner: "{{ kafka_broker_user }}"
     secrets_file_group: "{{ kafka_broker_group }}"
     handler: restart kafka

--- a/roles/confluent.kafka_broker/templates/client.properties.j2
+++ b/roles/confluent.kafka_broker/templates/client.properties.j2
@@ -1,4 +1,5 @@
 # Maintained by Ansible
+# Note: Secrets file for decryption when secrets protection is enabled can be found in {{ ssl_file_dir_final }}/kafka-broker-client-security.properties
 {# kafka_broker_client_properties defined in the confluent.variables role #}
 {% for key, value in kafka_broker_client_properties|dictsort%}
 {{key}}={{value}}

--- a/roles/confluent.test/molecule/mtls-custombundle-rhel/verify.yml
+++ b/roles/confluent.test/molecule/mtls-custombundle-rhel/verify.yml
@@ -20,6 +20,15 @@
         property: listener.name.internal.ssl.key.password
         expected_value: ${securepass:/var/ssl/private/kafka-broker-security.properties:server.properties/listener.name.internal.ssl.key.password}
 
+    - name: Secrets Protection Test Client Configuration
+      import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: /etc/kafka/client.properties
+        property: ssl.truststore.password
+        expected_value: ${securepass:/var/ssl/private/kafka-broker-client-security.properties:client.properties/ssl.truststore.password}
+
     - name: Secrets Protection Test Backslashes not lost
       import_role:
         name: confluent.test

--- a/roles/confluent.variables/defaults/main.yml
+++ b/roles/confluent.variables/defaults/main.yml
@@ -1222,6 +1222,15 @@ secrets_protection_encrypt_passwords: "{{secrets_protection_enabled}}"
 ### Boolean to enable secrets protection in Kafka broker.
 kafka_broker_secrets_protection_enabled: "{{secrets_protection_enabled}}"
 
+### Boolean to enable secrets protection on kafka broker client configuration.
+kafka_broker_client_secrets_protection_enabled: "{{secrets_protection_enabled}}"
+
+### Boolean to encrypt sensitive properties, such as those containing 'password', 'basic.auth.user.info', or 'sasl.jaas.config' for Kafka.
+kafka_broker_client_secrets_protection_encrypt_passwords: "{{secrets_protection_encrypt_passwords}}"
+
+### List of Kafka client properties to encrypt. Can be used in addition to kafka_broker_client_secrets_protection_encrypt_passwords.
+kafka_broker_client_secrets_protection_encrypt_properties: []
+
 ### Boolean to encrypt sensitive properties, such as those containing 'password', 'basic.auth.user.info', or 'sasl.jaas.config' for Kafka.
 kafka_broker_secrets_protection_encrypt_passwords: "{{secrets_protection_encrypt_passwords}}"
 


### PR DESCRIPTION
# Description

This PR adds functionality to encrypt the kafka client properties when secrets protection is enabled.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Validated and added a test on mtls-custombundle-rhel.


**Test Configuration**:

`    - name: Secrets Protection Test Client Configuration
      import_role:
        name: confluent.test
        tasks_from: check_property.yml
      vars:
        file_path: /etc/kafka/client.properties
        property: ssl.truststore.password
        expected_value: ${securepass:/var/ssl/private/kafka-broker-client-security.properties:client.properties/ssl.truststore.password}`


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible