### PR TITLE
Reading binaries/version for molecule tests from env variables

### DIFF
--- a/roles/confluent.test/molecule/Dockerfile-debian.j2
+++ b/roles/confluent.test/molecule/Dockerfile-debian.j2
@@ -17,7 +17,7 @@ RUN wget -qO - {{ lookup('env', 'COMMON_REPO_URL') | default('https://packages.c
     apt-get update
 
 RUN apt-get install --yes \
-      confluent-common={{ lookup('env', 'VERSION') | default('{{ lookup('env', 'VERSION') | default('5.5.7', true) }}', true) }}-1 \
+      confluent-common={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
       confluent-rebalancer={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
       confluent-rest-utils={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
       confluent-metadata-service={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \

--- a/roles/confluent.test/molecule/Dockerfile-debian.j2
+++ b/roles/confluent.test/molecule/Dockerfile-debian.j2
@@ -12,26 +12,30 @@ RUN apt-get update && \
       unzip \
       curl
 
-RUN wget -qO - {{ lookup('env', 'COMMON_REPO_URL') | default('https://packages.confluent.io', true) }}/deb/{{ lookup('env', 'VERSION') | regex_replace('^([0-9])\\.([0-9]*).*', '\\1.\\2') | default('5.5', true) }}/archive.key | sudo apt-key add - && \
-    add-apt-repository "deb [arch=amd64] {{ lookup('env', 'COMMON_REPO_URL') | default('https://packages.confluent.io', true) }}/deb/{{ lookup('env', 'VERSION') | regex_replace('^([0-9])\\.([0-9]*).*', '\\1.\\2') | default('5.5', true) }} stable main" && \
+{% set PACKAGE_VER = lookup('env', 'VERSION') | default('5.5.7', true) %}
+{% set REPO_VER = lookup('env', 'VERSION') | regex_replace('^([0-9])\\.([0-9]*).*', '\\1.\\2') | default('5.5', true) %}
+{% set COMMON_REPO_URL = lookup('env', 'COMMON_REPO_URL') | default('https://packages.confluent.io', true) %}
+
+RUN wget -qO - {{ COMMON_REPO_URL }}/deb/{{ REPO_VER }}/archive.key | sudo apt-key add - && \
+    add-apt-repository "deb [arch=amd64] {{ COMMON_REPO_URL }}/deb/{{ REPO_VER }} stable main" && \
     apt-get update
 
 RUN apt-get install --yes \
-      confluent-common={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-rebalancer={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-rest-utils={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-metadata-service={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-server={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-kafka-connect-elasticsearch={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-kafka-connect-jdbc={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-kafka-connect-jms={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-kafka-connect-replicator={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-kafka-connect-s3={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-kafka-connect-storage-common={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-kafka-rest={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-ksqldb={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-schema-registry={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-security={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-control-center-fe={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-control-center={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-schema-registry={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1
+      confluent-common={{ PACKAGE_VER }}-1 \
+      confluent-rebalancer={{ PACKAGE_VER }}-1 \
+      confluent-rest-utils={{ PACKAGE_VER }}-1 \
+      confluent-metadata-service={{ PACKAGE_VER }}-1 \
+      confluent-server={{ PACKAGE_VER }}-1 \
+      confluent-kafka-connect-elasticsearch={{ PACKAGE_VER }}-1 \
+      confluent-kafka-connect-jdbc={{ PACKAGE_VER }}-1 \
+      confluent-kafka-connect-jms={{ PACKAGE_VER }}-1 \
+      confluent-kafka-connect-replicator={{ PACKAGE_VER }}-1 \
+      confluent-kafka-connect-s3={{ PACKAGE_VER }}-1 \
+      confluent-kafka-connect-storage-common={{ PACKAGE_VER }}-1 \
+      confluent-kafka-rest={{ PACKAGE_VER }}-1 \
+      confluent-ksqldb={{ PACKAGE_VER }}-1 \
+      confluent-schema-registry={{ PACKAGE_VER }}-1 \
+      confluent-security={{ PACKAGE_VER }}-1 \
+      confluent-control-center-fe={{ PACKAGE_VER }}-1 \
+      confluent-control-center={{ PACKAGE_VER }}-1 \
+      confluent-schema-registry={{ PACKAGE_VER }}-1

--- a/roles/confluent.test/molecule/Dockerfile-debian.j2
+++ b/roles/confluent.test/molecule/Dockerfile-debian.j2
@@ -13,7 +13,7 @@ RUN apt-get update && \
       curl
 
 {% set PACKAGE_VER = lookup('env', 'VERSION') | default('5.5.7', true) %}
-{% set REPO_VER = lookup('env', 'VERSION') | regex_replace('^([0-9])\\.([0-9]*).*', '\\1.\\2') | default('5.5', true) %}
+{% set REPO_VER = PACKAGE_VER | regex_replace('^([0-9])\\.([0-9]*).*', '\\1.\\2') %}
 {% set COMMON_REPO_URL = lookup('env', 'COMMON_REPO_URL') | default('https://packages.confluent.io', true) %}
 
 RUN wget -qO - {{ COMMON_REPO_URL }}/deb/{{ REPO_VER }}/archive.key | sudo apt-key add - && \

--- a/roles/confluent.test/molecule/Dockerfile-debian.j2
+++ b/roles/confluent.test/molecule/Dockerfile-debian.j2
@@ -12,26 +12,26 @@ RUN apt-get update && \
       unzip \
       curl
 
-RUN wget -qO - https://packages.confluent.io/deb/5.5/archive.key | sudo apt-key add - && \
-    add-apt-repository "deb [arch=amd64] https://packages.confluent.io/deb/5.5 stable main" && \
+RUN wget -qO - {{ lookup('env', 'COMMON_REPO_URL') | default('https://packages.confluent.io', true) }}/deb/{{ lookup('env', 'VERSION') | regex_replace('^([0-9])\\.([0-9]*).*', '\\1.\\2') | default('5.5', true) }}/archive.key | sudo apt-key add - && \
+    add-apt-repository "deb [arch=amd64] {{ lookup('env', 'COMMON_REPO_URL') | default('https://packages.confluent.io', true) }}/deb/{{ lookup('env', 'VERSION') | regex_replace('^([0-9])\\.([0-9]*).*', '\\1.\\2') | default('5.5', true) }} stable main" && \
     apt-get update
 
 RUN apt-get install --yes \
-      confluent-common=5.5.7-1 \
-      confluent-rebalancer=5.5.7-1 \
-      confluent-rest-utils=5.5.7-1 \
-      confluent-metadata-service=5.5.7-1 \
-      confluent-server=5.5.7-1 \
-      confluent-kafka-connect-elasticsearch=5.5.7-1 \
-      confluent-kafka-connect-jdbc=5.5.7-1 \
-      confluent-kafka-connect-jms=5.5.7-1 \
-      confluent-kafka-connect-replicator=5.5.7-1 \
-      confluent-kafka-connect-s3=5.5.7-1 \
-      confluent-kafka-connect-storage-common=5.5.7-1 \
-      confluent-kafka-rest=5.5.7-1 \
-      confluent-ksqldb=5.5.7-1 \
-      confluent-schema-registry=5.5.7-1 \
-      confluent-security=5.5.7-1 \
-      confluent-control-center-fe=5.5.7-1 \
-      confluent-control-center=5.5.7-1 \
-      confluent-schema-registry=5.5.7-1
+      confluent-common={{ lookup('env', 'VERSION') | default('{{ lookup('env', 'VERSION') | default('5.5.7', true) }}', true) }}-1 \
+      confluent-rebalancer={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
+      confluent-rest-utils={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
+      confluent-metadata-service={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
+      confluent-server={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
+      confluent-kafka-connect-elasticsearch={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
+      confluent-kafka-connect-jdbc={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
+      confluent-kafka-connect-jms={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
+      confluent-kafka-connect-replicator={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
+      confluent-kafka-connect-s3={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
+      confluent-kafka-connect-storage-common={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
+      confluent-kafka-rest={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
+      confluent-ksqldb={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
+      confluent-schema-registry={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
+      confluent-security={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
+      confluent-control-center-fe={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
+      confluent-control-center={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
+      confluent-schema-registry={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1

--- a/roles/confluent.test/molecule/Dockerfile-ubuntu.j2
+++ b/roles/confluent.test/molecule/Dockerfile-ubuntu.j2
@@ -26,26 +26,26 @@ RUN apt-get update -y && \
     && apt-get clean && \
     sed -i 's/^\($ModLoad imklog\)/#\1/' /etc/rsyslog.conf
 
-RUN wget -qO - https://packages.confluent.io/deb/5.5/archive.key | sudo apt-key add - && \
-    add-apt-repository "deb [arch=amd64] https://packages.confluent.io/deb/5.5 stable main" && \
+RUN wget -qO - {{ lookup('env', 'COMMON_REPO_URL') | default('https://packages.confluent.io', true) }}/deb/{{ lookup('env', 'VERSION') | regex_replace('^([0-9])\\.([0-9]*).*', '\\1.\\2') | default('5.5', true) }}/archive.key | sudo apt-key add - && \
+    add-apt-repository "deb [arch=amd64] {{ lookup('env', 'COMMON_REPO_URL') | default('https://packages.confluent.io', true) }}/deb/{{ lookup('env', 'VERSION') | regex_replace('^([0-9])\\.([0-9]*).*', '\\1.\\2') | default('5.5', true) }} stable main" && \
     apt-get update
 
 RUN apt-get install --yes \
-      confluent-common=5.5.7-1 \
-      confluent-rebalancer=5.5.7-1 \
-      confluent-rest-utils=5.5.7-1 \
-      confluent-metadata-service=5.5.7-1 \
-      confluent-server=5.5.7-1 \
-      confluent-kafka-connect-elasticsearch=5.5.7-1 \
-      confluent-kafka-connect-jdbc=5.5.7-1 \
-      confluent-kafka-connect-jms=5.5.7-1 \
-      confluent-kafka-connect-replicator=5.5.7-1 \
-      confluent-kafka-connect-s3=5.5.7-1 \
-      confluent-kafka-connect-storage-common=5.5.7-1 \
-      confluent-kafka-rest=5.5.7-1 \
-      confluent-ksqldb=5.5.7-1 \
-      confluent-schema-registry=5.5.7-1 \
-      confluent-security=5.5.7-1 \
-      confluent-control-center-fe=5.5.7-1 \
-      confluent-control-center=5.5.7-1 \
-      confluent-schema-registry=5.5.7-1
+      confluent-common={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
+      confluent-rebalancer={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
+      confluent-rest-utils={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
+      confluent-metadata-service={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
+      confluent-server={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
+      confluent-kafka-connect-elasticsearch={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
+      confluent-kafka-connect-jdbc={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
+      confluent-kafka-connect-jms={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
+      confluent-kafka-connect-replicator={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
+      confluent-kafka-connect-s3={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
+      confluent-kafka-connect-storage-common={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
+      confluent-kafka-rest={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
+      confluent-ksqldb={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
+      confluent-schema-registry={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
+      confluent-security={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
+      confluent-control-center-fe={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
+      confluent-control-center={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
+      confluent-schema-registry={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1

--- a/roles/confluent.test/molecule/Dockerfile-ubuntu.j2
+++ b/roles/confluent.test/molecule/Dockerfile-ubuntu.j2
@@ -26,26 +26,30 @@ RUN apt-get update -y && \
     && apt-get clean && \
     sed -i 's/^\($ModLoad imklog\)/#\1/' /etc/rsyslog.conf
 
-RUN wget -qO - {{ lookup('env', 'COMMON_REPO_URL') | default('https://packages.confluent.io', true) }}/deb/{{ lookup('env', 'VERSION') | regex_replace('^([0-9])\\.([0-9]*).*', '\\1.\\2') | default('5.5', true) }}/archive.key | sudo apt-key add - && \
-    add-apt-repository "deb [arch=amd64] {{ lookup('env', 'COMMON_REPO_URL') | default('https://packages.confluent.io', true) }}/deb/{{ lookup('env', 'VERSION') | regex_replace('^([0-9])\\.([0-9]*).*', '\\1.\\2') | default('5.5', true) }} stable main" && \
+{% set PACKAGE_VER = lookup('env', 'VERSION') | default('5.5.7', true) %}
+{% set REPO_VER = lookup('env', 'VERSION') | regex_replace('^([0-9])\\.([0-9]*).*', '\\1.\\2') | default('5.5', true) %}
+{% set COMMON_REPO_URL = lookup('env', 'COMMON_REPO_URL') | default('https://packages.confluent.io', true) %}
+
+RUN wget -qO - {{ COMMON_REPO_URL }}/deb/{{ REPO_VER }}/archive.key | sudo apt-key add - && \
+    add-apt-repository "deb [arch=amd64] {{ COMMON_REPO_URL }}/deb/{{ REPO_VER }} stable main" && \
     apt-get update
 
 RUN apt-get install --yes \
-      confluent-common={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-rebalancer={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-rest-utils={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-metadata-service={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-server={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-kafka-connect-elasticsearch={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-kafka-connect-jdbc={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-kafka-connect-jms={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-kafka-connect-replicator={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-kafka-connect-s3={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-kafka-connect-storage-common={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-kafka-rest={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-ksqldb={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-schema-registry={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-security={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-control-center-fe={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-control-center={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-schema-registry={{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1
+      confluent-common={{ PACKAGE_VER }}-1 \
+      confluent-rebalancer={{ PACKAGE_VER }}-1 \
+      confluent-rest-utils={{ PACKAGE_VER }}-1 \
+      confluent-metadata-service={{ PACKAGE_VER }}-1 \
+      confluent-server={{ PACKAGE_VER }}-1 \
+      confluent-kafka-connect-elasticsearch={{ PACKAGE_VER }}-1 \
+      confluent-kafka-connect-jdbc={{ PACKAGE_VER }}-1 \
+      confluent-kafka-connect-jms={{ PACKAGE_VER }}-1 \
+      confluent-kafka-connect-replicator={{ PACKAGE_VER }}-1 \
+      confluent-kafka-connect-s3={{ PACKAGE_VER }}-1 \
+      confluent-kafka-connect-storage-common={{ PACKAGE_VER }}-1 \
+      confluent-kafka-rest={{ PACKAGE_VER }}-1 \
+      confluent-ksqldb={{ PACKAGE_VER }}-1 \
+      confluent-schema-registry={{ PACKAGE_VER }}-1 \
+      confluent-security={{ PACKAGE_VER }}-1 \
+      confluent-control-center-fe={{ PACKAGE_VER }}-1 \
+      confluent-control-center={{ PACKAGE_VER }}-1 \
+      confluent-schema-registry={{ PACKAGE_VER }}-1

--- a/roles/confluent.test/molecule/Dockerfile-ubuntu.j2
+++ b/roles/confluent.test/molecule/Dockerfile-ubuntu.j2
@@ -27,7 +27,7 @@ RUN apt-get update -y && \
     sed -i 's/^\($ModLoad imklog\)/#\1/' /etc/rsyslog.conf
 
 {% set PACKAGE_VER = lookup('env', 'VERSION') | default('5.5.7', true) %}
-{% set REPO_VER = lookup('env', 'VERSION') | regex_replace('^([0-9])\\.([0-9]*).*', '\\1.\\2') | default('5.5', true) %}
+{% set REPO_VER = PACKAGE_VER | regex_replace('^([0-9])\\.([0-9]*).*', '\\1.\\2') %}
 {% set COMMON_REPO_URL = lookup('env', 'COMMON_REPO_URL') | default('https://packages.confluent.io', true) %}
 
 RUN wget -qO - {{ COMMON_REPO_URL }}/deb/{{ REPO_VER }}/archive.key | sudo apt-key add - && \

--- a/roles/confluent.test/molecule/Dockerfile.j2
+++ b/roles/confluent.test/molecule/Dockerfile.j2
@@ -17,36 +17,40 @@ RUN yum -y install java-1.8.0-openjdk \
       krb5-workstation \
       unzip
 
+{% set PACKAGE_VER = lookup('env', 'VERSION') | default('5.5.7', true) %}
+{% set REPO_VER = lookup('env', 'VERSION') | regex_replace('^([0-9])\\.([0-9]*).*', '\\1.\\2') | default('5.5', true) %}
+{% set COMMON_REPO_URL = lookup('env', 'COMMON_REPO_URL') | default('https://packages.confluent.io', true) %}
+
 RUN echo $'[Confluent.dist]\n\
 name=Confluent repository (dist)\n\
-baseurl={{ lookup("env", "COMMON_REPO_URL") | default("https://packages.confluent.io", true) }}/rpm/{{ lookup("env", "VERSION") | regex_replace("^([0-9])\\.([0-9]*).*", "\\1.\\2") | default("5.5", true) }}/7\n\
+baseurl={{ COMMON_REPO_URL }}/rpm/{{ REPO_VER }}/7\n\
 gpgcheck=1\n\
-gpgkey={{ lookup("env", "COMMON_REPO_URL") | default("https://packages.confluent.io", true) }}/rpm/{{ lookup("env", "VERSION") | regex_replace("^([0-9])\\.([0-9]*).*", "\\1.\\2") | default("5.5", true) }}/archive.key\n\
+gpgkey={{ COMMON_REPO_URL }}/rpm/{{ REPO_VER }}/archive.key\n\
 enabled=1\n\
 \n\
 [Confluent]\n\
 name=Confluent repository\n\
-baseurl={{ lookup("env", "COMMON_REPO_URL") | default("https://packages.confluent.io", true) }}/rpm/{{ lookup("env", "VERSION") | regex_replace("^([0-9])\\.([0-9]*).*", "\\1.\\2") | default("5.5", true) }}\n\
+baseurl={{ COMMON_REPO_URL }}/rpm/{{ REPO_VER }}\n\
 gpgcheck=1\n\
-gpgkey={{ lookup("env", "COMMON_REPO_URL") | default("https://packages.confluent.io", true) }}/rpm/{{ lookup("env", "VERSION") | regex_replace("^([0-9])\\.([0-9]*).*", "\\1.\\2") | default("5.5", true) }}/archive.key\n\
+gpgkey={{ COMMON_REPO_URL }}/rpm/{{ REPO_VER }}/archive.key\n\
 enabled=1' >> /etc/yum.repos.d/confluent.repo
 
 RUN yum clean all && \
-    yum -y install confluent-common-{{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-rebalancer-{{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-rest-utils-{{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-metadata-service-{{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-server-{{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-kafka-connect-elasticsearch-{{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-kafka-connect-jdbc-{{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-kafka-connect-jms-{{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-kafka-connect-replicator-{{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-kafka-connect-s3-{{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-kafka-connect-storage-common-{{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-kafka-rest-{{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-ksqldb-{{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-schema-registry-{{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-security-{{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-control-center-fe-{{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-control-center-{{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
-      confluent-schema-registry-{{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1
+    yum -y install confluent-common-{{ PACKAGE_VER }}-1 \
+      confluent-rebalancer-{{ PACKAGE_VER }}-1 \
+      confluent-rest-utils-{{ PACKAGE_VER }}-1 \
+      confluent-metadata-service-{{ PACKAGE_VER }}-1 \
+      confluent-server-{{ PACKAGE_VER }}-1 \
+      confluent-kafka-connect-elasticsearch-{{ PACKAGE_VER }}-1 \
+      confluent-kafka-connect-jdbc-{{ PACKAGE_VER }}-1 \
+      confluent-kafka-connect-jms-{{ PACKAGE_VER }}-1 \
+      confluent-kafka-connect-replicator-{{ PACKAGE_VER }}-1 \
+      confluent-kafka-connect-s3-{{ PACKAGE_VER }}-1 \
+      confluent-kafka-connect-storage-common-{{ PACKAGE_VER }}-1 \
+      confluent-kafka-rest-{{ PACKAGE_VER }}-1 \
+      confluent-ksqldb-{{ PACKAGE_VER }}-1 \
+      confluent-schema-registry-{{ PACKAGE_VER }}-1 \
+      confluent-security-{{ PACKAGE_VER }}-1 \
+      confluent-control-center-fe-{{ PACKAGE_VER }}-1 \
+      confluent-control-center-{{ PACKAGE_VER }}-1 \
+      confluent-schema-registry-{{ PACKAGE_VER }}-1

--- a/roles/confluent.test/molecule/Dockerfile.j2
+++ b/roles/confluent.test/molecule/Dockerfile.j2
@@ -18,7 +18,7 @@ RUN yum -y install java-1.8.0-openjdk \
       unzip
 
 {% set PACKAGE_VER = lookup('env', 'VERSION') | default('5.5.7', true) %}
-{% set REPO_VER = lookup('env', 'VERSION') | regex_replace('^([0-9])\\.([0-9]*).*', '\\1.\\2') | default('5.5', true) %}
+{% set REPO_VER = PACKAGE_VER | regex_replace('^([0-9])\\.([0-9]*).*', '\\1.\\2') %}
 {% set COMMON_REPO_URL = lookup('env', 'COMMON_REPO_URL') | default('https://packages.confluent.io', true) %}
 
 RUN echo $'[Confluent.dist]\n\

--- a/roles/confluent.test/molecule/Dockerfile.j2
+++ b/roles/confluent.test/molecule/Dockerfile.j2
@@ -19,34 +19,34 @@ RUN yum -y install java-1.8.0-openjdk \
 
 RUN echo $'[Confluent.dist]\n\
 name=Confluent repository (dist)\n\
-baseurl=https://packages.confluent.io/rpm/5.5/7\n\
+baseurl={{ lookup("env", "COMMON_REPO_URL") | default("https://packages.confluent.io", true) }}/rpm/{{ lookup("env", "VERSION") | regex_replace("^([0-9])\\.([0-9]*).*", "\\1.\\2") | default("5.5", true) }}/7\n\
 gpgcheck=1\n\
-gpgkey=https://packages.confluent.io/rpm/5.5/archive.key\n\
+gpgkey={{ lookup("env", "COMMON_REPO_URL") | default("https://packages.confluent.io", true) }}/rpm/{{ lookup("env", "VERSION") | regex_replace("^([0-9])\\.([0-9]*).*", "\\1.\\2") | default("5.5", true) }}/archive.key\n\
 enabled=1\n\
 \n\
 [Confluent]\n\
 name=Confluent repository\n\
-baseurl=https://packages.confluent.io/rpm/5.5\n\
+baseurl={{ lookup("env", "COMMON_REPO_URL") | default("https://packages.confluent.io", true) }}/rpm/{{ lookup("env", "VERSION") | regex_replace("^([0-9])\\.([0-9]*).*", "\\1.\\2") | default("5.5", true) }}\n\
 gpgcheck=1\n\
-gpgkey=https://packages.confluent.io/rpm/5.5/archive.key\n\
+gpgkey={{ lookup("env", "COMMON_REPO_URL") | default("https://packages.confluent.io", true) }}/rpm/{{ lookup("env", "VERSION") | regex_replace("^([0-9])\\.([0-9]*).*", "\\1.\\2") | default("5.5", true) }}/archive.key\n\
 enabled=1' >> /etc/yum.repos.d/confluent.repo
 
 RUN yum clean all && \
-    yum -y install confluent-common-5.5.7-1 \
-      confluent-rebalancer-5.5.7-1 \
-      confluent-rest-utils-5.5.7-1 \
-      confluent-metadata-service-5.5.7-1 \
-      confluent-server-5.5.7-1 \
-      confluent-kafka-connect-elasticsearch-5.5.7-1 \
-      confluent-kafka-connect-jdbc-5.5.7-1 \
-      confluent-kafka-connect-jms-5.5.7-1 \
-      confluent-kafka-connect-replicator-5.5.7-1 \
-      confluent-kafka-connect-s3-5.5.7-1 \
-      confluent-kafka-connect-storage-common-5.5.7-1 \
-      confluent-kafka-rest-5.5.7-1 \
-      confluent-ksqldb-5.5.7-1 \
-      confluent-schema-registry-5.5.7-1 \
-      confluent-security-5.5.7-1 \
-      confluent-control-center-fe-5.5.7-1 \
-      confluent-control-center-5.5.7-1 \
-      confluent-schema-registry-5.5.7-1
+    yum -y install confluent-common-{{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
+      confluent-rebalancer-{{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
+      confluent-rest-utils-{{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
+      confluent-metadata-service-{{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
+      confluent-server-{{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
+      confluent-kafka-connect-elasticsearch-{{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
+      confluent-kafka-connect-jdbc-{{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
+      confluent-kafka-connect-jms-{{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
+      confluent-kafka-connect-replicator-{{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
+      confluent-kafka-connect-s3-{{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
+      confluent-kafka-connect-storage-common-{{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
+      confluent-kafka-rest-{{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
+      confluent-ksqldb-{{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
+      confluent-schema-registry-{{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
+      confluent-security-{{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
+      confluent-control-center-fe-{{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
+      confluent-control-center-{{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1 \
+      confluent-schema-registry-{{ lookup('env', 'VERSION') | default('5.5.7', true) }}-1


### PR DESCRIPTION
# Description

https://confluentinc.atlassian.net/browse/ANSIENG-1047?atlOrigin=eyJpIjoiOWEyOWJkNmRlMzc4NDBiYTk3Nzc5YjM0NDk2MDc3MDYiLCJwIjoiaiJ9

For automating our patch releases, we need to read new binaries directly when running molecule tests. This change introduces env variables which'll resolve to new package binaries and new versions at runtime. 

With these change in place, to run a new patch, we'll need to set env variables COMMON_REPO_URL and VERSION before running the molecule tests to change dockerfiles. To make other relevant changes, we'll need to pass variables confluent_common_repository_baseurl and confluent_package_version/confluent_repo_version in molecule run. 

Default behaviour stays unchanged. 

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

cp-ansible-on-demand run 74. 


**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible