### PR TITLE
Fix ANSIENG-916

### DIFF
--- a/roles/confluent.variables/filter_plugins/filters.py
+++ b/roles/confluent.variables/filter_plugins/filters.py
@@ -99,7 +99,6 @@ class FilterModule(object):
                     properties_tmp[p] = str(properties_dict[prop].get('properties')[p])
                 final_dict.update(properties_tmp)
                 properties_tmp = {}
-        print(final_dict)
         return final_dict
 
     def split_to_dict(self, string):


### PR DESCRIPTION
Remove print function from combine_properties filter. Every time we
use this filter the entire property gets printed on the console.
This exposes the configuration along with possible secrets.

# Description

This PR is an exception from regular process. Since this issue is critical, we are merging the fix in -post branch to make it available to all customer as soon as possible. 

Fixes # ANSIENG-916

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Interestingly the properties are not getting on console when running with molecule. We executed ansible playbook to reproduce the bug and ensure the fix.
```ANSIBLE_COLLECTIONS_PATH=../.. ansible-playbook -i ~/.cache/molecule/platform/plain-rhel/inventory confluent.platform.all --tags zookeeper --skip-tags package,common```


**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible