### PR TITLE
Improve internal handling of SSL certificates

### DIFF
--- a/roles/ssl/tasks/custom_certs.yml
+++ b/roles/ssl/tasks/custom_certs.yml
@@ -10,12 +10,24 @@
   copy:
     remote_src: "{{ssl_custom_certs_remote_src}}"
     src: "{{ssl_signed_cert_filepath}}"
-    dest: "{{ ssl_file_dir_final }}/{{service_name}}.chain"
+    dest: "{{ cert_path }}"
 
-- name: Extract Final Cert from Signed Cert Chain
-  shell: |
-    tac {{ ssl_file_dir_final }}/{{service_name}}.chain | awk '!flag; /-----BEGIN CERTIFICATE-----/{flag = 1};' | tac > {{cert_path}}
-  diff: "{{ not mask_sensitive_diff|bool }}"
+- name: Slurp Signed Cert
+  slurp:
+    src: "{{ cert_path }}"
+  register: slurped_signed_cert
+
+- name: Verify Cert Chain
+  community.crypto.certificate_complete_chain:
+    input_chain: "{{ slurped_signed_cert['content'] | b64decode }}"
+    root_certificates:
+      - "{{ ca_cert_path }}"
+  register: custom_cert_chain
+
+- name: Write Cert Chain
+  copy:
+    content: "{{ ''.join(custom_cert_chain.complete_chain) }}"
+    dest: "{{ ssl_file_dir_final }}/{{ service_name }}.chain"
 
 - name: Copy Key to Host
   copy:

--- a/roles/ssl/tasks/self_signed_certs.yml
+++ b/roles/ssl/tasks/self_signed_certs.yml
@@ -41,9 +41,22 @@
       -extensions v3_req
   no_log: "{{mask_secrets|bool}}"
 
-- name: Create Cert Chain
-  shell: |
-    cat {{ca_cert_path}} {{cert_path}} > {{ ssl_file_dir_final }}/{{service_name}}.chain
+- name: Slurp Signed Cert
+  slurp:
+    src: "{{ cert_path }}"
+  register: slurped_signed_cert
+
+- name: Verify Cert Chain
+  community.crypto.certificate_complete_chain:
+    input_chain: "{{ slurped_signed_cert['content'] | b64decode }}"
+    root_certificates:
+      - "{{ ca_cert_path }}"
+  register: self_signed_cert_chain
+
+- name: Write Cert Chain
+  copy:
+    content: "{{ ''.join(self_signed_cert_chain.complete_chain) }}"
+    dest: "{{ ssl_file_dir_final }}/{{ service_name }}.chain"
 
 - name: Create Keystore and Truststore from Certs
   include_tasks: create_keystores_from_certs.yml


### PR DESCRIPTION
# Description

Use Ansible module community.crypto.certificate_complete_chain to make SSL cert handling more robust. Targeting the `7.0.x` branch, since older branches might have users with older Ansible versions - that do not support using the `community.crypto` collection.

Fixes #737 #738 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I do not currently have an environment available to run CP 7.x, so I trust the CI to catch any problems.

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible