### PR TITLE
Fix connector name in 'verify' for scenario 'rbac-mtls-rhel'

### DIFF
--- a/roles/confluent.test/molecule/rbac-mtls-rhel/verify.yml
+++ b/roles/confluent.test/molecule/rbac-mtls-rhel/verify.yml
@@ -107,7 +107,7 @@
       shell: |
         curl -k -X PUT https://localhost:8083/connectors/conn1/config \
           -H "Content-Type: application/json" -u mds:password \
-          -d '{"connector.class": "org.apache.kafka.connect.file.FileStreamSinkConnector",
+          -d '{"connector.class": "org.apache.kafka.connect.tools.VerifiableSinkConnector",
           "tasks.max": "1",
           "topics": "${secret:conn1:topic}",
           "file": "/tmp/file-sink-test.txt",


### PR DESCRIPTION
# Description

'Verify' step in molecule tests of scenario 'rbac-mtls-rhel' fails on task `Create connector`
Issue is resolved with the updated name of the connector. 

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

`molecule --debug test -s rbac-mtls-rhel` on branch 5.5.x gives all pass/success.


**Test Configuration**: 


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible