### PR TITLE
Added additional task to create sysctl.d directory on Debian 10.

### DIFF
--- a/roles/kafka_broker/tasks/main.yml
+++ b/roles/kafka_broker/tasks/main.yml
@@ -390,7 +390,7 @@
   tags:
     - systemd
 
-- name: Create sysctl directory on Debian
+- name: Create sysctl directory on Debian distributions
   file:
     path: /usr/lib/sysctl.d
     state: directory

--- a/roles/kafka_broker/tasks/main.yml
+++ b/roles/kafka_broker/tasks/main.yml
@@ -390,6 +390,15 @@
   tags:
     - systemd
 
+- name: Create sysctl directory on Debian
+  file:
+    path: /usr/lib/sysctl.d
+    state: directory
+  when: ansible_distribution == "Debian"
+  tags:
+    - sysctl
+    - privileged
+
 - name: Tune virtual memory settings
   sysctl:
     name: "{{ item.key }}"


### PR DESCRIPTION
# Description

This PR adds a new task to create the sysctl.d directory in /usr/lib as it is no longer present by default in Debian 10, despite being a valid configuration directory for systemd.  It previously existed in Debian 9.

Fixes # (issue)

ANSIENG-1054

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Successfully ran the rbac-kafka-connect-replicator-kerberos-mtls-custom-debian10 scenario after adding this additional task.

Original error:

`An exception occurred during task execution. To see the full traceback, use -vvv. The error was: FileNotFoundError: [Errno 2] No such file or directory: '/usr/lib/sysctl.d/.ansible_m_sysctl_c8kl51w4.conf'
failed: [mds-kafka-broker1] (item={'key': 'vm.max_map_count', 'value': 262144}) => {"ansible_loop_var": "item", "changed": false, "item": {"key": "vm.max_map_count", "value": 262144}, "module_stderr": "Traceback (most recent call last):\n  File "/root/.ansible/tmp/ansible-tmp-1645635257.6285272-27042-148316897414678/AnsiballZ_sysctl.py", line 100, in <module>\n    _ansiballz_main()\n  File "/root/.ansible/tmp/ansible-tmp-1645635257.6285272-27042-148316897414678/AnsiballZ_sysctl.py", line 92, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File "/root/.ansible/tmp/ansible-tmp-1645635257.6285272-27042-148316897414678/AnsiballZ_sysctl.py", line 41, in invoke_module\n    run_name='main', alter_sys=True)\n  File "/usr/lib/python3.7/runpy.py", line 205, in run_module\n    return _run_module_code(code, init_globals, run_name, mod_spec)\n  File "/usr/lib/python3.7/runpy.py", line 96, in _run_module_code\n    mod_name, mod_spec, pkg_name, script_name)\n  File "/usr/lib/python3.7/runpy.py", line 85, in _run_code\n    exec(code, run_globals)\n  File "/tmp/ansible_sysctl_payload_l827yvwa/ansible_sysctl_payload.zip/ansible_collections/ansible/posix/plugins/modules/sysctl.py", line 420, in <module>\n  File "/tmp/ansible_sysctl_payload_l827yvwa/ansible_sysctl_payload.zip/ansible_collections/ansible/posix/plugins/modules/sysctl.py", line 414, in main\n  File "/tmp/ansible_sysctl_payload_l827yvwa/ansible_sysctl_payload.zip/ansible_collections/ansible/posix/plugins/modules/sysctl.py", line 133, in init\n  File "/tmp/ansible_sysctl_payload_l827yvwa/ansible_sysctl_payload.zip/ansible_collections/ansible/posix/plugins/modules/sysctl.py", line 193, in process\n  File "/tmp/ansible_sysctl_payload_l827yvwa/ansible_sysctl_payload.zip/ansible_collections/ansible/posix/plugins/modules/sysctl.py", line 369, in write_sysctl\n  File "/usr/lib/python3.7/tempfile.py", line 479, in mkstemp\n    return _mkstemp_inner(dir, prefix, suffix, flags, output_type)\n  File "/usr/lib/python3.7/tempfile.py", line 397, in _mkstemp_inner\n    fd = _os.open(file, flags, 0o600)\nFileNotFoundError: [Errno 2] No such file or directory: '/usr/lib/sysctl.d/.ansible_m_sysctl_c8kl51w4.conf'\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}`


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible