### PR TITLE
Fix problem with healthcheck for ssl-enabled zookeeper.

### DIFF
--- a/roles/zookeeper/tasks/dynamic_groups.yml
+++ b/roles/zookeeper/tasks/dynamic_groups.yml
@@ -30,7 +30,7 @@
   vars:
     archive_version: "{{ zookeeper_current_version | default(confluent_package_version) }}"
     zookeeper_ssl_enabled: "{{ (slurped_properties.content|b64decode).split('\n') |
-      select('match', '^ssl.clientAuth=need') | list | length > 0 }}"
+      select('match', '^serverCnxnFactory=org.apache.zookeeper.server.NettyServerCnxnFactory') | list | length > 0 }}"
   register: leader_query
   changed_when: false
   check_mode: false


### PR DESCRIPTION
Use serverCnxnFactory=org.apache.zookeeper.server.NettyServerCnxnFactory as the canary
instead of ssl.clientAuth=need.

# Description

Change canary search for SSL-enabled ZooKeeper from ssl.clientAuth=need to serverCnxnFactory=org.apache.zookeeper.server.NettyServerCnxnFactory.

Fixes # (issue)

cp-ansible searches for the string

  ssl.clientAuth=need

to determine if ZooKeeper has SSL enabled for the health check (done via FourLetterWord).
Customers who use SASL for the brokers to authenticate against ZooKeeper have ssl.clientAuth=none set instead (since ZooKeeper 3.5.7).

Therefore the health check will fail for rolling deployments.

This fix changes the search string to

  serverCnxnFactory=org.apache.zookeeper.server.NettyServerCnxnFactory

This setting is a necessary requirement for enabling TLS for ZooKeeper so should be a good indicator.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Create a working cluster with SSL and SASL authentication for ZooKeeper and deploy.
Rerun Ansible script again with deployment_strategy=rolling and see the ZooKeeper health check fail.

Repeat the test with this fix and the deployment should succeed.

**Test Configuration**:

Cluster secured with

SSL
Kerberos (GSSAPI) - or probably any other SASL mechanism
Hence Zookeeper properties

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible