### PR TITLE
Assert java version to be 8

### DIFF
--- a/molecule/mtls-java8-debian/verify.yml
+++ b/molecule/mtls-java8-debian/verify.yml
@@ -1,18 +1,17 @@
 ---
-### Validates that Java 11 is in use.
+### Validates that Java 8 is in use.
 
 - name: Verify
   hosts: all
   gather_facts: false
   tasks:
     - name: Get Java Version
-      shell: java --version
+      shell: java -version
       register: version_output
 
-    - name: Assert Java Version is 11
+    - name: Assert Java Version is 8
       assert:
         that:
-          - version_output.stdout_lines[0].split(' ')[1] is version('11.0.0', '>=')
-          - version_output.stdout_lines[0].split(' ')[1] is version('12.0.0', '<')
-        fail_msg: "Current Java Version is: {{version_output.stdout_lines[0].split(' ')[1]}} Should be 11"
+          - version_output.stderr_lines[0] | regex_search("1\.8\.")
+        fail_msg: "Current Java Version is: {{version_output.stderr_lines[0]}}. Verify again"
         quiet: true

--- a/molecule/mtls-java8-rhel/verify.yml
+++ b/molecule/mtls-java8-rhel/verify.yml
@@ -1,18 +1,17 @@
 ---
-### Validates that Java 11 is in use.
+### Validates that Java 8 is in use.
 
 - name: Verify
   hosts: all
   gather_facts: false
   tasks:
     - name: Get Java Version
-      shell: java --version
+      shell: java -version
       register: version_output
 
-    - name: Assert Java Version is 11
+    - name: Assert Java Version is 8
       assert:
         that:
-          - version_output.stdout_lines[0].split(' ')[1] is version('11.0.0', '>=')
-          - version_output.stdout_lines[0].split(' ')[1] is version('12.0.0', '<')
-        fail_msg: "Current Java Version is: {{version_output.stdout_lines[0].split(' ')[1]}} Should be 11"
+          - version_output.stderr_lines[0] | regex_search("1\.8\.")
+        fail_msg: "Current Java Version is: {{version_output.stderr_lines[0]}}. Verify again"
         quiet: true

--- a/molecule/mtls-java8-ubuntu/verify.yml
+++ b/molecule/mtls-java8-ubuntu/verify.yml
@@ -1,18 +1,17 @@
 ---
-### Validates that Java 11 is in use.
+### Validates that Java 8 is in use.
 
 - name: Verify
   hosts: all
   gather_facts: false
   tasks:
     - name: Get Java Version
-      shell: java --version
+      shell: java -version
       register: version_output
 
-    - name: Assert Java Version is 11
+    - name: Assert Java Version is 8
       assert:
         that:
-          - version_output.stdout_lines[0].split(' ')[1] is version('11.0.0', '>=')
-          - version_output.stdout_lines[0].split(' ')[1] is version('12.0.0', '<')
-        fail_msg: "Current Java Version is: {{version_output.stdout_lines[0].split(' ')[1]}} Should be 11"
+          - version_output.stderr_lines[0] | regex_search("1\.8\.")
+        fail_msg: "Current Java Version is: {{version_output.stderr_lines[0]}}. Verify again"
         quiet: true


### PR DESCRIPTION
# Description

The scenarios mtls-java8-ubuntu, mtls-java8-debian and mtls-java8-rhel were updated to use java8 in place of java11. But the verify.yml of these scenarios weren't updated corresponding to that change. 
This PR asserts the java version to be 8 in place of 11.
`java --version` is erroneous and hence `java -version` has been used. 
Surprisingly, the stderr_lines contained the real version output and not the stdout_lines which was empty. Hence, it has been used. 

Fixes # (ANSIENG-1075 ANSIENG-1077)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested locally with max verbosity for mtls-java8-ubuntu using `molecule verify -s mtls-java8-ubuntu`
The scenario in itself runs without any issue -> cp-ansible-on-demand run 83

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible