### PR TITLE
Fix molecule tests for scenario 'zookeeper-mtls'

### DIFF
--- a/roles/confluent.test/molecule/zookeeper-mtls/molecule.yml
+++ b/roles/confluent.test/molecule/zookeeper-mtls/molecule.yml
@@ -97,7 +97,7 @@ provisioner:
     group_vars:
       all:
         scenario_name: zookeeper-mtls
-
+        ssl_enabled: true
         zookeeper_ssl_enabled: true
         zookeeper_ssl_mutual_auth_enabled: true
         sasl_protocol: scram

--- a/roles/confluent.test/molecule/zookeeper-mtls/verify.yml
+++ b/roles/confluent.test/molecule/zookeeper-mtls/verify.yml
@@ -33,4 +33,4 @@
       vars:
         file_path: /etc/schema-registry/schema-registry.properties
         property: kafkastore.security.protocol
-        expected_value: SASL_PLAINTEXT
+        expected_value: SASL_SSL


### PR DESCRIPTION
# Description

Molecule tests for scenario zookeeper-mtls were failing on task 
`TASK [confluent.ssl : Copy CA Cert to Host]`
because of the task  `Create Certificate Authority and Copy to Ansible Host` getting skipped. 
Setting ssl_enabled to true fixes the issue. 
Accordingly, one of the VERIFY tasks need to be changed since the expected value of property kafkastore.security.protocol will now be SASL_SSL. 

Fixes # ([As part of 5.5.x release readiness](https://confluentinc.atlassian.net/browse/ANSIENG-963?atlOrigin=eyJpIjoiYTU0MThmZGMyZjc1NGY5MGFhOTUyMzEyMTA1N2M3MjUiLCJwIjoiaiJ9))

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

`molecule --debug test -s zookeeper-mtls` gives an all pass/success. 

**Test Configuration**:  molecule run for scenario zookeeper-mtls on 5.5.x


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible