### PR TITLE
Added canonicalize = false property to krb5.conf to better support Active Directory.

### DIFF
--- a/roles/confluent.kerberos/defaults/main.yml
+++ b/roles/confluent.kerberos/defaults/main.yml
@@ -8,4 +8,4 @@ kerberos:
   default_tkt_enctypes: aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 arc-four-hmac rc4-hmac
   default_tgs_enctypes: aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 arc-four-hmac rc4-hmac
   permitted_enctypes: aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 arc-four-hmac rc4-hmac
-  canonicalize: false
+  canonicalize: true

--- a/roles/confluent.kerberos/defaults/main.yml
+++ b/roles/confluent.kerberos/defaults/main.yml
@@ -8,3 +8,4 @@ kerberos:
   default_tkt_enctypes: aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 arc-four-hmac rc4-hmac
   default_tgs_enctypes: aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 arc-four-hmac rc4-hmac
   permitted_enctypes: aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 arc-four-hmac rc4-hmac
+  canonicalize: false

--- a/roles/confluent.kerberos/templates/krb5.conf.j2
+++ b/roles/confluent.kerberos/templates/krb5.conf.j2
@@ -8,6 +8,7 @@
  default_tkt_enctypes = {{ kerberos.default_tkt_enctypes }}
  default_tgs_enctypes = {{ kerberos.default_tgs_enctypes }}
  permitted_enctypes = {{ kerberos.permitted_enctypes }}
+ canonicalize = {{ kerberos.canonicalize }}
 
 [realms]
  {{ kerberos.realm| upper() }} = {


### PR DESCRIPTION
# Description

This PR adds an additional configuration property to the krb5.conf to true in order to better support Active Directory when it is being used as the KDC.  It makes sure that the correct principal is used when RBAC and ACLs are enabled with kerberos on AD.

Fixes # (issue)

ANSIENG-164

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This has been validated by running the kerberos-rhel scenario to validate that the additional property does not break existing functionality as well as working with the MIT KDC.

Output of krb5.conf here:

```
[libdefaults]
 default_realm = REALM.EXAMPLE.COM
 dns_lookup_realm = false
 dns_lookup_kdc = false
 ticket_lifetime = 24h
 forwardable = true
 udp_preference_limit = 1
 default_tkt_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 arc-four-hmac rc4-hmac
 default_tgs_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 arc-four-hmac rc4-hmac
 permitted_enctypes = aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 arc-four-hmac rc4-hmac
 canonicalize = true
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible