### PR TITLE
Update command to get cluster id from secured zookeeper

### DIFF
--- a/tasks/rbac_setup.yml
+++ b/tasks/rbac_setup.yml
@@ -19,8 +19,11 @@
   when: cluster_id_source | default('erp') == 'erp'
 
 - name: Get Kafka Cluster ID from Zookeeper
-  shell: /usr/bin/zookeeper-shell localhost:2181 get /cluster/id | grep version
-  delegate_to: "{{ groups['zookeeper'][0] }}"
+  shell: >
+      {{ binary_base_path }}/bin/zookeeper-shell {{ groups['zookeeper'][0] }}:{{zookeeper_client_port}} \
+      {% if zookeeper_ssl_enabled|bool %}-zk-tls-config-file {{ kafka_broker.zookeeper_tls_client_config_file \
+      if kafka_broker_secrets_protection_enabled else kafka_broker.config_file }}{% endif %} \
+      get /cluster/id | grep version
   register: zk_cluster_id_query
   when: cluster_id_source | default('erp') == 'zookeeper'
 


### PR DESCRIPTION
# Description

1. Removed hardcoded zookeeper port
2. Run the command kafka broker using zookeeper fqdn
3. Update the logic for secure zookeeper to include `-zk-tls-config-file`

Fixes # (RCCA-5206)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

` molecule --debug converge -s rbac-scram-custom-rhel ` removed the when condition for the task ` Get Kafka Cluster ID from Zookeeper` and added a debug messsage 
```
TASK [confluent.platform.common : Get Kafka Cluster ID from Zookeeper] *********
changed: [kafka-broker1]
changed: [kafka-broker3]
changed: [kafka-broker2]

TASK [confluent.platform.common : debug cluser id form zookeeper] **************
ok: [kafka-broker1] => {
    "msg": {
        "id": "xQMFtit3SUK3Z1jgEV09HA",
        "version": "1"
    }
}
ok: [kafka-broker2] => {
    "msg": {
        "id": "xQMFtit3SUK3Z1jgEV09HA",
        "version": "1"
    }
}
ok: [kafka-broker3] => {
    "msg": {
        "id": "xQMFtit3SUK3Z1jgEV09HA",
        "version": "1"
    }
}

```


**Test Configuration**:
Zookeeper is running in secure mode on port 2082

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible