### PR TITLE
Add force: true when using get_url module to better support upgrade

### DIFF
--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -52,6 +52,14 @@ Default:  /opt/jolokia/jolokia.jar
 
 ***
 
+### jolokia_jar_url_force
+
+Boolean to force update of Jolokia Agent Jar (must be set to true if jolokia_jar_path already exists)
+
+Default:  false
+
+***
+
 ### jolokia_auth_mode
 
 Authentication Mode for Jolokia Agent. Possible values: none, basic. If selecting basic, you must set jolokia_user and jolokia_password
@@ -97,6 +105,14 @@ Default:  false
 Full path to download the Prometheus Exporter Agent Jar
 
 Default:  /opt/prometheus/jmx_prometheus_javaagent.jar
+
+***
+
+### jmxexporter_jar_url_force
+
+Boolean to force update of Prometheus Exporter Agent Jar (must be set to true if jmxexporter_jar_path already exists)
+
+Default:  false
 
 ***
 

--- a/roles/confluent.common/tasks/main.yml
+++ b/roles/confluent.common/tasks/main.yml
@@ -68,12 +68,12 @@
   when:
     - jolokia_enabled|bool
     - not jolokia_url_remote|bool
-    - not ansible_check_mode
 
 - name: Download Jolokia Jar
   get_url:
     url: "{{ jolokia_jar_url }}"
     dest: "{{ jolokia_jar_path }}"
+    force: "{{ jolokia_jar_url_force }}"
     mode: 0755
   register: jolokia_download_result
   until: jolokia_download_result is success
@@ -82,7 +82,7 @@
   when:
     - jolokia_enabled|bool
     - jolokia_url_remote|bool
-    - not ansible_check_mode
+    - not ansible_check_mode # (Bug ansible/ansible#65687)
 
 - name: Create Prometheus install directory
   file:
@@ -99,12 +99,12 @@
   when:
     - jmxexporter_enabled|bool
     - not jmxexporter_url_remote|bool
-    - not ansible_check_mode
 
 - name: Download Prometheus JMX Exporter Jar
   get_url:
     url: "{{ jmxexporter_jar_url }}"
     dest: "{{ jmxexporter_jar_path }}"
+    force: "{{ jmxexporter_jar_url_force }}"
     mode: 0755
   register: prometheus_download_result
   until: prometheus_download_result is success
@@ -113,8 +113,7 @@
   when:
     - jmxexporter_enabled|bool
     - jmxexporter_url_remote|bool
-    - not ansible_check_mode
-
+    - not ansible_check_mode # (Bug ansible/ansible#65687)
 
 - name: Install Confluent CLI
   include_tasks: confluent_cli.yml

--- a/roles/confluent.variables/defaults/main.yml
+++ b/roles/confluent.variables/defaults/main.yml
@@ -26,6 +26,9 @@ jolokia_enabled: false
 ### Full path to download the Jolokia Agent Jar
 jolokia_jar_path: /opt/jolokia/jolokia.jar
 
+### Boolean to force update of Jolokia Agent Jar (must be set to true if jolokia_jar_path already exists)
+jolokia_jar_url_force: false
+
 ### Authentication Mode for Jolokia Agent. Possible values: none, basic. If selecting basic, you must set jolokia_user and jolokia_password
 jolokia_auth_mode: none
 
@@ -43,6 +46,9 @@ jmxexporter_enabled: false
 
 ### Full path to download the Prometheus Exporter Agent Jar
 jmxexporter_jar_path: /opt/prometheus/jmx_prometheus_javaagent.jar
+
+### Boolean to force update of Prometheus Exporter Agent Jar (must be set to true if jmxexporter_jar_path already exists)
+jmxexporter_jar_url_force: false
 
 ### Boolean to have cp-ansible configure components with FIPS security settings. Must have ssl_enabled: true and use Java 8. Only valid for self signed certs and ssl_custom_certs: true, not ssl_provided_keystore_and_truststore: true.
 fips_enabled: false


### PR DESCRIPTION
# Description

I was originally trying to fix an issue related to check mode when trying to upgrade Prometheus JMX Exporter. Somehow I didn't understand why some of the tasks were skipped in check mode - until I discovered https://github.com/ansible/ansible/issues/65687.

Then I actually tried to upgrade, and discovered that files were actually NOT updated. After some digging, it seems like we need to set the [force parameter](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/get_url_module.html#parameter-force) when using the `get_url` module, because the destination file does not change when modifying the version inventory variable. So without this fix, you will be stuck with the version installed initially.

Setting `force` to `true` is not recommended, since the file will be downloaded each time, but I think it should be ok in this case. Both the Prometheus JMX Exporter and Jolokia jar-files are relatively small....

UPDATE: Since reviewer did not want to change the actual (IMO buggy) behavior, I have now added two new variables that retains the existing behavoir (`force: false`), but allows users to force re-download of Jolokia and JMX Exporter to upgrade/downgrade the jar-files, thus making actual state equal to desired state.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I have tested the change on actual host in our dev cluster, and also in check mode.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible