### PR TITLE
Update regex to get correct version of archive installer

### DIFF
--- a/roles/confluent.zookeeper/tasks/dynamic_groups.yml
+++ b/roles/confluent.zookeeper/tasks/dynamic_groups.yml
@@ -13,7 +13,7 @@
   set_fact:
     zookeeper_current_version: "{{ (slurped_override.content|b64decode) .split('\n') |
       select('match', '^ExecStart=' + archive_config_base_path + '/confluent-(.*)/bin/zookeeper-server-start ' + zookeeper.config_file) |
-      list | first | regex_search('[0-9]+(.[0-9]+)+') }}"
+      list | first | regex_search('confluent-([0-9]+(.[0-9]+)+)\/bin\/', '\\1') | first }}"
   when: installation_method == "archive"
 
 - name: Load zookeeper.properties


### PR DESCRIPTION
JIRA - ANSIENG-920

# Description

Updated the regex patter to get the correct version of confluent platform. The current implementation was only looking for 3 digits in the path. The PR updated the search string in path between "confluent-" and "/bin/"


Fixes #ANSIENG-920

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

1. Updated the "archive_destination_path" in the scenario file of "archive-plain-debian"
2. Converged scenario archive-plain-debian
3. In first pass the dynamic_goups tasks doesn't get triggered
4. converge the scenario again
5. Verify the path in confluent.zookeeper : Get Leader/Follower
6. Tested with below values for archive_destination_path 
    - /svc/engn001/confluent
    - /opt/confluent700/
    - /opt/confluent  



**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible