### PR TITLE
fix: remove 'yum makecache' task

### DIFF
--- a/roles/confluent.common/tasks/redhat.yml
+++ b/roles/confluent.common/tasks/redhat.yml
@@ -40,13 +40,10 @@
   command: yum clean all
   args:
     warn: false
-  when: confluent_dist_repo_result.changed|default(False) or confluent_repo_result.changed|default(False) or custom_repo_result.changed|default(False) or repository_configuration == 'custom'
-
-- name: yum-makecache
-  command: yum makecache
-  args:
-    warn: false
-  when: confluent_dist_repo_result.changed|default(False) or confluent_repo_result.changed|default(False) or custom_repo_result.changed|default(False) or repository_configuration == 'custom'
+  when: >
+    confluent_dist_repo_result.changed|default(False) or
+    confluent_repo_result.changed|default(False) or
+    repository_configuration == 'custom'
 
 - name: Install Java
   yum:


### PR DESCRIPTION
# Description

This PR is a partial revert of https://github.com/confluentinc/cp-ansible/pull/786. It removes the `yum makecache` tasks - which seems to slow down our pipeline significantly and requires a lot more disk space for the yum cache than it used to (blowing our disks in a couple of clusters). And there should be no need to build up a full cache right after `yum clean all` (the task right before).

Also cleaned up the when on the `yum-clean-all` task - to make it more readable. The play will still always run `yum clean all` for configurations with `repository_configuration == 'custom'` - as introduced with https://github.com/confluentinc/cp-ansible/pull/786.

It would be nice if @22RC could check this feature branch with regards to https://github.com/confluentinc/cp-ansible/issues/785.

And I really want this merged up to the 7.0-branches! 😄 

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested in one of our local clusters

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible