### PR TITLE
Discontinue deprecated way of specifying kafka logs dir

### DIFF
--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -433,10 +433,6 @@ kafka_broker:
   appender_log_path: "{{kafka_broker_default_log_dir}}"
   # Deprecated way of providing custom properties
   properties: {}
-  # Deprecated way of setting kafkas log.dirs property, use kafka_broker_custom_properties:
-  # log.dirs: dir1,dir2
-  datadir:
-    - /var/lib/kafka/data
 
 ### Boolean to configure Schema Validation on Kafka
 kafka_broker_schema_validation_enabled: true

--- a/roles/variables/vars/main.yml
+++ b/roles/variables/vars/main.yml
@@ -130,7 +130,7 @@ kafka_broker_properties:
       confluent.support.metrics.enable: "true"
       confluent.support.customer.id: anonymous
       zookeeper.connect: "{{ groups['zookeeper'] | default(['localhost']) | confluent.platform.resolve_hostnames(hostvars) | join(':' + zookeeper_client_port|string + ',') }}:{{zookeeper_client_port}}{{zookeeper_chroot}}"
-      log.dirs: "{{ kafka_broker.datadir | join(',') }}"
+      log.dirs: "/var/lib/kafka/data"
       listener.security.protocol.map: "{% for listener in kafka_broker_listeners|dict2items %}{% if loop.index > 1%},{% endif %}{{ listener['value']['name'] }}:{{ listener['value'] | confluent.platform.kafka_protocol_defaults(ssl_enabled, sasl_protocol)}}{% endfor %}"
       listeners: "{% for listener in kafka_broker_listeners|dict2items %}{% if loop.index > 1%},{% endif %}{{ listener['value']['name'] }}://{{ listener['value']['ip'] | default('') }}:{{ listener['value']['port'] }}{% endfor %}"
       advertised.listeners: "{% for listener in kafka_broker_listeners|dict2items %}{% if loop.index > 1%},{% endif %}{{ listener['value']['name'] }}://{{ listener['value']['hostname'] | default(hostvars[inventory_hostname]|confluent.platform.resolve_hostname)  }}:{{ listener['value']['port'] }}{% endfor %}"


### PR DESCRIPTION
# Description

Discontinue the deprecated way of providing/overriding the data directory for kafka. Going forward, we should be using 
kafka_broker_custom_properties for the same. 
```
kafka_broker_custom_properties:
    log.dirs: dir1,dir2
```
Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?
`molecule --debug converge -s mtls-ubuntu `


**Test Configuration**:
Docker based molecule scenario.
```
PLAY RECAP *********************************************************************
control-center1            : ok=78   changed=31   unreachable=0    failed=0    skipped=40   rescued=0    ignored=0
kafka-broker1              : ok=83   changed=36   unreachable=0    failed=0    skipped=48   rescued=0    ignored=0
kafka-broker2              : ok=83   changed=36   unreachable=0    failed=0    skipped=45   rescued=0    ignored=0
kafka-broker3              : ok=83   changed=36   unreachable=0    failed=0    skipped=45   rescued=0    ignored=0
kafka-connect1             : ok=78   changed=32   unreachable=0    failed=0    skipped=49   rescued=0    ignored=0
kafka-rest1                : ok=75   changed=30   unreachable=0    failed=0    skipped=43   rescued=0    ignored=0
ksql1                      : ok=74   changed=31   unreachable=0    failed=0    skipped=43   rescued=0    ignored=0
schema-registry1           : ok=72   changed=30   unreachable=0    failed=0    skipped=43   rescued=0    ignored=0
zookeeper1                 : ok=81   changed=31   unreachable=0    failed=0    skipped=49   rescued=0    ignored=0

```
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible