### PR TITLE
Update regex to get correct version of cp archive

### DIFF
--- a/roles/confluent.kafka_broker/tasks/dynamic_groups.yml
+++ b/roles/confluent.kafka_broker/tasks/dynamic_groups.yml
@@ -32,7 +32,7 @@
   set_fact:
     kafka_broker_current_version: "{{ (slurped_override.content|b64decode) .split('\n') |
       select('match', '^ExecStart=' + archive_config_base_path + '/confluent-(.*)/bin/kafka-server-start ' + kafka_broker.config_file) |
-      list | first | regex_search('[0-9]+(.[0-9]+)+') }}"
+      list | first | regex_search('confluent-([0-9]+(.[0-9]+)+)/bin/', '\\1') | first }}"
   when: installation_method == "archive"
 
 # TODO When Zookeeper is removed, use kafka-metadata-quorum script. See KIP-595

--- a/roles/confluent.zookeeper/tasks/dynamic_groups.yml
+++ b/roles/confluent.zookeeper/tasks/dynamic_groups.yml
@@ -13,7 +13,7 @@
   set_fact:
     zookeeper_current_version: "{{ (slurped_override.content|b64decode) .split('\n') |
       select('match', '^ExecStart=' + archive_config_base_path + '/confluent-(.*)/bin/zookeeper-server-start ' + zookeeper.config_file) |
-      list | first | regex_search('[0-9]+(.[0-9]+)+') }}"
+      list | first | regex_search('confluent-([0-9]+(.[0-9]+)+)/bin/', '\\1') | first }}"
   when: installation_method == "archive"
 
 - name: Get Leader/Follower


### PR DESCRIPTION
# Description

Update regex to get the correct version of Confluent Platform

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Converged scenario archive-plain-debian
In first pass the dynamic_goups tasks doesn't get triggered
converge the scenario again
Verify the path in confluent.zookeeper : Get Leader/Follower
Tested with below values for archive_destination_path
/svc/engn001/confluent
/opt/confluent700/
/opt/confluent

**Test Configuration**:
Local Environment

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible