### PR TITLE
fix: more lenient Internet access check

### DIFF
--- a/roles/confluent.common/tasks/host_validations.yml
+++ b/roles/confluent.common/tasks/host_validations.yml
@@ -35,7 +35,10 @@
 - name: Check Internet Access for Confluent Packages/Archive
   uri:
     url: "{{confluent_common_repository_baseurl}}"
-    status_code: 200
+    status_code:
+      - 200
+      - 302
+      - 307
   when: >
     ( installation_method == 'package' and repository_configuration == 'confluent') or
     ( installation_method == 'archive' and confluent_common_repository_baseurl in confluent_archive_file_source )


### PR DESCRIPTION
# Description

We are using a proxy to reach https://packages.confluent.io, and this proxy insists on a trailing slash added to `confluent_common_repository_baseurl` variable to return HTTP 200 OK as part of the "host validations". This trailing slash is unwanted in our configuration because it "breaks" the other variables deduced from `confluent_common_repository_baseurl`.

This PR fixes this by allowing temporary redirect status codes (302 and 307) in addition to 200 OK.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible