### PR TITLE
Remove plaintext URI on LDAP when TLS is enabled

### DIFF
--- a/roles/confluent.test.ldap/files/slapd
+++ b/roles/confluent.test.ldap/files/slapd
@@ -5,8 +5,8 @@
 # - ldapi:/// is required for on-the-fly configuration using client tools
 #   (use SASL with EXTERNAL mechanism for authentication)
 # - default: ldapi:/// ldap:///
-# - example: ldapi:/// ldap://127.0.0.1/ ldap://10.0.0.1:1389/ ldaps:///
-SLAPD_URLS="ldapi:/// ldap:/// ldaps:///"
+# - example: ldapi:/// ldap://127.0.0.1/ ldaps:///
+SLAPD_URLS="ldapi:/// ldaps:///"
 
 # Any custom options
 #SLAPD_OPTIONS=""


### PR DESCRIPTION
# Description

When TLS is enabled on LDAP, the LDAP server will still serve over a plaintext connection on port 389. This isn't good practice, and since our tests are often used in the field as a "best practice" reference, I suggest removing that URI when LDAPS is enabled. This is a non breaking change since it is only for the molecule tests, and the affected tests use LDAPS on port 636.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

This can be tested on any molecule scenario that enables LDAPS.

**Test Configuration**:


# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible