### PR TITLE
71x validate memory

### DIFF
--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -148,6 +148,70 @@ Default:  1000
 
 ***
 
+### required_total_memory_mb_zookeeper
+
+Variable to define the minimum amount of memory in MB required to run zookeeper.  Calculated as default heap size plus 1GB for OS.
+
+Default:  2000
+
+***
+
+### required_total_memory_mb_kafka_broker
+
+Variable to define the minimum amount of memory in MB required to run kafka Broker. Calculated as default heap size plus 1GB for OS.
+
+Default:  7000
+
+***
+
+### required_total_memory_mb_kafka_connect
+
+Variable to define the minimum amount of memory in MB required to run kafka Connect. Calculated as default heap size plus 1GB for OS.
+
+Default:  3000
+
+***
+
+### required_total_memory_mb_schema_registry
+
+Variable to define the minimum amount of memory in MB required to run Schema Registry. Calculated as default heap size plus 1GB for OS.
+
+Default:  2000
+
+***
+
+### required_total_memory_mb_ksql
+
+Variable to define the minimum amount of memory in MB required to run KSQL. Calculated as default heap size plus 1GB for OS.
+
+Default:  4000
+
+***
+
+### required_total_memory_mb_kafka_rest
+
+Variable to define the minimum amount of memory in MB required to run Rest Proxy. Calculated as default heap size plus 1GB for OS.
+
+Default:  3000
+
+***
+
+### required_total_memory_mb_control_center
+
+Variable to define the minimum amount of memory in MB required to run Control Center. Calculated as default heap size plus 1GB for OS.
+
+Default:  7000
+
+***
+
+### required_total_memory_mb_kafka_connect_replicator
+
+Variable to define the minimum amount of memory in MB required to run Kafka Connect Replicator. Calculated as default heap size plus 1GB for OS.
+
+Default:  3000
+
+***
+
 ### confluent_server_enabled
 
 Boolean to install commercially licensed confluent-server instead of community version: confluent-kafka

--- a/roles/common/tasks/host_validations.yml
+++ b/roles/common/tasks/host_validations.yml
@@ -79,7 +79,7 @@
   - validate
   - validate_tmp_access
   
-  - name: Validate enough free disk space for package installation
+- name: Validate enough free disk space for package installation
   assert:
     that: item.size_available > {{ required_disk_space_mb }}|float
     fail_msg: >- 
@@ -89,3 +89,99 @@
   tags: 
     - validate
     - validate_disk_usage
+
+- name: Validate enough free memory for Zookeeper hosts
+  assert:
+    that: ansible_memtotal_mb > {{ required_total_memory_mb_zookeeper }}|float
+    fail_msg: >- 
+      "Not enough memory to run Zookeeper.  Minimum memory required is {{ required_total_memory_mb_zookeeper }}MB, please add more memory to host
+      or choose a different host to install Zookeeper to continue installation."
+  when: groups['zookeeper'] is defined and inventory_hostname in groups['zookeeper']
+  tags: 
+    - validate
+    - validate_memory_usage
+    - validate_memory_usage_zookeeper
+
+- name: Validate enough free memory for Kafka Broker hosts
+  assert:
+    that: ansible_memtotal_mb > {{ required_total_memory_mb_kafka_broker }}|float
+    fail_msg: >- 
+      "Not enough memory to run Kafka Broker.  Minimum memory required is {{ required_total_memory_mb_kafka_broker }}MB, please add more memory to host
+      or choose a different host to install Kafka Broker to continue installation."
+  when: groups['kafka_broker'] is defined and inventory_hostname in groups['kafka_broker']
+  tags: 
+    - validate
+    - validate_memory_usage
+    - validate_memory_usage_kafka_broker
+
+- name: Validate enough free memory for Kafka Connect hosts
+  assert:
+    that: ansible_memtotal_mb > {{ required_total_memory_mb_kafka_connect }}|float
+    fail_msg: >- 
+      "Not enough memory to run Kafka Connect.  Minimum memory required is {{ required_total_memory_mb_kafka_connect }}MB, please add more memory to host
+      or choose a different host to install Kafka Connect to continue installation."
+  when: groups['kafka_connect'] is defined and inventory_hostname in groups['kafka_connect']
+  tags: 
+    - validate
+    - validate_memory_usage
+    - validate_memory_usage_kafka_connect
+
+- name: Validate enough free memory for Schema Registry hosts
+  assert:
+    that: ansible_memtotal_mb > {{ required_total_memory_mb_schema_registry }}|float
+    fail_msg: >- 
+      "Not enough memory to run Schema Registry.  Minimum memory required is {{ required_total_memory_mb_schema_registry }}MB, please add more memory to host
+      or choose a different host to install Kafka Connect to continue installation."
+  when: groups['schema_registry'] is defined and inventory_hostname in groups['schema_registry']
+  tags: 
+    - validate
+    - validate_memory_usage
+    - validate_memory_usage_schema_registry
+
+- name: Validate enough free memory for KSQL hosts
+  assert:
+    that: ansible_memtotal_mb > {{ required_total_memory_mb_ksql }}|float
+    fail_msg: >- 
+      "Not enough memory to run KSQL.  Minimum memory required is {{ required_total_memory_mb_ksql }}MB, please add more memory to host
+      or choose a different host to install Kafka Connect to continue installation."
+  when: groups['ksql'] is defined and inventory_hostname in groups['ksql']
+  tags: 
+    - validate
+    - validate_memory_usage
+    - validate_memory_usage_ksql
+
+- name: Validate enough free memory for Rest Proxy hosts
+  assert:
+    that: ansible_memtotal_mb > {{ required_total_memory_mb_kafka_rest }}|float
+    fail_msg: >- 
+      "Not enough memory to run Kafka Rest Proxy.  Minimum memory required is {{ required_total_memory_mb_kafka_rest }}MB, please add more memory to host
+      or choose a different host to install Rest Proxy to continue installation."
+  when: groups['kafka_rest'] is defined and inventory_hostname in groups['kafka_rest']
+  tags:
+    - validate
+    - validate_memory_usage
+    - validate_memory_usage_kafka_rest_proxy
+
+- name: Validate enough free memory for Control Center hosts
+  assert:
+    that: ansible_memtotal_mb > {{ required_total_memory_mb_control_center }}|float
+    fail_msg: >- 
+      "Not enough memory to run Control Center.  Minimum memory required is {{ required_total_memory_mb_control_center }}MB, please add more memory to host
+      or choose a different host to install Control Center to continue installation."
+  when: groups['control_center'] is defined and inventory_hostname in groups['control_center']
+  tags: 
+    - validate
+    - validate_memory_usage
+    - validate_memory_usage_control_center
+
+- name: Validate enough free memory for Kafka Connect Replicator hosts
+  assert:
+    that: ansible_memtotal_mb > {{ required_total_memory_mb_kafka_connect_replicator }}|float
+    fail_msg: >- 
+      "Not enough memory to run Kafka Connect Replicator.  Minimum memory required is {{ required_total_memory_mb_kafka_connect_replicator }}MB, please add more memory to host
+      or choose a different host to install Kafka Connect Replicator to continue installation."
+  when: groups['kafka_connect_replicator'] is defined and inventory_hostname in groups['kafka_connect_replicator']
+  tags: 
+    - validate
+    - validate_memory_usage
+    - validate_memory_usage_kafka_connect_replicator

--- a/roles/common/tasks/host_validations.yml
+++ b/roles/common/tasks/host_validations.yml
@@ -92,7 +92,7 @@
 
 - name: Validate enough free memory for Zookeeper hosts
   assert:
-    that: ansible_memtotal_mb > {{ required_total_memory_mb_zookeeper }}|float
+    that: ansible_memfree_mb > {{ required_total_memory_mb_zookeeper }}|float
     fail_msg: >-
       "Not enough memory to run Zookeeper.  Minimum memory required is {{ required_total_memory_mb_zookeeper }}MB, please add more memory to host
       or choose a different host to install Zookeeper to continue installation."
@@ -104,7 +104,7 @@
 
 - name: Validate enough free memory for Kafka Broker hosts
   assert:
-    that: ansible_memtotal_mb > {{ required_total_memory_mb_kafka_broker }}|float
+    that: ansible_memfree_mb > {{ required_total_memory_mb_kafka_broker }}|float
     fail_msg: >-
       "Not enough memory to run Kafka Broker.  Minimum memory required is {{ required_total_memory_mb_kafka_broker }}MB, please add more memory to host
       or choose a different host to install Kafka Broker to continue installation."
@@ -116,7 +116,7 @@
 
 - name: Validate enough free memory for Kafka Connect hosts
   assert:
-    that: ansible_memtotal_mb > {{ required_total_memory_mb_kafka_connect }}|float
+    that: ansible_memfree_mb > {{ required_total_memory_mb_kafka_connect }}|float
     fail_msg: >-
       "Not enough memory to run Kafka Connect.  Minimum memory required is {{ required_total_memory_mb_kafka_connect }}MB, please add more memory to host
       or choose a different host to install Kafka Connect to continue installation."
@@ -128,7 +128,7 @@
 
 - name: Validate enough free memory for Schema Registry hosts
   assert:
-    that: ansible_memtotal_mb > {{ required_total_memory_mb_schema_registry }}|float
+    that: ansible_memfree_mb > {{ required_total_memory_mb_schema_registry }}|float
     fail_msg: >-
       "Not enough memory to run Schema Registry.  Minimum memory required is {{ required_total_memory_mb_schema_registry }}MB, please add more memory to host
       or choose a different host to install Kafka Connect to continue installation."
@@ -140,7 +140,7 @@
 
 - name: Validate enough free memory for KSQL hosts
   assert:
-    that: ansible_memtotal_mb > {{ required_total_memory_mb_ksql }}|float
+    that: ansible_memfree_mb > {{ required_total_memory_mb_ksql }}|float
     fail_msg: >-
       "Not enough memory to run KSQL.  Minimum memory required is {{ required_total_memory_mb_ksql }}MB, please add more memory to host
       or choose a different host to install Kafka Connect to continue installation."
@@ -152,7 +152,7 @@
 
 - name: Validate enough free memory for Rest Proxy hosts
   assert:
-    that: ansible_memtotal_mb > {{ required_total_memory_mb_kafka_rest }}|float
+    that: ansible_memfree_mb > {{ required_total_memory_mb_kafka_rest }}|float
     fail_msg: >-
       "Not enough memory to run Kafka Rest Proxy.  Minimum memory required is {{ required_total_memory_mb_kafka_rest }}MB, please add more memory to host
       or choose a different host to install Rest Proxy to continue installation."
@@ -164,7 +164,7 @@
 
 - name: Validate enough free memory for Control Center hosts
   assert:
-    that: ansible_memtotal_mb > {{ required_total_memory_mb_control_center }}|float
+    that: ansible_memfree_mb > {{ required_total_memory_mb_control_center }}|float
     fail_msg: >-
       "Not enough memory to run Control Center.  Minimum memory required is {{ required_total_memory_mb_control_center }}MB, please add more memory to host
       or choose a different host to install Control Center to continue installation."
@@ -176,7 +176,7 @@
 
 - name: Validate enough free memory for Kafka Connect Replicator hosts
   assert:
-    that: ansible_memtotal_mb > {{ required_total_memory_mb_kafka_connect_replicator }}|float
+    that: ansible_memfree_mb > {{ required_total_memory_mb_kafka_connect_replicator }}|float
     fail_msg: >-
       "Not enough memory to run Kafka Connect Replicator.  Minimum memory required is {{ required_total_memory_mb_kafka_connect_replicator }}MB, please add more memory to host
       or choose a different host to install Kafka Connect Replicator to continue installation."

--- a/roles/common/tasks/host_validations.yml
+++ b/roles/common/tasks/host_validations.yml
@@ -8,7 +8,7 @@
   vars:
     redhat_supported_versions: ['7', '8']
   when: ansible_os_family == "RedHat"
-  tags: 
+  tags:
   - validate
   - validate_os_version
 
@@ -21,7 +21,7 @@
   vars:
     ubuntu_supported_versions: ['16', '18', '20']
   when: ansible_distribution == "Ubuntu"
-  tags: 
+  tags:
   - validate
   - validate_os_version
 
@@ -34,7 +34,7 @@
   vars:
     debian_supported_versions: ['9', '10']
   when: ansible_distribution == "Debian"
-  tags: 
+  tags:
   - validate
   - validate_os_vesion
 
@@ -50,7 +50,7 @@
     ( installation_method == 'archive' and confluent_common_repository_baseurl in confluent_archive_file_source )
   ignore_errors: true
   register: internet_access_check
-  tags: 
+  tags:
   - validate
   - validate_internet_access
 
@@ -65,7 +65,7 @@
   stat:
     path: "/tmp"
   register: path_exists
-  tags: 
+  tags:
   - validate
   - validate_tmp_access
 
@@ -78,26 +78,26 @@
   tags:
   - validate
   - validate_tmp_access
-  
+
 - name: Validate enough free disk space for package installation
   assert:
     that: item.size_available > {{ required_disk_space_mb }}|float
-    fail_msg: >- 
-      "Not enough free disk space for package installation.  Minimum space required is {{ required_disk_space_mb }}MB, please free up more disk space 
+    fail_msg: >-
+      "Not enough free disk space for package installation.  Minimum space required is {{ required_disk_space_mb }}MB, please free up more disk space
       to continue installation. To skip host validations, set validate_hosts to false."
   with_items: "{{ ansible_mounts }}"
-  tags: 
+  tags:
     - validate
     - validate_disk_usage
 
 - name: Validate enough free memory for Zookeeper hosts
   assert:
     that: ansible_memtotal_mb > {{ required_total_memory_mb_zookeeper }}|float
-    fail_msg: >- 
+    fail_msg: >-
       "Not enough memory to run Zookeeper.  Minimum memory required is {{ required_total_memory_mb_zookeeper }}MB, please add more memory to host
       or choose a different host to install Zookeeper to continue installation."
   when: groups['zookeeper'] is defined and inventory_hostname in groups['zookeeper']
-  tags: 
+  tags:
     - validate
     - validate_memory_usage
     - validate_memory_usage_zookeeper
@@ -105,11 +105,11 @@
 - name: Validate enough free memory for Kafka Broker hosts
   assert:
     that: ansible_memtotal_mb > {{ required_total_memory_mb_kafka_broker }}|float
-    fail_msg: >- 
+    fail_msg: >-
       "Not enough memory to run Kafka Broker.  Minimum memory required is {{ required_total_memory_mb_kafka_broker }}MB, please add more memory to host
       or choose a different host to install Kafka Broker to continue installation."
   when: groups['kafka_broker'] is defined and inventory_hostname in groups['kafka_broker']
-  tags: 
+  tags:
     - validate
     - validate_memory_usage
     - validate_memory_usage_kafka_broker
@@ -117,11 +117,11 @@
 - name: Validate enough free memory for Kafka Connect hosts
   assert:
     that: ansible_memtotal_mb > {{ required_total_memory_mb_kafka_connect }}|float
-    fail_msg: >- 
+    fail_msg: >-
       "Not enough memory to run Kafka Connect.  Minimum memory required is {{ required_total_memory_mb_kafka_connect }}MB, please add more memory to host
       or choose a different host to install Kafka Connect to continue installation."
   when: groups['kafka_connect'] is defined and inventory_hostname in groups['kafka_connect']
-  tags: 
+  tags:
     - validate
     - validate_memory_usage
     - validate_memory_usage_kafka_connect
@@ -129,11 +129,11 @@
 - name: Validate enough free memory for Schema Registry hosts
   assert:
     that: ansible_memtotal_mb > {{ required_total_memory_mb_schema_registry }}|float
-    fail_msg: >- 
+    fail_msg: >-
       "Not enough memory to run Schema Registry.  Minimum memory required is {{ required_total_memory_mb_schema_registry }}MB, please add more memory to host
       or choose a different host to install Kafka Connect to continue installation."
   when: groups['schema_registry'] is defined and inventory_hostname in groups['schema_registry']
-  tags: 
+  tags:
     - validate
     - validate_memory_usage
     - validate_memory_usage_schema_registry
@@ -141,11 +141,11 @@
 - name: Validate enough free memory for KSQL hosts
   assert:
     that: ansible_memtotal_mb > {{ required_total_memory_mb_ksql }}|float
-    fail_msg: >- 
+    fail_msg: >-
       "Not enough memory to run KSQL.  Minimum memory required is {{ required_total_memory_mb_ksql }}MB, please add more memory to host
       or choose a different host to install Kafka Connect to continue installation."
   when: groups['ksql'] is defined and inventory_hostname in groups['ksql']
-  tags: 
+  tags:
     - validate
     - validate_memory_usage
     - validate_memory_usage_ksql
@@ -153,7 +153,7 @@
 - name: Validate enough free memory for Rest Proxy hosts
   assert:
     that: ansible_memtotal_mb > {{ required_total_memory_mb_kafka_rest }}|float
-    fail_msg: >- 
+    fail_msg: >-
       "Not enough memory to run Kafka Rest Proxy.  Minimum memory required is {{ required_total_memory_mb_kafka_rest }}MB, please add more memory to host
       or choose a different host to install Rest Proxy to continue installation."
   when: groups['kafka_rest'] is defined and inventory_hostname in groups['kafka_rest']
@@ -165,11 +165,11 @@
 - name: Validate enough free memory for Control Center hosts
   assert:
     that: ansible_memtotal_mb > {{ required_total_memory_mb_control_center }}|float
-    fail_msg: >- 
+    fail_msg: >-
       "Not enough memory to run Control Center.  Minimum memory required is {{ required_total_memory_mb_control_center }}MB, please add more memory to host
       or choose a different host to install Control Center to continue installation."
   when: groups['control_center'] is defined and inventory_hostname in groups['control_center']
-  tags: 
+  tags:
     - validate
     - validate_memory_usage
     - validate_memory_usage_control_center
@@ -177,11 +177,11 @@
 - name: Validate enough free memory for Kafka Connect Replicator hosts
   assert:
     that: ansible_memtotal_mb > {{ required_total_memory_mb_kafka_connect_replicator }}|float
-    fail_msg: >- 
+    fail_msg: >-
       "Not enough memory to run Kafka Connect Replicator.  Minimum memory required is {{ required_total_memory_mb_kafka_connect_replicator }}MB, please add more memory to host
       or choose a different host to install Kafka Connect Replicator to continue installation."
   when: groups['kafka_connect_replicator'] is defined and inventory_hostname in groups['kafka_connect_replicator']
-  tags: 
+  tags:
     - validate
     - validate_memory_usage
     - validate_memory_usage_kafka_connect_replicator

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -3,7 +3,7 @@
   assert:
     that: lookup('config', 'DEFAULT_HASH_BEHAVIOUR') == 'merge'
     fail_msg: "Hash Merging must be enabled in ansible.cfg"
-  tags: 
+  tags:
   - validate
   - validate_hash_merge
 
@@ -29,7 +29,7 @@
 - name: Host Validations
   include_tasks: host_validations.yml
   when: validate_hosts|bool
-  tags: 
+  tags:
   - validate
 
 - name: Red Hat Repo Setup and Java Installation

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -72,6 +72,30 @@ open_file_limit: 500000
 ### Variable to define minimum free disk space in MB for installation.
 required_disk_space_mb: 1000
 
+### Variable to define the minimum amount of memory in MB required to run zookeeper.  Calculated as default heap size plus 1GB for OS.
+required_total_memory_mb_zookeeper: 2000
+
+### Variable to define the minimum amount of memory in MB required to run kafka Broker. Calculated as default heap size plus 1GB for OS.
+required_total_memory_mb_kafka_broker: 7000
+
+### Variable to define the minimum amount of memory in MB required to run kafka Connect. Calculated as default heap size plus 1GB for OS.
+required_total_memory_mb_kafka_connect: 3000
+
+### Variable to define the minimum amount of memory in MB required to run Schema Registry. Calculated as default heap size plus 1GB for OS.
+required_total_memory_mb_schema_registry: 2000
+
+### Variable to define the minimum amount of memory in MB required to run KSQL. Calculated as default heap size plus 1GB for OS.
+required_total_memory_mb_ksql: 4000
+
+### Variable to define the minimum amount of memory in MB required to run Rest Proxy. Calculated as default heap size plus 1GB for OS.
+required_total_memory_mb_kafka_rest: 3000
+
+### Variable to define the minimum amount of memory in MB required to run Control Center. Calculated as default heap size plus 1GB for OS.
+required_total_memory_mb_control_center: 7000
+
+### Variable to define the minimum amount of memory in MB required to run Kafka Connect Replicator. Calculated as default heap size plus 1GB for OS.
+required_total_memory_mb_kafka_connect_replicator: 3000
+
 ### Boolean to install commercially licensed confluent-server instead of community version: confluent-kafka
 confluent_server_enabled: true
 


### PR DESCRIPTION
# Description

This PR adds additional hosts checks to confirm that their is enough memory to install and run the given component.  Note, this is specifically to run the component based on its default heap size with extra buffer (1GB) for the operating system.  It is not considered to be the recommended setting for a production environment.

Fixes # (issue)

ANSIENG-256

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This has been validated by running the mtls-customcerts-rhel scenario and confirm that all checks pass in addition to the replicator memory check being skipped as it's not available in this scenario.  This confirms that logic is correct for when to run the given check.

`TASK [confluent.platform.common : Validate enough free memory for Zookeeper hosts] ***
skipping: [kafka-broker1]
skipping: [kafka-broker2]
skipping: [kafka-broker3]
skipping: [schema-registry1]
skipping: [kafka-connect1]
skipping: [ksql1]
skipping: [control-center1]
skipping: [kafka-rest1]
ok: [zookeeper1] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [confluent.platform.common : Validate enough free memory for Kafka Broker hosts] ***
skipping: [zookeeper1]
skipping: [schema-registry1]
skipping: [kafka-connect1]
skipping: [ksql1]
skipping: [control-center1]
skipping: [kafka-rest1]
ok: [kafka-broker1] => {
    "changed": false,
    "msg": "All assertions passed"
}
ok: [kafka-broker2] => {
    "changed": false,
    "msg": "All assertions passed"
}
ok: [kafka-broker3] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [confluent.platform.common : Validate enough free memory for Kafka Connect hosts] ***
skipping: [zookeeper1]
skipping: [kafka-broker1]
skipping: [kafka-broker2]
skipping: [kafka-broker3]
skipping: [schema-registry1]
skipping: [ksql1]
skipping: [control-center1]
skipping: [kafka-rest1]
ok: [kafka-connect1] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [confluent.platform.common : Validate enough free memory for Schema Registry hosts] ***
skipping: [zookeeper1]
skipping: [kafka-broker1]
skipping: [kafka-broker2]
skipping: [kafka-broker3]
skipping: [kafka-connect1]
skipping: [ksql1]
skipping: [control-center1]
skipping: [kafka-rest1]
ok: [schema-registry1] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [confluent.platform.common : Validate enough free memory for KSQL hosts] ***
skipping: [zookeeper1]
skipping: [kafka-broker1]
skipping: [kafka-broker2]
skipping: [kafka-broker3]
skipping: [schema-registry1]
skipping: [kafka-connect1]
skipping: [control-center1]
skipping: [kafka-rest1]
ok: [ksql1] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [confluent.platform.common : Validate enough free memory for Rest Proxy hosts] ***
skipping: [zookeeper1]
skipping: [kafka-broker1]
skipping: [kafka-broker2]
skipping: [kafka-broker3]
skipping: [schema-registry1]
skipping: [kafka-connect1]
skipping: [ksql1]
skipping: [control-center1]
ok: [kafka-rest1] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [confluent.platform.common : Validate enough free memory for Control Center hosts] ***
skipping: [zookeeper1]
skipping: [kafka-broker1]
skipping: [kafka-broker2]
skipping: [kafka-broker3]
skipping: [schema-registry1]
skipping: [kafka-connect1]
skipping: [ksql1]
skipping: [kafka-rest1]
ok: [control-center1] => {
    "changed": false,
    "msg": "All assertions passed"
}

TASK [confluent.platform.common : Validate enough free memory for Kafka Connect Replicator hosts] ***
skipping: [zookeeper1]
skipping: [kafka-broker1]
skipping: [kafka-broker2]
skipping: [kafka-broker3]
skipping: [schema-registry1]
skipping: [kafka-connect1]
skipping: [ksql1]
skipping: [control-center1]
skipping: [kafka-rest1]`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible