### PR TITLE
Fix for ANSIENG-912

### DIFF
--- a/sample_inventories/kafka_connect_replicator.yml
+++ b/sample_inventories/kafka_connect_replicator.yml
@@ -8,61 +8,61 @@ all:
   vars:
 
 kafka_connect_replicator:
+  vars:
+    kafka_connect_replicator_listener:
+      ssl_enabled: true
+      ssl_mutual_auth_enabled: false
+      sasl_protocol: kerberos
 
-  kafka_connect_replicator_listener:
-    ssl_enabled: true
-    ssl_mutual_auth_enabled: false
-    sasl_protocol: kerberos
+    kafka_connect_replicator_white_list: test-replicator-source
+    kafka_connect_replicator_bootstrap_servers: ip-10-0-0-10.eu-west-2.compute.internal:9092
+    kafka_connect_replicator_kerberos_principal: "replicator/kafka-connect-replicator1.confluent@CONFLUENT.EXAMPLE.COM"
+    kafka_connect_replicator_kerberos_keytab_path: "/keytabs/kafka-connect-replicator1.keytab"
+    kafka_connect_replicator_ssl_ca_cert_path: "/generated_ssl_files/ca.crt"
+    kafka_connect_replicator_ssl_cert_path: "/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
+    kafka_connect_replicator_ssl_key_path: "/generated_ssl_files/{{inventory_hostname}}-key.pem"
+    kafka_connect_replicator_ssl_key_password: keypass
 
-  kafka_connect_replicator_white_list: test-replicator-source
-  kafka_connect_replicator_bootstrap_servers: ip-10-0-0-10.eu-west-2.compute.internal:9092
-  kafka_connect_replicator_kerberos_principal: "replicator/kafka-connect-replicator1.confluent@CONFLUENT.EXAMPLE.COM"
-  kafka_connect_replicator_kerberos_keytab_path: "/keytabs/kafka-connect-replicator1.keytab"
-  kafka_connect_replicator_ssl_ca_cert_path: "/generated_ssl_files/ca.crt"
-  kafka_connect_replicator_ssl_cert_path: "/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
-  kafka_connect_replicator_ssl_key_path: "/generated_ssl_files/{{inventory_hostname}}-key.pem"
-  kafka_connect_replicator_ssl_key_password: keypass
+    kafka_connect_replicator_consumer_listener:
+      ssl_enabled: true
+      ssl_mutual_auth_enabled: false
+      sasl_protocol: plain
 
-  kafka_connect_replicator_consumer_listener:
-    ssl_enabled: true
-    ssl_mutual_auth_enabled: false
-    sasl_protocol: plain
+    kafka_connect_replicator_consumer_bootstrap_servers: ip-10-0-0-250.eu-west-2.compute.internal:9092
+    kafka_connect_replicator_consumer_ssl_ca_cert_path: "/generated_ssl_files/ca.crt"
+    kafka_connect_replicator_consumer_ssl_cert_path: "/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
+    kafka_connect_replicator_consumer_ssl_key_path: "/generated_ssl_files/{{inventory_hostname}}-key.pem"
+    kafka_connect_replicator_consumer_ssl_key_password: keypass
+    kafka_connect_replicator_consumer_custom_properties:
+      client.id: consumer-test
 
-  kafka_connect_replicator_consumer_bootstrap_servers: ip-10-0-0-250.eu-west-2.compute.internal:9092
-  kafka_connect_replicator_consumer_ssl_ca_cert_path: "/generated_ssl_files/ca.crt"
-  kafka_connect_replicator_consumer_ssl_cert_path: "/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
-  kafka_connect_replicator_consumer_ssl_key_path: "/generated_ssl_files/{{inventory_hostname}}-key.pem"
-  kafka_connect_replicator_consumer_ssl_key_password: keypass
-  kafka_connect_replicator_consumer_custom_properties:
-    client.id: consumer-test
+    kafka_connect_replicator_producer_listener:
+      ssl_enabled: true
+      ssl_mutual_auth_enabled: false
+      sasl_protocol: kerberos
 
-  kafka_connect_replicator_producer_listener:
-    ssl_enabled: true
-    ssl_mutual_auth_enabled: false
-    sasl_protocol: kerberos
+    kafka_connect_replicator_producer_bootstrap_servers: ip-10-0-0-223.eu-west-2.compute.internal:9092
+    kafka_connect_replicator_producer_kerberos_principal: "replicator/kafka-connect-replicator1.confluent@CONFLUENT.EXAMPLE.COM"
+    kafka_connect_replicator_producer_kerberos_keytab_path: "/keytabs/kafka-connect-replicator1.keytab"
+    kafka_connect_replicator_producer_ssl_ca_cert_path: "/generated_ssl_files/ca.crt"
+    kafka_connect_replicator_producer_ssl_cert_path: "/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
+    kafka_connect_replicator_producer_ssl_key_path: "/generated_ssl_files/{{inventory_hostname}}-key.pem"
+    kafka_connect_replicator_producer_ssl_key_password: keypass
+    kafka_connect_replicator_producer_custom_properties:
+      client.id: producer-test
 
-  kafka_connect_replicator_producer_bootstrap_servers: ip-10-0-0-223.eu-west-2.compute.internal:9092
-  kafka_connect_replicator_producer_kerberos_principal: "replicator/kafka-connect-replicator1.confluent@CONFLUENT.EXAMPLE.COM"
-  kafka_connect_replicator_producer_kerberos_keytab_path: "/keytabs/kafka-connect-replicator1.keytab"
-  kafka_connect_replicator_producer_ssl_ca_cert_path: "/generated_ssl_files/ca.crt"
-  kafka_connect_replicator_producer_ssl_cert_path: "/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
-  kafka_connect_replicator_producer_ssl_key_path: "/generated_ssl_files/{{inventory_hostname}}-key.pem"
-  kafka_connect_replicator_producer_ssl_key_password: keypass
-  kafka_connect_replicator_producer_custom_properties:
-    client.id: producer-test
+    kafka_connect_replicator_monitoring_interceptor_listener:
+      ssl_enabled: true
+      ssl_mutual_auth_enabled: false
+      sasl_protocol: kerberos
 
-  kafka_connect_replicator_monitoring_interceptor_listener:
-    ssl_enabled: true
-    ssl_mutual_auth_enabled: false
-    sasl_protocol: kerberos
-
-  kafka_connect_replicator_monitoring_interceptor_bootstrap_servers: ip-10-0-0-10.eu-west-2.compute.internal:9092
-  kafka_connect_replicator_monitoring_interceptor_kerberos_principal: "replicator/kafka-connect-replicator1.confluent@CONFLUENT.EXAMPLE.COM"
-  kafka_connect_replicator_monitoring_interceptor_kerberos_keytab_path: "/keytabs/kafka-connect-replicator1.keytab"
-  kafka_connect_replicator_monitoring_interceptor_ssl_ca_cert_path: "/generated_ssl_files/ca.crt"
-  kafka_connect_replicator_monitoring_interceptor_ssl_cert_path: "/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
-  kafka_connect_replicator_monitoring_interceptor_ssl_key_path: "/generated_ssl_files/{{inventory_hostname}}-key.pem"
-  kafka_connect_replicator_monitoring_interceptor_ssl_key_password: keypass
+    kafka_connect_replicator_monitoring_interceptor_bootstrap_servers: ip-10-0-0-10.eu-west-2.compute.internal:9092
+    kafka_connect_replicator_monitoring_interceptor_kerberos_principal: "replicator/kafka-connect-replicator1.confluent@CONFLUENT.EXAMPLE.COM"
+    kafka_connect_replicator_monitoring_interceptor_kerberos_keytab_path: "/keytabs/kafka-connect-replicator1.keytab"
+    kafka_connect_replicator_monitoring_interceptor_ssl_ca_cert_path: "/generated_ssl_files/ca.crt"
+    kafka_connect_replicator_monitoring_interceptor_ssl_cert_path: "/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
+    kafka_connect_replicator_monitoring_interceptor_ssl_key_path: "/generated_ssl_files/{{inventory_hostname}}-key.pem"
+    kafka_connect_replicator_monitoring_interceptor_ssl_key_password: keypass
 
   hosts:
     ip-10-0-0-250.eu-west-2.compute.internal:


### PR DESCRIPTION
Backporting the changes from 6.2.1 as part of 5fe1b992f6d0efa86dcb31b075e7b278a783dbf2

# Description

vars label was missing in 6.2.0 which got added in 6.2.1
This PR backports the changes from 6.2.1 to 6.2.0

Fixes # ANSIENG-912

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
No tests has been run for this change


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible