### PR TITLE
ANSIENG 1073

### DIFF
--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -1582,6 +1582,9 @@ control_center_health_check_password: "{{ control_center_ldap_password if rbac_e
 ### Note - Only valid to customize when installation_method: archive
 kafka_connect_replicator_config_prefix: "{{ config_prefix }}/kafka-connect-replicator"
 
+### Boolean used for disabling of systemd service restarts when rootless install is executed
+kafka_connect_replicator_skip_restarts: "{{ skip_restarts }}"
+
 ## Set this variable to customize the Linux User that the Kafka Connect Replicator Service runs with. Default user is cp-kafka-connect-replicator.
 kafka_connect_replicator_user: "{{kafka_connect_replicator_default_user}}"
 


### PR DESCRIPTION
# Description

As part of this PR https://github.com/confluentinc/cp-ansible/pull/783 to enable rootless installs, new variables to skip handlers were created. But a variable was left to be defined. This PR defines the variable `kafka_connect_replicator_skip_restarts`

Fixes # (ANSIENG-1073)
Also fixes 1056, 1069, 1064

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

cp-ansible-on-demand job 78. The logs are available on the jenkins job. 


**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible