### PR TITLE
Updated export check of certs from jks file to be lower case

### DIFF
--- a/roles/confluent.ssl/tasks/export_certs_from_keystore_and_truststore.yml
+++ b/roles/confluent.ssl/tasks/export_certs_from_keystore_and_truststore.yml
@@ -23,7 +23,7 @@
     openssl pkcs12 -in {{keystore_path}} \
       -nokeys -out {{cert_path}} \
       -passin pass:{{keystore_storepass}}
-  when: keytool_type.stdout == 'PKCS12'
+  when: keytool_type.stdout|lower == 'pkcs12'
   no_log: "{{mask_secrets|bool}}"
 
 - name: Export Key from Keystore - PKCS12
@@ -31,7 +31,7 @@
     openssl pkcs12 -in {{keystore_path}} \
       -nodes -nocerts -out {{key_path}} \
       -passin pass:{{keystore_storepass}}
-  when: keytool_type.stdout|lower == 'PKCS12'
+  when: keytool_type.stdout|lower == 'pkcs12'
   no_log: "{{mask_secrets|bool}}"
 
 - set_fact:

--- a/roles/confluent.ssl/tasks/export_certs_from_keystore_and_truststore.yml
+++ b/roles/confluent.ssl/tasks/export_certs_from_keystore_and_truststore.yml
@@ -31,20 +31,20 @@
     openssl pkcs12 -in {{keystore_path}} \
       -nodes -nocerts -out {{key_path}} \
       -passin pass:{{keystore_storepass}}
-  when: keytool_type.stdout == 'PKCS12'
+  when: keytool_type.stdout|lower == 'PKCS12'
   no_log: "{{mask_secrets|bool}}"
 
 - set_fact:
     extra_args: ""
   when:
     - not fips_enabled|bool
-    - keytool_type.stdout == 'jks'
+    - keytool_type.stdout|lower == 'jks'
 
 - set_fact:
     extra_args: "-providerpath {{fips_jar_path}} -providerclass {{fips_provider_class}}"
   when:
     - fips_enabled|bool
-    - keytool_type.stdout == 'jks'
+    - keytool_type.stdout|lower == 'jks'
 
 - name: Convert Keystore to Pem Format - JKS
   shell: |
@@ -56,7 +56,7 @@
       -deststorepass {{keystore_storepass}} \
       -destkeypass {{keystore_storepass}} {{extra_args}}
   failed_when: false
-  when: keytool_type.stdout == 'jks'
+  when: keytool_type.stdout|lower == 'jks'
   no_log: "{{mask_secrets|bool}}"
 
 - name: Export Certificate from Keystore - JKS
@@ -64,7 +64,7 @@
     openssl pkcs12 -in {{ ssl_file_dir_final }}/generation/{{service_name}}.p12 \
       -nokeys -out {{cert_path}} \
       -passin pass:{{keystore_storepass}}
-  when: keytool_type.stdout == 'jks'
+  when: keytool_type.stdout|lower == 'jks'
   no_log: "{{mask_secrets|bool}}"
 
 - name: Export Key from Keystore - JKS
@@ -72,5 +72,5 @@
     openssl pkcs12 -in {{ ssl_file_dir_final }}/generation/{{service_name}}.p12 \
       -nodes -nocerts -out {{key_path}} \
       -passin pass:{{keystore_storepass}}
-  when: keytool_type.stdout == 'jks'
+  when: keytool_type.stdout|lower == 'jks'
   no_log: "{{mask_secrets|bool}}"


### PR DESCRIPTION
# Description

Minor bug fix to standardize the output of '.jks' to lower case to make sure that the correct checks are run when exporting from user provided keystores and truststores.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This has been validated against the following molecule scenario:

rbac-plain-provided-debian

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible