### PR TITLE
Read packages/version from env vars - 6.0.x

### DIFF
--- a/roles/confluent.test/molecule/Dockerfile-debian.j2
+++ b/roles/confluent.test/molecule/Dockerfile-debian.j2
@@ -12,23 +12,26 @@ RUN apt-get update && \
       unzip \
       curl
 
-RUN wget -qO - https://packages.confluent.io/deb/6.0/archive.key | sudo apt-key add - && \
-   add-apt-repository "deb [arch=amd64] https://packages.confluent.io/deb/6.0 stable main" && \
+{% set PACKAGE_VER = lookup('env', 'VERSION') | default('6.0.5', true) %}
+{% set REPO_VER = PACKAGE_VER | regex_replace('^([0-9])\\.([0-9]*).*', '\\1.\\2') %}
+{% set COMMON_REPO_URL = lookup('env', 'COMMON_REPO_URL') | default('https://packages.confluent.io', true) %}
+
+RUN wget -qO - {{ COMMON_REPO_URL }}/deb/{{ REPO_VER }}/archive.key | sudo apt-key add - && \
+   add-apt-repository "deb [arch=amd64] {{ COMMON_REPO_URL }}/deb/{{ REPO_VER }} stable main" && \
    apt-get update
 
 RUN apt-get install --yes \
-     confluent-common=6.0.0-1 \
-     confluent-hub-client=6.0.0-1 \
-     confluent-rebalancer=6.0.0-1 \
-     confluent-rest-utils=6.0.0-1 \
-     confluent-metadata-service=6.0.0-1 \
-     confluent-server=6.0.0-1 \
-     confluent-kafka-connect-replicator=6.0.0-1 \
-     confluent-kafka-rest=6.0.0-1 \
-     confluent-ksqldb=6.0.0-1 \
-     confluent-schema-registry=6.0.0-1 \
-     confluent-security=6.0.0-1 \
-     confluent-control-center-fe=6.0.0-1 \
-     confluent-control-center=6.0.0-1 \
-     confluent-schema-registry=6.0.0-1
-
+     confluent-common={{ PACKAGE_VER }}-1 \
+     confluent-hub-client={{ PACKAGE_VER }}-1 \
+     confluent-rebalancer={{ PACKAGE_VER }}-1 \
+     confluent-rest-utils={{ PACKAGE_VER }}-1 \
+     confluent-metadata-service={{ PACKAGE_VER }}-1 \
+     confluent-server={{ PACKAGE_VER }}-1 \
+     confluent-kafka-connect-replicator={{ PACKAGE_VER }}-1 \
+     confluent-kafka-rest={{ PACKAGE_VER }}-1 \
+     confluent-ksqldb={{ PACKAGE_VER }}-1 \
+     confluent-schema-registry={{ PACKAGE_VER }}-1 \
+     confluent-security={{ PACKAGE_VER }}-1 \
+     confluent-control-center-fe={{ PACKAGE_VER }}-1 \
+     confluent-control-center={{ PACKAGE_VER }}-1 \
+     confluent-schema-registry={{ PACKAGE_VER }}-1

--- a/roles/confluent.test/molecule/Dockerfile-debian.j2
+++ b/roles/confluent.test/molecule/Dockerfile-debian.j2
@@ -12,7 +12,7 @@ RUN apt-get update && \
       unzip \
       curl
 
-{% set DEFAULT_PACKAGE_VER = lookup('pipe', "awk '/confluent_package_version:/ {print $2}' $MOLECULE_PROJECT_DIRECTORY/roles/confluent.variables/defaults/main.yml" ) %}
+{% set DEFAULT_PACKAGE_VER = lookup('pipe', "awk '/confluent_package_version:/ {print $2}' $MOLECULE_PROJECT_DIRECTORY/../confluent.variables/defaults/main.yml" ) %}
 {% set PACKAGE_VER = lookup('env', 'VERSION') | default(DEFAULT_PACKAGE_VER, true) %}
 {% set REPO_VER = PACKAGE_VER | regex_replace('^([0-9])\\.([0-9]*).*', '\\1.\\2') %}
 {% set COMMON_REPO_URL = lookup('env', 'COMMON_REPO_URL') | default('https://packages.confluent.io', true) %}

--- a/roles/confluent.test/molecule/Dockerfile-debian.j2
+++ b/roles/confluent.test/molecule/Dockerfile-debian.j2
@@ -12,7 +12,8 @@ RUN apt-get update && \
       unzip \
       curl
 
-{% set PACKAGE_VER = lookup('env', 'VERSION') | default('6.0.5', true) %}
+{% set DEFAULT_PACKAGE_VER = lookup('pipe', "awk '/confluent_package_version:/ {print $2}' $MOLECULE_PROJECT_DIRECTORY/roles/confluent.variables/defaults/main.yml" ) %}
+{% set PACKAGE_VER = lookup('env', 'VERSION') | default(DEFAULT_PACKAGE_VER, true) %}
 {% set REPO_VER = PACKAGE_VER | regex_replace('^([0-9])\\.([0-9]*).*', '\\1.\\2') %}
 {% set COMMON_REPO_URL = lookup('env', 'COMMON_REPO_URL') | default('https://packages.confluent.io', true) %}
 

--- a/roles/confluent.test/molecule/Dockerfile-tar.j2
+++ b/roles/confluent.test/molecule/Dockerfile-tar.j2
@@ -4,7 +4,11 @@ RUN yum -y install java-11-openjdk \
       rsync \
       openssl
 
+{% set PACKAGE_VER = lookup('env', 'VERSION') | default('6.0.5', true) %}
+{% set REPO_VER = PACKAGE_VER | regex_replace('^([0-9])\\.([0-9]*).*', '\\1.\\2') %}
+{% set COMMON_REPO_URL = lookup('env', 'COMMON_REPO_URL') | default('http://packages.confluent.io', true) %}
+
 RUN mkdir /opt/confluent && \
-    curl -o /opt/confluent/confluent-6.0.5.tar.gz http://packages.confluent.io/archive/6.0/confluent-6.0.5.tar.gz && \
-    tar xzf /opt/confluent/confluent-6.0.5.tar.gz -C /opt/confluent/ && \
-    rm -rf /opt/confluent/confluent-6.0.5.tar.gz
+    curl -o /opt/confluent/confluent-{{ PACKAGE_VER }}.tar.gz {{ COMMON_REPO_URL }}/archive/{{ REPO_VER }}/confluent-{{ PACKAGE_VER }}.tar.gz && \
+    tar xzf /opt/confluent/confluent-{{ PACKAGE_VER }}.tar.gz -C /opt/confluent/ && \
+    rm -rf /opt/confluent/confluent-{{ PACKAGE_VER }}.tar.gz

--- a/roles/confluent.test/molecule/Dockerfile-tar.j2
+++ b/roles/confluent.test/molecule/Dockerfile-tar.j2
@@ -4,7 +4,8 @@ RUN yum -y install java-11-openjdk \
       rsync \
       openssl
 
-{% set PACKAGE_VER = lookup('env', 'VERSION') | default('6.0.5', true) %}
+{% set DEFAULT_PACKAGE_VER = lookup('pipe', "awk '/confluent_package_version:/ {print $2}' $MOLECULE_PROJECT_DIRECTORY/roles/confluent.variables/defaults/main.yml" ) %}
+{% set PACKAGE_VER = lookup('env', 'VERSION') | default(DEFAULT_PACKAGE_VER, true) %}
 {% set REPO_VER = PACKAGE_VER | regex_replace('^([0-9])\\.([0-9]*).*', '\\1.\\2') %}
 {% set COMMON_REPO_URL = lookup('env', 'COMMON_REPO_URL') | default('http://packages.confluent.io', true) %}
 

--- a/roles/confluent.test/molecule/Dockerfile-tar.j2
+++ b/roles/confluent.test/molecule/Dockerfile-tar.j2
@@ -4,7 +4,7 @@ RUN yum -y install java-11-openjdk \
       rsync \
       openssl
 
-{% set DEFAULT_PACKAGE_VER = lookup('pipe', "awk '/confluent_package_version:/ {print $2}' $MOLECULE_PROJECT_DIRECTORY/roles/confluent.variables/defaults/main.yml" ) %}
+{% set DEFAULT_PACKAGE_VER = lookup('pipe', "awk '/confluent_package_version:/ {print $2}' $MOLECULE_PROJECT_DIRECTORY/../confluent.variables/defaults/main.yml" ) %}
 {% set PACKAGE_VER = lookup('env', 'VERSION') | default(DEFAULT_PACKAGE_VER, true) %}
 {% set REPO_VER = PACKAGE_VER | regex_replace('^([0-9])\\.([0-9]*).*', '\\1.\\2') %}
 {% set COMMON_REPO_URL = lookup('env', 'COMMON_REPO_URL') | default('http://packages.confluent.io', true) %}

--- a/roles/confluent.test/molecule/Dockerfile-ubuntu.j2
+++ b/roles/confluent.test/molecule/Dockerfile-ubuntu.j2
@@ -4,7 +4,7 @@ RUN mkdir -p /usr/share/man/man1 && \
     apt-get update -y && \
     apt-get install -y openjdk-8-jdk wget gnupg
 
-{% set DEFAULT_PACKAGE_VER = lookup('pipe', "awk '/confluent_package_version:/ {print $2}' $MOLECULE_PROJECT_DIRECTORY/roles/confluent.variables/defaults/main.yml" ) %}
+{% set DEFAULT_PACKAGE_VER = lookup('pipe', "awk '/confluent_package_version:/ {print $2}' $MOLECULE_PROJECT_DIRECTORY/../confluent.variables/defaults/main.yml" ) %}
 {% set PACKAGE_VER = lookup('env', 'VERSION') | default(DEFAULT_PACKAGE_VER, true) %}
 {% set REPO_VER = PACKAGE_VER | regex_replace('^([0-9])\\.([0-9]*).*', '\\1.\\2') %}
 {% set COMMON_REPO_URL = lookup('env', 'COMMON_REPO_URL') | default('https://packages.confluent.io', true) %}

--- a/roles/confluent.test/molecule/Dockerfile-ubuntu.j2
+++ b/roles/confluent.test/molecule/Dockerfile-ubuntu.j2
@@ -4,7 +4,8 @@ RUN mkdir -p /usr/share/man/man1 && \
     apt-get update -y && \
     apt-get install -y openjdk-8-jdk wget gnupg
 
-{% set PACKAGE_VER = lookup('env', 'VERSION') | default('6.0.5', true) %}
+{% set DEFAULT_PACKAGE_VER = lookup('pipe', "awk '/confluent_package_version:/ {print $2}' $MOLECULE_PROJECT_DIRECTORY/roles/confluent.variables/defaults/main.yml" ) %}
+{% set PACKAGE_VER = lookup('env', 'VERSION') | default(DEFAULT_PACKAGE_VER, true) %}
 {% set REPO_VER = PACKAGE_VER | regex_replace('^([0-9])\\.([0-9]*).*', '\\1.\\2') %}
 {% set COMMON_REPO_URL = lookup('env', 'COMMON_REPO_URL') | default('https://packages.confluent.io', true) %}
 

--- a/roles/confluent.test/molecule/Dockerfile-ubuntu.j2
+++ b/roles/confluent.test/molecule/Dockerfile-ubuntu.j2
@@ -4,8 +4,12 @@ RUN mkdir -p /usr/share/man/man1 && \
     apt-get update -y && \
     apt-get install -y openjdk-8-jdk wget gnupg
 
-RUN wget -qO - https://packages.confluent.io/deb/6.0/archive.key | sudo apt-key add - && \
-    add-apt-repository "deb [arch=amd64] https://packages.confluent.io/deb/6.0 stable main" && \
+{% set PACKAGE_VER = lookup('env', 'VERSION') | default('6.0.5', true) %}
+{% set REPO_VER = PACKAGE_VER | regex_replace('^([0-9])\\.([0-9]*).*', '\\1.\\2') %}
+{% set COMMON_REPO_URL = lookup('env', 'COMMON_REPO_URL') | default('https://packages.confluent.io', true) %}
+
+RUN wget -qO - {{ COMMON_REPO_URL }}/deb/{{ REPO_VER }}/archive.key | sudo apt-key add - && \
+    add-apt-repository "deb [arch=amd64] {{ COMMON_REPO_URL }}/deb/{{ REPO_VER }} stable main" && \
     apt-get update
 
 RUN apt-get install --yes \

--- a/roles/confluent.test/molecule/Dockerfile.j2
+++ b/roles/confluent.test/molecule/Dockerfile.j2
@@ -17,18 +17,22 @@ RUN yum -y install java-1.8.0-openjdk \
       krb5-workstation \
       unzip
 
+{% set PACKAGE_VER = lookup('env', 'VERSION') | default('6.0.5', true) %}
+{% set REPO_VER = PACKAGE_VER | regex_replace('^([0-9])\\.([0-9]*).*', '\\1.\\2') %}
+{% set COMMON_REPO_URL = lookup('env', 'COMMON_REPO_URL') | default('https://packages.confluent.io', true) %}
+
 RUN echo $'[Confluent.dist]\n\
 name=Confluent repository (dist)\n\
-baseurl=https://packages.confluent.io/rpm/6.0\n\
+baseurl={{ COMMON_REPO_URL }}/rpm/{{ REPO_VER }}\n\
 gpgcheck=1\n\
-gpgkey=https://packages.confluent.io/rpm/6.0/archive.key\n\
+gpgkey={{ COMMON_REPO_URL }}/rpm/{{ REPO_VER }}/archive.key\n\
 enabled=1\n\
 \n\
 [Confluent]\n\
 name=Confluent repository\n\
-baseurl=https://packages.confluent.io/rpm/6.0\n\
+baseurl={{ COMMON_REPO_URL }}/rpm/{{ REPO_VER }}\n\
 gpgcheck=1\n\
-gpgkey=https://packages.confluent.io/rpm/6.0/archive.key\n\
+gpgkey={{ COMMON_REPO_URL }}/rpm/{{ REPO_VER }}/archive.key\n\
 enabled=1' >> /etc/yum.repos.d/confluent.repo
 
 RUN yum clean all && \

--- a/roles/confluent.test/molecule/Dockerfile.j2
+++ b/roles/confluent.test/molecule/Dockerfile.j2
@@ -17,7 +17,8 @@ RUN yum -y install java-1.8.0-openjdk \
       krb5-workstation \
       unzip
 
-{% set PACKAGE_VER = lookup('env', 'VERSION') | default('6.0.5', true) %}
+{% set DEFAULT_PACKAGE_VER = lookup('pipe', "awk '/confluent_package_version:/ {print $2}' $MOLECULE_PROJECT_DIRECTORY/roles/confluent.variables/defaults/main.yml" ) %}
+{% set PACKAGE_VER = lookup('env', 'VERSION') | default(DEFAULT_PACKAGE_VER, true) %}
 {% set REPO_VER = PACKAGE_VER | regex_replace('^([0-9])\\.([0-9]*).*', '\\1.\\2') %}
 {% set COMMON_REPO_URL = lookup('env', 'COMMON_REPO_URL') | default('https://packages.confluent.io', true) %}
 

--- a/roles/confluent.test/molecule/Dockerfile.j2
+++ b/roles/confluent.test/molecule/Dockerfile.j2
@@ -17,7 +17,7 @@ RUN yum -y install java-1.8.0-openjdk \
       krb5-workstation \
       unzip
 
-{% set DEFAULT_PACKAGE_VER = lookup('pipe', "awk '/confluent_package_version:/ {print $2}' $MOLECULE_PROJECT_DIRECTORY/roles/confluent.variables/defaults/main.yml" ) %}
+{% set DEFAULT_PACKAGE_VER = lookup('pipe', "awk '/confluent_package_version:/ {print $2}' $MOLECULE_PROJECT_DIRECTORY/../confluent.variables/defaults/main.yml" ) %}
 {% set PACKAGE_VER = lookup('env', 'VERSION') | default(DEFAULT_PACKAGE_VER, true) %}
 {% set REPO_VER = PACKAGE_VER | regex_replace('^([0-9])\\.([0-9]*).*', '\\1.\\2') %}
 {% set COMMON_REPO_URL = lookup('env', 'COMMON_REPO_URL') | default('https://packages.confluent.io', true) %}


### PR DESCRIPTION
# Description

Extension of https://github.com/confluentinc/cp-ansible/pull/918 for 6.0.x
This also fixes a Dockerfile where we were reading 6.0.0 in place of 6.0.5

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested as part of 918

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible