### PR TITLE
Correct url in multi-ksql-connect-rhel verify.yml

### DIFF
--- a/roles/confluent.test/molecule/multi-ksql-connect-rhel/verify.yml
+++ b/roles/confluent.test/molecule/multi-ksql-connect-rhel/verify.yml
@@ -68,7 +68,7 @@
 
     - name: Get Connectors on connect cluster3
       uri:
-        url: "https://kafka-connect3:8083/connectors"
+        url: "http://kafka-connect3:8083/connectors"
         status_code: 200
         validate_certs: false
       register: connectors


### PR DESCRIPTION
# Description

This corrects url used for connect cluster 3. And makes it similar to cluster 1 and cluster 2. 

Fixes # (ANSIENG-1065)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested locally on the mentioned scenario. 


**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible