### PR TITLE
build: Set validate_hosts to false when triggered by CI/CD Nightly Job

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,6 +47,8 @@ def job = {
 
     // ansible_fqdn within certs does not match the FQDN that zookeeper verifies
     override_config['zookeeper_custom_java_args'] = '-Dzookeeper.ssl.hostnameVerification=false -Dzookeeper.ssl.quorum.hostnameVerification=false'
+    // CI/CD Nightly passes URLs that return 400s when directly querying confluent_common_repository_baseurl URL. 
+    override_config['validate_hosts'] = false
 
     def branch_name = targetBranch().toString()
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,13 +47,13 @@ def job = {
 
     // ansible_fqdn within certs does not match the FQDN that zookeeper verifies
     override_config['zookeeper_custom_java_args'] = '-Dzookeeper.ssl.hostnameVerification=false -Dzookeeper.ssl.quorum.hostnameVerification=false'
-    // CI/CD Nightly passes URLs that return 400s when directly querying confluent_common_repository_baseurl URL. 
-    override_config['validate_hosts'] = false
 
     def branch_name = targetBranch().toString()
 
     if(params.CONFLUENT_PACKAGE_BASEURL) {
         override_config['confluent_common_repository_baseurl'] = params.CONFLUENT_PACKAGE_BASEURL
+        // CI/CD Nightly passes URLs that return 400s when directly querying confluent_common_repository_baseurl URL. 
+        override_config['validate_hosts'] = false
     }
 
     if(params.CONFLUENT_PACKAGE_VERSION) {


### PR DESCRIPTION
The Ci/CD Nightly job will pass a URL that will (likely) return a 400 as its an S3 bucket + key path. Which there is no indexing. Trust that the triggering job knows that there are packages at confluent_common_repository_baseurl.

# Description

This check was added: https://github.com/confluentinc/cp-ansible/commit/cc7d5f341bc7c6d11c83ec9cde7e225b7308653e some time back. In the nightly CI/CD context though, this check is meaningless, because whats passed for CI/CD will return a 400, as there is no Key at (for example) `https://s3-us-west-2.amazonaws.com/<nightly-bucket>/6.2.x/433`, but RPM, DEB and Archive packages are there if the paths are appended (ie: `https://s3-us-west-2.amazonaws.com/<nightly-bucket>/6.2.x/433/archive/6.2/confluent-6.2.1.tgz` ), so we disable this check in CI/CD.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

PR build should pass. Currently the 6.2.x, 7.0.x & master branch builders are failing on this issue.



**Test Configuration**:


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible