### PR TITLE
Make upgrade script work with ansible collections

### DIFF
--- a/test_scripts/confluent-kafka-kerberos-customcerts-rhel-upgrade-550-current.sh
+++ b/test_scripts/confluent-kafka-kerberos-customcerts-rhel-upgrade-550-current.sh
@@ -10,9 +10,6 @@ export START_UPGRADE_VERSION=5.5
 
 export CURRENT_VERSION=true
 
-## If upgrading from 6.2.0 or later, this should be false as upgrade playbooks no longer exist.  Upgrades are handled via reconfiguration.
-export UPGRADE_PLAYBOOK=true
-
 ## Set to true if testing 6.0.0 or later.  Will run admin API upgrade.
 export ADMIN_API=false
 

--- a/test_scripts/cp-kafka-plain-rhel-upgrade-550-current.sh
+++ b/test_scripts/cp-kafka-plain-rhel-upgrade-550-current.sh
@@ -10,9 +10,6 @@ export START_UPGRADE_VERSION=5.5
 
 export CURRENT_VERSION=true
 
-## If upgrading from 6.2.0 or later, this should be false as upgrade playbooks no longer exist.  Upgrades are handled via reconfiguration.
-export UPGRADE_PLAYBOOK=true
-
 ## Set to true if testing 6.0.0 or later.  Will run admin API upgrade.
 export ADMIN_API=false
 

--- a/test_scripts/minor-release-plaintext-rhel-upgrade-540-54x.sh
+++ b/test_scripts/minor-release-plaintext-rhel-upgrade-540-54x.sh
@@ -12,9 +12,6 @@ export START_UPGRADE_VERSION=5.4
 export END_BRANCH=5.4.5-post
 export CURRENT_VERSION=false
 
-## If upgrading from 6.2.0 or later, this should be false as upgrade playbooks no longer exist.  Upgrades are handled via reconfiguration.
-export UPGRADE_PLAYBOOK=true
-
 ## Set to true if testing 6.0.0 or later.  Will run admin API upgrade.
 export ADMIN_API=false
 

--- a/test_scripts/minor-release-rbac-scram-custom-rhel-upgrade-550-55x.sh
+++ b/test_scripts/minor-release-rbac-scram-custom-rhel-upgrade-550-55x.sh
@@ -12,9 +12,6 @@ export START_UPGRADE_VERSION=5.5
 export END_BRANCH=5.5.6-post
 export CURRENT_VERSION=false
 
-## If upgrading from 6.2.0 or later, this should be false as upgrade playbooks no longer exist.  Upgrades are handled via reconfiguration.
-export UPGRADE_PLAYBOOK=true
-
 ## Set to true if testing 6.0.0 or later.  Will run admin API upgrade.
 export ADMIN_API=false
 

--- a/test_scripts/minor-release-rbac-scram-custom-rhel-upgrade-600-60x.sh
+++ b/test_scripts/minor-release-rbac-scram-custom-rhel-upgrade-600-60x.sh
@@ -12,9 +12,6 @@ export START_UPGRADE_VERSION=6.0
 export END_BRANCH=6.0.4-post
 export CURRENT_VERSION=false
 
-## If upgrading from 6.2.0 or later, this should be false as upgrade playbooks no longer exist.  Upgrades are handled via reconfiguration.
-export UPGRADE_PLAYBOOK=true
-
 ## Set to true if testing 6.0.0 or later.  Will run admin API upgrade.
 export ADMIN_API=true
 

--- a/test_scripts/minor-release-rbac-scram-custom-rhel-upgrade-610-61x.sh
+++ b/test_scripts/minor-release-rbac-scram-custom-rhel-upgrade-610-61x.sh
@@ -12,9 +12,6 @@ export START_UPGRADE_VERSION=6.1
 export END_BRANCH=6.1.3-post
 export CURRENT_VERSION=false
 
-## If upgrading from 6.2.0 or later, this should be false as upgrade playbooks no longer exist.  Upgrades are handled via reconfiguration.
-export UPGRADE_PLAYBOOK=true
-
 ## Set to true if testing 6.0.0 or later.  Will run admin API upgrade.
 export ADMIN_API=true
 

--- a/test_scripts/minor-release-rbac-scram-custom-rhel-upgrade-620-62x.sh
+++ b/test_scripts/minor-release-rbac-scram-custom-rhel-upgrade-620-62x.sh
@@ -12,9 +12,6 @@ export START_UPGRADE_VERSION=6.2
 export END_BRANCH=6.2.1-post
 export CURRENT_VERSION=false
 
-## If upgrading from 6.2.0 or later, this should be false as upgrade playbooks no longer exist.  Upgrades are handled via reconfiguration.
-export UPGRADE_PLAYBOOK=false
-
 ## Set to true if testing 6.0.0 or later.  Will run admin API upgrade.
 export ADMIN_API=true
 

--- a/test_scripts/mtls-customcerts-rhel-540-current.sh
+++ b/test_scripts/mtls-customcerts-rhel-540-current.sh
@@ -10,9 +10,6 @@ export START_UPGRADE_VERSION=5.4
 
 export CURRENT_VERSION=true
 
-## If upgrading from 6.2.0 or later, this should be false as upgrade playbooks no longer exist.  Upgrades are handled via reconfiguration.
-export UPGRADE_PLAYBOOK=true
-
 ## Set to true if testing 6.0.0 or later.  Will run admin API upgrade.
 export ADMIN_API=false
 

--- a/test_scripts/mtls-debian-540-current.sh
+++ b/test_scripts/mtls-debian-540-current.sh
@@ -10,9 +10,6 @@ export START_UPGRADE_VERSION=5.4
 
 export CURRENT_VERSION=true
 
-## If upgrading from 6.2.0 or later, this should be false as upgrade playbooks no longer exist.  Upgrades are handled via reconfiguration.
-export UPGRADE_PLAYBOOK=true
-
 ## Set to true if testing 6.0.0 or later.  Will run admin API upgrade.
 export ADMIN_API=false
 

--- a/test_scripts/plaintext-rhel-upgrade-540-current.sh
+++ b/test_scripts/plaintext-rhel-upgrade-540-current.sh
@@ -10,9 +10,6 @@ export START_UPGRADE_VERSION=5.4
 
 export CURRENT_VERSION=true
 
-## If upgrading from 6.2.0 or later, this should be false as upgrade playbooks no longer exist.  Upgrades are handled via reconfiguration.
-export UPGRADE_PLAYBOOK=true
-
 ## Set to true if testing 6.0.0 or later.  Will run admin API upgrade.
 export ADMIN_API=false
 

--- a/test_scripts/rbac-scram-custom-rhel-upgrade-550-current.sh
+++ b/test_scripts/rbac-scram-custom-rhel-upgrade-550-current.sh
@@ -10,9 +10,6 @@ export START_UPGRADE_VERSION=5.5
 
 export CURRENT_VERSION=true
 
-## If upgrading from 6.2.0 or later, this should be false as upgrade playbooks no longer exist.  Upgrades are handled via reconfiguration.
-export UPGRADE_PLAYBOOK=true
-
 ## Set to true if testing 6.0.0 or later.  Will run admin API upgrade.
 export ADMIN_API=false
 

--- a/test_scripts/rbac-scram-provided-debian-upgrade-550-current.sh
+++ b/test_scripts/rbac-scram-provided-debian-upgrade-550-current.sh
@@ -10,9 +10,6 @@ export START_UPGRADE_VERSION=5.5
 
 export CURRENT_VERSION=true
 
-## If upgrading from 6.2.0 or later, this should be false as upgrade playbooks no longer exist.  Upgrades are handled via reconfiguration.
-export UPGRADE_PLAYBOOK=true
-
 ## Set to true if testing 6.0.0 or later.  Will run admin API upgrade.
 export ADMIN_API=false
 

--- a/test_scripts/upgrade.sh
+++ b/test_scripts/upgrade.sh
@@ -27,15 +27,20 @@ echo "Checking out $START_BRANCH branch"
 git checkout $START_BRANCH
 
 ## Change to molecule directory on pre 7.0 branches
-
-cd roles/confluent.test/
+if [[ $START_BRANCH != 7* ]]
+then
+  cd roles/confluent.test/
+fi
 
 ## Run Molecule Converge on scenario
 echo "Running molecule converge on $SCENARIO_NAME"
 molecule converge -s $SCENARIO_NAME
 
 ## Change to base of cp-ansible
-cd ../..
+if [[ $START_BRANCH != 7* ]]
+then
+  cd ../..
+fi
 
 ## Checkout ending branch
 echo "Checkout $END_BRANCH branch"


### PR DESCRIPTION
# Description

This PR aims to solve ANSIENG-981 by

- Making script compatible to work with ansible collections, by using correct collections path and referring to playbooks in the collection way
- Resolve inventory file lookout by having a new env variable, which changes as per the start branch

Fixes # (ANSIENG-981)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested by running `bash cp-kafka-plain-rhel-upgrade-550-current.sh`, the upgrades start working.

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible