### PR TITLE
Add missing task for MDS private key extraction

### DIFF
--- a/tasks/certificate_authority.yml
+++ b/tasks/certificate_authority.yml
@@ -49,6 +49,16 @@
     ansible_connection: local
     ansible_become: false
 
+- name: Register if MDS Private Key Exists on Ansible Controller
+  tags: certificate_authority
+  stat:
+    path: "{{playbook_dir}}/generated_ssl_files/{{token_services_private_pem_file|basename}}"
+  register: controller_mds_private_key_stat
+  delegate_to: localhost
+  vars:
+    ansible_connection: local
+    ansible_become: false
+
 - name: Generate SSL Files
   block:
     - name: Gather OS Facts


### PR DESCRIPTION
# Description

Add task to generate MDS private key. This task was missing in recent changes. 

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

` molecule --debug converge -s mtls-java8-ubuntu`


**Test Configuration**:
```
TASK [Register if MDS Private Key Exists on Ansible Controller] ****************
ok: [zookeeper1 -> localhost]

````
```
PLAY RECAP *********************************************************************
control-center1            : ok=68   changed=29   unreachable=0    failed=0    skipped=35   rescued=0    ignored=0
kafka-broker1              : ok=73   changed=34   unreachable=0    failed=0    skipped=43   rescued=0    ignored=0
kafka-broker2              : ok=73   changed=34   unreachable=0    failed=0    skipped=40   rescued=0    ignored=0
kafka-broker3              : ok=73   changed=34   unreachable=0    failed=0    skipped=40   rescued=0    ignored=0
kafka-connect1             : ok=68   changed=30   unreachable=0    failed=0    skipped=44   rescued=0    ignored=0
kafka-rest1                : ok=65   changed=28   unreachable=0    failed=0    skipped=38   rescued=0    ignored=0
ksql1                      : ok=64   changed=29   unreachable=0    failed=0    skipped=38   rescued=0    ignored=0
schema-registry1           : ok=62   changed=28   unreachable=0    failed=0    skipped=38   rescued=0    ignored=0
zookeeper1                 : ok=70   changed=28   unreachable=0    failed=0    skipped=44   rescued=0    ignored=0

```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible