### PR TITLE
Fix molecule tests for scenario 'mtls-customcerts-rhel'

### DIFF
--- a/roles/confluent.test/molecule/mtls-customcerts-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/mtls-customcerts-rhel/molecule.yml
@@ -125,8 +125,6 @@ provisioner:
       all:
         scenario_name: mtls-customcerts-rhel
 
-        confluent_server_enabled: false
-
         ssl_enabled: true
         ssl_mutual_auth_enabled: true
 

--- a/roles/confluent.test/molecule/mtls-customcerts-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/mtls-customcerts-rhel/molecule.yml
@@ -7,7 +7,7 @@ platforms:
     groups:
       - zookeeper
     image: geerlingguy/docker-centos7-ansible
-    dockerfile: ../Dockerfile.j2
+    # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -19,7 +19,7 @@ platforms:
     groups:
       - kafka_broker
     image: geerlingguy/docker-centos7-ansible
-    dockerfile: ../Dockerfile.j2
+    # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -31,7 +31,7 @@ platforms:
     groups:
       - kafka_broker
     image: geerlingguy/docker-centos7-ansible
-    dockerfile: ../Dockerfile.j2
+    # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -43,7 +43,7 @@ platforms:
     groups:
       - kafka_broker
     image: geerlingguy/docker-centos7-ansible
-    dockerfile: ../Dockerfile.j2
+    # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -55,7 +55,7 @@ platforms:
     groups:
       - schema_registry
     image: geerlingguy/docker-centos7-ansible
-    dockerfile: ../Dockerfile.j2
+    # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -67,7 +67,7 @@ platforms:
     groups:
       - kafka_rest
     image: geerlingguy/docker-centos7-ansible
-    dockerfile: ../Dockerfile.j2
+    # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -79,7 +79,7 @@ platforms:
     groups:
       - kafka_connect
     image: geerlingguy/docker-centos7-ansible
-    dockerfile: ../Dockerfile.j2
+    # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -91,7 +91,7 @@ platforms:
     groups:
       - ksql
     image: geerlingguy/docker-centos7-ansible
-    dockerfile: ../Dockerfile.j2
+    # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -103,7 +103,7 @@ platforms:
     groups:
       - control_center
     image: geerlingguy/docker-centos7-ansible
-    dockerfile: ../Dockerfile.j2
+    # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -124,6 +124,8 @@ provisioner:
     group_vars:
       all:
         scenario_name: mtls-customcerts-rhel
+
+        confluent_server_enabled: false
 
         ssl_enabled: true
         ssl_mutual_auth_enabled: true

--- a/roles/confluent.test/molecule/mtls-customcerts-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/mtls-customcerts-rhel/molecule.yml
@@ -7,7 +7,6 @@ platforms:
     groups:
       - zookeeper
     image: geerlingguy/docker-centos7-ansible
-    # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -19,7 +18,6 @@ platforms:
     groups:
       - kafka_broker
     image: geerlingguy/docker-centos7-ansible
-    # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -31,7 +29,6 @@ platforms:
     groups:
       - kafka_broker
     image: geerlingguy/docker-centos7-ansible
-    # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -43,7 +40,6 @@ platforms:
     groups:
       - kafka_broker
     image: geerlingguy/docker-centos7-ansible
-    # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -55,7 +51,6 @@ platforms:
     groups:
       - schema_registry
     image: geerlingguy/docker-centos7-ansible
-    # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -67,7 +62,6 @@ platforms:
     groups:
       - kafka_rest
     image: geerlingguy/docker-centos7-ansible
-    # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -79,7 +73,6 @@ platforms:
     groups:
       - kafka_connect
     image: geerlingguy/docker-centos7-ansible
-    # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -91,7 +84,6 @@ platforms:
     groups:
       - ksql
     image: geerlingguy/docker-centos7-ansible
-    # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -103,7 +95,6 @@ platforms:
     groups:
       - control_center
     image: geerlingguy/docker-centos7-ansible
-    # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro


### PR DESCRIPTION
# Description

Molecule tests for the scenario 'mtls-customcerts-rhel' were failing on task:
`TASK [confluent.zookeeper : Install the Zookeeper Packages]` with error as `Error: confluent-server conflicts with confluent-kafka-2.12-5.5.7-1.noarch`
Enabling default value of 'confluent_server_enabled' (which is true) resolved the issue. 

Fixes # ([As part of 5.5.x release readiness](https://confluentinc.atlassian.net/browse/ANSIENG-963?atlOrigin=eyJpIjoiYjZhOTEyNGUwYzgxNGRhMjllNGVkZmMzNWRlMDdiNWYiLCJwIjoiaiJ9))

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

`molecule --debug test -s mtls-customcerts-rhel` gives all pass/success.


**Test Configuration**: molecule run for scenario mtls-customcerts-rhel on 5.5.x


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible