### PR TITLE
Generalise client repo url in molecule verify

### DIFF
--- a/molecule/rbac-kafka-connect-replicator-kerberos-mtls-custom-debian10/verify.yml
+++ b/molecule/rbac-kafka-connect-replicator-kerberos-mtls-custom-debian10/verify.yml
@@ -76,7 +76,9 @@
   hosts: kafka_broker
   gather_facts: false
   tasks:
-    - shell: grep -Fq "deb https://packages.confluent.io/clients/deb/ buster main" /etc/apt/sources.list.d/packages_confluent_io_clients_deb.list
+    - import_role:
+        name: common
+    - shell: grep -Fq "deb {{confluent_clients_repository_baseurl}}/clients/deb/ buster main" /etc/apt/sources.list.d/packages_confluent_io_clients_deb.list
       register: linecheck
       check_mode: false
       changed_when: false

--- a/molecule/rbac-kafka-connect-replicator-kerberos-mtls-custom-ubuntu2004/verify.yml
+++ b/molecule/rbac-kafka-connect-replicator-kerberos-mtls-custom-ubuntu2004/verify.yml
@@ -76,7 +76,9 @@
   hosts: kafka_broker
   gather_facts: false
   tasks:
-    - shell: grep -Fq "deb https://packages.confluent.io/clients/deb/ buster main" /etc/apt/sources.list
+    - import_role:
+        name: common
+    - shell: grep -Fq "deb {{confluent_clients_repository_baseurl}}/clients/deb/ buster main" /etc/apt/sources.list
       register: linecheck
       check_mode: false
       changed_when: false

--- a/molecule/rbac-mtls-provided-ubuntu/verify.yml
+++ b/molecule/rbac-mtls-provided-ubuntu/verify.yml
@@ -97,7 +97,9 @@
   hosts: kafka_broker
   gather_facts: false
   tasks:
-    - shell: grep -Fq "deb https://packages.confluent.io/clients/deb/ stretch main" /etc/apt/sources.list
+    - import_role:
+        name: common
+    - shell: grep -Fq "deb {{confluent_clients_repository_baseurl}}/clients/deb/ stretch main" /etc/apt/sources.list
       register: linecheck
       check_mode: false
       changed_when: false

--- a/molecule/rbac-plain-provided-debian/verify.yml
+++ b/molecule/rbac-plain-provided-debian/verify.yml
@@ -131,7 +131,9 @@
   hosts: kafka_broker
   gather_facts: false
   tasks:
-    - shell: grep -Fq "deb https://packages.confluent.io/clients/deb/" /etc/apt/sources.list
+    - import_role:
+        name: common
+    - shell: grep -Fq "deb {{confluent_clients_repository_baseurl}}/clients/deb/" /etc/apt/sources.list
       register: linecheck
       check_mode: false
       changed_when: false


### PR DESCRIPTION
# Description

Verify playbooks of molecule were using hard coded client repository base url. This PR changes that to read from the variable defined in the role 'common' 

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested by running verify stage of scenario - rbac-mtls-provided ubuntu on 7.0.x


**Test Configuration**:


# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible