### PR TITLE
fix: fully manage yum confluent.repo file

### DIFF
--- a/roles/confluent.common/tasks/redhat.yml
+++ b/roles/confluent.common/tasks/redhat.yml
@@ -1,29 +1,9 @@
 ---
-- name: Add Confluent Dist Yum Repo
-  yum_repository:
-    name: Confluent.dist
-    file: confluent
-    description: "Confluent repository (dist)"
-    baseurl: "{{confluent_common_repository_redhat_dist_baseurl}}"
-    gpgcheck: "{{confluent_common_repository_redhat_dist_gpgcheck}}"
-    gpgkey: "{{confluent_common_repository_redhat_dist_gpgkey}}"
-    enabled: "{{confluent_common_repository_redhat_dist_enabled}}"
-    proxy: "{{proxy_env.http_proxy | default(omit)}}"
-  register: confluent_dist_repo_result
-  when:
-    - repository_configuration == 'confluent'
-    - installation_method == "package"
-
-- name: Add Confluent Yum Repo
-  yum_repository:
-    name: Confluent
-    file: confluent
-    description: "Confluent repository"
-    baseurl: "{{confluent_common_repository_redhat_main_baseurl}}"
-    gpgcheck: "{{confluent_common_repository_redhat_main_gpgcheck}}"
-    gpgkey: "{{confluent_common_repository_redhat_main_gpgkey}}"
-    enabled: "{{confluent_common_repository_redhat_main_enabled}}"
-    proxy: "{{proxy_env.http_proxy | default(omit)}}"
+- name: Add Confluent Repo file
+  template:
+    src: confluent.repo.j2
+    dest: /etc/yum.repos.d/confluent.repo
+    mode: 0644
   register: confluent_repo_result
   when:
     - repository_configuration == 'confluent'
@@ -34,7 +14,6 @@
     src: "{{custom_yum_repofile_filepath}}"
     dest: /etc/yum.repos.d/custom-confluent.repo
     mode: 0644
-  register: custom_repo_result
   when: repository_configuration == 'custom'
 
 # Not using handler because of https://github.com/ansible/ansible/issues/41313
@@ -43,7 +22,6 @@
   args:
     warn: false
   when: >
-    confluent_dist_repo_result.changed|default(False) or
     confluent_repo_result.changed|default(False) or
     repository_configuration == 'custom'
 

--- a/roles/confluent.common/templates/confluent.repo.j2
+++ b/roles/confluent.common/templates/confluent.repo.j2
@@ -1,0 +1,13 @@
+# Maintained by Ansible
+{% for name, repo in confluent_yum_repositories.items() %}
+[{{ name }}]
+async = 1
+baseurl = {{ repo.baseurl }}
+enabled = {{ repo.enabled | int }}
+gpgcheck = {{ repo.gpgcheck | int }}
+gpgkey = {{ repo.gpgkey }}
+name = {{ repo.description }}
+{% if 'http_proxy' in proxy_env %}
+proxy = {{ proxy_env.http_proxy }}
+{% endif %}
+{% endfor %}

--- a/roles/confluent.common/vars/main.yml
+++ b/roles/confluent.common/vars/main.yml
@@ -10,3 +10,17 @@ confluent_cli_goarch:
 
 ### Filename of Confluent CLI binary inside the archive
 confluent_cli_binary: confluent
+
+confluent_yum_repositories:
+  "Confluent":
+    description: "Confluent repository"
+    baseurl: "{{confluent_common_repository_redhat_main_baseurl}}"
+    gpgcheck: "{{confluent_common_repository_redhat_main_gpgcheck}}"
+    gpgkey: "{{confluent_common_repository_redhat_main_gpgkey}}"
+    enabled: "{{confluent_common_repository_redhat_main_enabled}}"
+  "Confluent.dist":
+    description: "Confluent repository (dist)"
+    baseurl: "{{confluent_common_repository_redhat_dist_baseurl}}"
+    gpgcheck: "{{confluent_common_repository_redhat_dist_gpgcheck}}"
+    gpgkey: "{{confluent_common_repository_redhat_dist_gpgkey}}"
+    enabled: "{{confluent_common_repository_redhat_dist_enabled}}"


### PR DESCRIPTION
# Description

This PR makes cp-ansible fully manage the yum `confluent.repo` file using a template; to mend the version upgrade/downgrade issues described in #833. This will assure the correct/desired state on the repo-file when repositories are removed on upgrade/downgrade.

This might be considered a breaking change if any user has added additional repositories to `confluent.repo`.

Fixes #833 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

**Test Configuration**:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible