### PR TITLE
Add list filter (ANSIENG-117)

### DIFF
--- a/roles/confluent.common/tasks/secrets_protection.yml
+++ b/roles/confluent.common/tasks/secrets_protection.yml
@@ -57,7 +57,7 @@
 - name: Create Encrypt Properties List
   set_fact:
     final_encrypt_properties: "{{ (final_properties | dict2items | map(attribute='key') | select('match', properties_patterns|join('|'))
-      + encrypt_properties) | unique if encrypt_passwords|bool else encrypt_properties }}"
+      | list +  encrypt_properties) | unique if encrypt_passwords|bool else encrypt_properties }}"
   vars:
     properties_patterns:
       - '.*password.*'


### PR DESCRIPTION
With some older python version we get Generator object error while
performing a dic and list operation. Its always a good idea to
typecast to list before performing any list operation

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # ANSIENG-117

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

` molecule converge -s mtls-custombundle-rhel -- --skip-tags package`

```
TASK [confluent.common : Create Encrypt Properties List] ***********************
ok: [kafka-broker1]
ok: [kafka-broker2]
ok: [kafka-broker3]


```
**Test Configuration**:
Local docker enviornment

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Any variable changes have been validated to be backwards compatible