### PR TITLE
Added force restart tasks

### DIFF
--- a/roles/control_center/defaults/main.yml
+++ b/roles/control_center/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 # More control_center variables are defined in the variables role
 
+control_center_force_restart: false
+
 ### Boolean to reconfigure Control Center's logging with RollingFileAppender and log cleanup
 control_center_custom_log4j: "{{ custom_log4j }}"
 

--- a/roles/control_center/tasks/main.yml
+++ b/roles/control_center/tasks/main.yml
@@ -268,6 +268,11 @@
   notify: restart control center
   when: certs_updated|bool
 
+- name: Verify force Restart
+  command: /bin/true
+  notify: restart control center
+  when: confluent_force_service_restart|bool
+
 - meta: flush_handlers
 
 - name: Start Control Center Service

--- a/roles/control_center/tasks/main.yml
+++ b/roles/control_center/tasks/main.yml
@@ -268,10 +268,10 @@
   notify: restart control center
   when: certs_updated|bool
 
-- name: Verify force Restart
+- name: Force Restart
   command: /bin/true
   notify: restart control center
-  when: confluent_force_service_restart|bool
+  when: control_center_force_restart|bool
 
 - meta: flush_handlers
 

--- a/roles/kafka_broker/defaults/main.yml
+++ b/roles/kafka_broker/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 # More kafka_broker variables are defined in the variables role
 
+kafka_broker_force_restart: false
+
 ### Boolean to reconfigure Kafka's logging with RollingFileAppender and log cleanup
 kafka_broker_custom_log4j: "{{ custom_log4j }}"
 

--- a/roles/kafka_broker/tasks/main.yml
+++ b/roles/kafka_broker/tasks/main.yml
@@ -363,10 +363,10 @@
   notify: restart kafka
   when: certs_updated|bool
 
-- name: Verify force Restart
+- name: Force Restart
   command: /bin/true
   notify: restart kafka
-  when: confluent_force_service_restart|bool
+  when: kafka_broker_force_restart|bool
 
 - meta: flush_handlers
 

--- a/roles/kafka_broker/tasks/main.yml
+++ b/roles/kafka_broker/tasks/main.yml
@@ -363,6 +363,11 @@
   notify: restart kafka
   when: certs_updated|bool
 
+- name: Verify force Restart
+  command: /bin/true
+  notify: restart kafka
+  when: confluent_force_service_restart|bool
+
 - meta: flush_handlers
 
 - name: Kafka Started

--- a/roles/kafka_connect/defaults/main.yml
+++ b/roles/kafka_connect/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 # More kafka_connect variables are defined in the variables role
 
+kafka_connect_force_restart: false
 ### Boolean to reconfigure Kafka Connect's logging with the RollingFileAppender and log cleanup functionality.
 kafka_connect_custom_log4j: "{{ custom_log4j }}"
 

--- a/roles/kafka_connect/tasks/main.yml
+++ b/roles/kafka_connect/tasks/main.yml
@@ -257,6 +257,11 @@
   notify: restart connect distributed
   when: certs_updated|bool
 
+- name: Verify force Restart
+  command: /bin/true
+  notify: restart connect distributed
+  when: confluent_force_service_restart|bool
+
 - meta: flush_handlers
 
 - name: Start Connect Service

--- a/roles/kafka_connect/tasks/main.yml
+++ b/roles/kafka_connect/tasks/main.yml
@@ -257,10 +257,10 @@
   notify: restart connect distributed
   when: certs_updated|bool
 
-- name: Verify force Restart
+- name: Force Restart
   command: /bin/true
   notify: restart connect distributed
-  when: confluent_force_service_restart|bool
+  when: kafka_connect_force_restart|bool
 
 - meta: flush_handlers
 

--- a/roles/kafka_connect_replicator/defaults/main.yml
+++ b/roles/kafka_connect_replicator/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 # More Kafka Connect Replicator variables are defined in the variables role
 
+kafka_connect_replicator_force_restart: false
 ### Boolean to reconfigure Kafka Connect Replicator's logging with the RollingFileAppender and log cleanup functionality.
 kafka_connect_replicator_custom_log4j: "{{ custom_log4j }}"
 

--- a/roles/kafka_connect_replicator/tasks/main.yml
+++ b/roles/kafka_connect_replicator/tasks/main.yml
@@ -350,6 +350,11 @@
   notify: Restart Kafka Connect Replicator
   when: certs_updated|bool
 
+- name: Verify force Restart
+  command: /bin/true
+  notify: Restart Kafka Connect Replicator
+  when: confluent_force_service_restart|bool
+
 - meta: flush_handlers
 
 - name: Start Kafka Connect Replicator Service

--- a/roles/kafka_connect_replicator/tasks/main.yml
+++ b/roles/kafka_connect_replicator/tasks/main.yml
@@ -350,10 +350,10 @@
   notify: Restart Kafka Connect Replicator
   when: certs_updated|bool
 
-- name: Verify force Restart
+- name: Force Restart
   command: /bin/true
   notify: Restart Kafka Connect Replicator
-  when: confluent_force_service_restart|bool
+  when: kafka_connect_replicator_force_restart|bool
 
 - meta: flush_handlers
 

--- a/roles/kafka_rest/defaults/main.yml
+++ b/roles/kafka_rest/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 # More kafka_rest variables are defined in the variables role
 
+kafka_rest_force_restart: false
 ### Boolean to reconfigure Rest Proxy's logging with RollingFileAppender and log cleanup
 kafka_rest_custom_log4j: "{{ custom_log4j }}"
 

--- a/roles/kafka_rest/tasks/main.yml
+++ b/roles/kafka_rest/tasks/main.yml
@@ -260,10 +260,10 @@
   notify: restart kafka-rest
   when: certs_updated|bool
 
-- name: Verify force Restart
+- name: Force Restart
   command: /bin/true
   notify: restart kafka-rest
-  when: confluent_force_service_restart|bool
+  when: kafka_rest_force_restart|bool
 
 - meta: flush_handlers
 

--- a/roles/kafka_rest/tasks/main.yml
+++ b/roles/kafka_rest/tasks/main.yml
@@ -260,6 +260,11 @@
   notify: restart kafka-rest
   when: certs_updated|bool
 
+- name: Verify force Restart
+  command: /bin/true
+  notify: restart kafka-rest
+  when: confluent_force_service_restart|bool
+
 - meta: flush_handlers
 
 - name: Start Kafka Rest Service

--- a/roles/ksql/defaults/main.yml
+++ b/roles/ksql/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 # More ksql variables are defined in the variables role
 
+ksql_force_restart: false
+
 ### Boolean to reconfigure ksqlDB's logging with the RollingFileAppender and log cleanup functionality.
 ksql_custom_log4j: "{{ custom_log4j }}"
 

--- a/roles/ksql/tasks/main.yml
+++ b/roles/ksql/tasks/main.yml
@@ -277,6 +277,11 @@
   notify: restart ksql
   when: certs_updated|bool
 
+- name: Force Restart
+  command: /bin/true
+  notify: restart ksql
+  when: ksql_force_restart|bool
+
 - meta: flush_handlers
 
 - name: Start Ksql Service

--- a/roles/schema_registry/defaults/main.yml
+++ b/roles/schema_registry/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 # More schema_registry variables are defined in the variables role
 
+schema_registry_force_restart: false
+
 ### Boolean to reconfigure Schema Registry's logging with RollingFileAppender and log cleanup
 schema_registry_custom_log4j: "{{ custom_log4j }}"
 

--- a/roles/schema_registry/tasks/main.yml
+++ b/roles/schema_registry/tasks/main.yml
@@ -244,10 +244,10 @@
   notify: restart schema-registry
   when: certs_updated|bool
 
-- name: Verify force Restart
+- name: Force Restart
   command: /bin/true
   notify: restart schema-registry
-  when: confluent_force_service_restart|bool
+  when: schema_registry_force_restart|bool
 
 - meta: flush_handlers
 

--- a/roles/schema_registry/tasks/main.yml
+++ b/roles/schema_registry/tasks/main.yml
@@ -244,6 +244,11 @@
   notify: restart schema-registry
   when: certs_updated|bool
 
+- name: Verify force Restart
+  command: /bin/true
+  notify: restart schema-registry
+  when: confluent_force_service_restart|bool
+
 - meta: flush_handlers
 
 - name: Start Schema Registry Service

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -10,6 +10,9 @@ confluent_package_debian_suffix: "{{ '=' + confluent_full_package_version if con
 confluent_common_repository_redhat_release_version: "{{ ansible_distribution_major_version if ansible_os_family == 'RedHat' else ''}}"
 confluent_common_repository_debian_release_version: "{{ansible_distribution_release if ansible_os_family == 'Debian' else ''}}"
 
+### To force restart confluent services
+confluent_force_service_restart: false
+
 ### To copy from Ansible control host or download
 jolokia_url_remote: true
 

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -10,9 +10,6 @@ confluent_package_debian_suffix: "{{ '=' + confluent_full_package_version if con
 confluent_common_repository_redhat_release_version: "{{ ansible_distribution_major_version if ansible_os_family == 'RedHat' else ''}}"
 confluent_common_repository_debian_release_version: "{{ansible_distribution_release if ansible_os_family == 'Debian' else ''}}"
 
-### To force restart confluent services
-confluent_force_service_restart: false
-
 ### To copy from Ansible control host or download
 jolokia_url_remote: true
 

--- a/roles/zookeeper/defaults/main.yml
+++ b/roles/zookeeper/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 # More zookeeper variables are defined in the variables role
 
+zookeeper_force_restart: false
 ### Boolean to reconfigure Zookeeper's logging with RollingFileAppender and log cleanup
 zookeeper_custom_log4j: "{{ custom_log4j }}"
 

--- a/roles/zookeeper/tasks/main.yml
+++ b/roles/zookeeper/tasks/main.yml
@@ -250,10 +250,10 @@
   notify: restart zookeeper
   when: certs_updated|bool
 
-- name: Verify force Restart
+- name: Force Restart
   command: /bin/true
   notify: restart zookeeper
-  when: confluent_force_service_restart|bool
+  when: zookeeper_force_restart|bool
 
 - meta: flush_handlers
 

--- a/roles/zookeeper/tasks/main.yml
+++ b/roles/zookeeper/tasks/main.yml
@@ -250,6 +250,11 @@
   notify: restart zookeeper
   when: certs_updated|bool
 
+- name: Verify force Restart
+  command: /bin/true
+  notify: restart zookeeper
+  when: confluent_force_service_restart|bool
+
 - meta: flush_handlers
 
 - name: Zookeeper Service Started


### PR DESCRIPTION
# Description

Force restart without doing any change on all services

Fixes # (806)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Example command launched

Restart service:
```
$ ansible-playbook -i /path/to/hosts.yml all.yml --skip-tags package --tags zookeeper -e 'confluent_force_service_restart=true'
$ ansible-playbook -i /path/to/hosts.yml all.yml --skip-tags package --tags kafka_broker -e 'confluent_force_service_restart=true'
....
$ ansible-playbook -i /path/to/hosts.yml all.yml --skip-tags package --tags control_center -e 'confluent_force_service_restart=true'
```
Do nothings
```
$ ansible-playbook -i /path/to/hosts.yml all.yml --skip-tags package --tags zookeeper -e 'confluent_force_service_restart=false'
or
$ ansible-playbook -i /path/to/hosts.yml all.yml --skip-tags package --tags zookeeper
```


**Test Configuration**:


# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible