### PR TITLE
log4j template does not prefix the ksql service id

### DIFF
--- a/roles/confluent.ksql/templates/ksql-server_log4j.properties.j2
+++ b/roles/confluent.ksql/templates/ksql-server_log4j.properties.j2
@@ -49,7 +49,7 @@ log4j.appender.kafka_appender=org.apache.kafka.log4jappender.KafkaLog4jAppender
 log4j.appender.kafka_appender.layout=io.confluent.common.logging.log4j.StructuredJsonLayout
 log4j.appender.kafka_appender.BrokerList={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ host }}:{{kafka_broker_listeners[ksql_processing_log_kafka_listener_name]['port']}}{% endfor %}
 
-log4j.appender.kafka_appender.Topic={{ksql_processing_log}}
+log4j.appender.kafka_appender.Topic={{ksql_service_id}}{{ksql_processing_log}}
 {% set listener = kafka_broker_listeners[ksql_processing_log_kafka_listener_name] %}
 
 log4j.appender.kafka_appender.SecurityProtocol={{listener | kafka_protocol_defaults(sasl_protocol, ssl_enabled) }}


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
The log4j template does not prefix the service id.
Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration



**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible