### PR TITLE
Allow selecting specific kafka listeners for Kafka Connect consumers and producers

### DIFF
--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -1484,6 +1484,20 @@ Default:  ""
 
 ***
 
+### kafka_connect_producer_kafka_listener_name
+Allows you to select a custom kafka listener for Kafka Connect producers
+
+Default: internal
+
+***
+
+### kafka_connect_consumer_kafka_listener_name
+Allows you to select a custom kafka listener for Kafka Connect consumers
+
+Default: internal
+
+***
+
 ### ksql_user
 
 Set this variable to customize the Linux User that the ksqlDB Service runs with. Default user is cp-ksql.

--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -1324,6 +1324,22 @@ Default:  "{{kafka_connect.appender_log_path}}"
 
 ***
 
+### kafka_connect_producer_kafka_listener_name
+
+Allows you to select a custom kafka listener for Kafka Connect producers
+
+Default:  "{{kafka_connect_kafka_listener_name}}"
+
+***
+
+### kafka_connect_consumer_kafka_listener_name
+
+Allows you to select a custom kafka listener for Kafka Connect consumers
+
+Default:  "{{kafka_connect_kafka_listener_name}}"
+
+***
+
 ### kafka_connect_custom_rest_extension_classes
 
 Additional set of Connect extension classes.
@@ -1481,20 +1497,6 @@ Default:  "{{ monitoring_interceptors_enabled }}"
 Use to register and identify your Kafka Connect cluster in the MDS.
 
 Default:  ""
-
-***
-
-### kafka_connect_producer_kafka_listener_name
-Allows you to select a custom kafka listener for Kafka Connect producers
-
-Default: internal
-
-***
-
-### kafka_connect_consumer_kafka_listener_name
-Allows you to select a custom kafka listener for Kafka Connect consumers
-
-Default: internal
 
 ***
 

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -752,6 +752,8 @@ kafka_connect_key_path: "{{ ssl_file_dir_final }}/kafka_connect.key"
 kafka_connect_export_certs: "{{ True if kafka_connect_authentication_type == 'mtls' else False }}"
 kafka_connect_keytab_path: /etc/security/keytabs/kafka_connect.keytab
 kafka_connect_kafka_listener_name: internal
+kafka_connect_producer_kafka_listener_name: internal
+kafka_connect_consumer_kafka_listener_name: internal
 
 ### Additional set of Connect extension classes.
 kafka_connect_custom_rest_extension_classes: []

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -752,8 +752,12 @@ kafka_connect_key_path: "{{ ssl_file_dir_final }}/kafka_connect.key"
 kafka_connect_export_certs: "{{ True if kafka_connect_authentication_type == 'mtls' else False }}"
 kafka_connect_keytab_path: /etc/security/keytabs/kafka_connect.keytab
 kafka_connect_kafka_listener_name: internal
-kafka_connect_producer_kafka_listener_name: internal
-kafka_connect_consumer_kafka_listener_name: internal
+
+### Allows you to select a custom kafka listener for Kafka Connect producers
+kafka_connect_producer_kafka_listener_name: "{{kafka_connect_kafka_listener_name}}"
+
+### Allows you to select a custom kafka listener for Kafka Connect consumers
+kafka_connect_consumer_kafka_listener_name: "{{kafka_connect_kafka_listener_name}}"
 
 ### Additional set of Connect extension classes.
 kafka_connect_custom_rest_extension_classes: []

--- a/roles/variables/vars/main.yml
+++ b/roles/variables/vars/main.yml
@@ -533,6 +533,8 @@ kafka_connect_rest_extension_classes:
 kafka_connect_final_rest_extension_classes: "{{(kafka_connect_rest_extension_classes|difference(['']) + kafka_connect_custom_rest_extension_classes) | unique}}"
 
 kafka_connect_bootstrap_servers: "{{ groups['kafka_broker'] | default(['localhost']) | confluent.platform.resolve_hostnames(hostvars) | join(':' + kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']|string + ',') }}:{{kafka_broker_listeners[kafka_connect_kafka_listener_name]['port']}}"
+kafka_connect_producer_bootstrap_servers: "{{ groups['kafka_broker'] | default(['localhost']) | confluent.platform.resolve_hostnames(hostvars) | join(':' + kafka_broker_listeners[kafka_connect_producer_kafka_listener_name]['port']|string + ',') }}:{{kafka_broker_listeners[kafka_connect_producer_kafka_listener_name]['port']}}"
+kafka_connect_consumer_bootstrap_servers: "{{ groups['kafka_broker'] | default(['localhost']) | confluent.platform.resolve_hostnames(hostvars) | join(':' + kafka_broker_listeners[kafka_connect_consumer_kafka_listener_name]['port']|string + ',') }}:{{kafka_broker_listeners[kafka_connect_consumer_kafka_listener_name]['port']}}"
 
 kafka_connect_properties:
   defaults:
@@ -560,8 +562,8 @@ kafka_connect_properties:
       rest.advertised.host.name: "{{ hostvars[inventory_hostname]|confluent.platform.resolve_hostname }}"
       rest.advertised.port: "{{kafka_connect_rest_port}}"
       bootstrap.servers: "{{ ccloud_kafka_bootstrap_servers if ccloud_kafka_enabled|bool else kafka_connect_bootstrap_servers }}"
-      producer.bootstrap.servers: "{{ ccloud_kafka_bootstrap_servers if ccloud_kafka_enabled|bool else kafka_connect_bootstrap_servers }}"
-      consumer.bootstrap.servers: "{{ ccloud_kafka_bootstrap_servers if ccloud_kafka_enabled|bool else kafka_connect_bootstrap_servers }}"
+      producer.bootstrap.servers: "{{ ccloud_kafka_bootstrap_servers if ccloud_kafka_enabled|bool else kafka_connect_producer_bootstrap_servers }}"
+      consumer.bootstrap.servers: "{{ ccloud_kafka_bootstrap_servers if ccloud_kafka_enabled|bool else kafka_connect_consumer_bootstrap_servers }}"
       confluent.license.topic: _confluent-command
   rest_classes:
     enabled: "{{ kafka_connect_final_rest_extension_classes|length > 0 }}"
@@ -613,14 +615,14 @@ kafka_connect_properties:
                             false, kafka_connect_ldap_user, kafka_connect_ldap_password, mds_bootstrap_server_urls) }}"
   producer:
     enabled: true
-    properties: "{{ kafka_broker_listeners[kafka_connect_kafka_listener_name] | confluent.platform.client_properties(ssl_enabled, False, ssl_mutual_auth_enabled, sasl_protocol,
+    properties: "{{ kafka_broker_listeners[kafka_connect_producer_kafka_listener_name] | confluent.platform.client_properties(ssl_enabled, False, ssl_mutual_auth_enabled, sasl_protocol,
                             'producer.', kafka_connect_truststore_path, kafka_connect_truststore_storepass, public_certificates_enabled, kafka_connect_keystore_path, kafka_connect_keystore_storepass, kafka_connect_keystore_keypass,
                             rbac_enabled, sasl_plain_users_final.kafka_connect.principal, sasl_plain_users_final.kafka_connect.password, sasl_scram_users_final.kafka_connect.principal, sasl_scram_users_final.kafka_connect.password, sasl_scram256_users_final.kafka_connect.principal, sasl_scram256_users_final.kafka_connect.password,
                             kerberos_kafka_broker_primary, kafka_connect_keytab_path, kafka_connect_kerberos_principal|default('kafka'),
                             false, kafka_connect_ldap_user, kafka_connect_ldap_password, mds_bootstrap_server_urls) }}"
   consumer:
     enabled: true
-    properties: "{{ kafka_broker_listeners[kafka_connect_kafka_listener_name] | confluent.platform.client_properties(ssl_enabled, False, ssl_mutual_auth_enabled, sasl_protocol,
+    properties: "{{ kafka_broker_listeners[kafka_connect_consumer_kafka_listener_name] | confluent.platform.client_properties(ssl_enabled, False, ssl_mutual_auth_enabled, sasl_protocol,
                             'consumer.', kafka_connect_truststore_path, kafka_connect_truststore_storepass, public_certificates_enabled, kafka_connect_keystore_path, kafka_connect_keystore_storepass, kafka_connect_keystore_keypass,
                             rbac_enabled, sasl_plain_users_final.kafka_connect.principal, sasl_plain_users_final.kafka_connect.password, sasl_scram_users_final.kafka_connect.principal, sasl_scram_users_final.kafka_connect.password, sasl_scram256_users_final.kafka_connect.principal, sasl_scram256_users_final.kafka_connect.password,
                             kerberos_kafka_broker_primary, kafka_connect_keytab_path, kafka_connect_kerberos_principal|default('kafka'),


### PR DESCRIPTION
# Description

I've added 2 new variables that lets you select an specific listener for Kafka Connect consumers and producers.

By default Connector producers and consumers are configured by cp-ansible to work against the Internal listener (9092). So all your connectors will use (e.g.) the `SASL_SSL` listener, but you might want to authenticate using mTLS, so you have an `SSL` listener. With this variables you can select the specific listener you want yo use for internal kafka connect clients.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I've made a preliminary version of this changes for a customer on site, which is now deployed and working as expected in different environments.

In this PR I've given better naming and the needed doc, not an extensive change

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible