### PR TITLE
Audit logs test scenario update

### DIFF
--- a/roles/confluent.kafka_broker/tasks/rbac_rolebindings.yml
+++ b/roles/confluent.kafka_broker/tasks/rbac_rolebindings.yml
@@ -31,7 +31,7 @@
 # confluent iam rolebinding create --principal User:<audit-log-admin> --role ResourceOwner --resource Topic:confluent-audit-log-events --prefix --cluster-name audit_logs
 - name: Grant Audit Logs Principal ResourceOwner on confluent-audit-log-events Prefixed Topics
   uri:
-    url: "http://mds-kafka-broker1:8090/security/1.0/principals/User:{{audit_logs_destination_principal}}/roles/ResourceOwner/bindings"
+    url: "{{mds_bootstrap_server_urls.split(',')[0]}}/security/1.0/principals/User:{{audit_logs_destination_principal}}/roles/ResourceOwner/bindings"
     method: POST
     validate_certs: false
     force_basic_auth: true
@@ -51,13 +51,13 @@
           "patternType":"PREFIXED"
         }]
       }
-    status_code: 200
+    status_code: [200, 204]
   when: audit_logs_destination_enabled|bool and not ansible_check_mode
 
 # confluent iam rolebinding create --principal User:<audit-log-writer> --role DeveloperWrite --resource Topic:confluent-audit-log-events --prefix --cluster-name audit_logs
 - name: Grant Audit Logs Principal DeveloperWrite on confluent-audit-log-events Prefixed Topics
   uri:
-    url: "http://mds-kafka-broker1:8090/security/1.0/principals/User:{{audit_logs_destination_principal}}/roles/DeveloperWrite/bindings"
+    url: "{{mds_bootstrap_server_urls.split(',')[0]}}/security/1.0/principals/User:{{audit_logs_destination_principal}}/roles/DeveloperWrite/bindings"
     method: POST
     validate_certs: false
     force_basic_auth: true
@@ -77,5 +77,5 @@
           "patternType":"PREFIXED"
         }]
       }
-    status_code: 200
+    status_code: [200, 204]
   when: audit_logs_destination_enabled|bool and not ansible_check_mode

--- a/roles/confluent.kafka_broker/tasks/rbac_rolebindings.yml
+++ b/roles/confluent.kafka_broker/tasks/rbac_rolebindings.yml
@@ -51,7 +51,9 @@
           "patternType":"PREFIXED"
         }]
       }
-    status_code: [200, 204]
+    status_code:
+      - 200
+      - 204
   when: audit_logs_destination_enabled|bool and not ansible_check_mode
 
 # confluent iam rolebinding create --principal User:<audit-log-writer> --role DeveloperWrite --resource Topic:confluent-audit-log-events --prefix --cluster-name audit_logs
@@ -77,5 +79,7 @@
           "patternType":"PREFIXED"
         }]
       }
-    status_code: [200, 204]
+    status_code:
+      - 200
+      - 204
   when: audit_logs_destination_enabled|bool and not ansible_check_mode

--- a/roles/confluent.kafka_broker/tasks/set_principal.yml
+++ b/roles/confluent.kafka_broker/tasks/set_principal.yml
@@ -48,8 +48,3 @@
     - listener['sasl_protocol'] | default(sasl_protocol) | normalize_sasl_protocol == 'none'
     - listener['ssl_enabled'] | default(ssl_enabled) | bool
     - listener['ssl_mutual_auth_enabled'] | default(ssl_mutual_auth_enabled) | bool
-
-- name: Validate that auth is set for RBAC on internal listener
-  fail:
-    msg: "Role Based Access Control (RBAC) requires that an authorization mechanism is set on the internal listener, please review Confluent documentation for further details."
-  when: kafka_broker_principal is undefined

--- a/roles/confluent.test/molecule/rbac-mds-mtls-custom-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/rbac-mds-mtls-custom-rhel/molecule.yml
@@ -235,6 +235,7 @@ provisioner:
           - user1
 
       mds:
+        kafka_broker_cluster_name: mds
         audit_logs_destination_enabled: true
         audit_logs_destination_bootstrap_servers: kafka-broker1:9091,kafka-broker2:9091,kafka-broker3:9091
         audit_logs_destination_kafka_cluster_name: mds
@@ -262,6 +263,7 @@ provisioner:
           ldap.user.object.class: account
 
       cluster2:
+        kafka_broker_cluster_name: audit_logs
         external_mds_enabled: true
         kafka_broker_rest_ssl_enabled: true
         mds_broker_bootstrap_servers: mds-kafka-broker1:9093,mds-kafka-broker2:9093


### PR DESCRIPTION
# Description

This PR corrects the following:

1. Updates the rbac-mds-mtls-custom-rhel scenario to use cluster names to test audit logging properly
2. Removes hardcoded URL paths for setting RBAC permissions on audit logs
3. Added both 200 and 204 codes as acceptable responses for RBAC permission creation for audit logs.
3. Removes a check for the user being set on the internal listener due to inconsistent performance.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This has been validated by running the  rbac-mds-mtls-custom-rhel scenario with full verification.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible