### PR TITLE
Add mds_advertised_listener_hostname to default variables

### DIFF
--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -1436,6 +1436,14 @@ Default:  "{{mds_super_user_password}}"
 
 ***
 
+### mds_advertised_listener_hostname
+
+Unique advertised hostname for Metadata Server
+
+Default:  ""
+
+***
+
 ### schema_registry_ldap_user
 
 LDAP User for Schema Registry to authenticate as

--- a/roles/confluent.kafka_broker/tasks/health_check.yml
+++ b/roles/confluent.kafka_broker/tasks/health_check.yml
@@ -62,7 +62,7 @@
 
 - name: Wait for Metadata Service to start
   uri:
-    url: "{{mds_http_protocol}}://{{ mds_advertised_listener_hostname | default(inventory_hostname) }}:{{mds_port}}/security/1.0/authenticate"
+    url: "{{mds_http_protocol}}://{{ mds_advertised_listener_hostname | default(inventory_hostname, True) }}:{{mds_port}}/security/1.0/authenticate"
     validate_certs: false
     return_content: true
     status_code: 200

--- a/roles/confluent.variables/defaults/main.yml
+++ b/roles/confluent.variables/defaults/main.yml
@@ -361,7 +361,7 @@ kafka_broker_jolokia_password: "{{jolokia_password}}"
 kafka_broker_jolokia_java_arg_ssl_addon: ",keystore={{kafka_broker_keystore_path}},keystorePassword={{kafka_broker_keystore_storepass}},protocol=https"
 kafka_broker_jolokia_urp_url: "{{ 'https' if kafka_broker_jolokia_ssl_enabled|bool else 'http' }}://{{inventory_hostname}}:{{kafka_broker_jolokia_port}}/jolokia/read/kafka.server:type=ReplicaManager,name=UnderReplicatedPartitions"
 kafka_broker_jolokia_active_controller_url: "{{ 'https' if kafka_broker_jolokia_ssl_enabled|bool else 'http' }}://{{inventory_hostname}}:{{kafka_broker_jolokia_port}}/jolokia/read/kafka.controller:type=KafkaController,name=ActiveControllerCount"
-kafka_broker_erp_clusters_url: "{{mds_http_protocol}}://{{ mds_advertised_listener_hostname | default(inventory_hostname) }}:{{mds_port}}/kafka/v3/clusters"
+kafka_broker_erp_clusters_url: "{{mds_http_protocol}}://{{ mds_advertised_listener_hostname | default(inventory_hostname, True) }}:{{mds_port}}/kafka/v3/clusters"
 
 ### Boolean to enable Prometheus Exporter Agent installation and configuration on kafka
 kafka_broker_jmxexporter_enabled: "{{jmxexporter_enabled}}"
@@ -829,6 +829,9 @@ kafka_broker_ldap_user: "{{mds_super_user}}"
 
 ### Password to kafka_broker_ldap_user LDAP User
 kafka_broker_ldap_password: "{{mds_super_user_password}}"
+
+### Unique advertised hostname for Metadata Server
+mds_advertised_listener_hostname: ""
 
 ### LDAP User for Schema Registry to authenticate as
 schema_registry_ldap_user: schema-registry

--- a/roles/confluent.variables/vars/main.yml
+++ b/roles/confluent.variables/vars/main.yml
@@ -204,7 +204,7 @@ kafka_broker_properties:
   rbac_mds:
     enabled: "{{ rbac_enabled and not external_mds_enabled }}"
     properties:
-      confluent.metadata.server.advertised.listeners: "{{mds_http_protocol}}://{{ mds_advertised_listener_hostname | default(inventory_hostname) }}:{{mds_port}}"
+      confluent.metadata.server.advertised.listeners: "{{mds_http_protocol}}://{{ mds_advertised_listener_hostname | default(inventory_hostname, True) }}:{{mds_port}}"
       confluent.metadata.server.listeners: "{{mds_http_protocol}}://0.0.0.0:{{mds_port}}"
       confluent.metadata.server.token.auth.enable: "true"
       confluent.metadata.server.token.max.lifetime.ms: 3600000
@@ -246,7 +246,7 @@ kafka_broker_properties:
     # Do not need duplicating confluent.metadata.server and confluent.http.server config, rely on mds configs when kafka is the mds
     enabled: "{{ kafka_broker_rest_proxy_enabled and (not rbac_enabled or (rbac_enabled and external_mds_enabled)) }}"
     properties:
-      confluent.http.server.advertised.listeners: "{{mds_http_protocol}}://{{ mds_advertised_listener_hostname | default(inventory_hostname) }}:{{mds_port}}"
+      confluent.http.server.advertised.listeners: "{{mds_http_protocol}}://{{ mds_advertised_listener_hostname | default(inventory_hostname, True) }}:{{mds_port}}"
       confluent.http.server.listeners: "{{mds_http_protocol}}://0.0.0.0:{{mds_port}}"
   embedded_rest_proxy_ssl:
     enabled: "{{ kafka_broker_rest_proxy_enabled and (not rbac_enabled or (rbac_enabled and external_mds_enabled)) and kafka_broker_rest_ssl_enabled }}"


### PR DESCRIPTION
# Description

`mds_advertised_listener_hostname` is used to reference any external mds server. However the same is neither part of default variables, nor of doc.
A null or empty string doesn't translate to None while evaluating in the playbook. We have to evaluate as binary to work it in expected way. 

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

` molecule --debug converge -s mtls-debian`
```
PLAY RECAP *********************************************************************
control-center1            : ok=66   changed=37   unreachable=0    failed=0    skipped=30   rescued=0    ignored=0
kafka-broker1              : ok=78   changed=40   unreachable=0    failed=0    skipped=38   rescued=0    ignored=0
kafka-broker2              : ok=78   changed=40   unreachable=0    failed=0    skipped=37   rescued=0    ignored=0
kafka-broker3              : ok=78   changed=40   unreachable=0    failed=0    skipped=37   rescued=0    ignored=0
kafka-connect1             : ok=76   changed=41   unreachable=0    failed=0    skipped=38   rescued=0    ignored=0
kafka-rest1                : ok=69   changed=38   unreachable=0    failed=0    skipped=35   rescued=0    ignored=0
ksql1                      : ok=72   changed=40   unreachable=0    failed=0    skipped=33   rescued=0    ignored=0
schema-registry1           : ok=68   changed=38   unreachable=0    failed=0    skipped=32   rescued=0    ignored=0
zookeeper1                 : ok=80   changed=43   unreachable=0    failed=0    skipped=36   rescued=0    ignored=0
```

```
TASK [confluent.kafka_broker : Wait for Metadata Service to start] *************
skipping: [kafka-broker1]
skipping: [kafka-broker2]
skipping: [kafka-broker3]
```


**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible