### PR TITLE
Corrected indentation on disk space validation task.

### DIFF
--- a/roles/common/tasks/host_validations.yml
+++ b/roles/common/tasks/host_validations.yml
@@ -79,7 +79,18 @@
   - validate
   - validate_tmp_access
   
-  - name: Validate enough free disk space for package installation
+- name: Validate enough free disk space for package installation
+  assert:
+    that: item.size_available > {{ required_disk_space_mb }}|float
+    fail_msg: >- 
+      "Not enough free disk space for package installation.  Minimum space required is {{ required_disk_space_mb }}MB, please free up more disk space 
+      to continue installation. To skip host validations, set validate_hosts to false."
+  with_items: "{{ ansible_mounts }}"
+  tags: 
+    - validate
+    - validate_disk_usage
+
+- name: Validate enough free disk space for package installation
   assert:
     that: item.size_available > {{ required_disk_space_mb }}|float
     fail_msg: >- 

--- a/roles/common/tasks/host_validations.yml
+++ b/roles/common/tasks/host_validations.yml
@@ -89,14 +89,3 @@
   tags: 
     - validate
     - validate_disk_usage
-
-- name: Validate enough free disk space for package installation
-  assert:
-    that: item.size_available > {{ required_disk_space_mb }}|float
-    fail_msg: >- 
-      "Not enough free disk space for package installation.  Minimum space required is {{ required_disk_space_mb }}MB, please free up more disk space 
-      to continue installation. To skip host validations, set validate_hosts to false."
-  with_items: "{{ ansible_mounts }}"
-  tags: 
-    - validate
-    - validate_disk_usage


### PR DESCRIPTION
# Description

Noticed that the spacing/indentation on the following task was wrong in the host_validations.yml:

  - name: Validate enough free disk space for package installation
  assert:
    that: item.size_available > {{ required_disk_space_mb }}|float
    fail_msg: >- 
      "Not enough free disk space for package installation.  Minimum space required is {{ required_disk_space_mb }}MB, please free up more disk space 
      to continue installation. To skip host validations, set validate_hosts to false."
  with_items: "{{ ansible_mounts }}"
  tags: 
    - validate
    - validate_disk_usage

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Ran mtls-customcerts-rhel to validate it runs correctly.
TASK [confluent.platform.common : Validate enough free disk space for package installation] ***
ok: [kafka-broker1] => (item={'block_used': 8916424, 'uuid': 'N/A', 'size_total': 270294650880, 'block_total': 65989905, 'mount': '/etc/hostname', 'block_available': 57073481, 'size_available': 233772978176, 'fstype': 'ext4', 'inode_total': 16777216, 'options': 'rw,relatime,bind', 'device': '/dev/vda1', 'inode_used': 281053, 'block_size': 4096, 'inode_available': 16496163}) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "block_available": 57073481,
        "block_size": 4096,
        "block_total": 65989905,
        "block_used": 8916424,
        "device": "/dev/vda1",
        "fstype": "ext4",
        "inode_available": 16496163,
        "inode_total": 16777216,
        "inode_used": 281053,
        "mount": "/etc/hostname",
        "options": "rw,relatime,bind",
        "size_available": 233772978176,
        "size_total": 270294650880,
        "uuid": "N/A"
    },
    "msg": "All assertions passed"
}
ok: [zookeeper1] => (item={'block_used': 8916372, 'uuid': 'N/A', 'size_total': 270294650880, 'block_total': 65989905, 'mount': '/etc/hosts', 'block_available': 57073533, 'size_available': 233773191168, 'fstype': 'ext4', 'inode_total': 16777216, 'options': 'rw,relatime,bind', 'device': '/dev/vda1', 'inode_used': 281051, 'block_size': 4096, 'inode_available': 16496165}) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "block_available": 57073533,
        "block_size": 4096,
        "block_total": 65989905,
        "block_used": 8916372,
        "device": "/dev/vda1",
        "fstype": "ext4",
        "inode_available": 16496165,
        "inode_total": 16777216,
        "inode_used": 281051,
        "mount": "/etc/hosts",
        "options": "rw,relatime,bind",
        "size_available": 233773191168,
        "size_total": 270294650880,
        "uuid": "N/A"
    },
    "msg": "All assertions passed"
}
ok: [kafka-broker2] => (item={'block_used': 8916424, 'uuid': 'N/A', 'size_total': 270294650880, 'block_total': 65989905, 'mount': '/etc/hosts', 'block_available': 57073481, 'size_available': 233772978176, 'fstype': 'ext4', 'inode_total': 16777216, 'options': 'rw,relatime,bind', 'device': '/dev/vda1', 'inode_used': 281053, 'block_size': 4096, 'inode_available': 16496163}) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "block_available": 57073481,
        "block_size": 4096,
        "block_total": 65989905,
        "block_used": 8916424,
        "device": "/dev/vda1",
        "fstype": "ext4",
        "inode_available": 16496163,
        "inode_total": 16777216,
        "inode_used": 281053,
        "mount": "/etc/hosts",
        "options": "rw,relatime,bind",
        "size_available": 233772978176,
        "size_total": 270294650880,
        "uuid": "N/A"
    },
    "msg": "All assertions passed"
}
ok: [kafka-broker3] => (item={'block_used': 8916424, 'uuid': 'N/A', 'size_total': 270294650880, 'block_total': 65989905, 'mount': '/etc/hostname', 'block_available': 57073481, 'size_available': 233772978176, 'fstype': 'ext4', 'inode_total': 16777216, 'options': 'rw,relatime,bind', 'device': '/dev/vda1', 'inode_used': 281053, 'block_size': 4096, 'inode_available': 16496163}) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "block_available": 57073481,
        "block_size": 4096,
        "block_total": 65989905,
        "block_used": 8916424,
        "device": "/dev/vda1",
        "fstype": "ext4",
        "inode_available": 16496163,
        "inode_total": 16777216,
        "inode_used": 281053,
        "mount": "/etc/hostname",
        "options": "rw,relatime,bind",
        "size_available": 233772978176,
        "size_total": 270294650880,
        "uuid": "N/A"
    },
    "msg": "All assertions passed"
}
ok: [schema-registry1] => (item={'block_used': 8916424, 'uuid': 'N/A', 'size_total': 270294650880, 'block_total': 65989905, 'mount': '/etc/hosts', 'block_available': 57073481, 'size_available': 233772978176, 'fstype': 'ext4', 'inode_total': 16777216, 'options': 'rw,relatime,bind', 'device': '/dev/vda1', 'inode_used': 281053, 'block_size': 4096, 'inode_available': 16496163}) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "block_available": 57073481,
        "block_size": 4096,
        "block_total": 65989905,
        "block_used": 8916424,
        "device": "/dev/vda1",
        "fstype": "ext4",
        "inode_available": 16496163,
        "inode_total": 16777216,
        "inode_used": 281053,
        "mount": "/etc/hosts",
        "options": "rw,relatime,bind",
        "size_available": 233772978176,
        "size_total": 270294650880,
        "uuid": "N/A"
    },
    "msg": "All assertions passed"
}
ok: [kafka-connect1] => (item={'block_used': 8916320, 'uuid': 'N/A', 'size_total': 270294650880, 'block_total': 65989905, 'mount': '/etc/resolv.conf', 'block_available': 57073585, 'size_available': 233773404160, 'fstype': 'ext4', 'inode_total': 16777216, 'options': 'rw,relatime,bind', 'device': '/dev/vda1', 'inode_used': 281049, 'block_size': 4096, 'inode_available': 16496167}) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "block_available": 57073585,
        "block_size": 4096,
        "block_total": 65989905,
        "block_used": 8916320,
        "device": "/dev/vda1",
        "fstype": "ext4",
        "inode_available": 16496167,
        "inode_total": 16777216,
        "inode_used": 281049,
        "mount": "/etc/resolv.conf",
        "options": "rw,relatime,bind",
        "size_available": 233773404160,
        "size_total": 270294650880,
        "uuid": "N/A"
    },
    "msg": "All assertions passed"
}
ok: [ksql1] => (item={'block_used': 8916372, 'uuid': 'N/A', 'size_total': 270294650880, 'block_total': 65989905, 'mount': '/etc/hosts', 'block_available': 57073533, 'size_available': 233773191168, 'fstype': 'ext4', 'inode_total': 16777216, 'options': 'rw,relatime,bind', 'device': '/dev/vda1', 'inode_used': 281051, 'block_size': 4096, 'inode_available': 16496165}) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "block_available": 57073533,
        "block_size": 4096,
        "block_total": 65989905,
        "block_used": 8916372,
        "device": "/dev/vda1",
        "fstype": "ext4",
        "inode_available": 16496165,
        "inode_total": 16777216,
        "inode_used": 281051,
        "mount": "/etc/hosts",
        "options": "rw,relatime,bind",
        "size_available": 233773191168,
        "size_total": 270294650880,
        "uuid": "N/A"
    },
    "msg": "All assertions passed"
}
ok: [control-center1] => (item={'block_used': 8916424, 'uuid': 'N/A', 'size_total': 270294650880, 'block_total': 65989905, 'mount': '/etc/hosts', 'block_available': 57073481, 'size_available': 233772978176, 'fstype': 'ext4', 'inode_total': 16777216, 'options': 'rw,relatime,bind', 'device': '/dev/vda1', 'inode_used': 281053, 'block_size': 4096, 'inode_available': 16496163}) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "block_available": 57073481,
        "block_size": 4096,
        "block_total": 65989905,
        "block_used": 8916424,
        "device": "/dev/vda1",
        "fstype": "ext4",
        "inode_available": 16496163,
        "inode_total": 16777216,
        "inode_used": 281053,
        "mount": "/etc/hosts",
        "options": "rw,relatime,bind",
        "size_available": 233772978176,
        "size_total": 270294650880,
        "uuid": "N/A"
    },
    "msg": "All assertions passed"
}
ok: [kafka-rest1] => (item={'block_used': 8916268, 'uuid': 'N/A', 'size_total': 270294650880, 'block_total': 65989905, 'mount': '/etc/hosts', 'block_available': 57073637, 'size_available': 233773617152, 'fstype': 'ext4', 'inode_total': 16777216, 'options': 'rw,relatime,bind', 'device': '/dev/vda1', 'inode_used': 281047, 'block_size': 4096, 'inode_available': 16496169}) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "block_available": 57073637,
        "block_size": 4096,
        "block_total": 65989905,
        "block_used": 8916268,
        "device": "/dev/vda1",
        "fstype": "ext4",
        "inode_available": 16496169,
        "inode_total": 16777216,
        "inode_used": 281047,
        "mount": "/etc/hosts",
        "options": "rw,relatime,bind",
        "size_available": 233773617152,
        "size_total": 270294650880,
        "uuid": "N/A"
    },
    "msg": "All assertions passed"
}
ok: [kafka-broker1] => (item={'block_used': 8916424, 'uuid': 'N/A', 'size_total': 270294650880, 'block_total': 65989905, 'mount': '/etc/hosts', 'block_available': 57073481, 'size_available': 233772978176, 'fstype': 'ext4', 'inode_total': 16777216, 'options': 'rw,relatime,bind', 'device': '/dev/vda1', 'inode_used': 281053, 'block_size': 4096, 'inode_available': 16496163}) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "block_available": 57073481,
        "block_size": 4096,
        "block_total": 65989905,
        "block_used": 8916424,
        "device": "/dev/vda1",
        "fstype": "ext4",
        "inode_available": 16496163,
        "inode_total": 16777216,
        "inode_used": 281053,
        "mount": "/etc/hosts",
        "options": "rw,relatime,bind",
        "size_available": 233772978176,
        "size_total": 270294650880,
        "uuid": "N/A"
    },
    "msg": "All assertions passed"
}
ok: [zookeeper1] => (item={'block_used': 8916372, 'uuid': 'N/A', 'size_total': 270294650880, 'block_total': 65989905, 'mount': '/etc/hostname', 'block_available': 57073533, 'size_available': 233773191168, 'fstype': 'ext4', 'inode_total': 16777216, 'options': 'rw,relatime,bind', 'device': '/dev/vda1', 'inode_used': 281051, 'block_size': 4096, 'inode_available': 16496165}) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "block_available": 57073533,
        "block_size": 4096,
        "block_total": 65989905,
        "block_used": 8916372,
        "device": "/dev/vda1",
        "fstype": "ext4",
        "inode_available": 16496165,
        "inode_total": 16777216,
        "inode_used": 281051,
        "mount": "/etc/hostname",
        "options": "rw,relatime,bind",
        "size_available": 233773191168,
        "size_total": 270294650880,
        "uuid": "N/A"
    },
    "msg": "All assertions passed"
}
ok: [schema-registry1] => (item={'block_used': 8916424, 'uuid': 'N/A', 'size_total': 270294650880, 'block_total': 65989905, 'mount': '/etc/hostname', 'block_available': 57073481, 'size_available': 233772978176, 'fstype': 'ext4', 'inode_total': 16777216, 'options': 'rw,relatime,bind', 'device': '/dev/vda1', 'inode_used': 281053, 'block_size': 4096, 'inode_available': 16496163}) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "block_available": 57073481,
        "block_size": 4096,
        "block_total": 65989905,
        "block_used": 8916424,
        "device": "/dev/vda1",
        "fstype": "ext4",
        "inode_available": 16496163,
        "inode_total": 16777216,
        "inode_used": 281053,
        "mount": "/etc/hostname",
        "options": "rw,relatime,bind",
        "size_available": 233772978176,
        "size_total": 270294650880,
        "uuid": "N/A"
    },
    "msg": "All assertions passed"
}
ok: [kafka-broker2] => (item={'block_used': 8916424, 'uuid': 'N/A', 'size_total': 270294650880, 'block_total': 65989905, 'mount': '/etc/hostname', 'block_available': 57073481, 'size_available': 233772978176, 'fstype': 'ext4', 'inode_total': 16777216, 'options': 'rw,relatime,bind', 'device': '/dev/vda1', 'inode_used': 281053, 'block_size': 4096, 'inode_available': 16496163}) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "block_available": 57073481,
        "block_size": 4096,
        "block_total": 65989905,
        "block_used": 8916424,
        "device": "/dev/vda1",
        "fstype": "ext4",
        "inode_available": 16496163,
        "inode_total": 16777216,
        "inode_used": 281053,
        "mount": "/etc/hostname",
        "options": "rw,relatime,bind",
        "size_available": 233772978176,
        "size_total": 270294650880,
        "uuid": "N/A"
    },
    "msg": "All assertions passed"
}
ok: [kafka-broker3] => (item={'block_used': 8916424, 'uuid': 'N/A', 'size_total': 270294650880, 'block_total': 65989905, 'mount': '/etc/resolv.conf', 'block_available': 57073481, 'size_available': 233772978176, 'fstype': 'ext4', 'inode_total': 16777216, 'options': 'rw,relatime,bind', 'device': '/dev/vda1', 'inode_used': 281053, 'block_size': 4096, 'inode_available': 16496163}) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "block_available": 57073481,
        "block_size": 4096,
        "block_total": 65989905,
        "block_used": 8916424,
        "device": "/dev/vda1",
        "fstype": "ext4",
        "inode_available": 16496163,
        "inode_total": 16777216,
        "inode_used": 281053,
        "mount": "/etc/resolv.conf",
        "options": "rw,relatime,bind",
        "size_available": 233772978176,
        "size_total": 270294650880,
        "uuid": "N/A"
    },
    "msg": "All assertions passed"
}
ok: [kafka-connect1] => (item={'block_used': 8916320, 'uuid': 'N/A', 'size_total': 270294650880, 'block_total': 65989905, 'mount': '/etc/hosts', 'block_available': 57073585, 'size_available': 233773404160, 'fstype': 'ext4', 'inode_total': 16777216, 'options': 'rw,relatime,bind', 'device': '/dev/vda1', 'inode_used': 281049, 'block_size': 4096, 'inode_available': 16496167}) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "block_available": 57073585,
        "block_size": 4096,
        "block_total": 65989905,
        "block_used": 8916320,
        "device": "/dev/vda1",
        "fstype": "ext4",
        "inode_available": 16496167,
        "inode_total": 16777216,
        "inode_used": 281049,
        "mount": "/etc/hosts",
        "options": "rw,relatime,bind",
        "size_available": 233773404160,
        "size_total": 270294650880,
        "uuid": "N/A"
    },
    "msg": "All assertions passed"
}
ok: [ksql1] => (item={'block_used': 8916372, 'uuid': 'N/A', 'size_total': 270294650880, 'block_total': 65989905, 'mount': '/etc/hostname', 'block_available': 57073533, 'size_available': 233773191168, 'fstype': 'ext4', 'inode_total': 16777216, 'options': 'rw,relatime,bind', 'device': '/dev/vda1', 'inode_used': 281051, 'block_size': 4096, 'inode_available': 16496165}) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "block_available": 57073533,
        "block_size": 4096,
        "block_total": 65989905,
        "block_used": 8916372,
        "device": "/dev/vda1",
        "fstype": "ext4",
        "inode_available": 16496165,
        "inode_total": 16777216,
        "inode_used": 281051,
        "mount": "/etc/hostname",
        "options": "rw,relatime,bind",
        "size_available": 233773191168,
        "size_total": 270294650880,
        "uuid": "N/A"
    },
    "msg": "All assertions passed"
}
ok: [control-center1] => (item={'block_used': 8916424, 'uuid': 'N/A', 'size_total': 270294650880, 'block_total': 65989905, 'mount': '/etc/hostname', 'block_available': 57073481, 'size_available': 233772978176, 'fstype': 'ext4', 'inode_total': 16777216, 'options': 'rw,relatime,bind', 'device': '/dev/vda1', 'inode_used': 281053, 'block_size': 4096, 'inode_available': 16496163}) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "block_available": 57073481,
        "block_size": 4096,
        "block_total": 65989905,
        "block_used": 8916424,
        "device": "/dev/vda1",
        "fstype": "ext4",
        "inode_available": 16496163,
        "inode_total": 16777216,
        "inode_used": 281053,
        "mount": "/etc/hostname",
        "options": "rw,relatime,bind",
        "size_available": 233772978176,
        "size_total": 270294650880,
        "uuid": "N/A"
    },
    "msg": "All assertions passed"
}
ok: [kafka-rest1] => (item={'block_used': 8916268, 'uuid': 'N/A', 'size_total': 270294650880, 'block_total': 65989905, 'mount': '/etc/resolv.conf', 'block_available': 57073637, 'size_available': 233773617152, 'fstype': 'ext4', 'inode_total': 16777216, 'options': 'rw,relatime,bind', 'device': '/dev/vda1', 'inode_used': 281047, 'block_size': 4096, 'inode_available': 16496169}) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "block_available": 57073637,
        "block_size": 4096,
        "block_total": 65989905,
        "block_used": 8916268,
        "device": "/dev/vda1",
        "fstype": "ext4",
        "inode_available": 16496169,
        "inode_total": 16777216,
        "inode_used": 281047,
        "mount": "/etc/resolv.conf",
        "options": "rw,relatime,bind",
        "size_available": 233773617152,
        "size_total": 270294650880,
        "uuid": "N/A"
    },
    "msg": "All assertions passed"
}
ok: [kafka-broker1] => (item={'block_used': 8916424, 'uuid': 'N/A', 'size_total': 270294650880, 'block_total': 65989905, 'mount': '/etc/resolv.conf', 'block_available': 57073481, 'size_available': 233772978176, 'fstype': 'ext4', 'inode_total': 16777216, 'options': 'rw,relatime,bind', 'device': '/dev/vda1', 'inode_used': 281053, 'block_size': 4096, 'inode_available': 16496163}) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "block_available": 57073481,
        "block_size": 4096,
        "block_total": 65989905,
        "block_used": 8916424,
        "device": "/dev/vda1",
        "fstype": "ext4",
        "inode_available": 16496163,
        "inode_total": 16777216,
        "inode_used": 281053,
        "mount": "/etc/resolv.conf",
        "options": "rw,relatime,bind",
        "size_available": 233772978176,
        "size_total": 270294650880,
        "uuid": "N/A"
    },
    "msg": "All assertions passed"
}
ok: [zookeeper1] => (item={'block_used': 8916372, 'uuid': 'N/A', 'size_total': 270294650880, 'block_total': 65989905, 'mount': '/etc/resolv.conf', 'block_available': 57073533, 'size_available': 233773191168, 'fstype': 'ext4', 'inode_total': 16777216, 'options': 'rw,relatime,bind', 'device': '/dev/vda1', 'inode_used': 281051, 'block_size': 4096, 'inode_available': 16496165}) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "block_available": 57073533,
        "block_size": 4096,
        "block_total": 65989905,
        "block_used": 8916372,
        "device": "/dev/vda1",
        "fstype": "ext4",
        "inode_available": 16496165,
        "inode_total": 16777216,
        "inode_used": 281051,
        "mount": "/etc/resolv.conf",
        "options": "rw,relatime,bind",
        "size_available": 233773191168,
        "size_total": 270294650880,
        "uuid": "N/A"
    },
    "msg": "All assertions passed"
}
ok: [schema-registry1] => (item={'block_used': 8916424, 'uuid': 'N/A', 'size_total': 270294650880, 'block_total': 65989905, 'mount': '/etc/resolv.conf', 'block_available': 57073481, 'size_available': 233772978176, 'fstype': 'ext4', 'inode_total': 16777216, 'options': 'rw,relatime,bind', 'device': '/dev/vda1', 'inode_used': 281053, 'block_size': 4096, 'inode_available': 16496163}) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "block_available": 57073481,
        "block_size": 4096,
        "block_total": 65989905,
        "block_used": 8916424,
        "device": "/dev/vda1",
        "fstype": "ext4",
        "inode_available": 16496163,
        "inode_total": 16777216,
        "inode_used": 281053,
        "mount": "/etc/resolv.conf",
        "options": "rw,relatime,bind",
        "size_available": 233772978176,
        "size_total": 270294650880,
        "uuid": "N/A"
    },
    "msg": "All assertions passed"
}
ok: [kafka-broker2] => (item={'block_used': 8916424, 'uuid': 'N/A', 'size_total': 270294650880, 'block_total': 65989905, 'mount': '/etc/resolv.conf', 'block_available': 57073481, 'size_available': 233772978176, 'fstype': 'ext4', 'inode_total': 16777216, 'options': 'rw,relatime,bind', 'device': '/dev/vda1', 'inode_used': 281053, 'block_size': 4096, 'inode_available': 16496163}) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "block_available": 57073481,
        "block_size": 4096,
        "block_total": 65989905,
        "block_used": 8916424,
        "device": "/dev/vda1",
        "fstype": "ext4",
        "inode_available": 16496163,
        "inode_total": 16777216,
        "inode_used": 281053,
        "mount": "/etc/resolv.conf",
        "options": "rw,relatime,bind",
        "size_available": 233772978176,
        "size_total": 270294650880,
        "uuid": "N/A"
    },
    "msg": "All assertions passed"
}
ok: [kafka-connect1] => (item={'block_used': 8916320, 'uuid': 'N/A', 'size_total': 270294650880, 'block_total': 65989905, 'mount': '/etc/hostname', 'block_available': 57073585, 'size_available': 233773404160, 'fstype': 'ext4', 'inode_total': 16777216, 'options': 'rw,relatime,bind', 'device': '/dev/vda1', 'inode_used': 281049, 'block_size': 4096, 'inode_available': 16496167}) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "block_available": 57073585,
        "block_size": 4096,
        "block_total": 65989905,
        "block_used": 8916320,
        "device": "/dev/vda1",
        "fstype": "ext4",
        "inode_available": 16496167,
        "inode_total": 16777216,
        "inode_used": 281049,
        "mount": "/etc/hostname",
        "options": "rw,relatime,bind",
        "size_available": 233773404160,
        "size_total": 270294650880,
        "uuid": "N/A"
    },
    "msg": "All assertions passed"
}
ok: [kafka-broker3] => (item={'block_used': 8916424, 'uuid': 'N/A', 'size_total': 270294650880, 'block_total': 65989905, 'mount': '/etc/hosts', 'block_available': 57073481, 'size_available': 233772978176, 'fstype': 'ext4', 'inode_total': 16777216, 'options': 'rw,relatime,bind', 'device': '/dev/vda1', 'inode_used': 281053, 'block_size': 4096, 'inode_available': 16496163}) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "block_available": 57073481,
        "block_size": 4096,
        "block_total": 65989905,
        "block_used": 8916424,
        "device": "/dev/vda1",
        "fstype": "ext4",
        "inode_available": 16496163,
        "inode_total": 16777216,
        "inode_used": 281053,
        "mount": "/etc/hosts",
        "options": "rw,relatime,bind",
        "size_available": 233772978176,
        "size_total": 270294650880,
        "uuid": "N/A"
    },
    "msg": "All assertions passed"
}
ok: [ksql1] => (item={'block_used': 8916372, 'uuid': 'N/A', 'size_total': 270294650880, 'block_total': 65989905, 'mount': '/etc/resolv.conf', 'block_available': 57073533, 'size_available': 233773191168, 'fstype': 'ext4', 'inode_total': 16777216, 'options': 'rw,relatime,bind', 'device': '/dev/vda1', 'inode_used': 281051, 'block_size': 4096, 'inode_available': 16496165}) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "block_available": 57073533,
        "block_size": 4096,
        "block_total": 65989905,
        "block_used": 8916372,
        "device": "/dev/vda1",
        "fstype": "ext4",
        "inode_available": 16496165,
        "inode_total": 16777216,
        "inode_used": 281051,
        "mount": "/etc/resolv.conf",
        "options": "rw,relatime,bind",
        "size_available": 233773191168,
        "size_total": 270294650880,
        "uuid": "N/A"
    },
    "msg": "All assertions passed"
}
ok: [control-center1] => (item={'block_used': 8916424, 'uuid': 'N/A', 'size_total': 270294650880, 'block_total': 65989905, 'mount': '/etc/resolv.conf', 'block_available': 57073481, 'size_available': 233772978176, 'fstype': 'ext4', 'inode_total': 16777216, 'options': 'rw,relatime,bind', 'device': '/dev/vda1', 'inode_used': 281053, 'block_size': 4096, 'inode_available': 16496163}) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "block_available": 57073481,
        "block_size": 4096,
        "block_total": 65989905,
        "block_used": 8916424,
        "device": "/dev/vda1",
        "fstype": "ext4",
        "inode_available": 16496163,
        "inode_total": 16777216,
        "inode_used": 281053,
        "mount": "/etc/resolv.conf",
        "options": "rw,relatime,bind",
        "size_available": 233772978176,
        "size_total": 270294650880,
        "uuid": "N/A"
    },
    "msg": "All assertions passed"
}
ok: [kafka-rest1] => (item={'block_used': 8916268, 'uuid': 'N/A', 'size_total': 270294650880, 'block_total': 65989905, 'mount': '/etc/hostname', 'block_available': 57073637, 'size_available': 233773617152, 'fstype': 'ext4', 'inode_total': 16777216, 'options': 'rw,relatime,bind', 'device': '/dev/vda1', 'inode_used': 281047, 'block_size': 4096, 'inode_available': 16496169}) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": {
        "block_available": 57073637,
        "block_size": 4096,
        "block_total": 65989905,
        "block_used": 8916268,
        "device": "/dev/vda1",
        "fstype": "ext4",
        "inode_available": 16496169,
        "inode_total": 16777216,
        "inode_used": 281047,
        "mount": "/etc/hostname",
        "options": "rw,relatime,bind",
        "size_available": 233773617152,
        "size_total": 270294650880,
        "uuid": "N/A"
    },
    "msg": "All assertions passed"
}

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible