### PR TITLE
Rcca 5725 - Get broker.id from meta properties

### DIFF
--- a/roles/confluent.kafka_broker/tasks/dynamic_groups.yml
+++ b/roles/confluent.kafka_broker/tasks/dynamic_groups.yml
@@ -8,6 +8,11 @@
     src: "{{ kafka_broker.config_file }}"
   register: slurped_properties
 
+- name: Load meta.properties
+  slurp:
+    src: "{{ kafka_broker_final_properties['log.dirs'].split(',')[0] }}/meta.properties"
+  register: slurped_meta_properties
+
 # Zookeeper shell cannot read server.properties if secrets protection is enabled. Creates a non encrypted file
 - name: Create Zookeeper TLS Client Config
   template:
@@ -54,7 +59,7 @@
 - name: Get broker_id
   set_fact:
     controller_json: "{{ controller_query.stdout }}"
-    broker_id: "{{ (slurped_properties.content|b64decode).split('\n') | select('match', '^broker.id.*') | list \
+    broker_id: "{{ (slurped_meta_properties.content|b64decode).split('\n') | select('match', '^broker.id.*') | list \
       | first | regex_replace('^[-a-zA-Z0-9.]*[ ]?=[ ]?(.*)$', '\\1') }}"
 
 - debug:


### PR DESCRIPTION
# Description
Detailed history on the inc-rcca-5725 [slack channel](https://join.slack.com/share/enQtMzEwOTkxNzQwMDk3Ni0zMGIwYmNiNzIyOTc4ZDk4NWMxNTY4N2JlYTgzNjNkMjkxOTY1MGRkNjlhYTlmNGUxZGMyNjBkOTg5YWUxNWM3) 

This change will read broker.id from meta.properties in place of server.properties in dynamic_groups.yml. 
Reason for the change: 
During upgrade of co-located components, when all confluent services are stopped on the host, the server.properties gets wiped out and the broker.id goes to 0. This is restored by the end of upgrade for all but the host which is the kafka controller (for reasons unknown as of now). When we use the tasks in dynamic_groups.yml to read broker.id from meta.properties, things work as expected. The broker.id upholds its original value at the end of the upgrade. 


Fixes # ([issue](https://confluentinc.atlassian.net/browse/RCCA-5725))

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Has been tested for upgrade of co-located components as mentioned here - https://docs.confluent.io/ansible/6.2.0/ansible-upgrade.html#upgrade-co-located-cp-components
I have tested it with cp-kafka-plain-rhel molecule scenario which provides co-located hosts. Another test running rn. 
Has also been tested by the support engineer for his environment which mimics the customer's environment. 

**Test Configuration**:


# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible