### PR TITLE
Updated scenario to use correct docker file.

### DIFF
--- a/molecule/rbac-mtls-rhel8/molecule.yml
+++ b/molecule/rbac-mtls-rhel8/molecule.yml
@@ -12,7 +12,7 @@ platforms:
     groups:
       - ldap_server
     image: geerlingguy/docker-centos7-ansible
-    dockerfile: ../Dockerfile-rhel-java8.j2
+    dockerfile: ../Dockerfile-rhel-base.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -24,7 +24,7 @@ platforms:
     groups:
       - zookeeper
     image: geerlingguy/docker-centos8-ansible
-    dockerfile: ../Dockerfile-rhel-java8.j2
+    dockerfile: ../Dockerfile-rhel-base.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -36,7 +36,7 @@ platforms:
     groups:
       - kafka_broker
     image: geerlingguy/docker-centos8-ansible
-    dockerfile: ../Dockerfile-rhel-java8.j2
+    dockerfile: ../Dockerfile-rhel-base.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -48,7 +48,7 @@ platforms:
     groups:
       - kafka_broker
     image: geerlingguy/docker-centos8-ansible
-    dockerfile: ../Dockerfile-rhel-java8.j2
+    dockerfile: ../Dockerfile-rhel-base.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -60,7 +60,7 @@ platforms:
     groups:
       - kafka_broker
     image: geerlingguy/docker-centos8-ansible
-    dockerfile: ../Dockerfile-rhel-java8.j2
+    dockerfile: ../Dockerfile-rhel-base.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -72,7 +72,7 @@ platforms:
     groups:
       - schema_registry
     image: geerlingguy/docker-centos8-ansible
-    dockerfile: ../Dockerfile-rhel-java8.j2
+    dockerfile: ../Dockerfile-rhel-base.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -84,7 +84,7 @@ platforms:
     groups:
       - kafka_rest
     image: geerlingguy/docker-centos8-ansible
-    dockerfile: ../Dockerfile-rhel-java8.j2
+    dockerfile: ../Dockerfile-rhel-base.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -96,7 +96,7 @@ platforms:
     groups:
       - kafka_connect
     image: geerlingguy/docker-centos8-ansible
-    dockerfile: ../Dockerfile-rhel-java8.j2
+    dockerfile: ../Dockerfile-rhel-base.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -108,7 +108,7 @@ platforms:
     groups:
       - ksql
     image: geerlingguy/docker-centos8-ansible
-    dockerfile: ../Dockerfile-rhel-java8.j2
+    dockerfile: ../Dockerfile-rhel-base.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -120,7 +120,7 @@ platforms:
     groups:
       - control_center
     image: geerlingguy/docker-centos8-ansible
-    dockerfile: ../Dockerfile-rhel-java8.j2
+    dockerfile: ../Dockerfile-rhel-base.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/molecule/rbac-mtls-rhel8/verify.yml
+++ b/molecule/rbac-mtls-rhel8/verify.yml
@@ -51,7 +51,7 @@
       changed_when: false
 
 - name: Verify Client Packages
-  hosts: all
+  hosts: zookeeper kafka_broker schema_registry kafka_rest kafka_connect ksql control_center
   gather_facts: false
   tasks:
     - shell: "yum list available |grep Confluent.clients"


### PR DESCRIPTION
# Description

This PR updates the rbac-mtls-rhel8 scenario to use the correct docker file.  It also updates the verification to not check the ldap host for confluent client packages as they are not installed there.

Fixes # (issue)

ANSIENG-1084

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Successfully ran rbac-mtls-rhel8 scenario with verification:

`PLAY RECAP *********************************************************************
control-center1            : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
kafka-broker1              : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
kafka-broker2              : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
kafka-broker3              : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
kafka-connect1             : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
kafka-rest1                : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
ksql1                      : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
schema-registry1           : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
zookeeper1                 : ok=2    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0`


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible