### PR TITLE
ANSIENG-1063/1067

### DIFF
--- a/molecule/zookeeper-mtls-rhel/molecule.yml
+++ b/molecule/zookeeper-mtls-rhel/molecule.yml
@@ -146,7 +146,7 @@ provisioner:
     defaults:
       hash_behaviour: merge
   playbooks:
-    converge: ../../../../all.yml
+    converge: ../../playbooks/all.yml
   inventory:
     group_vars:
       all:

--- a/molecule/zookeeper-mtls-rhel/molecule.yml
+++ b/molecule/zookeeper-mtls-rhel/molecule.yml
@@ -145,8 +145,6 @@ provisioner:
   config_options:
     defaults:
       hash_behaviour: merge
-  playbooks:
-    converge: ../../playbooks/all.yml
   inventory:
     group_vars:
       all:

--- a/molecule/zookeeper-tls-rhel/molecule.yml
+++ b/molecule/zookeeper-tls-rhel/molecule.yml
@@ -146,8 +146,6 @@ provisioner:
   config_options:
     defaults:
       hash_behaviour: merge
-  playbooks:
-    converge: ../../playbooks/all.yml
   inventory:
     group_vars:
       all:

--- a/molecule/zookeeper-tls-rhel/molecule.yml
+++ b/molecule/zookeeper-tls-rhel/molecule.yml
@@ -147,7 +147,7 @@ provisioner:
     defaults:
       hash_behaviour: merge
   playbooks:
-    converge: ../../../../all.yml
+    converge: ../../playbooks/all.yml
   inventory:
     group_vars:
       all:


### PR DESCRIPTION
# Description

Molecule tests for zookeeper-tls-rhel and zookeeper-mtls-rhel use the incorrect location of all.yml. This PR resolves that. 

Fixes # (ANSIENG-1063 ANSIENG-1067)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

cp-ansible-on-demand run 77 passes for both zookeeper-tls-rhel and zookeeper-mtls-rhel. Logs available on the jenkins job. 

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible