### PR TITLE
Ability to specify the interface to listen on for the broker listeners

### DIFF
--- a/hosts_example.yml
+++ b/hosts_example.yml
@@ -322,13 +322,13 @@ kafka_broker:
       # kafka_broker_custom_listeners:
       #   broker:
       #     ip: 123.123.123.123
-      #     hostname: 'broker1.something.local'
+      #     hostname: broker1.something.local
       #   internal:
       #     ip: 123.123.123.123
-      #     hostname: 'broker1.something.local'
+      #     hostname: broker1.something.local
       #   client_listener:
       #     ip: 123.123.123.123
-      #     hostname: 'broker1.something.local'
+      #     hostname: broker1.something.local
 
       ## For kerberos sasl protocol, EACH host will need these two variables:
       # kafka_broker_kerberos_keytab_path: <The path on ansible host to keytab file, eg. /tmp/keytabs/ip-172-31-34-246.us-east-2.compute.internal>

--- a/hosts_example.yml
+++ b/hosts_example.yml
@@ -315,6 +315,21 @@ kafka_broker:
       #   broker.rack: us-east-1d
       #   replica.selector.class: org.apache.kafka.common.replica.RackAwareReplicaSelector
 
+      # Per host, in case there are multiple interfaces and you need to listen on only one of them,
+      # you can also specify which interface to listen on, per listener.
+      # On each listener, you need to add an 'ip' value. This will adjust the 'listeners' section per host.
+      # 
+      # kafka_broker_custom_listeners:
+      #   broker:
+      #     ip: 123.123.123.123
+      #     hostname: 'broker1.something.local'
+      #   internal:
+      #     ip: 123.123.123.123
+      #     hostname: 'broker1.something.local'
+      #   client_listener:
+      #     ip: 123.123.123.123
+      #     hostname: 'broker1.something.local'
+
       ## For kerberos sasl protocol, EACH host will need these two variables:
       # kafka_broker_kerberos_keytab_path: <The path on ansible host to keytab file, eg. /tmp/keytabs/ip-172-31-34-246.us-east-2.compute.internal>
       # kafka_broker_kerberos_principal: <The principal configured in kdc server, eg. kafka/ip-172-31-34-246.us-east-2.compute.internal@REALM.EXAMPLE.COM>

--- a/hosts_example.yml
+++ b/hosts_example.yml
@@ -318,7 +318,7 @@ kafka_broker:
       # Per host, in case there are multiple interfaces and you need to listen on only one of them,
       # you can also specify which interface to listen on, per listener.
       # On each listener, you need to add an 'ip' value. This will adjust the 'listeners' section per host.
-      # 
+      #
       # kafka_broker_custom_listeners:
       #   broker:
       #     ip: 123.123.123.123

--- a/roles/variables/vars/main.yml
+++ b/roles/variables/vars/main.yml
@@ -132,7 +132,7 @@ kafka_broker_properties:
       zookeeper.connect: "{{ groups['zookeeper'] | default(['localhost']) | confluent.platform.resolve_hostnames(hostvars) | join(':' + zookeeper_client_port|string + ',') }}:{{zookeeper_client_port}}{{zookeeper_chroot}}"
       log.dirs: "{{ kafka_broker.datadir | join(',') }}"
       listener.security.protocol.map: "{% for listener in kafka_broker_listeners|dict2items %}{% if loop.index > 1%},{% endif %}{{ listener['value']['name'] }}:{{ listener['value'] | confluent.platform.kafka_protocol_defaults(ssl_enabled, sasl_protocol)}}{% endfor %}"
-      listeners: "{% for listener in kafka_broker_listeners|dict2items %}{% if loop.index > 1%},{% endif %}{{ listener['value']['name'] }}://:{{ listener['value']['port'] }}{% endfor %}"
+      listeners: "{% for listener in kafka_broker_listeners|dict2items %}{% if loop.index > 1%},{% endif %}{{ listener['value']['name'] }}://{{ custom_listeners['properties'][listener['key']]['ip'] | default('') }}:{{ listener['value']['port'] }}{% endfor %}"
       advertised.listeners: "{% for listener in kafka_broker_listeners|dict2items %}{% if loop.index > 1%},{% endif %}{{ listener['value']['name'] }}://{{ listener['value']['hostname'] | default(hostvars[inventory_hostname]|confluent.platform.resolve_hostname)  }}:{{ listener['value']['port'] }}{% endfor %}"
       inter.broker.listener.name: "{{kafka_broker_listeners[kafka_broker_inter_broker_listener_name]['name']}}"
       kafka.rest.enable: "{{kafka_broker_rest_proxy_enabled|string|lower}}"

--- a/roles/variables/vars/main.yml
+++ b/roles/variables/vars/main.yml
@@ -132,7 +132,7 @@ kafka_broker_properties:
       zookeeper.connect: "{{ groups['zookeeper'] | default(['localhost']) | confluent.platform.resolve_hostnames(hostvars) | join(':' + zookeeper_client_port|string + ',') }}:{{zookeeper_client_port}}{{zookeeper_chroot}}"
       log.dirs: "{{ kafka_broker.datadir | join(',') }}"
       listener.security.protocol.map: "{% for listener in kafka_broker_listeners|dict2items %}{% if loop.index > 1%},{% endif %}{{ listener['value']['name'] }}:{{ listener['value'] | confluent.platform.kafka_protocol_defaults(ssl_enabled, sasl_protocol)}}{% endfor %}"
-      listeners: "{% for listener in kafka_broker_listeners|dict2items %}{% if loop.index > 1%},{% endif %}{{ listener['value']['name'] }}://{{ custom_listeners['properties'][listener['key']]['ip'] | default('') }}:{{ listener['value']['port'] }}{% endfor %}"
+      listeners: "{% for listener in kafka_broker_listeners|dict2items %}{% if loop.index > 1%},{% endif %}{{ listener['value']['name'] }}://{{ listener['value']['ip'] | default('') }}:{{ listener['value']['port'] }}{% endfor %}"
       advertised.listeners: "{% for listener in kafka_broker_listeners|dict2items %}{% if loop.index > 1%},{% endif %}{{ listener['value']['name'] }}://{{ listener['value']['hostname'] | default(hostvars[inventory_hostname]|confluent.platform.resolve_hostname)  }}:{{ listener['value']['port'] }}{% endfor %}"
       inter.broker.listener.name: "{{kafka_broker_listeners[kafka_broker_inter_broker_listener_name]['name']}}"
       kafka.rest.enable: "{{kafka_broker_rest_proxy_enabled|string|lower}}"


### PR DESCRIPTION
# Description

Per host, in case there are multiple interfaces and you need to listen on only one of them, you can also specify which interface to listen on, per listener.
On each listener, you need to add an 'ip' value. This will adjust the 'listeners' section per host.

Inventory example is provided.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

We have tested it at the customer site.


**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Any variable changes have been validated to be backwards compatible