### PR TITLE
fix(ccloud): set SR url when ccloud SR is enabled

### DIFF
--- a/roles/confluent.variables/vars/main.yml
+++ b/roles/confluent.variables/vars/main.yml
@@ -574,7 +574,7 @@ kafka_connect_properties:
     properties:
       listeners.https.ssl.client.auth: required
   sr:
-    enabled: "{{ 'schema_registry' in groups }}"
+    enabled: "{{ 'schema_registry' in groups or ccloud_schema_registry_enabled|bool }}"
     properties:
       value.converter.schema.registry.url: "{{schema_registry_url}}"
       key.converter.schema.registry.url: "{{schema_registry_url}}"


### PR DESCRIPTION
# Description

When CCloud Schema Registry is enabled, and no schema_registry group defined, URL is not set properly.

Fixes #802

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Against CCloud.

**Test Configuration**:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible