### PR TITLE
Updated mount storage host check to be informational.

### DIFF
--- a/roles/common/tasks/host_validations.yml
+++ b/roles/common/tasks/host_validations.yml
@@ -80,7 +80,7 @@
   - validate_tmp_access
 
 - name: Validate disk space usage
-  Debug:
+  debug:
     msg:  >- 
       "Not enough free disk space for package installation.  Minimum space required is {{ required_disk_space_mb }}MB, please free up more disk space
        to continue installation. To skip host validations, set validate_hosts to false."

--- a/roles/common/tasks/host_validations.yml
+++ b/roles/common/tasks/host_validations.yml
@@ -84,7 +84,7 @@
     msg:  >- 
       "Not enough free disk space for package installation.  Minimum space required is {{ required_disk_space_mb }}MB, please free up more disk space
        to continue installation. To skip host validations, set validate_hosts to false."
-  when: (item.size_available > required_disk_space_mb|float)
+  when: (item.size_available < required_disk_space_mb|float)
   with_items: "{{ ansible_mounts }}"
   tags:
     - validate

--- a/roles/common/tasks/host_validations.yml
+++ b/roles/common/tasks/host_validations.yml
@@ -78,14 +78,14 @@
   tags:
   - validate
   - validate_tmp_access
-  
-- name: Validate enough free disk space for package installation
-  assert:
-    that: item.size_available > {{ required_disk_space_mb }}|float
-    fail_msg: >- 
+
+- name: Validate disk space usage
+  Debug:
+    msg:  >- 
       "Not enough free disk space for package installation.  Minimum space required is {{ required_disk_space_mb }}MB, please free up more disk space 
       to continue installation. To skip host validations, set validate_hosts to false."
+  when: (item.size_available < required_disk_space_mb|float)
   with_items: "{{ ansible_mounts }}"
-  tags: 
+  tags:
     - validate
     - validate_disk_usage

--- a/roles/common/tasks/host_validations.yml
+++ b/roles/common/tasks/host_validations.yml
@@ -118,13 +118,6 @@
   tags:
   - validate
   - validate_ssl_keys_certs
-  
-- name: Validate enough free disk space for package installation
-  assert:
-    that: item.size_available > {{ required_disk_space_mb }}|float
-    fail_msg: >-
-      "Not enough free disk space for package installation.  Minimum space required is {{ required_disk_space_mb }}MB, please free up more disk space
->>>>>>> public/7.1.x
 
 - name: Validate enough free memory for Zookeeper hosts
   assert:

--- a/roles/common/tasks/host_validations.yml
+++ b/roles/common/tasks/host_validations.yml
@@ -84,7 +84,7 @@
     msg:  >- 
       "Not enough free disk space for package installation.  Minimum space required is {{ required_disk_space_mb }}MB, please free up more disk space
        to continue installation. To skip host validations, set validate_hosts to false."
-  when: (item.size_available < required_disk_space_mb|float)
+  when: (item.size_available > required_disk_space_mb|float)
   with_items: "{{ ansible_mounts }}"
   tags:
     - validate


### PR DESCRIPTION
# Description

This PR updates the mount storage check to be informational only.  This is due to limitations in confluent packaging as well different packaging mechanisms (snap).

Fixes # (issue)

ANSIENG-1051

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This has been validated against mtls-ubuntu.

**Test Configuration**:

`TASK [confluent.platform.common : Validate disk space usage] *******************
skipping: [zookeeper1] => (item={'mount': '/run', 'device': '/dev/vda1', 'fstype': 'ext4', 'options': 'rw,relatime,bind', 'size_total': 270294650880, 'size_available': 228907823104, 'block_size': 4096, 'block_total': 65989905, 'block_available': 55885699, 'block_used': 10104206, 'inode_total': 16777216, 'inode_available': 16401038, 'inode_used': 376178, 'uuid': 'N/A'})
skipping: [zookeeper1] => (item={'mount': '/tmp', 'device': '/dev/vda1', 'fstype': 'ext4', 'options': 'rw,relatime,bind', 'size_total': 270294650880, 'size_available': 228907823104, 'block_size': 4096, 'block_total': 65989905, 'block_available': 55885699, 'block_used': 10104206, 'inode_total': 16777216, 'inode_available': 16401038, 'inode_used': 376178, 'uuid': 'N/A'})
skipping: [zookeeper1] => (item={'mount': '/etc/resolv.conf', 'device': '/dev/vda1', 'fstype': 'ext4', 'options': 'rw,relatime,bind', 'size_total': 270294650880, 'size_available': 228907823104, 'block_size': 4096, 'block_total': 65989905, 'block_available': 55885699, 'block_used': 10104206, 'inode_total': 16777216, 'inode_available': 16401038, 'inode_used': 376178, 'uuid': 'N/A'})
skipping: [zookeeper1] => (item={'mount': '/etc/hostname', 'device': '/dev/vda1', 'fstype': 'ext4', 'options': 'rw,relatime,bind', 'size_total': 270294650880, 'size_available': 228907823104, 'block_size': 4096, 'block_total': 65989905, 'block_available': 55885699, 'block_used': 10104206, 'inode_total': 16777216, 'inode_available': 16401038, 'inode_used': 376178, 'uuid': 'N/A'})
skipping: [zookeeper1] => (item={'mount': '/etc/hosts', 'device': '/dev/vda1', 'fstype': 'ext4', 'options': 'rw,relatime,bind', 'size_total': 270294650880, 'size_available': 228907823104, 'block_size': 4096, 'block_total': 65989905, 'block_available': 55885699, 'block_used': 10104206, 'inode_total': 16777216, 'inode_available': 16401038, 'inode_used': 376178, 'uuid': 'N/A'})
skipping: [kafka-broker1] => (item={'mount': '/run', 'device': '/dev/vda1', 'fstype': 'ext4', 'options': 'rw,relatime,bind', 'size_total': 270294650880, 'size_available': 228905488384, 'block_size': 4096, 'block_total': 65989905, 'block_available': 55885129, 'block_used': 10104776, 'inode_total': 16777216, 'inode_available': 16401024, 'inode_used': 376192, 'uuid': 'N/A'})
skipping: [kafka-broker1] => (item={'mount': '/tmp', 'device': '/dev/vda1', 'fstype': 'ext4', 'options': 'rw,relatime,bind', 'size_total': 270294650880, 'size_available': 228905488384, 'block_size': 4096, 'block_total': 65989905, 'block_available': 55885129, 'block_used': 10104776, 'inode_total': 16777216, 'inode_available': 16401024, 'inode_used': 376192, 'uuid': 'N/A'})
skipping: [kafka-broker1] => (item={'mount': '/etc/resolv.conf', 'device': '/dev/vda1', 'fstype': 'ext4', 'options': 'rw,relatime,bind', 'size_total': 270294650880, 'size_available': 228905488384, 'block_size': 4096, 'block_total': 65989905, 'block_available': 55885129, 'block_used': 10104776, 'inode_total': 16777216, 'inode_available': 16401024, 'inode_used': 376192, 'uuid': 'N/A'})
skipping: [kafka-broker1] => (item={'mount': '/etc/hostname', 'device': '/dev/vda1', 'fstype': 'ext4', 'options': 'rw,relatime,bind', 'size_total': 270294650880, 'size_available': 228905488384, 'block_size': 4096, 'block_total': 65989905, 'block_available': 55885129, 'block_used': 10104776, 'inode_total': 16777216, 'inode_available': 16401024, 'inode_used': 376192, 'uuid': 'N/A'})
skipping: [kafka-broker1] => (item={'mount': '/etc/hosts', 'device': '/dev/vda1', 'fstype': 'ext4', 'options': 'rw,relatime,bind', 'size_total': 270294650880, 'size_available': 228905488384, 'block_size': 4096, 'block_total': 65989905, 'block_available': 55885129, 'block_used': 10104776, 'inode_total': 16777216, 'inode_available': 16401024, 'inode_used': 376192, 'uuid': 'N/A'})
skipping: [kafka-broker2] => (item={'mount': '/run', 'device': '/dev/vda1', 'fstype': 'ext4', 'options': 'rw,relatime,bind', 'size_total': 270294650880, 'size_available': 228905488384, 'block_size': 4096, 'block_total': 65989905, 'block_available': 55885129, 'block_used': 10104776, 'inode_total': 16777216, 'inode_available': 16401024, 'inode_used': 376192, 'uuid': 'N/A'})
skipping: [kafka-broker2] => (item={'mount': '/tmp', 'device': '/dev/vda1', 'fstype': 'ext4', 'options': 'rw,relatime,bind', 'size_total': 270294650880, 'size_available': 228905488384, 'block_size': 4096, 'block_total': 65989905, 'block_available': 55885129, 'block_used': 10104776, 'inode_total': 16777216, 'inode_available': 16401024, 'inode_used': 376192, 'uuid': 'N/A'})
skipping: [kafka-broker2] => (item={'mount': '/etc/resolv.conf', 'device': '/dev/vda1', 'fstype': 'ext4', 'options': 'rw,relatime,bind', 'size_total': 270294650880, 'size_available': 228905488384, 'block_size': 4096, 'block_total': 65989905, 'block_available': 55885129, 'block_used': 10104776, 'inode_total': 16777216, 'inode_available': 16401024, 'inode_used': 376192, 'uuid': 'N/A'})
skipping: [kafka-broker2] => (item={'mount': '/etc/hostname', 'device': '/dev/vda1', 'fstype': 'ext4', 'options': 'rw,relatime,bind', 'size_total': 270294650880, 'size_available': 228905488384, 'block_size': 4096, 'block_total': 65989905, 'block_available': 55885129, 'block_used': 10104776, 'inode_total': 16777216, 'inode_available': 16401024, 'inode_used': 376192, 'uuid': 'N/A'})
skipping: [kafka-broker2] => (item={'mount': '/etc/hosts', 'device': '/dev/vda1', 'fstype': 'ext4', 'options': 'rw,relatime,bind', 'size_total': 270294650880, 'size_available': 228905488384, 'block_size': 4096, 'block_total': 65989905, 'block_available': 55885129, 'block_used': 10104776, 'inode_total': 16777216, 'inode_available': 16401024, 'inode_used': 376192, 'uuid': 'N/A'})
skipping: [kafka-broker3] => (item={'mount': '/tmp', 'device': '/dev/vda1', 'fstype': 'ext4', 'options': 'rw,relatime,bind', 'size_total': 270294650880, 'size_available': 228906553344, 'block_size': 4096, 'block_total': 65989905, 'block_available': 55885389, 'block_used': 10104516, 'inode_total': 16777216, 'inode_available': 16401034, 'inode_used': 376182, 'uuid': 'N/A'})
skipping: [kafka-broker3] => (item={'mount': '/run', 'device': '/dev/vda1', 'fstype': 'ext4', 'options': 'rw,relatime,bind', 'size_total': 270294650880, 'size_available': 228906553344, 'block_size': 4096, 'block_total': 65989905, 'block_available': 55885389, 'block_used': 10104516, 'inode_total': 16777216, 'inode_available': 16401034, 'inode_used': 376182, 'uuid': 'N/A'})
skipping: [kafka-broker3] => (item={'mount': '/etc/resolv.conf', 'device': '/dev/vda1', 'fstype': 'ext4', 'options': 'rw,relatime,bind', 'size_total': 270294650880, 'size_available': 228906553344, 'block_size': 4096, 'block_total': 65989905, 'block_available': 55885389, 'block_used': 10104516, 'inode_total': 16777216, 'inode_available': 16401034, 'inode_used': 376182, 'uuid': 'N/A'})
skipping: [kafka-broker3] => (item={'mount': '/etc/hostname', 'device': '/dev/vda1', 'fstype': 'ext4', 'options': 'rw,relatime,bind', 'size_total': 270294650880, 'size_available': 228906553344, 'block_size': 4096, 'block_total': 65989905, 'block_available': 55885389, 'block_used': 10104516, 'inode_total': 16777216, 'inode_available': 16401034, 'inode_used': 376182, 'uuid': 'N/A'})
skipping: [kafka-broker3] => (item={'mount': '/etc/hosts', 'device': '/dev/vda1', 'fstype': 'ext4', 'options': 'rw,relatime,bind', 'size_total': 270294650880, 'size_available': 228906553344, 'block_size': 4096, 'block_total': 65989905, 'block_available': 55885389, 'block_used': 10104516, 'inode_total': 16777216, 'inode_available': 16401034, 'inode_used': 376182, 'uuid': 'N/A'})
skipping: [schema-registry1] => (item={'mount': '/run', 'device': '/dev/vda1', 'fstype': 'ext4', 'options': 'rw,relatime,bind', 'size_total': 270294650880, 'size_available': 228905914368, 'block_size': 4096, 'block_total': 65989905, 'block_available': 55885233, 'block_used': 10104672, 'inode_total': 16777216, 'inode_available': 16401028, 'inode_used': 376188, 'uuid': 'N/A'})
skipping: [schema-registry1] => (item={'mount': '/tmp', 'device': '/dev/vda1', 'fstype': 'ext4', 'options': 'rw,relatime,bind', 'size_total': 270294650880, 'size_available': 228905914368, 'block_size': 4096, 'block_total': 65989905, 'block_available': 55885233, 'block_used': 10104672, 'inode_total': 16777216, 'inode_available': 16401028, 'inode_used': 376188, 'uuid': 'N/A'})
skipping: [schema-registry1] => (item={'mount': '/etc/resolv.conf', 'device': '/dev/vda1', 'fstype': 'ext4', 'options': 'rw,relatime,bind', 'size_total': 270294650880, 'size_available': 228905914368, 'block_size': 4096, 'block_total': 65989905, 'block_available': 55885233, 'block_used': 10104672, 'inode_total': 16777216, 'inode_available': 16401028, 'inode_used': 376188, 'uuid': 'N/A'})
skipping: [schema-registry1] => (item={'mount': '/etc/hostname', 'device': '/dev/vda1', 'fstype': 'ext4', 'options': 'rw,relatime,bind', 'size_total': 270294650880, 'size_available': 228905914368, 'block_size': 4096, 'block_total': 65989905, 'block_available': 55885233, 'block_used': 10104672, 'inode_total': 16777216, 'inode_available': 16401028, 'inode_used': 376188, 'uuid': 'N/A'})
skipping: [schema-registry1] => (item={'mount': '/etc/hosts', 'device': '/dev/vda1', 'fstype': 'ext4', 'options': 'rw,relatime,bind', 'size_total': 270294650880, 'size_available': 228905914368, 'block_size': 4096, 'block_total': 65989905, 'block_available': 55885233, 'block_used': 10104672, 'inode_total': 16777216, 'inode_available': 16401028, 'inode_used': 376188, 'uuid': 'N/A'})
skipping: [kafka-connect1] => (item={'mount': '/run', 'device': '/dev/vda1', 'fstype': 'ext4', 'options': 'rw,relatime,bind', 'size_total': 270294650880, 'size_available': 228905488384, 'block_size': 4096, 'block_total': 65989905, 'block_available': 55885129, 'block_used': 10104776, 'inode_total': 16777216, 'inode_available': 16401024, 'inode_used': 376192, 'uuid': 'N/A'})
skipping: [kafka-connect1] => (item={'mount': '/tmp', 'device': '/dev/vda1', 'fstype': 'ext4', 'options': 'rw,relatime,bind', 'size_total': 270294650880, 'size_available': 228905488384, 'block_size': 4096, 'block_total': 65989905, 'block_available': 55885129, 'block_used': 10104776, 'inode_total': 16777216, 'inode_available': 16401024, 'inode_used': 376192, 'uuid': 'N/A'})
skipping: [kafka-connect1] => (item={'mount': '/etc/resolv.conf', 'device': '/dev/vda1', 'fstype': 'ext4', 'options': 'rw,relatime,bind', 'size_total': 270294650880, 'size_available': 228905488384, 'block_size': 4096, 'block_total': 65989905, 'block_available': 55885129, 'block_used': 10104776, 'inode_total': 16777216, 'inode_available': 16401024, 'inode_used': 376192, 'uuid': 'N/A'})
skipping: [kafka-connect1] => (item={'mount': '/etc/hostname', 'device': '/dev/vda1', 'fstype': 'ext4', 'options': 'rw,relatime,bind', 'size_total': 270294650880, 'size_available': 228905488384, 'block_size': 4096, 'block_total': 65989905, 'block_available': 55885129, 'block_used': 10104776, 'inode_total': 16777216, 'inode_available': 16401024, 'inode_used': 376192, 'uuid': 'N/A'})
skipping: [kafka-connect1] => (item={'mount': '/etc/hosts', 'device': '/dev/vda1', 'fstype': 'ext4', 'options': 'rw,relatime,bind', 'size_total': 270294650880, 'size_available': 228905488384, 'block_size': 4096, 'block_total': 65989905, 'block_available': 55885129, 'block_used': 10104776, 'inode_total': 16777216, 'inode_available': 16401024, 'inode_used': 376192, 'uuid': 'N/A'})
skipping: [ksql1] => (item={'mount': '/tmp', 'device': '/dev/vda1', 'fstype': 'ext4', 'options': 'rw,relatime,bind', 'size_total': 270294650880, 'size_available': 228906127360, 'block_size': 4096, 'block_total': 65989905, 'block_available': 55885285, 'block_used': 10104620, 'inode_total': 16777216, 'inode_available': 16401030, 'inode_used': 376186, 'uuid': 'N/A'})
skipping: [ksql1] => (item={'mount': '/run', 'device': '/dev/vda1', 'fstype': 'ext4', 'options': 'rw,relatime,bind', 'size_total': 270294650880, 'size_available': 228906127360, 'block_size': 4096, 'block_total': 65989905, 'block_available': 55885285, 'block_used': 10104620, 'inode_total': 16777216, 'inode_available': 16401030, 'inode_used': 376186, 'uuid': 'N/A'})
skipping: [ksql1] => (item={'mount': '/etc/resolv.conf', 'device': '/dev/vda1', 'fstype': 'ext4', 'options': 'rw,relatime,bind', 'size_total': 270294650880, 'size_available': 228906127360, 'block_size': 4096, 'block_total': 65989905, 'block_available': 55885285, 'block_used': 10104620, 'inode_total': 16777216, 'inode_available': 16401030, 'inode_used': 376186, 'uuid': 'N/A'})
skipping: [ksql1] => (item={'mount': '/etc/hostname', 'device': '/dev/vda1', 'fstype': 'ext4', 'options': 'rw,relatime,bind', 'size_total': 270294650880, 'size_available': 228906127360, 'block_size': 4096, 'block_total': 65989905, 'block_available': 55885285, 'block_used': 10104620, 'inode_total': 16777216, 'inode_available': 16401030, 'inode_used': 376186, 'uuid': 'N/A'})
skipping: [ksql1] => (item={'mount': '/etc/hosts', 'device': '/dev/vda1', 'fstype': 'ext4', 'options': 'rw,relatime,bind', 'size_total': 270294650880, 'size_available': 228906127360, 'block_size': 4096, 'block_total': 65989905, 'block_available': 55885285, 'block_used': 10104620, 'inode_total': 16777216, 'inode_available': 16401030, 'inode_used': 376186, 'uuid': 'N/A'})
skipping: [control-center1] => (item={'mount': '/tmp', 'device': '/dev/vda1', 'fstype': 'ext4', 'options': 'rw,relatime,bind', 'size_total': 270294650880, 'size_available': 228905914368, 'block_size': 4096, 'block_total': 65989905, 'block_available': 55885233, 'block_used': 10104672, 'inode_total': 16777216, 'inode_available': 16401028, 'inode_used': 376188, 'uuid': 'N/A'})
skipping: [control-center1] => (item={'mount': '/run', 'device': '/dev/vda1', 'fstype': 'ext4', 'options': 'rw,relatime,bind', 'size_total': 270294650880, 'size_available': 228905914368, 'block_size': 4096, 'block_total': 65989905, 'block_available': 55885233, 'block_used': 10104672, 'inode_total': 16777216, 'inode_available': 16401028, 'inode_used': 376188, 'uuid': 'N/A'})
skipping: [control-center1] => (item={'mount': '/etc/resolv.conf', 'device': '/dev/vda1', 'fstype': 'ext4', 'options': 'rw,relatime,bind', 'size_total': 270294650880, 'size_available': 228905914368, 'block_size': 4096, 'block_total': 65989905, 'block_available': 55885233, 'block_used': 10104672, 'inode_total': 16777216, 'inode_available': 16401028, 'inode_used': 376188, 'uuid': 'N/A'})
skipping: [control-center1] => (item={'mount': '/etc/hostname', 'device': '/dev/vda1', 'fstype': 'ext4', 'options': 'rw,relatime,bind', 'size_total': 270294650880, 'size_available': 228905914368, 'block_size': 4096, 'block_total': 65989905, 'block_available': 55885233, 'block_used': 10104672, 'inode_total': 16777216, 'inode_available': 16401028, 'inode_used': 376188, 'uuid': 'N/A'})
skipping: [control-center1] => (item={'mount': '/etc/hosts', 'device': '/dev/vda1', 'fstype': 'ext4', 'options': 'rw,relatime,bind', 'size_total': 270294650880, 'size_available': 228905914368, 'block_size': 4096, 'block_total': 65989905, 'block_available': 55885233, 'block_used': 10104672, 'inode_total': 16777216, 'inode_available': 16401028, 'inode_used': 376188, 'uuid': 'N/A'})
skipping: [kafka-rest1] => (item={'mount': '/tmp', 'device': '/dev/vda1', 'fstype': 'ext4', 'options': 'rw,relatime,bind', 'size_total': 270294650880, 'size_available': 228905914368, 'block_size': 4096, 'block_total': 65989905, 'block_available': 55885233, 'block_used': 10104672, 'inode_total': 16777216, 'inode_available': 16401028, 'inode_used': 376188, 'uuid': 'N/A'})
skipping: [kafka-rest1] => (item={'mount': '/run', 'device': '/dev/vda1', 'fstype': 'ext4', 'options': 'rw,relatime,bind', 'size_total': 270294650880, 'size_available': 228905914368, 'block_size': 4096, 'block_total': 65989905, 'block_available': 55885233, 'block_used': 10104672, 'inode_total': 16777216, 'inode_available': 16401028, 'inode_used': 376188, 'uuid': 'N/A'})
skipping: [kafka-rest1] => (item={'mount': '/etc/resolv.conf', 'device': '/dev/vda1', 'fstype': 'ext4', 'options': 'rw,relatime,bind', 'size_total': 270294650880, 'size_available': 228905914368, 'block_size': 4096, 'block_total': 65989905, 'block_available': 55885233, 'block_used': 10104672, 'inode_total': 16777216, 'inode_available': 16401028, 'inode_used': 376188, 'uuid': 'N/A'})
skipping: [kafka-rest1] => (item={'mount': '/etc/hostname', 'device': '/dev/vda1', 'fstype': 'ext4', 'options': 'rw,relatime,bind', 'size_total': 270294650880, 'size_available': 228905914368, 'block_size': 4096, 'block_total': 65989905, 'block_available': 55885233, 'block_used': 10104672, 'inode_total': 16777216, 'inode_available': 16401028, 'inode_used': 376188, 'uuid': 'N/A'})
skipping: [kafka-rest1] => (item={'mount': '/etc/hosts', 'device': '/dev/vda1', 'fstype': 'ext4', 'options': 'rw,relatime,bind', 'size_total': 270294650880, 'size_available': 228905914368, 'block_size': 4096, 'block_total': 65989905, 'block_available': 55885233, 'block_used': 10104672, 'inode_total': 16777216, 'inode_available': 16401028, 'inode_used': 376188, 'uuid': 'N/A'})`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible