### PR TITLE
(Copy of #911) Read broker.id from meta properties file

### DIFF
--- a/roles/confluent.kafka_broker/tasks/dynamic_groups.yml
+++ b/roles/confluent.kafka_broker/tasks/dynamic_groups.yml
@@ -8,6 +8,11 @@
     src: "{{ kafka_broker.config_file }}"
   register: slurped_properties
 
+- name: Load meta.properties
+  slurp:
+    src: "{{ kafka_broker_final_properties['log.dirs'].split(',')[0] }}/meta.properties"
+  register: slurped_meta_properties
+
 # Zookeeper shell cannot read server.properties if secrets protection is enabled. Creates a non encrypted file
 - name: Create Zookeeper TLS Client Config
   template:
@@ -59,7 +64,7 @@
 - name: Get broker_id
   set_fact:
     controller_json: "{{ controller_query.stdout }}"
-    broker_id: "{{ (slurped_properties.content|b64decode).split('\n') | select('match', '^broker.id.*') | list \
+    broker_id: "{{ (slurped_meta_properties.content|b64decode).split('\n') | select('match', '^broker.id.*') | list \
       | first | regex_replace('^[-a-zA-Z0-9.]*[ ]?=[ ]?(.*)$', '\\1') }}"
 
 - debug:


### PR DESCRIPTION
# Description

This is to apply https://github.com/confluentinc/cp-ansible/pull/911 to 6.1.x too. 
Since, this branch also follows the similar flow of reading broker.id. 

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

As tested on 6.2.x (prev PR) 

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible