### PR TITLE
Fixing the test failure with scenario archive-plain-rhel

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -2,6 +2,7 @@
 hash_behaviour=merge
 callback_whitelist=profile_tasks
 remote_tmp=~/.ansible/tmp
+collections_paths=~/.ansible/collections:../../../
 
 [ssh_connection]
 pipelining = True

--- a/molecule/archive-plain-rhel/verify.yml
+++ b/molecule/archive-plain-rhel/verify.yml
@@ -20,14 +20,6 @@
         tasks_from: check_property.yml
       vars:
         file_path: /opt/confluent/etc/kafka/server.properties
-        property: security.providers
-        expected_value: io.confluent.kafka.security.fips.provider.BcFipsProviderCreator,io.confluent.kafka.security.fips.provider.BcFipsJsseProviderCreator
-
-    - import_role:
-        name: confluent.test
-        tasks_from: check_property.yml
-      vars:
-        file_path: /opt/confluent/etc/kafka/server.properties
         property: log.dirs
         expected_value: /tmp/logs1,/tmp/logs2
 

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -9,9 +9,9 @@
 
 - name: Verify Ansible version
   assert:
-    that: "ansible_version.full is version_compare('2.10', '>=')"
+    that: "ansible_version.full is version_compare('2.9', '>=')"
     fail_msg: >-
-      "You must update Ansible to at least 2.11 to use these playbooks."
+      "You must update Ansible to at least 2.9 to use these playbooks."
   tags:
   - validate
   - validate_ansi_version


### PR DESCRIPTION
# Description
We have disables fips on archive-plain-rhel scenario with commit 0be567a31bfb3bd7099cac70fbd4bc0d4bf98d3d, while a test in verify still. looks for fips-related properties to exist, which was causing the `molecule verify` command to fail.
Have removed that test itself as it does not make sense for this scenario anymore.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

`molecule verify -s archive-plain-rhel`


PLAY RECAP ****************************************************************************************************************************************************************
control-center1            : ok=7    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
kafka-broker1              : ok=9    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
kafka-connect1             : ok=7    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
kafka-rest1                : ok=7    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
ksql1                      : ok=7    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
schema-registry1           : ok=7    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
zookeeper1                 : ok=5    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0

**Test Configuration**:
Molecule scenario archive-plain-rhel

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible