### PR TITLE
Add support for dmame extratction with given mapping rule

### DIFF
--- a/molecule/rbac-mtls-rhel/molecule.yml
+++ b/molecule/rbac-mtls-rhel/molecule.yml
@@ -5,6 +5,7 @@
 ### Secrets protection enabled.
 ### Kafka Broker Customer Listener.
 ### RBAC Additional System Admin.
+### Provided SSL Principal Mapping rule
 
 driver:
   name: docker
@@ -185,6 +186,9 @@ provisioner:
           ldap.group.name.attribute=cn
           ldap.group.member.attribute.pattern=CN=(.*),OU=rbac,DC=example,DC=com
           ldap.user.object.class=account
+
+        kafka_broker_custom_properties:
+           ssl.principal.mapping.rules: "RULE:.*O=(.*?),OU=TEST.*$$/$$1/"
 
       schema_registry:
         schema_registry_cluster_name: Test-Schema

--- a/molecule/rbac-mtls-rhel/verify.yml
+++ b/molecule/rbac-mtls-rhel/verify.yml
@@ -4,6 +4,7 @@
 ### Validates that secrets protection is masking the correct properties.
 ### Validates Kafka Connect secrets registry.
 ### Validates Cluster Registry.
+### Validates the filter resolve_principal with different ssl.mapping.rule
 
 - name: Verify - Zookeeper
   hosts: zookeeper
@@ -38,6 +39,14 @@
         property: ldap.java.naming.provider.url
         expected_value: ldap://ldap1:389
 
+    - import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: /etc/kafka/server.properties
+        property: ssl.principal.mapping.rules
+        expected_value: RULE:.*O=(.*?),OU=TEST.*$/$1/
+
     - name: Get super.users
       shell: grep "super.users" /etc/kafka/server.properties
       register: super_users_grep
@@ -47,6 +56,7 @@
         that:
           - "'User:dom' in super_users_grep.stdout"
           - "'User:jeff' in super_users_grep.stdout"
+          - "'User:CONFLUENT' in super_users_grep.stdout"
         fail_msg: "Super Users property: {{super_users_grep.stdout}} does not contain User:dom and User:jeff"
 
     - include_role:
@@ -188,6 +198,7 @@
         status_code: 200
         client_cert: /var/ssl/private/kafka_connect.crt
         client_key: /var/ssl/private/kafka_connect.key
+        ca_path: /var/ssl/private/ca.crt
         validate_certs: false
         url_username: mds
         url_password: password
@@ -208,6 +219,7 @@
         url_password: password
         client_cert: /var/ssl/private/kafka_connect.crt
         client_key: /var/ssl/private/kafka_connect.key
+        ca_path: /var/ssl/private/ca.crt
         force_basic_auth: true
       register: connector_status_response
       until: connector_status_response.json.connector.state == 'RUNNING'
@@ -311,13 +323,6 @@
     ksql_name: Test-Ksql
     schema_registry_name: Test-Schema
   tasks:
-    - name: Get Kafka Cluster Id
-      import_role:
-        name: common
-        tasks_from: rbac_setup.yml
-      vars:
-        copy_certs: false
-
     - name: Retrieve Cluster Registry details
       uri:
         url: "{{mds_http_protocol}}://{{ groups['kafka_broker'][0] }}:{{mds_port}}/security/1.0/registry/clusters"
@@ -359,3 +364,46 @@
           - schema_registry_name == "{{cluster_name_query_json[3]['clusterName']}}"
         fail_msg: "Schema Registry Cluster ID set to {{cluster_name_query_json[3]['clusterName']}} not {{schema_registry_name}}"
         quiet: true
+
+- name: Validate SSL mapping rule
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - import_role:
+            name: confluent.variables
+
+    - name: Validate mapping rule with Upper case single match
+      assert:
+        that:
+          - dname == "{{ common_names|resolve_principal(rules) }}"
+      vars:
+        rules: "^CN=(.*?), OU=(.*?)$/$1/U"
+        common_names: "CN=kafka-server1, OU=KAFKA"
+        dname: KAFKA-SERVER1
+
+    - name: Validate mapping rule with multiple match
+      assert:
+        that:
+          - dname == "{{ common_names|resolve_principal(rules) }}"
+      vars:
+        rules: "RULE:^CN=(.*?), OU=(.*?), O=(.*?), L=(.*?), ST=(.*?), C=(.*?)$/$1@$2/"
+        common_names: "CN=kafka1, OU=SME, O=mycp, L=Fulton, ST=MD, C=US"
+        dname: kafka1@SME
+
+    - name: Validate mapping rule with lowercase single match
+      assert:
+        that:
+          - dname == "{{ common_names|resolve_principal(rules) }}"
+      vars:
+        rules: "RULE:^cn=(.*?),ou=(.*?),dc=(.*?),dc=(.*?)$/$1/L"
+        common_names: "cn=kafka1,ou=SME,dc=mycp,dc=com"
+        dname: kafka1
+
+    - name: Validate multiple mapping rule
+      assert:
+        that:
+          - dname == "{{ common_names|resolve_principal(rules) }}"
+      vars:
+        rules: "RULE:^cn=(.*?),ou=(.*?),dc=(.*?),dc=(.*?)$/$1/LRULE:^CN=(.*?), OU=(.*?), O=(.*?), L=(.*?), ST=(.*?), C=(.*?)$/$1@$2/"
+        common_names: "cn=kafka1,ou=SME,dc=mycp,dc=com"
+        dname: kafka1

--- a/roles/kafka_broker/tasks/set_principal.yml
+++ b/roles/kafka_broker/tasks/set_principal.yml
@@ -43,7 +43,10 @@
 
 - name: Set Principal - SSL Mutual Auth
   set_fact:
-    kafka_broker_principal: "User:{{ distinguished_name_from_keystore.stdout }}"
+    kafka_broker_principal: "User:{{ extracted_principal }}"
+  vars:
+      extracted_principal: "{{distinguished_name_from_keystore.stdout if kafka_broker_final_properties['ssl.principal.mapping.rules'] is not defined \
+                             else distinguished_name_from_keystore.stdout|resolve_principal(kafka_broker_final_properties['ssl.principal.mapping.rules'])}}"
   when:
     - listener['sasl_protocol'] | default(sasl_protocol) | confluent.platform.normalize_sasl_protocol == 'none'
     - listener['ssl_enabled'] | default(ssl_enabled) | bool


### PR DESCRIPTION
# Description

CP-Ansible has been ignoring the provided ssl.principal.mapping.rule This change enables to extract the Distingushed name from the keystore based on the provided rule. If there ain't any rule OR rule doesn't match to any common name, it defaults back to existing behavior. Which is extract the first common name as distinguished name

We need to escape the $ character while providing the rules in inventory file. Please see the testing section below. 

Fixes # ([ANSIENG-983](https://confluentinc.atlassian.net/browse/ANSIENG-983))
Reference doc - https://cwiki.apache.org/confluence/display/KAFKA/KIP-371%3A+Add+a+configuration+to+build+custom+SSL+principal+name

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
`molecule --debug converge -s rbac-mtls-rhel`

The default case when no mapping rule is specified 
```
TASK [confluent.kafka_broker : Show principals] ********************************
ok: [kafka-broker1] => (item=kafka-broker1) => {
    "msg": "Principal for kafka-broker1 is  User:C=US,ST=Ca,L=PaloAlto,O=CONFLUENT,OU=TEST,CN=kafka_broker"
}
ok: [kafka-broker1] => (item=kafka-broker2) => {
    "msg": "Principal for kafka-broker2 is  User:C=US,ST=Ca,L=PaloAlto,O=CONFLUENT,OU=TEST,CN=kafka_broker"
}
ok: [kafka-broker1] => (item=kafka-broker3) => {
    "msg": "Principal for kafka-broker3 is  User:C=US,ST=Ca,L=PaloAlto,O=CONFLUENT,OU=TEST,CN=kafka_broker"
}

```

Set up mapping rule - 
```
kafka_broker_custom_properties:
          ssl.principal.mapping.rules: "RULE:.*O=(.*?),OU=TEST/$$1/"
```
```
TASK [confluent.kafka_broker : Show principals] ********************************
ok: [kafka-broker1] => (item=kafka-broker1) => {
    "msg": "Principal for kafka-broker1 is  User:CONFLUENT"
}
ok: [kafka-broker1] => (item=kafka-broker2) => {
    "msg": "Principal for kafka-broker2 is  User:CONFLUENT"
}
ok: [kafka-broker1] => (item=kafka-broker3) => {
    "msg": "Principal for kafka-broker3 is  User:CONFLUENT"
}

```

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible