### PR TITLE
61x kafka connect replicator plain kerberos rhel

### DIFF
--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -14,7 +14,7 @@ Default:  6.1.3
 
 ### mask_sensitive_logs
 
-Boolean to mask secrets in playbook output
+Boolean to mask secrets in playbook output, defaults to true
 
 Default:  "{{mask_secrets}}"
 
@@ -270,9 +270,9 @@ Default:  "/usr/local/bin/confluent"
 
 ### confluent_cli_version
 
-Confluent CLI version to download (e.g. "1.9.0"). By default is the latest version
+Confluent CLI version to download (e.g. "1.9.0"). Support matrix https://docs.confluent.io/platform/current/installation/versions-interoperability.html#confluent-cli
 
-Default:  latest
+Default:  1.43.0
 
 ***
 
@@ -776,7 +776,7 @@ Default:  8080
 
 Path on Ansible Controller for Kafka Broker jmx config file. Only necessary to set for custom config.
 
-Default:  kafka.yml
+Default:  kafka.yml.j2
 
 ***
 
@@ -2854,7 +2854,7 @@ Default:  ""
 
 ### kafka_connect_replicator_keystore_storepass
 
-The password for the Kafka Connect Replicator TLS keystore.  Defaults to confluentkeystorestorepass.
+The password for the Kafka Connect Replicator TLS keystore.
 
 Default:  ""
 
@@ -3046,7 +3046,7 @@ Default:  "{{ kafka_connect_replicator_truststore_storepass }}"
 
 ### kafka_connect_replicator_consumer_keystore_storepass
 
-The password for the Kafka Connect Replicator Consumer TLS keystore.
+The password for the Kafka Connect Replicator Consumer TLS keystore. Defaults to match kafka_connect_replicator_keystore_storepass.
 
 Default:  "{{  kafka_connect_replicator_keystore_storepass }}"
 

--- a/roles/confluent.kafka_broker/tasks/set_principal.yml
+++ b/roles/confluent.kafka_broker/tasks/set_principal.yml
@@ -48,8 +48,3 @@
     - listener['sasl_protocol'] | default(sasl_protocol) | normalize_sasl_protocol == 'none'
     - listener['ssl_enabled'] | default(ssl_enabled) | bool
     - listener['ssl_mutual_auth_enabled'] | default(ssl_mutual_auth_enabled) | bool
-
-# - name: Validate that auth is set for RBAC on internal listener
-#   fail:
-#     msg: "Role Based Access Control (RBAC) requires that an authorization mechanism is set on the internal listener, please review Confluent documentation for further details."
-#   when: kafka_broker_principal is undefined

--- a/roles/confluent.kafka_broker/tasks/set_principal.yml
+++ b/roles/confluent.kafka_broker/tasks/set_principal.yml
@@ -49,7 +49,7 @@
     - listener['ssl_enabled'] | default(ssl_enabled) | bool
     - listener['ssl_mutual_auth_enabled'] | default(ssl_mutual_auth_enabled) | bool
 
-- name: Validate that auth is set for RBAC on internal listener
-  fail:
-    msg: "Role Based Access Control (RBAC) requires that an authorization mechanism is set on the internal listener, please review Confluent documentation for further details."
-  when: kafka_broker_principal is undefined
+# - name: Validate that auth is set for RBAC on internal listener
+#   fail:
+#     msg: "Role Based Access Control (RBAC) requires that an authorization mechanism is set on the internal listener, please review Confluent documentation for further details."
+#   when: kafka_broker_principal is undefined

--- a/roles/confluent.test/molecule/kafka-connect-replicator-plain-kerberos-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/kafka-connect-replicator-plain-kerberos-rhel/molecule.yml
@@ -189,6 +189,9 @@ provisioner:
         control_center_ldap_user: control_center
         control_center_ldap_password: password
 
+        kafka_connect_replicator_ldap_user: replicator
+        kafka_connect_replicator_ldap_password: password
+
         rbac_component_additional_system_admins:
           - user1
 
@@ -198,8 +201,11 @@ provisioner:
           kdc_hostname: mds-kerberos1
           admin_hostname: mds-kerberos1
 
-
       mds:
+        ssl_enabled: true
+        ssl_custom_certs: true
+        sasl_protocol: plain
+
         _sasl_plain_users:
           admin:
             principal: admin
@@ -210,9 +216,9 @@ provisioner:
           kafka_connect_replicator:
             principal: kafka_connect_replicator
             password: kafka_connect_replicator-secret
-        sasl_protocol: plain
-        ssl_enabled: true
-        ssl_custom_certs: true
+        
+        kafka_broker_cluster_name: mds
+
         # Paths relative to all.yml
         ssl_ca_cert_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/ca.crt"
         ssl_signed_cert_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
@@ -237,22 +243,29 @@ provisioner:
           ldap.group.member.attribute.pattern: CN=(.*),OU=rbac,DC=example,DC=com
           ldap.user.object.class: account
 
-
-
       cluster2:
         ssl_enabled: true
         ssl_custom_certs: true
-        sasl_protocol: plain
+        sasl_protocol: kerberos
+
+        kafka_broker_cluster_name: destination_cluster
+
+        kafka_broker_custom_listeners:
+          client_listener:
+            ssl_enabled: false
+            ssl_mutual_auth_enabled: false
+            sasl_protocol: kerberos
+            name: CLIENT
+            port: 9093
 
         external_mds_enabled: true
-
         mds_broker_bootstrap_servers: mds-kafka-broker1:9093,mds-kafka-broker2:9093
         mds_bootstrap_server_urls: https://mds-kafka-broker1:8090,https://mds-kafka-broker2:8090
 
         mds_broker_listener:
           ssl_enabled: true
           ssl_mutual_auth_enabled: true
-          sasl_protocol: none
+          sasl_protocol: plain
 
         # Paths relative to all.yml
         ssl_ca_cert_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/ca.crt"
@@ -272,9 +285,10 @@ provisioner:
 
         kafka_connect_replicator_listener:
           ssl_enabled: true
-          ssl_mutual_auth_enabled: false
-          sasl_protocol: kerberos
+          ssl_mutual_auth_enabled: true
+          sasl_protocol: oauth
 
+        kafka_connect_replicator_cluster_name: replicator
         kafka_connect_replicator_white_list: test-replicator-source
         kafka_connect_replicator_bootstrap_servers: kafka-broker1:9092
         kafka_connect_replicator_kerberos_principal: "replicator/kafka-connect-replicator1.confluent@{{kerberos.realm | upper}}"
@@ -282,48 +296,61 @@ provisioner:
         kafka_connect_replicator_ssl_ca_cert_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/ca.crt"
         kafka_connect_replicator_ssl_cert_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
         kafka_connect_replicator_ssl_key_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-key.pem"
+        kafka_connect_replicator_truststore_storepass: confluenttruststorepass
+        kafka_connect_replicator_keystore_storepass: confluentkeystorestorepass
         kafka_connect_replicator_ssl_key_password: keypass
 
+        kakfa_connect_replicator_rbac_enabled: true
+        kafka_connect_replicator_erp_tls_enabled: false
+        kafka_connect_replicator_erp_host: https://mds-kafka-broker1:8090,https://mds-kafka-broker2:8090
+        kafka_connect_replicator_erp_admin_user: mds
+        kafka_connect_replicator_erp_admin_password: password
+        kafka_connect_replicator_kafka_cluster_name: destination_cluster
+        kafka_connect_replicator_erp_pem_file: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/public.pem"
+
         kafka_connect_replicator_consumer_listener:
-          ssl_enabled: true
+          ssl_enabled: false
           ssl_mutual_auth_enabled: false
-          sasl_protocol: plain
+          sasl_protocol: oauth
 
         kafka_connect_replicator_consumer_bootstrap_servers: mds-kafka-broker1:9092
-        kafka_connect_replicator_consumer_ssl_ca_cert_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/ca.crt"
-        kafka_connect_replicator_consumer_ssl_cert_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
-        kafka_connect_replicator_consumer_ssl_key_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-key.pem"
-        kafka_connect_replicator_consumer_ssl_key_password: keypass
         kafka_connect_replicator_consumer_custom_properties:
           client.id: consumer-test
 
+        kakfa_connect_replicator_consumer_rbac_enabled: true
+        kafka_connect_replicator_consumer_erp_tls_enabled: false
+        kafka_connect_replicator_consumer_erp_host: https://mds-kafka-broker1:8090,https://mds-kafka-broker2:8090
+        kafka_connect_replicator_consumer_erp_admin_user: mds
+        kafka_connect_replicator_consumer_erp_admin_password: password
+        kafka_connect_replicator_consumer_kafka_cluster_name: mds
+        kafka_connect_replicator_consumer_erp_pem_file: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/public.pem"
+        
+
         kafka_connect_replicator_producer_listener:
           ssl_enabled: true
-          ssl_mutual_auth_enabled: false
-          sasl_protocol: kerberos
+          ssl_mutual_auth_enabled: true
+          sasl_protocol: oauth
 
         kafka_connect_replicator_producer_bootstrap_servers: kafka-broker1:9092
-        kafka_connect_replicator_producer_kerberos_principal: "replicator/kafka-connect-replicator1.confluent@{{kerberos.realm | upper}}"
-        kafka_connect_replicator_producer_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/kafka-connect-replicator1.keytab"
-        kafka_connect_replicator_producer_ssl_ca_cert_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/ca.crt"
-        kafka_connect_replicator_producer_ssl_cert_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
-        kafka_connect_replicator_producer_ssl_key_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-key.pem"
-        kafka_connect_replicator_producer_ssl_key_password: keypass
+        # kafka_connect_replicator_producer_ssl_ca_cert_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/ca.crt"
+        # kafka_connect_replicator_producer_ssl_cert_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
+        # kafka_connect_replicator_producer_ssl_key_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-key.pem"
+        # kafka_connect_replicator_producer_ssl_key_password: keypass
         kafka_connect_replicator_producer_custom_properties:
           client.id: producer-test
 
         kafka_connect_replicator_monitoring_interceptor_listener:
           ssl_enabled: true
-          ssl_mutual_auth_enabled: false
-          sasl_protocol: kerberos
+          ssl_mutual_auth_enabled: true
+          sasl_protocol: oauth
 
         kafka_connect_replicator_monitoring_interceptor_bootstrap_servers: kafka-broker1:9092
         kafka_connect_replicator_monitoring_interceptor_kerberos_principal: "replicator/kafka-connect-replicator1.confluent@{{kerberos.realm | upper}}"
         kafka_connect_replicator_monitoring_interceptor_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/kafka-connect-replicator1.keytab"
-        kafka_connect_replicator_monitoring_interceptor_ssl_ca_cert_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/ca.crt"
-        kafka_connect_replicator_monitoring_interceptor_ssl_cert_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
-        kafka_connect_replicator_monitoring_interceptor_ssl_key_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-key.pem"
-        kafka_connect_replicator_monitoring_interceptor_ssl_key_password: keypass
+        # kafka_connect_replicator_monitoring_interceptor_ssl_ca_cert_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/ca.crt"
+        # kafka_connect_replicator_monitoring_interceptor_ssl_cert_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
+        # kafka_connect_replicator_monitoring_interceptor_ssl_key_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-key.pem"
+        # kafka_connect_replicator_monitoring_interceptor_ssl_key_password: keypass
 
       ldap_server:
         ldaps_enabled: true
@@ -372,6 +399,10 @@ provisioner:
             password: user1p
             uid: 9992
             guid: 92
+          - username: "{{kafka_connect_replicator_ldap_user}}"
+            password: "{{kafka_connect_replicator_ldap_password}}"
+            uid: 9991
+            guid: 91
 
       kerberos_server:
         realm_name: "{{ kerberos.realm | upper }}"

--- a/roles/confluent.test/molecule/kafka-connect-replicator-plain-kerberos-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/kafka-connect-replicator-plain-kerberos-rhel/molecule.yml
@@ -6,18 +6,6 @@
 driver:
   name: docker
 platforms:
-  - name: mds-ldap1
-    hostname: mds-ldap1.confluent
-    groups:
-      - ldap_server
-    image: geerlingguy/docker-centos7-ansible
-    dockerfile: ../Dockerfile.j2
-    command: ""
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
-    networks:
-      - name: confluent
   - name: mds-kerberos1
     hostname: mds-kerberos1.confluent
     groups:
@@ -158,54 +146,18 @@ provisioner:
       all:
         scenario_name: kafka-connect-replicator-plain-kerberos-rhel
 
-        rbac_enabled: true
-        create_mds_certs: false
-        token_services_public_pem_file: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/public.pem"
-        token_services_private_pem_file: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/tokenKeypair.pem"
-
-        kafka_broker_custom_listeners:
-          client_listener:
-            name: CLIENT
-            port: 9093
-
-        mds_super_user: mds
-        mds_super_user_password: password
-
-        kafka_broker_ldap_user: kafka_broker
-        kafka_broker_ldap_password: password
-
-        schema_registry_ldap_user: schema_registry
-        schema_registry_ldap_password: password
-
-        kafka_connect_ldap_user: kafka_connect
-        kafka_connect_ldap_password: password
-
-        ksql_ldap_user: ksql
-        ksql_ldap_password: password
-
-        kafka_rest_ldap_user: kafka_rest
-        kafka_rest_ldap_password: password
-
-        control_center_ldap_user: control_center
-        control_center_ldap_password: password
-
-        kafka_connect_replicator_ldap_user: replicator
-        kafka_connect_replicator_ldap_password: password
-
-        rbac_component_additional_system_admins:
-          - user1
-
         kerberos_kafka_broker_primary: kafka
         kerberos:
           realm: realm.example.com
           kdc_hostname: mds-kerberos1
           admin_hostname: mds-kerberos1
 
-      mds:
-        ssl_enabled: true
-        ssl_custom_certs: true
-        sasl_protocol: plain
+        zookeeper_kerberos_principal: "zookeeper/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
+        kafka_broker_kerberos_principal: "{{kerberos_kafka_broker_primary}}/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
+        zookeeper_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/zookeeper-{{inventory_hostname}}.keytab"
+        kafka_broker_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/kafka_broker-{{inventory_hostname}}.keytab"
 
+      mds:
         _sasl_plain_users:
           admin:
             principal: admin
@@ -216,55 +168,28 @@ provisioner:
           kafka_connect_replicator:
             principal: kafka_connect_replicator
             password: kafka_connect_replicator-secret
-        
-        kafka_broker_cluster_name: mds
-
+        sasl_protocol: plain
+        ssl_enabled: true
+        ssl_custom_certs: true
         # Paths relative to all.yml
         ssl_ca_cert_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/ca.crt"
         ssl_signed_cert_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
         ssl_key_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-key.pem"
         ssl_key_password: keypass
 
-        kafka_broker_custom_properties:
-          ldap.java.naming.factory.initial: com.sun.jndi.ldap.LdapCtxFactory
-          ldap.com.sun.jndi.ldap.read.timeout: 3000
-          ldap.java.naming.provider.url: ldaps://mds-ldap1:636
-          ldap.java.naming.security.protocol: SSL
-          ldap.ssl.truststore.location: /var/ssl/private/kafka_broker.truststore.jks
-          ldap.ssl.truststore.password: confluenttruststorepass
-          ldap.java.naming.security.principal: uid=mds,OU=rbac,DC=example,DC=com
-          ldap.java.naming.security.credentials: password
-          ldap.java.naming.security.authentication: simple
-          ldap.user.search.base: OU=rbac,DC=example,DC=com
-          ldap.group.search.base: OU=rbac,DC=example,DC=com
-          ldap.user.name.attribute: uid
-          ldap.user.memberof.attribute.pattern: CN=(.*),OU=rbac,DC=example,DC=com
-          ldap.group.name.attribute: cn
-          ldap.group.member.attribute.pattern: CN=(.*),OU=rbac,DC=example,DC=com
-          ldap.user.object.class: account
-
       cluster2:
         ssl_enabled: true
         ssl_custom_certs: true
         sasl_protocol: kerberos
 
-        kafka_broker_cluster_name: destination_cluster
-
-        kafka_broker_custom_listeners:
-          client_listener:
-            ssl_enabled: false
-            ssl_mutual_auth_enabled: false
-            sasl_protocol: kerberos
-            name: CLIENT
-            port: 9093
-
         external_mds_enabled: true
+
         mds_broker_bootstrap_servers: mds-kafka-broker1:9093,mds-kafka-broker2:9093
         mds_bootstrap_server_urls: https://mds-kafka-broker1:8090,https://mds-kafka-broker2:8090
 
         mds_broker_listener:
           ssl_enabled: true
-          ssl_mutual_auth_enabled: true
+          ssl_mutual_auth_enabled: false
           sasl_protocol: plain
 
         # Paths relative to all.yml
@@ -285,10 +210,9 @@ provisioner:
 
         kafka_connect_replicator_listener:
           ssl_enabled: true
-          ssl_mutual_auth_enabled: true
-          sasl_protocol: oauth
+          ssl_mutual_auth_enabled: false
+          sasl_protocol: kerberos
 
-        kafka_connect_replicator_cluster_name: replicator
         kafka_connect_replicator_white_list: test-replicator-source
         kafka_connect_replicator_bootstrap_servers: kafka-broker1:9092
         kafka_connect_replicator_kerberos_principal: "replicator/kafka-connect-replicator1.confluent@{{kerberos.realm | upper}}"
@@ -296,113 +220,50 @@ provisioner:
         kafka_connect_replicator_ssl_ca_cert_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/ca.crt"
         kafka_connect_replicator_ssl_cert_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
         kafka_connect_replicator_ssl_key_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-key.pem"
+        kafka_connect_replicator_ssl_key_password: keypass
         kafka_connect_replicator_truststore_storepass: confluenttruststorepass
         kafka_connect_replicator_keystore_storepass: confluentkeystorestorepass
-        kafka_connect_replicator_ssl_key_password: keypass
-
-        kakfa_connect_replicator_rbac_enabled: true
-        kafka_connect_replicator_erp_tls_enabled: false
-        kafka_connect_replicator_erp_host: https://mds-kafka-broker1:8090,https://mds-kafka-broker2:8090
-        kafka_connect_replicator_erp_admin_user: mds
-        kafka_connect_replicator_erp_admin_password: password
-        kafka_connect_replicator_kafka_cluster_name: destination_cluster
-        kafka_connect_replicator_erp_pem_file: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/public.pem"
 
         kafka_connect_replicator_consumer_listener:
-          ssl_enabled: false
+          ssl_enabled: true
           ssl_mutual_auth_enabled: false
-          sasl_protocol: oauth
+          sasl_protocol: plain
 
         kafka_connect_replicator_consumer_bootstrap_servers: mds-kafka-broker1:9092
+        kafka_connect_replicator_consumer_ssl_ca_cert_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/ca.crt"
+        kafka_connect_replicator_consumer_ssl_cert_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
+        kafka_connect_replicator_consumer_ssl_key_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-key.pem"
+        kafka_connect_replicator_consumer_ssl_key_password: keypass
         kafka_connect_replicator_consumer_custom_properties:
           client.id: consumer-test
 
-        kakfa_connect_replicator_consumer_rbac_enabled: true
-        kafka_connect_replicator_consumer_erp_tls_enabled: false
-        kafka_connect_replicator_consumer_erp_host: https://mds-kafka-broker1:8090,https://mds-kafka-broker2:8090
-        kafka_connect_replicator_consumer_erp_admin_user: mds
-        kafka_connect_replicator_consumer_erp_admin_password: password
-        kafka_connect_replicator_consumer_kafka_cluster_name: mds
-        kafka_connect_replicator_consumer_erp_pem_file: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/public.pem"
-        
-
         kafka_connect_replicator_producer_listener:
           ssl_enabled: true
-          ssl_mutual_auth_enabled: true
-          sasl_protocol: oauth
+          ssl_mutual_auth_enabled: false
+          sasl_protocol: kerberos
 
         kafka_connect_replicator_producer_bootstrap_servers: kafka-broker1:9092
-        # kafka_connect_replicator_producer_ssl_ca_cert_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/ca.crt"
-        # kafka_connect_replicator_producer_ssl_cert_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
-        # kafka_connect_replicator_producer_ssl_key_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-key.pem"
-        # kafka_connect_replicator_producer_ssl_key_password: keypass
+        kafka_connect_replicator_producer_kerberos_principal: "replicator/kafka-connect-replicator1.confluent@{{kerberos.realm | upper}}"
+        kafka_connect_replicator_producer_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/kafka-connect-replicator1.keytab"
+        kafka_connect_replicator_producer_ssl_ca_cert_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/ca.crt"
+        kafka_connect_replicator_producer_ssl_cert_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
+        kafka_connect_replicator_producer_ssl_key_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-key.pem"
+        kafka_connect_replicator_producer_ssl_key_password: keypass
         kafka_connect_replicator_producer_custom_properties:
           client.id: producer-test
 
         kafka_connect_replicator_monitoring_interceptor_listener:
           ssl_enabled: true
-          ssl_mutual_auth_enabled: true
-          sasl_protocol: oauth
+          ssl_mutual_auth_enabled: false
+          sasl_protocol: kerberos
 
         kafka_connect_replicator_monitoring_interceptor_bootstrap_servers: kafka-broker1:9092
         kafka_connect_replicator_monitoring_interceptor_kerberos_principal: "replicator/kafka-connect-replicator1.confluent@{{kerberos.realm | upper}}"
         kafka_connect_replicator_monitoring_interceptor_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/kafka-connect-replicator1.keytab"
-        # kafka_connect_replicator_monitoring_interceptor_ssl_ca_cert_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/ca.crt"
-        # kafka_connect_replicator_monitoring_interceptor_ssl_cert_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
-        # kafka_connect_replicator_monitoring_interceptor_ssl_key_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-key.pem"
-        # kafka_connect_replicator_monitoring_interceptor_ssl_key_password: keypass
-
-      ldap_server:
-        ldaps_enabled: true
-        ldaps_custom_certs: true
-        ssl_custom_certs: true
-        ssl_ca_cert_filepath: "{{scenario_name}}/generated_ssl_files/ca.crt"
-        ssl_signed_cert_filepath: "{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
-        ssl_key_filepath: "{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-key.pem"
-
-        ldap_admin_password: ldppassword
-
-        ldap_rbac_group: rbac
-        ldap_dc: example
-        ldap_dc_extension: com
-
-        ldap_users:
-          - username: "{{kafka_broker_ldap_user}}"
-            password: "{{kafka_broker_ldap_password}}"
-            uid: 9999
-            guid: 99
-          - username: "{{schema_registry_ldap_user}}"
-            password: "{{schema_registry_ldap_password}}"
-            uid: 9998
-            guid: 98
-          - username: "{{kafka_connect_ldap_user}}"
-            password: "{{kafka_connect_ldap_password}}"
-            uid: 9997
-            guid: 97
-          - username: "{{ksql_ldap_user}}"
-            password: "{{ksql_ldap_password}}"
-            uid: 9996
-            guid: 96
-          - username: "{{control_center_ldap_user}}"
-            password: "{{control_center_ldap_password}}"
-            uid: 9995
-            guid: 95
-          - username: "{{kafka_rest_ldap_user}}"
-            password: "{{kafka_rest_ldap_password}}"
-            uid: 9994
-            guid: 94
-          - username: "{{mds_super_user}}"
-            password: "{{mds_super_user_password}}"
-            uid: 9993
-            guid: 93
-          - username: user1
-            password: user1p
-            uid: 9992
-            guid: 92
-          - username: "{{kafka_connect_replicator_ldap_user}}"
-            password: "{{kafka_connect_replicator_ldap_password}}"
-            uid: 9991
-            guid: 91
+        kafka_connect_replicator_monitoring_interceptor_ssl_ca_cert_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/ca.crt"
+        kafka_connect_replicator_monitoring_interceptor_ssl_cert_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
+        kafka_connect_replicator_monitoring_interceptor_ssl_key_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-key.pem"
+        kafka_connect_replicator_monitoring_interceptor_ssl_key_password: keypass
 
       kerberos_server:
         realm_name: "{{ kerberos.realm | upper }}"

--- a/roles/confluent.test/molecule/rbac-kafka-connect-replicator-kerberos-mtls-custom-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/rbac-kafka-connect-replicator-kerberos-mtls-custom-rhel/molecule.yml
@@ -219,6 +219,7 @@ provisioner:
       cluster2:
         ssl_enabled: true
         ssl_mutual_auth_enabled: true
+        ssl_custom_certs: true
 
         kafka_broker_cluster_name: destination_cluster
 
@@ -230,20 +231,20 @@ provisioner:
             name: CLIENT
             port: 9093
 
-        ssl_custom_certs: true
+        external_mds_enabled: true
+        mds_broker_bootstrap_servers: mds-kafka-broker1:9093,mds-kafka-broker2:9093
+        mds_bootstrap_server_urls: http://mds-kafka-broker1:8090,http://mds-kafka-broker2:8090
+
+        mds_broker_listener:
+          ssl_enabled: false
+          ssl_mutual_auth_enabled: false
+          sasl_protocol: kerberos
+
         # Paths relative to all.yml
         ssl_ca_cert_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/ca.crt"
         ssl_signed_cert_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
         ssl_key_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-key.pem"
         ssl_key_password: keypass
-
-        external_mds_enabled: true
-        mds_broker_bootstrap_servers: mds-kafka-broker1:9093,mds-kafka-broker2:9093
-        mds_bootstrap_server_urls: http://mds-kafka-broker1:8090,http://mds-kafka-broker2:8090
-        mds_broker_listener:
-          ssl_enabled: false
-          ssl_mutual_auth_enabled: false
-          sasl_protocol: kerberos
 
       kafka_connect_replicator:
 
@@ -267,7 +268,6 @@ provisioner:
         kafka_connect_replicator_erp_host: http://mds-kafka-broker1:8090,http://mds-kafka-broker2:8090
         kafka_connect_replicator_erp_admin_user: mds
         kafka_connect_replicator_erp_admin_password: password
-        # kafka_connect_replicator_kafka_cluster_id: destination_cluster
         kafka_connect_replicator_kafka_cluster_name: destination_cluster
         kafka_connect_replicator_erp_pem_file: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/public.pem"
 

--- a/roles/confluent.test/molecule/rbac-kafka-connect-replicator-kerberos-mtls-custom-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/rbac-kafka-connect-replicator-kerberos-mtls-custom-rhel/molecule.yml
@@ -219,7 +219,6 @@ provisioner:
       cluster2:
         ssl_enabled: true
         ssl_mutual_auth_enabled: true
-        ssl_custom_certs: true
 
         kafka_broker_cluster_name: destination_cluster
 
@@ -231,20 +230,20 @@ provisioner:
             name: CLIENT
             port: 9093
 
-        external_mds_enabled: true
-        mds_broker_bootstrap_servers: mds-kafka-broker1:9093,mds-kafka-broker2:9093
-        mds_bootstrap_server_urls: http://mds-kafka-broker1:8090,http://mds-kafka-broker2:8090
-
-        mds_broker_listener:
-          ssl_enabled: false
-          ssl_mutual_auth_enabled: false
-          sasl_protocol: kerberos
-
+        ssl_custom_certs: true
         # Paths relative to all.yml
         ssl_ca_cert_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/ca.crt"
         ssl_signed_cert_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
         ssl_key_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-key.pem"
         ssl_key_password: keypass
+
+        external_mds_enabled: true
+        mds_broker_bootstrap_servers: mds-kafka-broker1:9093,mds-kafka-broker2:9093
+        mds_bootstrap_server_urls: http://mds-kafka-broker1:8090,http://mds-kafka-broker2:8090
+        mds_broker_listener:
+          ssl_enabled: false
+          ssl_mutual_auth_enabled: false
+          sasl_protocol: kerberos
 
       kafka_connect_replicator:
 
@@ -268,6 +267,7 @@ provisioner:
         kafka_connect_replicator_erp_host: http://mds-kafka-broker1:8090,http://mds-kafka-broker2:8090
         kafka_connect_replicator_erp_admin_user: mds
         kafka_connect_replicator_erp_admin_password: password
+        # kafka_connect_replicator_kafka_cluster_id: destination_cluster
         kafka_connect_replicator_kafka_cluster_name: destination_cluster
         kafka_connect_replicator_erp_pem_file: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/public.pem"
 

--- a/roles/confluent.variables/defaults/main.yml
+++ b/roles/confluent.variables/defaults/main.yml
@@ -1585,7 +1585,7 @@ kafka_connect_replicator_packages:
 ### The password for the Kafka Connect Replicator TLS truststore.
 kafka_connect_replicator_truststore_storepass: ""
 
-### The password for the Kafka Connect Replicator TLS keystore.  Defaults to confluentkeystorestorepass.
+### The password for the Kafka Connect Replicator TLS keystore.
 kafka_connect_replicator_keystore_storepass: ""
 
 kafka_connect_replicator_keystore_keypass: "{{ ssl_keystore_key_password if kafka_connect_replicator_ssl_provided_keystore_and_truststore|bool else kafka_connect_replicator_keystore_storepass }}"
@@ -1669,7 +1669,7 @@ kafka_connect_replicator_consumer_sasl_plain_password: "{{ sasl_plain_users_fina
 ### The password for the Kafka Connect Replicator Consumer TLS truststore.
 kafka_connect_replicator_consumer_truststore_storepass: "{{ kafka_connect_replicator_truststore_storepass }}"
 
-### The password for the Kafka Connect Replicator Consumer TLS keystore.
+### The password for the Kafka Connect Replicator Consumer TLS keystore. Defaults to match kafka_connect_replicator_keystore_storepass.
 kafka_connect_replicator_consumer_keystore_storepass: "{{  kafka_connect_replicator_keystore_storepass }}"
 
 kafka_connect_replicator_consumer_keystore_keypass: "{{ ssl_keystore_key_password if ssl_provided_keystore_and_truststore|bool else kafka_connect_replicator_consumer_keystore_storepass }}"


### PR DESCRIPTION
# Description

This PR updates the Kafka Connect Replicator Plain Kerberos RHEL scenario to properly run.  We needed to add additional properties for keystore and truststore passwords, remove rbac and ldap related properties as this scenario was introduced before RBAC support on replicator.

Fixes # (issue)

ansieng-985.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This Kafka Connect Replicator Plain Kerberos RHEL scenario  now completes and the verification produces and consumes data while it is transferred between clusters via replicator.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible