### PR TITLE
ansible 2.9 support for cp-ansible 7.1

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -2,6 +2,7 @@
 hash_behaviour=merge
 callback_whitelist=profile_tasks
 remote_tmp=~/.ansible/tmp
+collections_paths=~/.ansible/collections:../../../
 
 [ssh_connection]
 pipelining = True

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -9,9 +9,9 @@
 
 - name: Verify Ansible version
   assert:
-    that: "ansible_version.full is version_compare('2.10', '>=')"
+    that: "ansible_version.full is version_compare('2.9', '>=')"
     fail_msg: >-
-      "You must update Ansible to at least 2.11 to use these playbooks."
+      "You must update Ansible to at least 2.9 to use these playbooks."
   tags:
   - validate
   - validate_ansi_version


### PR DESCRIPTION
# Description
Ansible 2.9 is a supported Ansible release from Red Hat, and support for it is not going away in 2022. 
We are learning that our customers  would like to stay on Ansible 2.9 while continuing to use the latest CP 7.x
This PR extends the support for CP-Ansible 7.x to be  "Ansible 2.9 and up" instead of "Ansible 2.11 and up".

Fixes # (issue)
ANSIENG-1038

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Installed Ansible 2.9 on top of python 2.7
- Triggered a run of cp-ansible on branch 7.1 with the above prereqs (ansible and Python versions)
- The run ended successfully without any new error or warning.

**Test Configuration**:
branch 7.0.1-post
 - ksql
 - kafka_connect
 - schema_registry
 - zookeeper
 - kafka_brokers
 - control_center
 - mds_kafka_broker
 - kafka_rest
 - ssl_enabled
 - mtls enables

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible