### PR TITLE
Use command module on Kafka Broker "Set Permissions on Data Dir files…

### DIFF
--- a/roles/confluent.kafka_broker/tasks/main.yml
+++ b/roles/confluent.kafka_broker/tasks/main.yml
@@ -150,12 +150,12 @@
     mode: 0750
   with_items: "{{ kafka_broker_final_properties['log.dirs'].split(',') }}"
 
-- name: Set Permissions on Data Dir files
-  file:
-    path: "{{item}}"
-    owner: "{{kafka_broker_user}}"
-    group: "{{kafka_broker_group}}"
-    recurse: true
+- name: Set Permissions on Data Dir files  # noqa deprecated-command-syntax
+  # Have to use command + chown instead of the Ansible file module here as
+  # it seems like the file module can't handle files modified/deleted while running.
+  # See https://github.com/confluentinc/cp-ansible/pull/903 for details.
+  command: chown -R {{ kafka_broker_user }}:{{ kafka_broker_group }} {{ item }}
+  changed_when: false
   with_items: "{{ kafka_broker_final_properties['log.dirs'].split(',') }}"
 
 - name: Create Kafka Broker Config directory

--- a/roles/confluent.kafka_broker/tasks/main.yml
+++ b/roles/confluent.kafka_broker/tasks/main.yml
@@ -151,9 +151,9 @@
   with_items: "{{ kafka_broker_final_properties['log.dirs'].split(',') }}"
 
 - name: Set Permissions on Data Dir files  # noqa deprecated-command-syntax
-  # Have to use command + chown instead of the Ansible file module here as
-  # it seems like the file module can't handle files modified/deleted while running.
-  # See https://github.com/confluentinc/cp-ansible/pull/903 for details.
+  # Have to use command + chown instead of the Ansible file module here as it seems
+  # like the file module can't handle files modified/deleted while running. This task
+  # can fail on a very active cluster. See https://github.com/confluentinc/cp-ansible/pull/903 for details.
   command: chown -R {{ kafka_broker_user }}:{{ kafka_broker_group }} {{ item }}
   changed_when: false
   with_items: "{{ kafka_broker_final_properties['log.dirs'].split(',') }}"


### PR DESCRIPTION
…" task to avoid internal Ansible/Python race conditions.

# Description

We are struggling with frequent pipeline failures, typically in **active** (active when running playbook) clusters with considerable data-flow:
````
TASK [confluent.kafka_broker : Set Permissions on Data Dir files] **************
failed: [REDACTED] (item=/var/lib/kafka/data) => changed=false 
  ansible_loop_var: item
  item: /var/lib/kafka/data
  msg: path /var/lib/kafka/data/my-topic-groups-0-repartition-1/leader-epoch-checkpoint.tmp does not exist
  path: /var/lib/kafka/data/my-topic-0-repartition-1/leader-epoch-checkpoint.tmp
````

And it seems like the root cause is some change in the Kafka Broker data dir files that the Ansible/Python code inside the file-module does not handle correctly. Smells like a consistency bug in Ansible, but historically I've had trouble raising issues in the Ansible community - they tend to be rejected or ignored.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This change has been tested in one of our dev-clusters (3 brokers, 3 zookeepers). Everything runs as normal, and no changes to data dir files when running pipelines. We are not allowed to run an unreleased version in our high volume clusters, so I will only be able to verify if this workaround improves our situation after this is merged and released. But at least I am convinced that this change will not break anything.

After running our pipeline with this change (no changes):
````
[root@REDACTED ~]# ls -lart /var/lib/kafka/data
total 228
-rw-r--r--.   1 cp-kafka confluent     0 Dec 12  2020 .lock
drwxr-x---.   5 cp-kafka confluent    47 Feb  8  2021 ..
drwxr-xr-x.   2 cp-kafka confluent   167 Jan  4 09:18 __consumer_offsets-0
drwxr-xr-x.   2 cp-kafka confluent   167 Jan  4 09:18 __transaction_state-22
drwxr-xr-x.   2 cp-kafka confluent   167 Jan  4 09:18 __transaction_state-18
drwxr-xr-x.   2 cp-kafka confluent   167 Jan  4 09:18 __transaction_state-0
drwxr-xr-x.   2 cp-kafka confluent   167 Jan  4 09:18 __transaction_state-30
drwxr-xr-x.   2 cp-kafka confluent   167 Jan  4 09:18 __transaction_state-34
drwxr-xr-x.   2 cp-kafka confluent   167 Jan  4 09:18 __transaction_state-16
drwxr-xr-x.   2 cp-kafka confluent   167 Jan  4 09:18 __transaction_state-46
drwxr-xr-x.   2 cp-kafka confluent   167 Jan  4 09:18 __transaction_state-12
drwxr-xr-x.   2 cp-kafka confluent   167 Jan  4 09:18 __transaction_state-42
drwxr-xr-x.   2 cp-kafka confluent   167 Jan  4 09:18 __transaction_state-24
drwxr-xr-x.   2 cp-kafka confluent   167 Jan  4 09:18 __transaction_state-28
drwxr-xr-x.   2 cp-kafka confluent   167 Jan  4 09:18 __transaction_state-40
drwxr-xr-x.   2 cp-kafka confluent   167 Jan  4 09:18 __transaction_state-48
drwxr-xr-x.   2 cp-kafka confluent   167 Jan  4 09:18 __transaction_state-36
drwxr-xr-x.   2 cp-kafka confluent   167 Jan  4 09:18 __transaction_state-10
(...)
````

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible