### PR TITLE
Corrected password for trust store access for LDAP configuration.

### DIFF
--- a/roles/confluent.test/molecule/rbac-mtls-provided-ubuntu/molecule.yml
+++ b/roles/confluent.test/molecule/rbac-mtls-provided-ubuntu/molecule.yml
@@ -186,7 +186,7 @@ provisioner:
           ldap.java.naming.provider.url=ldaps://ldap1:636
           ldap.java.naming.security.protocol=SSL
           ldap.ssl.truststore.location=/var/ssl/private/kafka_broker.truststore.jks
-          ldap.ssl.truststore.password=confluenttruststorepass
+          ldap.ssl.truststore.password=truststorepass
           ldap.java.naming.security.principal=uid=mds,OU=rbac,DC=example,DC=com
           ldap.java.naming.security.credentials=password
           ldap.java.naming.security.authentication=simple


### PR DESCRIPTION
# Description

This PR corrects a bug in the 5.5.x molecule scenario rbac-mtls-provided-ubuntu.  The LDAP password for accessing the trust store to authentication was not set correctly.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This has been validated by running the rbac-mtls-provided-ubuntu scenario on the 5.5.x and validating that verification passes.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible