### PR TITLE
Disable fips on mtls-java11-rhel

### DIFF
--- a/roles/confluent.test/molecule/mtls-java11-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/mtls-java11-rhel/molecule.yml
@@ -97,8 +97,6 @@ provisioner:
 
         redhat_java_package_name: java-11-openjdk
 
-        fips_enabled: true
-
 verifier:
   name: ansible
 lint: |


### PR DESCRIPTION
# Description

Disabled fips to make the scenrio 'mtls-java11-rhel' work properly since fips is not supported with java11 as per the docs [here](https://docs.confluent.io/ansible/current/ansible-encrypt.html#configure-for-fips).

Fixes # (6.0.x release readiness)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

`molecule test -s mtls-java11-rhel` on 6.0.x gave all pass/success.


**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible