### PR TITLE
ca certs bug fix on debian host tests

### DIFF
--- a/molecule/Dockerfile-debian.j2
+++ b/molecule/Dockerfile-debian.j2
@@ -14,6 +14,10 @@ RUN apt-get update && \
       unzip \
       curl
 
+# Hack to fix cacerts on debian hosts, preventing confluenthub installs from working
+RUN /usr/bin/printf '\xfe\xed\xfe\xed\x00\x00\x00\x02\x00\x00\x00\x00\xe2\x68\x6e\x45\xfb\x43\xdf\xa4\xd9\x92\xdd\x41\xce\xb6\xb2\x1c\x63\x30\xd7\x92' > /etc/ssl/certs/java/cacerts && \
+    /var/lib/dpkg/info/ca-certificates-java.postinst configure
+
 RUN wget -qO - https://packages.confluent.io/clients/deb/archive.key | sudo apt-key add - && \
     add-apt-repository "deb https://packages.confluent.io/clients/deb/ stretch stable main" && \
     apt-get update


### PR DESCRIPTION
# Description

Some debian tests were failing with
```
Unexpected error: java.security.InvalidAlgorithmParameterException: the trustAnchors parameter must be non-empty
```

Solution copied from https://stackoverflow.com/questions/6784463/error-trustanchors-parameter-must-be-non-empty

Fixes #ANSIENG-930, #ANSIENG-924

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?


mtls-debian scenario now completes


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible