### PR TITLE
Fixing the issue with kafka_broker and kafka_connect log4j config

### DIFF
--- a/roles/kafka_broker/defaults/main.yml
+++ b/roles/kafka_broker/defaults/main.yml
@@ -42,6 +42,7 @@ kafka_broker_service_environment_overrides:
   KAFKA_HEAP_OPTS: "-Xms6g -Xmx6g -XX:MetaspaceSize=96m -XX:+UseG1GC -XX:MaxGCPauseMillis=20 -XX:InitiatingHeapOccupancyPercent=35 -XX:G1HeapRegionSize=16M -XX:MinMetaspaceFreeRatio=50 -XX:MaxMetaspaceFreeRatio=80"
   KAFKA_OPTS: "{{ kafka_broker_final_java_args | confluent.platform.java_arg_build_out }}"
   # Remove trailing slash if there is one
+  KAFKA_LOG4J_OPTS: "{% if kafka_broker_custom_log4j|bool %}-Dlog4j.configuration=file:{{ kafka_broker.log4j_file }}{% endif %}"
   LOG_DIR: "{{ kafka_broker_log_dir|regex_replace('\\/$', '') }}"
   CONFLUENT_SECURITY_MASTER_KEY: "{% if kafka_broker_secrets_protection_enabled|bool %}{{secrets_protection_masterkey}}{% endif %}"
 

--- a/roles/kafka_connect/defaults/main.yml
+++ b/roles/kafka_connect/defaults/main.yml
@@ -38,6 +38,7 @@ kafka_connect_service_environment_overrides:
   KAFKA_HEAP_OPTS: "-Xms256M -Xmx2G"
   KAFKA_OPTS: "{{ kafka_connect_final_java_args | confluent.platform.java_arg_build_out }}"
   # Remove trailing slash if there is one
+  KAFKA_LOG4J_OPTS: "{% if kafka_connect_custom_log4j|bool %}-Dlog4j.configuration=file:{{ kafka_connect.log4j_file }}{% endif %}"
   LOG_DIR: "{{ kafka_connect_log_dir|regex_replace('\\/$', '') }}"
   CONFLUENT_SECURITY_MASTER_KEY: "{% if kafka_connect_secrets_protection_enabled|bool %}{{secrets_protection_masterkey}}{% endif %}"
 


### PR DESCRIPTION
Fixing the issue with kafka_broker and kafka_connect log4j config files getting defaulted to wrong filepath

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
`molecule converge -s archive-plain-debian10`

```
PLAY RECAP ************************************************************************************************************************************
control-center1            : ok=44   changed=0    unreachable=0    failed=0    skipped=42   rescued=0    ignored=0
kafka-broker1              : ok=52   changed=2    unreachable=0    failed=0    skipped=50   rescued=0    ignored=0
kafka-connect1             : ok=52   changed=2    unreachable=0    failed=0    skipped=49   rescued=0    ignored=0
kafka-rest1                : ok=41   changed=0    unreachable=0    failed=0    skipped=45   rescued=0    ignored=0
ksql1                      : ok=40   changed=0    unreachable=0    failed=0    skipped=45   rescued=0    ignored=0
schema-registry1           : ok=38   changed=0    unreachable=0    failed=0    skipped=45   rescued=0    ignored=0
zookeeper1                 : ok=45   changed=0    unreachable=0    failed=0    skipped=51   rescued=0    ignored=0
```


`molecule verify -s archive-plain-debian10`

```
PLAY RECAP ************************************************************************************************************************************
control-center1            : ok=7    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
kafka-broker1              : ok=7    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
kafka-connect1             : ok=7    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
kafka-rest1                : ok=7    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
ksql1                      : ok=7    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
schema-registry1           : ok=7    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
zookeeper1                 : ok=5    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0

INFO     Verifier completed successfully.
```

**Test Configuration**:
Molecule test `archive-plain-debian10`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible