### PR TITLE
Add client properties for secure mds

### DIFF
--- a/roles/confluent.common/tasks/rbac_setup.yml
+++ b/roles/confluent.common/tasks/rbac_setup.yml
@@ -18,8 +18,6 @@
     kafka_cluster_id: "{{ cluster_id_query.json.data[0].cluster_id }}"
   when: (cluster_id_source | default('erp') == 'erp') and not ansible_check_mode
 
-
-# TODO this will not work for Secure ZK or Archive installation method
 - name: Get Kafka Cluster ID from Zookeeper
   shell: >
       {{ binary_base_path }}/bin/zookeeper-shell {{ groups['zookeeper'][0] }}:{{zookeeper_client_port}} \

--- a/roles/confluent.variables/filter_plugins/filters.py
+++ b/roles/confluent.variables/filter_plugins/filters.py
@@ -215,11 +215,6 @@ class FilterModule(object):
             final_dict[config_prefix + 'ssl.keystore.password'] = str(keystore_storepass)
             final_dict[config_prefix + 'ssl.key.password'] = str(keystore_keypass)
 
-        if listener_dict.get('ssl_mutual_auth_enabled', default_ssl_mutual_auth_enabled):
-            final_dict[config_prefix + 'ssl.keystore.location'] = keystore_path
-            final_dict[config_prefix + 'ssl.keystore.password'] = str(keystore_storepass)
-            final_dict[config_prefix + 'ssl.key.password'] = str(keystore_keypass)
-
         if bouncy_castle_keystore:
             final_dict[config_prefix + 'ssl.keymanager.algorithm'] = 'PKIX'
             final_dict[config_prefix + 'ssl.trustmanager.algorithm'] = 'PKIX'

--- a/roles/confluent.variables/vars/main.yml
+++ b/roles/confluent.variables/vars/main.yml
@@ -298,10 +298,10 @@ kafka_broker_properties:
   embedded_rest_proxy_client:
     enabled: "{{ kafka_broker_rest_proxy_enabled }}"
     properties: "{{ kafka_broker_listeners['internal'] | client_properties(ssl_enabled, fips_enabled, ssl_mutual_auth_enabled, sasl_protocol,
-                            'kafka.rest.client.', kafka_broker_truststore_path, kafka_broker_truststore_storepass, False, kafka_broker_keystore_path, kafka_broker_keystore_storepass, kafka_broker_keystore_keypass,
-                            false, sasl_plain_users_final.admin.principal, sasl_plain_users_final.admin.password, sasl_scram_users_final.admin.principal, sasl_scram_users_final.admin.password, sasl_scram256_users_final.admin.principal, sasl_scram256_users_final.admin.password,
-                            kerberos_kafka_broker_primary, kafka_broker_keytab_path, kafka_broker_kerberos_principal|default('kafka'),
-                            true, kafka_broker_ldap_user, kafka_broker_ldap_password, mds_bootstrap_server_urls) }}"
+                    'kafka.rest.client.', kafka_broker_truststore_path, kafka_broker_truststore_storepass, False, kafka_broker_keystore_path, kafka_broker_keystore_storepass, kafka_broker_keystore_keypass,
+                    false, sasl_plain_users_final.admin.principal, sasl_plain_users_final.admin.password, sasl_scram_users_final.admin.principal, sasl_scram_users_final.admin.password, sasl_scram256_users_final.admin.principal, sasl_scram256_users_final.admin.password,
+                    kerberos_kafka_broker_primary, kafka_broker_keytab_path, kafka_broker_kerberos_principal|default('kafka'),
+                    true, kafka_broker_ldap_user, kafka_broker_ldap_password, mds_bootstrap_server_urls) }}"
   embedded_rest_proxy_rbac:
     enabled: "{{ kafka_broker_rest_proxy_enabled and rbac_enabled }}"
     properties:
@@ -319,9 +319,9 @@ kafka_broker_properties:
   listeners:
     enabled: true
     properties: "{{ kafka_broker_listeners | listener_properties(ssl_enabled, fips_enabled, ssl_mutual_auth_enabled, sasl_protocol,
-                            kafka_broker_truststore_path, kafka_broker_truststore_storepass, kafka_broker_keystore_path, kafka_broker_keystore_storepass, kafka_broker_keystore_keypass,
-                            plain_jaas_config, kafka_broker_keytab_path, kafka_broker_kerberos_principal|default('kafka'), kerberos_kafka_broker_primary,
-                            sasl_scram_users_final.admin.principal, sasl_scram_users_final.admin.password, sasl_scram256_users_final.admin.principal, sasl_scram256_users_final.admin.password, rbac_enabled_public_pem_path ) }}"
+                    kafka_broker_truststore_path, kafka_broker_truststore_storepass, kafka_broker_keystore_path, kafka_broker_keystore_storepass, kafka_broker_keystore_keypass,
+                    plain_jaas_config, kafka_broker_keytab_path, kafka_broker_kerberos_principal|default('kafka'), kerberos_kafka_broker_primary,
+                    sasl_scram_users_final.admin.principal, sasl_scram_users_final.admin.password, sasl_scram256_users_final.admin.principal, sasl_scram256_users_final.admin.password, rbac_enabled_public_pem_path ) }}"
   controlplane_listener:
     enabled: "{{ kafka_broker_configure_control_plane_listener|bool and kafka_broker_configure_multiple_listeners|bool }}"
     properties:
@@ -335,10 +335,10 @@ kafka_broker_properties:
   metrics_reporter_client:
     enabled: "{{ kafka_broker_metrics_reporter_enabled|bool }}"
     properties: "{{ kafka_broker_listeners[kafka_broker_inter_broker_listener_name] | client_properties(ssl_enabled, fips_enabled, ssl_mutual_auth_enabled, sasl_protocol,
-                            'confluent.metrics.reporter.', kafka_broker_truststore_path, kafka_broker_truststore_storepass, False, kafka_broker_keystore_path, kafka_broker_keystore_storepass, kafka_broker_keystore_keypass,
-                            false, sasl_plain_users_final.admin.principal, sasl_plain_users_final.admin.password, sasl_scram_users_final.admin.principal, sasl_scram_users_final.admin.password, sasl_scram256_users_final.admin.principal, sasl_scram256_users_final.admin.password,
-                            kerberos_kafka_broker_primary, kafka_broker_keytab_path, kafka_broker_kerberos_principal|default('kafka'),
-                            false, kafka_broker_ldap_user, kafka_broker_ldap_password, mds_bootstrap_server_urls) }}"
+                    'confluent.metrics.reporter.', kafka_broker_truststore_path, kafka_broker_truststore_storepass, False, kafka_broker_keystore_path, kafka_broker_keystore_storepass, kafka_broker_keystore_keypass,
+                    false, sasl_plain_users_final.admin.principal, sasl_plain_users_final.admin.password, sasl_scram_users_final.admin.principal, sasl_scram_users_final.admin.password, sasl_scram256_users_final.admin.principal, sasl_scram256_users_final.admin.password,
+                    kerberos_kafka_broker_primary, kafka_broker_keytab_path, kafka_broker_kerberos_principal|default('kafka'),
+                    false, kafka_broker_ldap_user, kafka_broker_ldap_password, mds_bootstrap_server_urls) }}"
   telemetry:
     enabled: "{{kafka_broker_telemetry_enabled}}"
     properties:
@@ -366,10 +366,10 @@ kafka_broker_properties:
   audit_logs_destination_client:
     enabled: "{{audit_logs_destination_enabled and rbac_enabled}}"
     properties: "{{ audit_logs_destination_listener | client_properties(ssl_enabled, fips_enabled, ssl_mutual_auth_enabled, sasl_protocol,
-                            'confluent.security.event.logger.exporter.kafka.', kafka_broker_truststore_path, kafka_broker_truststore_storepass, False, kafka_broker_keystore_path, kafka_broker_keystore_storepass, kafka_broker_keystore_keypass,
-                            false, sasl_plain_users_final.admin.principal, sasl_plain_users_final.admin.password, sasl_scram_users_final.admin.principal, sasl_scram_users_final.admin.password, sasl_scram256_users_final.admin.principal, sasl_scram256_users_final.admin.password,
-                            kerberos_kafka_broker_primary|default('kafka'), kafka_broker_keytab_path, kafka_broker_kerberos_principal|default('kafka'),
-                            false, 'user', 'pass', mds_bootstrap_server_urls) }}"
+                    'confluent.security.event.logger.exporter.kafka.', kafka_broker_truststore_path, kafka_broker_truststore_storepass, False, kafka_broker_keystore_path, kafka_broker_keystore_storepass, kafka_broker_keystore_keypass,
+                    false, sasl_plain_users_final.admin.principal, sasl_plain_users_final.admin.password, sasl_scram_users_final.admin.principal, sasl_scram_users_final.admin.password, sasl_scram256_users_final.admin.principal, sasl_scram256_users_final.admin.password,
+                    kerberos_kafka_broker_primary|default('kafka'), kafka_broker_keytab_path, kafka_broker_kerberos_principal|default('kafka'),
+                    false, 'user', 'pass', mds_bootstrap_server_urls) }}"
   audit_logs_destination_admin:
     enabled: "{{audit_logs_destination_enabled and rbac_enabled and not external_mds_enabled}}"
     properties:
@@ -377,10 +377,10 @@ kafka_broker_properties:
   audit_logs_destination_admin_client:
     enabled: "{{audit_logs_destination_enabled and rbac_enabled and not external_mds_enabled}}"
     properties: "{{ audit_logs_destination_listener | client_properties(ssl_enabled, fips_enabled, ssl_mutual_auth_enabled, sasl_protocol,
-                            'confluent.security.event.logger.destination.admin.', kafka_broker_truststore_path, kafka_broker_truststore_storepass, False, kafka_broker_keystore_path, kafka_broker_keystore_storepass, kafka_broker_keystore_keypass,
-                            false, sasl_plain_users_final.admin.principal, sasl_plain_users_final.admin.password, sasl_scram_users_final.admin.principal, sasl_scram_users_final.admin.password, sasl_scram256_users_final.admin.principal, sasl_scram256_users_final.admin.password,
-                            kerberos_kafka_broker_primary|default('kafka'), kafka_broker_keytab_path, kafka_broker_kerberos_principal|default('kafka'),
-                            false, 'user', 'pass', mds_bootstrap_server_urls) }}"
+                    'confluent.security.event.logger.destination.admin.', kafka_broker_truststore_path, kafka_broker_truststore_storepass, False, kafka_broker_keystore_path, kafka_broker_keystore_storepass, kafka_broker_keystore_keypass,
+                    false, sasl_plain_users_final.admin.principal, sasl_plain_users_final.admin.password, sasl_scram_users_final.admin.principal, sasl_scram_users_final.admin.password, sasl_scram256_users_final.admin.principal, sasl_scram256_users_final.admin.password,
+                    kerberos_kafka_broker_primary|default('kafka'), kafka_broker_keytab_path, kafka_broker_kerberos_principal|default('kafka'),
+                    false, 'user', 'pass', mds_bootstrap_server_urls) }}"
 
 kafka_broker_combined_properties: "{{kafka_broker_properties | combine_properties}}"
 
@@ -456,10 +456,10 @@ schema_registry_properties:
   kafka_client:
     enabled: true
     properties: "{{ kafka_broker_listeners[schema_registry_kafka_listener_name] | client_properties(ssl_enabled, False, ssl_mutual_auth_enabled, sasl_protocol,
-                            'kafkastore.', schema_registry_truststore_path, schema_registry_truststore_storepass, public_certificates_enabled, schema_registry_keystore_path, schema_registry_keystore_storepass, schema_registry_keystore_keypass,
-                            false, sasl_plain_users_final.schema_registry.principal, sasl_plain_users_final.schema_registry.password, sasl_scram_users_final.schema_registry.principal, sasl_scram_users_final.schema_registry.password, sasl_scram256_users_final.schema_registry.principal, sasl_scram256_users_final.schema_registry.password,
-                            kerberos_kafka_broker_primary, schema_registry_keytab_path, schema_registry_kerberos_principal|default('kafka'),
-                            false, schema_registry_ldap_user, schema_registry_ldap_password, mds_bootstrap_server_urls) }}"
+                    'kafkastore.', schema_registry_truststore_path, schema_registry_truststore_storepass, public_certificates_enabled, schema_registry_keystore_path, schema_registry_keystore_storepass, schema_registry_keystore_keypass,
+                    false, sasl_plain_users_final.schema_registry.principal, sasl_plain_users_final.schema_registry.password, sasl_scram_users_final.schema_registry.principal, sasl_scram_users_final.schema_registry.password, sasl_scram256_users_final.schema_registry.principal, sasl_scram256_users_final.schema_registry.password,
+                    kerberos_kafka_broker_primary, schema_registry_keytab_path, schema_registry_kerberos_principal|default('kafka'),
+                    false, schema_registry_ldap_user, schema_registry_ldap_password, mds_bootstrap_server_urls) }}"
   rbac:
     enabled: "{{rbac_enabled}}"
     properties:
@@ -477,6 +477,13 @@ schema_registry_properties:
     properties:
       kafkastore.ssl.truststore.location: "{{schema_registry_truststore_path}}"
       kafkastore.ssl.truststore.password: "{{schema_registry_truststore_storepass}}"
+  mds_client:
+    enabled: "{{rbac_enabled and mds_tls_enabled }}"
+    properties:
+      confluent.metadata.ssl.truststore.location: "{{schema_registry_truststore_path}}"
+      confluent.metadata.ssl.truststore.password: "{{schema_registry_truststore_storepass}}"
+      confluent.metadata.ssl.endpoint.identification.algorithm:
+        HTTPS
   telemetry:
     enabled: "{{schema_registry_telemetry_enabled}}"
     properties:
@@ -660,6 +667,13 @@ kafka_connect_properties:
       ssl.truststore.password: "{{kafka_connect_truststore_storepass}}"
       config.providers.secret.param.kafkastore.ssl.truststore.location: "{{kafka_connect_truststore_path}}"
       config.providers.secret.param.kafkastore.ssl.truststore.password: "{{kafka_connect_truststore_storepass}}"
+  mds_client:
+    enabled: "{{rbac_enabled and mds_tls_enabled }}"
+    properties:
+      confluent.metadata.ssl.truststore.location: "{{kafka_connect_truststore_path}}"
+      confluent.metadata.ssl.truststore.password: "{{kafka_connect_truststore_storepass}}"
+      confluent.metadata.ssl.endpoint.identification.algorithm:
+        HTTPS
   secret_registry:
     enabled: "{{kafka_connect_secret_registry_enabled}}"
     properties:
@@ -673,10 +687,10 @@ kafka_connect_properties:
   secret_registry_client:
     enabled: true
     properties: "{{ kafka_broker_listeners[kafka_connect_kafka_listener_name] | client_properties(ssl_enabled, False, ssl_mutual_auth_enabled, sasl_protocol,
-                            'config.providers.secret.param.kafkastore.', kafka_connect_truststore_path, kafka_connect_truststore_storepass, public_certificates_enabled, kafka_connect_keystore_path, kafka_connect_keystore_storepass, kafka_connect_keystore_keypass,
-                            false, sasl_plain_users_final.kafka_connect.principal, sasl_plain_users_final.kafka_connect.password, sasl_scram_users_final.kafka_connect.principal, sasl_scram_users_final.kafka_connect.password, sasl_scram256_users_final.kafka_connect.principal, sasl_scram256_users_final.kafka_connect.password,
-                            kerberos_kafka_broker_primary, kafka_connect_keytab_path, kafka_connect_kerberos_principal|default('kafka'),
-                            false, kafka_connect_ldap_user, kafka_connect_ldap_password, mds_bootstrap_server_urls) }}"
+                    'config.providers.secret.param.kafkastore.', kafka_connect_truststore_path, kafka_connect_truststore_storepass, public_certificates_enabled, kafka_connect_keystore_path, kafka_connect_keystore_storepass, kafka_connect_keystore_keypass,
+                    false, sasl_plain_users_final.kafka_connect.principal, sasl_plain_users_final.kafka_connect.password, sasl_scram_users_final.kafka_connect.principal, sasl_scram_users_final.kafka_connect.password, sasl_scram256_users_final.kafka_connect.principal, sasl_scram256_users_final.kafka_connect.password,
+                    kerberos_kafka_broker_primary, kafka_connect_keytab_path, kafka_connect_kerberos_principal|default('kafka'),
+                    false, kafka_connect_ldap_user, kafka_connect_ldap_password, mds_bootstrap_server_urls) }}"
   telemetry:
     enabled: "{{kafka_connect_telemetry_enabled}}"
     properties:
@@ -836,6 +850,12 @@ ksql_properties:
     properties:
       ssl.truststore.location: "{{ksql_truststore_path}}"
       ssl.truststore.password: "{{ksql_truststore_storepass}}"
+  mds_client:
+    enabled: "{{rbac_enabled and mds_tls_enabled }}"
+    properties:
+      confluent.metadata.ssl.truststore.location: "{{ksql_truststore_path}}"
+      confluent.metadata.ssl.truststore.password: "{{ksql_truststore_storepass}}"
+      confluent.metadata.ssl.endpoint.identification.algorithm: HTTPS
   telemetry:
     enabled: "{{ksql_telemetry_enabled}}"
     properties:
@@ -922,10 +942,10 @@ kafka_rest_properties:
   kafka_client:
     enabled: true
     properties: "{{ kafka_broker_listeners[kafka_rest_kafka_listener_name] | client_properties(ssl_enabled, False, ssl_mutual_auth_enabled, sasl_protocol,
-                            'client.', kafka_rest_truststore_path, kafka_rest_truststore_storepass, public_certificates_enabled, kafka_rest_keystore_path, kafka_rest_keystore_storepass, kafka_rest_keystore_keypass,
-                            false, sasl_plain_users_final.kafka_rest.principal, sasl_plain_users_final.kafka_rest.password, sasl_scram_users_final.kafka_rest.principal, sasl_scram_users_final.kafka_rest.password, sasl_scram256_users_final.kafka_rest.principal, sasl_scram256_users_final.kafka_rest.password,
-                            kerberos_kafka_broker_primary, kafka_rest_keytab_path, kafka_rest_kerberos_principal|default('rp'),
-                            false, kafka_rest_ldap_user, kafka_rest_ldap_password, mds_bootstrap_server_urls) }}"
+                    'client.', kafka_rest_truststore_path, kafka_rest_truststore_storepass, public_certificates_enabled, kafka_rest_keystore_path, kafka_rest_keystore_storepass, kafka_rest_keystore_keypass,
+                    false, sasl_plain_users_final.kafka_rest.principal, sasl_plain_users_final.kafka_rest.password, sasl_scram_users_final.kafka_rest.principal, sasl_scram_users_final.kafka_rest.password, sasl_scram256_users_final.kafka_rest.principal, sasl_scram256_users_final.kafka_rest.password,
+                    kerberos_kafka_broker_primary, kafka_rest_keytab_path, kafka_rest_kerberos_principal|default('rp'),
+                    false, kafka_rest_ldap_user, kafka_rest_ldap_password, mds_bootstrap_server_urls) }}"
   kafka_client_password_protection:
     # Edge case for RP only- 'client' prefix not honored by secrets protection
     enabled: "{{ kafka_rest_secrets_protection_enabled }}"
@@ -979,6 +999,12 @@ kafka_rest_properties:
       ssl.truststore.password: "{{kafka_rest_truststore_storepass}}"
       client.ssl.truststore.location: "{{kafka_rest_truststore_path}}"
       client.ssl.truststore.password: "{{kafka_rest_truststore_storepass}}"
+  mds_client:
+    enabled: "{{rbac_enabled and mds_tls_enabled }}"
+    properties:
+      confluent.metadata.ssl.truststore.location: "{{kafka_rest_truststore_path}}"
+      confluent.metadata.ssl.truststore.password: "{{kafka_rest_truststore_storepass}}"
+      confluent.metadata.ssl.endpoint.identification.algorithm: HTTPS
   telemetry:
     enabled: "{{kafka_rest_telemetry_enabled}}"
     properties:
@@ -1057,17 +1083,18 @@ control_center_properties:
   kafka_client:
     enabled: true
     properties: "{{ kafka_broker_listeners[control_center_kafka_listener_name] | client_properties(ssl_enabled, False, ssl_mutual_auth_enabled, sasl_protocol,
-                            'confluent.controlcenter.streams.', control_center_truststore_path, control_center_truststore_storepass, public_certificates_enabled, control_center_keystore_path, control_center_keystore_storepass, control_center_keystore_keypass,
-                            false, sasl_plain_users_final.control_center.principal, sasl_plain_users_final.control_center.password, sasl_scram_users_final.control_center.principal, sasl_scram_users_final.control_center.password, sasl_scram256_users_final.control_center.principal, sasl_scram256_users_final.control_center.password,
-                            kerberos_kafka_broker_primary, control_center_keytab_path, control_center_kerberos_principal|default('c3'),
-                            false, control_center_ldap_user, control_center_ldap_password, mds_bootstrap_server_urls) }}"
+                    'confluent.controlcenter.streams.', control_center_truststore_path, control_center_truststore_storepass, public_certificates_enabled, control_center_keystore_path, control_center_keystore_storepass, control_center_keystore_keypass,
+                    false, sasl_plain_users_final.control_center.principal, sasl_plain_users_final.control_center.password, sasl_scram_users_final.control_center.principal, sasl_scram_users_final.control_center.password, sasl_scram256_users_final.control_center.principal, sasl_scram256_users_final.control_center.password,
+                    kerberos_kafka_broker_primary, control_center_keytab_path, control_center_kerberos_principal|default('c3'),
+                    false, control_center_ldap_user, control_center_ldap_password, mds_bootstrap_server_urls) }}"
+
   kafka_interceptors:
     enabled: true
     properties: "{{ kafka_broker_listeners[control_center_kafka_listener_name] | client_properties(ssl_enabled, False, ssl_mutual_auth_enabled, sasl_protocol,
-                            'confluent.monitoring.interceptor.', control_center_truststore_path, control_center_truststore_storepass, public_certificates_enabled, control_center_keystore_path, control_center_keystore_storepass, control_center_keystore_keypass,
-                            false, sasl_plain_users_final.control_center.principal, sasl_plain_users_final.control_center.password, sasl_scram_users_final.control_center.principal, sasl_scram_users_final.control_center.password, sasl_scram256_users_final.control_center.principal, sasl_scram256_users_final.control_center.password,
-                            kerberos_kafka_broker_primary, control_center_keytab_path, control_center_kerberos_principal|default('c3'),
-                            false, control_center_ldap_user, control_center_ldap_password, mds_bootstrap_server_urls) }}"
+                    'confluent.monitoring.interceptor.', control_center_truststore_path, control_center_truststore_storepass, public_certificates_enabled, control_center_keystore_path, control_center_keystore_storepass, control_center_keystore_keypass,
+                    false, sasl_plain_users_final.control_center.principal, sasl_plain_users_final.control_center.password, sasl_scram_users_final.control_center.principal, sasl_scram_users_final.control_center.password, sasl_scram256_users_final.control_center.principal, sasl_scram256_users_final.control_center.password,
+                    kerberos_kafka_broker_primary, control_center_keytab_path, control_center_kerberos_principal|default('c3'),
+                    false, control_center_ldap_user, control_center_ldap_password, mds_bootstrap_server_urls) }}"
   sr:
     enabled: "{{ 'schema_registry' in groups }}"
     properties:
@@ -1102,11 +1129,18 @@ control_center_properties:
       public.key.path: "{{rbac_enabled_public_pem_path}}"
       confluent.metadata.bootstrap.server.urls: "{{mds_bootstrap_server_urls}}"
       confluent.metadata.basic.auth.user.info: "{{ control_center_ldap_user | default('c3') }}:{{ control_center_ldap_password | default('pass') }}"
+      confluent.metadata.http.auth.credentials.provider: BASIC
   rbac_external_client:
     enabled: "{{rbac_enabled and external_mds_enabled and mds_tls_enabled }}"
     properties:
       confluent.controlcenter.streams.ssl.truststore.location: "{{control_center_truststore_path}}"
       confluent.controlcenter.streams.ssl.truststore.password: "{{control_center_truststore_storepass}}"
+  mds_client:
+    enabled: "{{rbac_enabled and mds_tls_enabled }}"
+    properties:
+      confluent.metadata.ssl.truststore.location: "{{control_center_truststore_path}}"
+      confluent.metadata.ssl.truststore.password: "{{control_center_truststore_storepass}}"
+      confluent.metadata.ssl.endpoint.identification.algorithm: HTTPS
   telemetry:
     enabled: "{{control_center_telemetry_enabled}}"
     properties:


### PR DESCRIPTION
# Description

This PR adds required properties for all CP components to talk to secured Metadata Server.  The detailed doc is [here](https://docs.confluent.io/platform/current/kafka/configure-mds/mds-ssl-config-for-components.html)

Fixes # ([FF-6440](https://confluentinc.atlassian.net/browse/ANSIENG-1024))

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

` molecule --debug converge -s rbac-mds-plain-custom-rhel`
```
PLAY RECAP *********************************************************************
control-center1            : ok=71   changed=30   unreachable=0    failed=0    skipped=40   rescued=0    ignored=0
kafka-broker1              : ok=86   changed=33   unreachable=0    failed=0    skipped=64   rescued=0    ignored=0
kafka-broker2              : ok=79   changed=33   unreachable=0    failed=0    skipped=46   rescued=0    ignored=0
kafka-broker3              : ok=79   changed=33   unreachable=0    failed=0    skipped=46   rescued=0    ignored=0
kafka-connect1             : ok=75   changed=31   unreachable=0    failed=0    skipped=48   rescued=0    ignored=0
kafka-rest1                : ok=71   changed=30   unreachable=0    failed=0    skipped=40   rescued=0    ignored=0
ksql1                      : ok=72   changed=30   unreachable=0    failed=0    skipped=44   rescued=0    ignored=0
mds-zookeeper1             : ok=2    changed=2    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
schema-registry1           : ok=67   changed=29   unreachable=0    failed=0    skipped=42   rescued=0    ignored=0
zookeeper1                 : ok=61   changed=28   unreachable=0    failed=0    skipped=38   rescued=0    ignored=0

```
MDS runs on secure mode

Verified properties from all components 
Keystore location and path would get added if `ssl_mutual_auth_enabled` is set to true
Kafka broker
```
confluent.metadata.sasl.mechanism=PLAIN
confluent.metadata.security.protocol=SASL_SSL
confluent.metadata.ssl.key.password=xxx
confluent.metadata.ssl.keystore.location=/xxx/kafka_broker.keystore.jks
confluent.metadata.ssl.keystore.password=xxx
confluent.metadata.ssl.truststore.location=/xxx/kafka_broker.truststore.jks
confluent.metadata.ssl.truststore.password=xxx
```
Control Center
```
confluent.metadata.sasl.login.callback.handler.class=io.confluent.kafka.clients.plugins.auth.token.TokenUserLoginCallbackHandler
confluent.metadata.sasl.mechanism=OAUTHBEARER
confluent.metadata.security.protocol=SASL_SSL
confluent.metadata.ssl.truststore.location=/xxxx/control_center.truststore.jks
confluent.metadata.ssl.truststore.password=xxxxxxxxx
```

2. No impact with usecase which doesn't have either `mds_tls_enabled` or `ssl_mutual_auth_enabled` set to true

`molecule --debug converge -s plain-rhel `
```
confluent.metadata.sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="control_center" password="control_center-secret";
confluent.metadata.sasl.mechanism=PLAIN
confluent.metadata.security.protocol=SASL_PLAINTEXT
```
**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible