### PR TITLE
feat: Refactor c/c++ clients release repository.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,6 +52,8 @@ def job = {
 
     if(params.CONFLUENT_PACKAGE_BASEURL) {
         override_config['confluent_common_repository_baseurl'] = params.CONFLUENT_PACKAGE_BASEURL
+        // CI/CD Nightly passes URLs that return 400s when directly querying confluent_common_repository_baseurl URL. 
+        override_config['validate_hosts'] = false
     }
 
     if(params.CONFLUENT_PACKAGE_VERSION) {

--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -3866,6 +3866,14 @@ Default:  "https://packages.confluent.io"
 
 ***
 
+### confluent_clients_repository_baseurl
+
+Base URL for Confluent C/C++ Clients RPM and Debian Package Repositories
+
+Default:  "https://packages.confluent.io"
+
+***
+
 ### install_java
 
 Boolean to have cp-ansible install Java on hosts

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -14,13 +14,15 @@ custom_apt_repo_filepath: ""
 
 ### Base URL for Confluent's RPM and Debian Package Repositories
 confluent_common_repository_baseurl: "https://packages.confluent.io"
+### Base URL for Confluent C/C++ Clients RPM and Debian Package Repositories
+confluent_clients_repository_baseurl: "https://packages.confluent.io"
 
 confluent_common_repository_debian_baseurl: "{{confluent_common_repository_baseurl}}/deb"
 confluent_common_repository_debian_key_url: "{{confluent_common_repository_debian_baseurl}}/{{confluent_repo_version}}/archive.key"
 confluent_common_repository_debian_repository: "deb [arch=amd64] {{confluent_common_repository_debian_baseurl}}/{{confluent_repo_version}} stable main"
 
-confluent_common_repository_debian_clients_key_url: "{{confluent_common_repository_baseurl}}/clients/deb/archive.key"
-confluent_common_repository_debian_clients_repository: "deb {{confluent_common_repository_baseurl}}/clients/deb/ {{confluent_common_repository_debian_release_version}} main"
+confluent_common_repository_debian_clients_key_url: "{{confluent_clients_repository_baseurl}}/clients/deb/archive.key"
+confluent_common_repository_debian_clients_repository: "deb {{confluent_clients_repository_baseurl}}/clients/deb/ {{confluent_common_repository_debian_release_version}} main"
 
 confluent_common_repository_redhat_baseurl: "{{confluent_common_repository_baseurl}}/rpm"
 confluent_common_repository_redhat_main_baseurl: "{{confluent_common_repository_redhat_baseurl}}/{{confluent_repo_version}}"
@@ -28,9 +30,9 @@ confluent_common_repository_redhat_main_gpgcheck: 1
 confluent_common_repository_redhat_main_gpgkey: "{{confluent_common_repository_redhat_baseurl}}/{{confluent_repo_version}}/archive.key"
 confluent_common_repository_redhat_main_enabled: 1
 
-confluent_common_repository_redhat_clients_baseurl: "{{confluent_common_repository_baseurl}}/clients/rpm/centos/{{confluent_common_repository_redhat_release_version}}/x86_64"
+confluent_common_repository_redhat_clients_baseurl: "{{confluent_clients_repository_baseurl}}/clients/rpm/centos/{{confluent_common_repository_redhat_release_version}}/x86_64"
 confluent_common_repository_redhat_clients_gpgcheck: 1
-confluent_common_repository_redhat_clients_gpgkey: "{{confluent_common_repository_baseurl}}/clients/rpm/archive.key"
+confluent_common_repository_redhat_clients_gpgkey: "{{confluent_clients_repository_baseurl}}/clients/rpm/archive.key"
 confluent_common_repository_redhat_clients_enabled: 1
 
 ### Boolean to have cp-ansible install Java on hosts


### PR DESCRIPTION
# Description

This change fixed a CI issue where the values feed into CONFLUENT_PACKAGE_BASEURL now longer have a `/clients` repo behind them. The ideal situation is that `https://packages.confluent.io/clients/` is unconditionally used irrespective of where we point `confluent_common_repository_baseurl` too with a nightly/staged release.

You can see these failures in CI when triggered by the upstream CI Packaging job.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

CI runs with params and without should work.



**Test Configuration**:


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible