### PR TITLE
Enable zkp ssl for molecule scenario zookeeper-mtls-secrets-rhel

### DIFF
--- a/roles/confluent.test/molecule/zookeeper-mtls-secrets-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/zookeeper-mtls-secrets-rhel/molecule.yml
@@ -154,6 +154,7 @@ provisioner:
         scenario_name: zookeeper-mtls-secrets-rhel
 
         ssl_enabled: true
+        zookeeper_ssl_mutual_auth_enabled: true
 
         kafka_broker_jolokia_ssl_enabled: false
 


### PR DESCRIPTION
# Description

The given scenario as defined by the name was supposed to use 'mtls'. But in the molecule file, mtls was not enabled. At the same time, we were checking some mtls related config in the verify.yml which breaks the test. 
This PR enables mtls for the given scenario. 

Fixes # (ANSIENG-1081)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

cp-ansible-on-demand run 81. Logs are available on the jenkins job. 


**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible