### PR TITLE
Remove internal listener principal check, due to inconsistent behaviour.

### DIFF
--- a/roles/confluent.kafka_broker/tasks/set_principal.yml
+++ b/roles/confluent.kafka_broker/tasks/set_principal.yml
@@ -48,8 +48,3 @@
     - listener['sasl_protocol'] | default(sasl_protocol) | normalize_sasl_protocol == 'none'
     - listener['ssl_enabled'] | default(ssl_enabled) | bool
     - listener['ssl_mutual_auth_enabled'] | default(ssl_mutual_auth_enabled) | bool
-
-- name: Validate that auth is set for RBAC on internal listener
-  fail:
-    msg: "Role Based Access Control (RBAC) requires that an authorization mechanism is set on the internal listener, please review Confluent documentation for further details."
-  when: kafka_broker_principal is undefined


### PR DESCRIPTION
# Description

This PR removes a check on the internal listener when RBAC is enabled, to confirm a principal is set.  Unfortunately this code behaves inconsistently for an unknown reason, thus we are removing it for now.


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This has been validated by running the rbac-mds-mtls-rhel scenario and validating it passes.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible