### PR TITLE
fix for rolebinding for ksql_log_streaming_enabled with centralized MDS

### DIFF
--- a/roles/confluent.ksql/tasks/rbac.yml
+++ b/roles/confluent.ksql/tasks/rbac.yml
@@ -178,7 +178,7 @@
 
 - name: Grant ksql user the ResourceOwner role on the Processing Log Topic
   uri:
-    url: "{{mds_http_protocol}}://{{ groups['kafka_broker'][0] }}:{{mds_port}}/security/1.0/principals/User:{{item}}/roles/ResourceOwner/bindings"
+    url: "{{mds_bootstrap_server_urls.split(',')[0]}}/security/1.0/principals/User:{{item}}/roles/ResourceOwner/bindings"
     method: POST
     validate_certs: false
     force_basic_auth: true


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

Failing to finish install when remote MDS is used due to incorrectly constructed mds URL when centralized MDS is used.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Executed installation with remote MDS with provisioning of ksql_processing_log

**Test Configuration**:

RBAC deployment with centralized MDS and KSQL processing log streamed to a topic ie `ksql_log_streaming_enabled:true`
 
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible