### PR TITLE
Remove deuplicate tasks from rbac_replicator_monitoring

### DIFF
--- a/roles/confluent.kafka_connect_replicator/tasks/rbac_replicator_monitoring.yml
+++ b/roles/confluent.kafka_connect_replicator/tasks/rbac_replicator_monitoring.yml
@@ -45,34 +45,7 @@
     status_code: 204
   when: (kafka_connect_replicator_monitoring_interceptors_enabled|bool) and (kafka_connect_replicator_monitoring_interceptor_kafka_cluster_id != "")
 
-- name: Grant connect user the DeveloperWrite role on Monitoring Interceptor Topic
-  uri:
-    url: "{{kafka_connect_replicator_monitoring_interceptor_erp_host.split(',')[0]}}/security/1.0/principals/User:{{kafka_connect_replicator_monitoring_interceptor_ldap_user}}/roles/DeveloperWrite/bindings"
-    method: POST
-    validate_certs: false
-    force_basic_auth: true
-    url_username: "{{kafka_connect_replicator_monitoring_interceptor_erp_admin_user}}"
-    url_password: "{{kafka_connect_replicator_monitoring_interceptor_erp_admin_password}}"
-    headers:
-      Content-Type: application/json
-    body_format: json
-    body: >
-      {
-        "scope": {
-          "clusterName": "{{ kafka_connect_replicator_monitoring_interceptor_kafka_cluster_name }}"
-        },
-        "resourcePatterns": [{
-          "resourceType": "Topic",
-          "name": "{{kafka_connect_replicator_monitoring_interceptor_final_properties['confluent.monitoring.interceptor.topic']}}",
-          "patternType":"LITERAL"
-        }]
-      }
-    status_code: 204
-  when: (kafka_connect_replicator_monitoring_interceptors_enabled|bool) and (kafka_connect_replicator_monitoring_interceptor_kafka_cluster_id != "")
-
-
 # The following block of URI calls sets up the permissions for replicator when cluster_name is used for the indetifier.
-
 - name: Grant connect user the DeveloperWrite role on Monitoring Interceptor Topic
   uri:
     url: "{{kafka_connect_replicator_monitoring_interceptor_erp_host.split(',')[0]}}/security/1.0/principals/User:{{kafka_connect_replicator_monitoring_interceptor_ldap_user}}/roles/DeveloperWrite/bindings"
@@ -89,32 +62,7 @@
         "scope": {
           "clusterName": "{{ kafka_connect_replicator_monitoring_interceptor_kafka_cluster_name }}"
         },
-            "resourcePatterns": [{
-          "resourceType": "Topic",
-          "name": "{{kafka_connect_replicator_monitoring_interceptor_final_properties['confluent.monitoring.interceptor.topic']}}",
-          "patternType":"LITERAL"
-        }]
-      }
-    status_code: 204
-  when: (kafka_connect_replicator_monitoring_interceptors_enabled|bool) and (kafka_connect_replicator_monitoring_interceptor_kafka_cluster_name != "")
-
-- name: Grant connect user the DeveloperWrite role on Monitoring Interceptor Topic
-  uri:
-    url: "{{kafka_connect_replicator_monitoring_interceptor_erp_host.split(',')[0]}}/security/1.0/principals/User:{{kafka_connect_replicator_monitoring_interceptor_ldap_user}}/roles/DeveloperWrite/bindings"
-    method: POST
-    validate_certs: false
-    force_basic_auth: true
-    url_username: "{{kafka_connect_replicator_monitoring_interceptor_erp_admin_user}}"
-    url_password: "{{kafka_connect_replicator_monitoring_interceptor_erp_admin_password}}"
-    headers:
-      Content-Type: application/json
-    body_format: json
-    body: >
-      {
-        "scope": {
-          "clusterName": "{{ kafka_connect_replicator_monitoring_interceptor_kafka_cluster_name }}"
-        },
-            "resourcePatterns": [{
+          "resourcePatterns": [{
           "resourceType": "Topic",
           "name": "{{kafka_connect_replicator_monitoring_interceptor_final_properties['confluent.monitoring.interceptor.topic']}}",
           "patternType":"LITERAL"


### PR DESCRIPTION
# Description

Remove duplicate and invalid tasks from rbac_replicator_rolebinding task

Fixes # (ANSIENG-1012)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

` molecule --debug converge -s rbac-kafka-connect-replicator-kerberos-mtls-custom-rhel`
```
TASK [confluent.kafka_connect_replicator : Create SSL Certificate Directory] ***
skipping: [kafka-connect-replicator1]

TASK [confluent.kafka_connect_replicator : Copy in MDS Public Pem File] ********
skipping: [kafka-connect-replicator1]

TASK [confluent.kafka_connect_replicator : Grant connect user the DeveloperWrite role on Monitoring Interceptor Topic] ***
skipping: [kafka-connect-replicator1]

TASK [confluent.kafka_connect_replicator : Grant connect user the DeveloperWrite role on Monitoring Interceptor Topic] ***
ok: [kafka-connect-replicator1]

```
**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible