### PR TITLE
Updated packaging paths for kafka clients

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.pyc
 *.idea
 *.iml
+*.jar
 generated_ssl_files/
 error_files/
 troubleshooting/

--- a/molecule/Dockerfile-debian.j2
+++ b/molecule/Dockerfile-debian.j2
@@ -1,7 +1,9 @@
 FROM {{ item.image }}
 
+RUN echo 'deb [check-valid-until=no] http://ftp.debian.org/debian stretch-backports main' | sudo tee /etc/apt/sources.list.d/stretch-backports.list
+
 RUN apt-get update && \
-    apt-get install --yes \
+    apt-get install --no-install-recommends --yes \
       apt-transport-https \
       gnupg \
       software-properties-common \
@@ -11,6 +13,10 @@ RUN apt-get update && \
       openssl \
       unzip \
       curl
+
+RUN wget -qO - https://packages.confluent.io/clients/deb/archive.key | sudo apt-key add - && \
+    add-apt-repository "deb https://packages.confluent.io/clients/deb/ stretch stable main" && \
+    apt-get update
 
 RUN wget -qO - https://packages.confluent.io/deb/6.2/archive.key | sudo apt-key add - && \
     add-apt-repository "deb [arch=amd64] https://packages.confluent.io/deb/6.2 stable main" && \

--- a/molecule/Dockerfile-debian10-archive.j2
+++ b/molecule/Dockerfile-debian10-archive.j2
@@ -12,3 +12,28 @@ RUN apt-get update && \
       openssl \
       unzip \
       curl
+
+RUN wget -qO - https://packages.confluent.io/clients/deb/archive.key | sudo apt-key add - && \
+    add-apt-repository "deb https://packages.confluent.io/clients/deb/ buster stable main" && \
+    apt-get update
+
+RUN wget -qO - https://packages.confluent.io/deb/6.2/archive.key | sudo apt-key add - && \
+   add-apt-repository "deb [arch=amd64] https://packages.confluent.io/deb/6.2 stable main" && \
+    apt-get update
+
+RUN apt-get install --yes \
+      confluent-common \
+      confluent-hub-client \
+      confluent-rebalancer \
+      confluent-rest-utils \
+      confluent-metadata-service \
+      confluent-server \
+      confluent-security \
+      confluent-kafka-connect-replicator \
+      confluent-kafka-rest \
+      confluent-ksqldb \
+      confluent-schema-registry \
+      confluent-security \
+      confluent-control-center-fe \
+      confluent-control-center \
+      confluent-schema-registry

--- a/molecule/Dockerfile-debian10-archive.j2
+++ b/molecule/Dockerfile-debian10-archive.j2
@@ -14,7 +14,7 @@ RUN apt-get update && \
       curl
 
 RUN wget -qO - https://packages.confluent.io/clients/deb/archive.key | sudo apt-key add - && \
-    add-apt-repository "deb https://packages.confluent.io/clients/deb/ buster stable main" && \
+    add-apt-repository "deb https://packages.confluent.io/clients/deb/ buster main" && \
     apt-get update
 
 RUN wget -qO - https://packages.confluent.io/deb/6.2/archive.key | sudo apt-key add - && \

--- a/molecule/Dockerfile-ubuntu.j2
+++ b/molecule/Dockerfile-ubuntu.j2
@@ -5,7 +5,7 @@ RUN mkdir -p /usr/share/man/man1 && \
     apt-get install -y openjdk-11-jdk wget gnupg
 
 RUN wget -qO - https://packages.confluent.io/clients/deb/archive.key | sudo apt-key add - && \
-    add-apt-repository "deb https://packages.confluent.io/clients/deb/ stretch stable main" && \
+    add-apt-repository "deb https://packages.confluent.io/clients/deb/ stretch main" && \
     apt-get update
 
 RUN wget -qO - https://packages.confluent.io/deb/6.2/archive.key | sudo apt-key add - && \

--- a/molecule/Dockerfile-ubuntu.j2
+++ b/molecule/Dockerfile-ubuntu.j2
@@ -4,6 +4,10 @@ RUN mkdir -p /usr/share/man/man1 && \
     apt-get update -y && \
     apt-get install -y openjdk-11-jdk wget gnupg
 
+RUN wget -qO - https://packages.confluent.io/clients/deb/archive.key | sudo apt-key add - && \
+    add-apt-repository "deb https://packages.confluent.io/clients/deb/ stretch stable main" && \
+    apt-get update
+
 RUN wget -qO - https://packages.confluent.io/deb/6.2/archive.key | sudo apt-key add - && \
    add-apt-repository "deb [arch=amd64] https://packages.confluent.io/deb/6.2 stable main" && \
     apt-get update

--- a/molecule/Dockerfile-ubuntu2004.j2
+++ b/molecule/Dockerfile-ubuntu2004.j2
@@ -4,3 +4,28 @@ RUN mkdir -p /usr/share/man/man1 && \
     apt-get update -y && \
     apt-get install -y openjdk-11-jdk wget gnupg && \
     apt-get install -y dirmngr
+
+RUN wget -qO - https://packages.confluent.io/clients/deb/archive.key | sudo apt-key add - && \
+    add-apt-repository "deb https://packages.confluent.io/clients/deb/ buster stable main" && \
+    apt-get update
+
+RUN wget -qO - https://packages.confluent.io/deb/6.2/archive.key | sudo apt-key add - && \
+   add-apt-repository "deb [arch=amd64] https://packages.confluent.io/deb/6.2 stable main" && \
+    apt-get update
+
+RUN apt-get install --yes \
+      confluent-common \
+      confluent-hub-client \
+      confluent-rebalancer \
+      confluent-rest-utils \
+      confluent-metadata-service \
+      confluent-server \
+      confluent-security \
+      confluent-kafka-connect-replicator \
+      confluent-kafka-rest \
+      confluent-ksqldb \
+      confluent-schema-registry \
+      confluent-security \
+      confluent-control-center-fe \
+      confluent-control-center \
+      confluent-schema-registry

--- a/molecule/Dockerfile-ubuntu2004.j2
+++ b/molecule/Dockerfile-ubuntu2004.j2
@@ -6,7 +6,7 @@ RUN mkdir -p /usr/share/man/man1 && \
     apt-get install -y dirmngr
 
 RUN wget -qO - https://packages.confluent.io/clients/deb/archive.key | sudo apt-key add - && \
-    add-apt-repository "deb https://packages.confluent.io/clients/deb/ buster stable main" && \
+    add-apt-repository "deb https://packages.confluent.io/clients/deb/ buster main" && \
     apt-get update
 
 RUN wget -qO - https://packages.confluent.io/deb/6.2/archive.key | sudo apt-key add - && \

--- a/molecule/Dockerfile.j2
+++ b/molecule/Dockerfile.j2
@@ -19,7 +19,7 @@ RUN yum -y install java-11-openjdk \
 
 RUN echo $'[Confluent.clients]\n\
 name=Confluent repository (clients)\n\
-baseurl=https://packages.confluent.io/clients/rpm/centos/$releasever/$basearch\n\
+baseurl=https://packages.confluent.io/clients/rpm/centos/\$releasever/\$basearch\n\
 gpgcheck=1\n\
 gpgkey=https://packages.confluent.io/clients/rpm/archive.key\n\
 enabled=1\n\

--- a/molecule/Dockerfile.j2
+++ b/molecule/Dockerfile.j2
@@ -19,7 +19,7 @@ RUN yum -y install java-11-openjdk \
 
 RUN echo $'[Confluent.clients]\n\
 name=Confluent repository (clients)\n\
-baseurl=https://packages.confluent.io/clients/rpm/centos/7/x86_64\n\
+baseurl=https://packages.confluent.io/clients/rpm/centos/$releasever/$basearch\n\
 gpgcheck=1\n\
 gpgkey=https://packages.confluent.io/clients/rpm/archive.key\n\
 enabled=1\n\

--- a/molecule/Dockerfile.j2
+++ b/molecule/Dockerfile.j2
@@ -17,11 +17,11 @@ RUN yum -y install java-11-openjdk \
       krb5-workstation \
       unzip
 
-RUN echo $'[Confluent.dist]\n\
-name=Confluent repository (dist)\n\
-baseurl=https://packages.confluent.io/rpm/6.2/8\n\
+RUN echo $'[Confluent.clients]\n\
+name=Confluent repository (clients)\n\
+baseurl=https://packages.confluent.io/clients/rpm/centos/7/x86_64\n\
 gpgcheck=1\n\
-gpgkey=https://packages.confluent.io/rpm/6.2/archive.key\n\
+gpgkey=https://packages.confluent.io/clients/rpm/archive.key\n\
 enabled=1\n\
 \n\
 [Confluent]\n\

--- a/molecule/plaintext-rhel/verify.yml
+++ b/molecule/plaintext-rhel/verify.yml
@@ -12,6 +12,10 @@
       register: package_grep
       failed_when: "package_grep.rc == 0"
       when: confluent_package_version != latest_version
+    
+    - shell: "yum list available |grep Confluent.clients"
+      register: client_package_grep
+      failed_when: "client_package_grep.rc > 0"
 
     - name: Verify log4j conf
       import_role:
@@ -225,6 +229,7 @@
       with_items:
         - "http://{{inventory_hostname}}:7771/jolokia/list"
         - "http://{{inventory_hostname}}:8080"
+
 - name: Verify - schema_registry
   hosts: schema_registry
   gather_facts: false
@@ -236,6 +241,7 @@
       with_items:
         - "http://{{inventory_hostname}}:7772/jolokia/list"
         - "http://{{inventory_hostname}}:8078"
+
 - name: Verify - kafka_connect
   hosts: kafka_connect
   gather_facts: false
@@ -247,6 +253,7 @@
       with_items:
         - "http://{{inventory_hostname}}:7773/jolokia/list"
         - "http://{{inventory_hostname}}:8077"
+
 - name: Verify - ksql
   hosts: ksql
   gather_facts: false
@@ -258,6 +265,7 @@
       with_items:
         - "http://{{inventory_hostname}}:7774/jolokia/list"
         - "http://{{inventory_hostname}}:8076"
+
 - name: Verify - kafka_rest
   hosts: kafka_rest
   gather_facts: false

--- a/molecule/plaintext-rhel/verify.yml
+++ b/molecule/plaintext-rhel/verify.yml
@@ -12,7 +12,7 @@
       register: package_grep
       failed_when: "package_grep.rc == 0"
       when: confluent_package_version != latest_version
-    
+
     - shell: "yum list available |grep Confluent.clients"
       register: client_package_grep
       failed_when: "client_package_grep.rc > 0"

--- a/molecule/rbac-kafka-connect-replicator-kerberos-mtls-custom-debian10/verify.yml
+++ b/molecule/rbac-kafka-connect-replicator-kerberos-mtls-custom-debian10/verify.yml
@@ -69,7 +69,7 @@
   hosts: kafka_broker
   gather_facts: false
   tasks:
-    - shell: grep -Fq "deb https://packages.confluent.io/clients/deb/ buster stable main" /etc/apt/sources.list.d/packages_confluent_io_clients_deb.list
+    - shell: grep -Fq "deb https://packages.confluent.io/clients/deb/ buster main" /etc/apt/sources.list.d/packages_confluent_io_clients_deb.list
       register: linecheck
       check_mode: false
       changed_when: false

--- a/molecule/rbac-kafka-connect-replicator-kerberos-mtls-custom-debian10/verify.yml
+++ b/molecule/rbac-kafka-connect-replicator-kerberos-mtls-custom-debian10/verify.yml
@@ -64,3 +64,13 @@
         custom_path: /var/log/confluent/kafka-connect-replicator/
         group: confluent
         user: cp-kafka-connect-replicator
+
+- name: Verify - Client Packages
+  hosts: kafka_broker
+  gather_facts: false
+  tasks:
+    - shell: grep -Fq "deb https://packages.confluent.io/clients/deb/ buster stable main" /etc/apt/sources.list.d/packages_confluent_io_clients_deb.list
+      register: linecheck
+      check_mode: false
+      changed_when: false
+      failed_when: linecheck.rc != 0

--- a/molecule/rbac-kafka-connect-replicator-kerberos-mtls-custom-ubuntu2004/verify.yml
+++ b/molecule/rbac-kafka-connect-replicator-kerberos-mtls-custom-ubuntu2004/verify.yml
@@ -64,3 +64,13 @@
         custom_path: /var/log/confluent/kafka-connect-replicator/
         group: confluent
         user: cp-kafka-connect-replicator
+
+- name: Verify - Client Packages
+  hosts: kafka_broker
+  gather_facts: false
+  tasks:
+    - shell: grep -Fq "deb https://packages.confluent.io/clients/deb/ buster stable main" /etc/apt/sources.list
+      register: linecheck
+      check_mode: false
+      changed_when: false
+      failed_when: linecheck.rc != 0

--- a/molecule/rbac-kafka-connect-replicator-kerberos-mtls-custom-ubuntu2004/verify.yml
+++ b/molecule/rbac-kafka-connect-replicator-kerberos-mtls-custom-ubuntu2004/verify.yml
@@ -69,7 +69,7 @@
   hosts: kafka_broker
   gather_facts: false
   tasks:
-    - shell: grep -Fq "deb https://packages.confluent.io/clients/deb/ buster stable main" /etc/apt/sources.list
+    - shell: grep -Fq "deb https://packages.confluent.io/clients/deb/ buster main" /etc/apt/sources.list
       register: linecheck
       check_mode: false
       changed_when: false

--- a/molecule/rbac-mtls-provided-ubuntu/verify.yml
+++ b/molecule/rbac-mtls-provided-ubuntu/verify.yml
@@ -93,7 +93,7 @@
   hosts: kafka_broker
   gather_facts: false
   tasks:
-    - shell: grep -Fq "deb https://packages.confluent.io/clients/deb/ stretch stable main" /etc/apt/sources.list
+    - shell: grep -Fq "deb https://packages.confluent.io/clients/deb/ stretch main" /etc/apt/sources.list
       register: linecheck
       check_mode: false
       changed_when: false

--- a/molecule/rbac-mtls-provided-ubuntu/verify.yml
+++ b/molecule/rbac-mtls-provided-ubuntu/verify.yml
@@ -77,7 +77,6 @@
         property: ssl.truststore.location
         expected_value: /var/ssl/private/ksql.truststore.jks
 
-
 - name: Verify - control_center
   hosts: control_center
   gather_facts: false
@@ -89,3 +88,13 @@
         file_path: /etc/confluent-control-center/control-center-production.properties
         property: confluent.controlcenter.streams.ssl.truststore.location
         expected_value: /var/ssl/private/control_center.truststore.jks
+
+- name: Verify - Client Packages
+  hosts: kafka_broker
+  gather_facts: false
+  tasks:
+    - shell: grep -Fq "deb https://packages.confluent.io/clients/deb/ stretch stable main" /etc/apt/sources.list
+      register: linecheck
+      check_mode: false
+      changed_when: false
+      failed_when: linecheck.rc != 0

--- a/molecule/rbac-mtls-rhel8/verify.yml
+++ b/molecule/rbac-mtls-rhel8/verify.yml
@@ -47,3 +47,11 @@
   tasks:
     - shell: grep "Djdk.tls.ephemeralDHKeySize=2048" /etc/systemd/system/confluent-control-center.service.d/override.conf
       changed_when: false
+
+- name: Verify Client Packages
+  hosts: all
+  gather_facts: false
+  tasks:
+    - shell: "yum list available |grep Confluent.clients"
+      register: client_package_grep
+      failed_when: "client_package_grep.rc > 0"

--- a/molecule/rbac-plain-provided-debian/verify.yml
+++ b/molecule/rbac-plain-provided-debian/verify.yml
@@ -122,3 +122,13 @@
         file_path: /etc/ksqldb/ksql-server.properties
         property: ksql.schema.registry.basic.auth.user.info
         expected_value: ${securepass:/var/ssl/private/ksql-security.properties:ksql-server.properties/ksql.schema.registry.basic.auth.user.info}
+
+- name: Verify - Client Packages
+  hosts: kafka_broker
+  gather_facts: false
+  tasks:
+    - shell: grep -Fq "deb https://packages.confluent.io/clients/deb/ stretch stable main" /etc/apt/sources.list
+      register: linecheck
+      check_mode: false
+      changed_when: false
+      failed_when: linecheck.rc != 0

--- a/molecule/rbac-plain-provided-debian/verify.yml
+++ b/molecule/rbac-plain-provided-debian/verify.yml
@@ -127,7 +127,7 @@
   hosts: kafka_broker
   gather_facts: false
   tasks:
-    - shell: grep -Fq "deb https://packages.confluent.io/clients/deb/ stretch stable main" /etc/apt/sources.list
+    - shell: grep -Fq "deb https://packages.confluent.io/clients/deb/ stretch main" /etc/apt/sources.list
       register: linecheck
       check_mode: false
       changed_when: false

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -19,16 +19,19 @@ confluent_common_repository_debian_baseurl: "{{confluent_common_repository_baseu
 confluent_common_repository_debian_key_url: "{{confluent_common_repository_debian_baseurl}}/{{confluent_repo_version}}/archive.key"
 confluent_common_repository_debian_repository: "deb [arch=amd64] {{confluent_common_repository_debian_baseurl}}/{{confluent_repo_version}} stable main"
 
+confluent_common_repository_debian_clients_key_url: "{{confluent_common_repository_baseurl}}/clients/deb/archive.key"
+confluent_common_repository_debian_clients_repository: "deb {{confluent_common_repository_baseurl}}/clients/deb/ {{confluent_common_repository_debian_release_version}} stable main"
+
 confluent_common_repository_redhat_baseurl: "{{confluent_common_repository_baseurl}}/rpm"
 confluent_common_repository_redhat_main_baseurl: "{{confluent_common_repository_redhat_baseurl}}/{{confluent_repo_version}}"
 confluent_common_repository_redhat_main_gpgcheck: 1
 confluent_common_repository_redhat_main_gpgkey: "{{confluent_common_repository_redhat_baseurl}}/{{confluent_repo_version}}/archive.key"
 confluent_common_repository_redhat_main_enabled: 1
 
-confluent_common_repository_redhat_dist_baseurl: "{{confluent_common_repository_redhat_baseurl}}/{{confluent_repo_version}}/$releasever"
-confluent_common_repository_redhat_dist_gpgcheck: 1
-confluent_common_repository_redhat_dist_gpgkey: "{{confluent_common_repository_redhat_baseurl}}/{{confluent_repo_version}}/archive.key"
-confluent_common_repository_redhat_dist_enabled: 1
+confluent_common_repository_redhat_clients_baseurl: "{{confluent_common_repository_baseurl}}/clients/rpm/centos/{{confluent_common_repository_redhat_release_version}}/x86_64"
+confluent_common_repository_redhat_clients_gpgcheck: 1
+confluent_common_repository_redhat_clients_gpgkey: "{{confluent_common_repository_baseurl}}/clients/rpm/archive.key"
+confluent_common_repository_redhat_clients_enabled: 1
 
 ### Boolean to have cp-ansible install Java on hosts
 install_java: true

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -20,7 +20,7 @@ confluent_common_repository_debian_key_url: "{{confluent_common_repository_debia
 confluent_common_repository_debian_repository: "deb [arch=amd64] {{confluent_common_repository_debian_baseurl}}/{{confluent_repo_version}} stable main"
 
 confluent_common_repository_debian_clients_key_url: "{{confluent_common_repository_baseurl}}/clients/deb/archive.key"
-confluent_common_repository_debian_clients_repository: "deb {{confluent_common_repository_baseurl}}/clients/deb/ {{confluent_common_repository_debian_release_version}} stable main"
+confluent_common_repository_debian_clients_repository: "deb {{confluent_common_repository_baseurl}}/clients/deb/ {{confluent_common_repository_debian_release_version}} main"
 
 confluent_common_repository_redhat_baseurl: "{{confluent_common_repository_baseurl}}/rpm"
 confluent_common_repository_redhat_main_baseurl: "{{confluent_common_repository_redhat_baseurl}}/{{confluent_repo_version}}"

--- a/roles/common/tasks/debian.yml
+++ b/roles/common/tasks/debian.yml
@@ -31,6 +31,26 @@
     - repository_configuration == 'confluent'
     - installation_method == "package"
 
+- name: Add Confluent Clients Apt Key
+  apt_key:
+    url: "{{confluent_common_repository_debian_clients_key_url}}"
+    state: present
+  when:
+    - repository_configuration == 'confluent'
+    - installation_method == "package"
+
+- name: Add Confluent Clients Apt Repo
+  apt_repository:
+    repo: "{{confluent_common_repository_debian_clients_repository}}"
+    state: present
+  register: apt_add_result
+  until: apt_add_result is success
+  retries: 10
+  delay: 5
+  when:
+    - repository_configuration == 'confluent'
+    - installation_method == "package"
+
 - name: Add Custom Apt Repo
   copy:
     src: "{{custom_apt_repo_filepath}}"

--- a/roles/common/tasks/redhat.yml
+++ b/roles/common/tasks/redhat.yml
@@ -1,18 +1,4 @@
 ---
-- name: Add Confluent Dist Yum Repo
-  yum_repository:
-    name: Confluent.dist
-    file: confluent
-    description: "Confluent repository (dist)"
-    baseurl: "{{confluent_common_repository_redhat_dist_baseurl}}"
-    gpgcheck: "{{confluent_common_repository_redhat_dist_gpgcheck}}"
-    gpgkey: "{{confluent_common_repository_redhat_dist_gpgkey}}"
-    enabled: "{{confluent_common_repository_redhat_dist_enabled}}"
-  register: confluent_dist_repo_result
-  when:
-    - repository_configuration == 'confluent'
-    - installation_method == "package"
-
 - name: Add Confluent Yum Repo
   yum_repository:
     name: Confluent
@@ -23,6 +9,20 @@
     gpgkey: "{{confluent_common_repository_redhat_main_gpgkey}}"
     enabled: "{{confluent_common_repository_redhat_main_enabled}}"
   register: confluent_repo_result
+  when:
+    - repository_configuration == 'confluent'
+    - installation_method == "package"
+
+- name: Add Confluent Clients Yum Repo
+  yum_repository:
+    name: Confluent.clients
+    file: confluent
+    description: "Confluent repository (clients)"
+    baseurl: "{{confluent_common_repository_redhat_clients_baseurl}}"
+    gpgcheck: "{{confluent_common_repository_redhat_clients_gpgcheck}}"
+    gpgkey: "{{confluent_common_repository_redhat_clients_gpgkey}}"
+    enabled: "{{confluent_common_repository_redhat_clients_enabled}}"
+  register: confluent_clients_repo_result
   when:
     - repository_configuration == 'confluent'
     - installation_method == "package"
@@ -40,7 +40,7 @@
   command: yum clean all
   args:
     warn: false
-  when: confluent_dist_repo_result.changed|default(False) or confluent_repo_result.changed|default(False) or custom_repo_result.changed|default(False)
+  when: confluent_clients_repo_result.changed|default(False) or confluent_repo_result.changed|default(False) or custom_repo_result.changed|default(False)
 
 - name: Install Java
   yum:

--- a/roles/common/tasks/ubuntu.yml
+++ b/roles/common/tasks/ubuntu.yml
@@ -19,6 +19,26 @@
     - repository_configuration == 'confluent'
     - installation_method == "package"
 
+- name: Add Confluent Clients Apt Key
+  apt_key:
+    url: "{{confluent_common_repository_debian_clients_key_url}}"
+    state: present
+  when:
+    - repository_configuration == 'confluent'
+    - installation_method == "package"
+
+- name: Add Confluent Clients Apt Repo
+  apt_repository:
+    repo: "{{confluent_common_repository_debian_clients_repository}}"
+    state: present
+  register: apt_add_result
+  until: apt_add_result is success
+  retries: 10
+  delay: 5
+  when:
+    - repository_configuration == 'confluent'
+    - installation_method == "package"
+
 - name: Add Custom Apt Repo
   copy:
     src: "{{custom_apt_repo_filepath}}"

--- a/roles/kafka_broker/tasks/main.yml
+++ b/roles/kafka_broker/tasks/main.yml
@@ -193,7 +193,7 @@
 
 - name: Create Kafka Broker Client Config with Secrets Protection
   include_role:
-    name: confluent.common
+    name: common
     tasks_from: secrets_protection.yml
   vars:
     final_properties: "{{ kafka_broker_client_properties }}"

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -7,6 +7,8 @@ confluent_package_version: 6.2.0
 confluent_full_package_version: "{{ confluent_package_version + '-1' }}"
 confluent_package_redhat_suffix: "{{ '-' + confluent_full_package_version if confluent_full_package_version != '' else ''}}"
 confluent_package_debian_suffix: "{{ '=' + confluent_full_package_version if confluent_full_package_version != '' else ''}}"
+confluent_common_repository_redhat_release_version: "{{ ansible_distribution_major_version if ansible_os_family == 'RedHat' else ''}}"
+confluent_common_repository_debian_release_version: "{{ansible_distribution_release if ansible_os_family == 'Debian' else ''}}"
 
 ### To copy from Ansible control host or download
 jolokia_url_remote: true


### PR DESCRIPTION
# Description

This PR includes changes to reflect the new packaging model for confluent platform.  Client packages are now being split out independently with the 7.0 release, so they can be updated/iterated on faster then the rest of the platform.

This PR adds the new package repos to all supported OS.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

The following molecule scenarios have been updated to validate that new packages are setup on all supported platforms:

rbac-kafka-connect-replicator-kerberos-mtls-custom-ubuntu2004
rbac-kafka-connect-replicator-kerberos-mtls-custom-debian10
rbac-mtls-rhel8
plaintext-rhel
rbac-mtls-provided-ubuntu
rbac-plain-provided-debian

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Any variable changes have been validated to be backwards compatible