### PR TITLE
fixed SSL handshake issue for ksql streaming log into kafka usig mTLS

### DIFF
--- a/roles/confluent.ksql/templates/ksql-server_log4j.properties.j2
+++ b/roles/confluent.ksql/templates/ksql-server_log4j.properties.j2
@@ -60,6 +60,7 @@ log4j.appender.kafka_appender.SslTruststorePassword={{ksql_truststore_storepass}
 log4j.appender.kafka_appender.SslKeystoreLocation={{ksql_keystore_path}}
 log4j.appender.kafka_appender.SslKeystorePassword={{ksql_keystore_keypass}}
 log4j.appender.kafka_appender.SslKeyPassword={{ksql_keystore_keypass}}
+log4j.appender.kafka_appender.SslKeystoreType=JKS
 {% endif %}
 {% endif %}
 {% if listener['sasl_protocol'] | default(sasl_protocol) | normalize_sasl_protocol == 'PLAIN' %}


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Tested with Kafka listener with mTLS and  ```ksql_log_streaming_enabled: true``` in the inventory file. This setup was failing with error ```errorMessage=SSL handshake failed caused by Empty client certificate chain``` . This got resolved when the additional setting was added. This matches the example provided in the ksql documentation here https://github.com/confluentinc/cp-demo/blob/master/scripts/helper/log4j-secure.properties

**Test Configuration**:

RBAC with BROKER listener utilizing mTLS and inventory set with ```ksql_log_streaming_enabled: true```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible