### PR TITLE
Updated systemD override location for kafka brokers.

### DIFF
--- a/roles/confluent.kafka_broker/defaults/main.yml
+++ b/roles/confluent.kafka_broker/defaults/main.yml
@@ -54,7 +54,7 @@ kafka_broker_sysctl:
   vm.dirty_ratio: 80
   vm.max_map_count: 262144
 
-kafka_broker_sysctl_file: /etc/sysctl.conf
+kafka_broker_sysctl_file: /usr/lib/sysctl.d/sysctl.conf
 
 ### Time in seconds to wait before starting Kafka Health Checks.
 kafka_broker_health_check_delay: 20


### PR DESCRIPTION
# Description

This issue updates the location of SystemD override locations for kafka brokers as per the best practices of systemD docs.

https://www.freedesktop.org/software/systemd/man/sysctl.d.html

Fixes # (issue)

Corrects: ANSIENG-909

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This has been validated by running the plaintext-rhel scenario successfully.

Have also manually verified the location of the overrides file on the file system.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible