### PR TITLE
Update the default state of each service

### DIFF
--- a/kafka_broker.yml
+++ b/kafka_broker.yml
@@ -15,7 +15,7 @@
       set_fact:
         install_pattern: "{{ 'parallel' if service_state != 'running' or kafka_broker_deployment_strategy == 'parallel' else 'serial' }}"
       vars:
-        service_state: "{{ ansible_facts.services[kafka_broker_service_name + '.service'].state | default('unknown') }}"
+        service_state: "{{ ansible_facts.services[kafka_broker_service_name + '.service'] | default({'state':'unknown'})['state'] }}"
 
     - name: Group Hosts by Installation Pattern
       group_by:

--- a/kafka_connect.yml
+++ b/kafka_connect.yml
@@ -15,7 +15,7 @@
       set_fact:
         install_pattern: "{{ 'parallel' if service_state != 'running' or kafka_connect_deployment_strategy == 'parallel' else 'serial' }}"
       vars:
-        service_state: "{{ ansible_facts.services[kafka_connect_service_name + '.service'].state | default('unknown') }}"
+        service_state: "{{ ansible_facts.services[kafka_connect_service_name + '.service'] | default({'state':'unknown'})['state'] }}"
 
     - name: Group Hosts by Installation Pattern
       group_by:

--- a/kafka_connect_replicator.yml
+++ b/kafka_connect_replicator.yml
@@ -15,7 +15,7 @@
       set_fact:
         install_pattern: "{{ 'parallel' if service_state != 'running' or kafka_connect_replicator_deployment_strategy == 'parallel' else 'serial' }}"
       vars:
-        service_state: "{{ ansible_facts.services[kafka_connect_replicator_service_name + '.service'].state | default('unknown') }}"
+        service_state: "{{ ansible_facts.services[kafka_connect_replicator_service_name + '.service'] | default({'state':'unknown'})['state'] }}"
 
     - name: Group Hosts by Installation Pattern
       group_by:

--- a/kafka_rest.yml
+++ b/kafka_rest.yml
@@ -15,7 +15,7 @@
       set_fact:
         install_pattern: "{{ 'parallel' if service_state != 'running' or kafka_rest_deployment_strategy == 'parallel' else 'serial' }}"
       vars:
-        service_state: "{{ ansible_facts.services[kafka_rest_service_name + '.service'].state | default('unknown') }}"
+        service_state: "{{ ansible_facts.services[kafka_rest_service_name + '.service'] | default({'state':'unknown'})['state'] }}"
 
     - name: Group Hosts by Installation Pattern
       group_by:

--- a/ksql.yml
+++ b/ksql.yml
@@ -15,7 +15,7 @@
       set_fact:
         install_pattern: "{{ 'parallel' if service_state != 'running' or ksql_deployment_strategy == 'parallel' else 'serial' }}"
       vars:
-        service_state: "{{ ansible_facts.services[ksql_service_name + '.service'].state | default('unknown') }}"
+      service_state: "{{ ansible_facts.services[ksql_service_name + '.service'] | default({'state':'unknown'})['state'] }}"
 
     - name: Group Hosts by Installation Pattern
       group_by:

--- a/zookeeper.yml
+++ b/zookeeper.yml
@@ -15,7 +15,7 @@
       set_fact:
         install_pattern: "{{ 'parallel' if service_state != 'running' or zookeeper_deployment_strategy == 'parallel' else 'serial' }}"
       vars:
-        service_state: "{{ ansible_facts.services[zookeeper_service_name + '.service'].state | default('unknown') }}"
+        service_state: "{{ ansible_facts.services[zookeeper_service_name + '.service'] | default({'state':'unknown'})['state'] }}"
 
     - name: Group Hosts by Installation Pattern
       group_by:


### PR DESCRIPTION
# Description

Update the default service state for greenfield environment when using Python27. This error is not reproducible with python3. 

Error message from customer who is trying to do a greenfield installation with python27
```
fatal: [s2-conf-zoo01.sig.mgt.intellicentre.net.au]: FAILED! => {"msg": "The field 'vars' has an invalid value, which includes an undefined variable. The error was: 'dict object' has no attribute u'confluent-zookeeper.service'\n\nThe error appears to have been in '/home/ansibleadmin/cp-ansible-6.2.1-post/zookeeper.yml': line 14, column 7, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n - name: Determine Installation Pattern - Parallel or Serial\n ^ here\n"}
```

The code in the PR unblocked them.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Verified locally


**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible