### PR TITLE
Error check to validate authentication is set with RBAC.

### DIFF
--- a/roles/confluent.kafka_broker/tasks/set_principal.yml
+++ b/roles/confluent.kafka_broker/tasks/set_principal.yml
@@ -47,3 +47,8 @@
   set_fact:
     kafka_broker_principal: "User:{{ kafka_broker_principal }}"
   when: kafka_broker_principal is defined
+
+- name: Validate that auth is set for RBAC on internal listener
+  fail:
+    msg: "Role Based Access Control (RBAC) requires that an authorization mechanism is set on the internal listener, please review Confluent documentation for further details."
+  when: kafka_broker_principal is undefined


### PR DESCRIPTION
# Description

This PR addresses the use case where a user has enabled RBAC but not set an authentication mechanism on the internal listener.  Previously in this scenario, a generic ansible error for an undefined error would be thrown.  Now a clear error stating that authentication must be set on the internal listener is thrown:

```
"Role Based Access Control (RBAC) requires that an authorization mechanism is set on the internal listener, please review Confluent documentation for further details."
```

Fixes # (issue)

ANSIENG-940

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This has been validated by running the rbac-scram-custom-rhel molecule scenario and not setting the sasl_protocol variable.

Output:

```
TASK [confluent.kafka_broker : Validate that auth is set for RBAC on internal listener] ***
fatal: [kafka-broker2]: FAILED! => {"changed": false, "msg": "Role Based Access Control (RBAC) requires that an authorization mechanism is set on the internal listener, please review Confluent documentation for further details."}
fatal: [kafka-broker1]: FAILED! => {"changed": false, "msg": "Role Based Access Control (RBAC) requires that an authorization mechanism is set on the internal listener, please review Confluent documentation for further details."}
fatal: [kafka-broker3]: FAILED! => {"changed": false, "msg": "Role Based Access Control (RBAC) requires that an authorization mechanism is set on the internal listener, please review Confluent documentation for further details."}
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible