### PR TITLE
Added additional task to create sysctl.d directory for configuration.

### DIFF
--- a/roles/confluent.kafka_broker/tasks/main.yml
+++ b/roles/confluent.kafka_broker/tasks/main.yml
@@ -351,6 +351,15 @@
   notify: restart kafka
   diff: "{{ not mask_sensitive_diff|bool }}"
 
+- name: Create sysctl directory on Debian distributions
+  file:
+    path: /usr/lib/sysctl.d
+    state: directory
+  when: ansible_distribution == "Debian"
+  tags:
+    - sysctl
+    - privileged
+
 - name: Tune virtual memory settings
   sysctl:
     name: "{{ item.key }}"


### PR DESCRIPTION
# Description

This PR adds an additional task to create the sysctl.d directory in  /usr/lib in order to facilitate systemd service configuration.

Its a back port of: https://github.com/confluentinc/cp-ansible/pull/926

Fixes # (issue)

ANSIENG-1083.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Validated by running the rbac-kerberos-debian scenario and completing successfully.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible