### PR TITLE
Added additional tags to host validations to allow for greater control.

### DIFF
--- a/roles/common/tasks/host_validations.yml
+++ b/roles/common/tasks/host_validations.yml
@@ -10,7 +10,7 @@
   when: ansible_os_family == "RedHat"
   tags: 
   - validate
-  - os_version
+  - validate_os_version
 
 - name: Confirm Ubuntu Version Supported
   assert:
@@ -23,7 +23,7 @@
   when: ansible_distribution == "Ubuntu"
   tags: 
   - validate
-  - os_version
+  - validate_os_version
 
 - name: Confirm Debian Version Supported
   assert:
@@ -36,7 +36,7 @@
   when: ansible_distribution == "Debian"
   tags: 
   - validate
-  - os_vesion
+  - validate_os_vesion
 
 - name: Check Internet Access for Confluent Packages/Archive
   uri:
@@ -52,7 +52,7 @@
   register: internet_access_check
   tags: 
   - validate
-  - internet_access
+  - validate_internet_access
 
 - name: Fail Provisioning because No Network Connectivity
   fail:
@@ -67,7 +67,7 @@
   register: path_exists
   tags: 
   - validate
-  - tmp_access
+  - validate_tmp_access
 
 - name: Assert /tmp is accessible
   assert:
@@ -77,4 +77,4 @@
       the location for temporary files in ansible.cfg."
   tags:
   - validate
-  - tmp_access
+  - validate_tmp_access

--- a/roles/common/tasks/host_validations.yml
+++ b/roles/common/tasks/host_validations.yml
@@ -8,7 +8,9 @@
   vars:
     redhat_supported_versions: ['7', '8']
   when: ansible_os_family == "RedHat"
-  tags: validate
+  tags: 
+  - validate
+  - os_version
 
 - name: Confirm Ubuntu Version Supported
   assert:
@@ -19,7 +21,9 @@
   vars:
     ubuntu_supported_versions: ['16', '18', '20']
   when: ansible_distribution == "Ubuntu"
-  tags: validate
+  tags: 
+  - validate
+  - os_version
 
 - name: Confirm Debian Version Supported
   assert:
@@ -30,7 +34,9 @@
   vars:
     debian_supported_versions: ['9', '10']
   when: ansible_distribution == "Debian"
-  tags: validate
+  tags: 
+  - validate
+  - os_vesion
 
 - name: Check Internet Access for Confluent Packages/Archive
   uri:
@@ -44,7 +50,9 @@
     ( installation_method == 'archive' and confluent_common_repository_baseurl in confluent_archive_file_source )
   ignore_errors: true
   register: internet_access_check
-  tags: validate
+  tags: 
+  - validate
+  - internet_access
 
 - name: Fail Provisioning because No Network Connectivity
   fail:
@@ -57,7 +65,9 @@
   stat:
     path: "/tmp"
   register: path_exists
-  tags: validate
+  tags: 
+  - validate
+  - tmp_access
 
 - name: Assert /tmp is accessible
   assert:

--- a/roles/common/tasks/host_validations.yml
+++ b/roles/common/tasks/host_validations.yml
@@ -75,3 +75,6 @@
     fail_msg: >-
       "The /tmp directory is not accessible by the Ansible user.  Please update your permissions on the /tmp directory or change
       the location for temporary files in ansible.cfg."
+  tags:
+  - validate
+  - tmp_access

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -3,13 +3,18 @@
   assert:
     that: lookup('config', 'DEFAULT_HASH_BEHAVIOUR') == 'merge'
     fail_msg: "Hash Merging must be enabled in ansible.cfg"
-  tags: validate
+  tags: 
+  - validate
+  - hash_merge
 
 - name: Verify Ansible version
   assert:
     that: "ansible_version.full is version_compare('2.10', '>=')"
     fail_msg: >-
       "You must update Ansible to at least 2.11 to use these playbooks."
+  tags:
+  - validate
+  - ansi_version
 
 - name: Gather OS Facts
   setup:
@@ -23,7 +28,8 @@
 - name: Host Validations
   include_tasks: host_validations.yml
   when: validate_hosts|bool
-  tags: validate
+  tags: 
+  - validate
 
 - name: Red Hat Repo Setup and Java Installation
   include_tasks: redhat.yml

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -5,7 +5,7 @@
     fail_msg: "Hash Merging must be enabled in ansible.cfg"
   tags: 
   - validate
-  - hash_merge
+  - validate_hash_merge
 
 - name: Verify Ansible version
   assert:
@@ -14,7 +14,7 @@
       "You must update Ansible to at least 2.11 to use these playbooks."
   tags:
   - validate
-  - ansi_version
+  - validate_ansi_version
 
 - name: Gather OS Facts
   setup:


### PR DESCRIPTION
# Description

This PR adds unique tags for each host validation check.  This allows the end user to have greater control over which validations they wish to run when deploying the platform.

Fixes # (issue)

ANSIENG-1041

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Validated successful completion of plaintext-rhel scenario.

Validated by skipping the /tmp directory check, note it skips and moves on to platform setup after internet check:

command: `molecule --debug converge -s plaintext-rhel -- --skip-tags="validate_tmp_access"|tee test1.txt`

Output:

`TASK [confluent.platform.common : Fail Provisioning because No Network Connectivity] ***
skipping: [zookeeper1]
skipping: [zookeeper2]
skipping: [zookeeper3]
skipping: [kafka-broker1]
skipping: [kafka-broker2]
skipping: [schema-registry1]
skipping: [kafka-connect1]
skipping: [ksql1]
skipping: [control-center1]
skipping: [kafka-rest1]

TASK [confluent.platform.common : Red Hat Repo Setup and Java Installation] ****
included: /Users/justin/repos/ansible_collections/confluent/platform/roles/common/tasks/redhat.yml for zookeeper1, zookeeper2, zookeeper3, kafka-broker1, kafka-broker2, schema-registry1, kafka-connect1, ksql1, control-center1, kafka-rest1`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible