### PR TITLE
Remove conflicting properties

### DIFF
--- a/docs/VARIABLES.md
+++ b/docs/VARIABLES.md
@@ -664,7 +664,7 @@ Default:  "{{'2182' if zookeeper_ssl_enabled|bool else '2181'}}"
 
 Set this variable to customize the directory that Zookeeper writes log files to. Default location is /var/log/kafka. NOTE- zookeeper.log_path is deprecated.
 
-Default:  "{{zookeeper.log_path}}"
+Default:  "{{zookeeper_default_log_dir}}"
 
 ***
 
@@ -792,7 +792,7 @@ Default:  []
 
 Use to set custom zookeeper properties. This variable is a dictionary. Put values true/false in quotation marks to perserve case. NOTE- zookeeper.properties is deprecated.
 
-Default:  "{{ zookeeper.properties }}"
+Default:  {}
 
 ***
 
@@ -864,7 +864,7 @@ Default:  "{{kafka_broker_default_group}}"
 
 Set this variable to customize the directory that the Kafka Broker writes log files to. Default location is /var/log/kafka. NOTE- kafka_broker.appender_log_path is deprecated.
 
-Default:  "{{kafka_broker.appender_log_path}}"
+Default:  "{{kafka_broker_default_log_dir}}"
 
 ***
 
@@ -992,7 +992,7 @@ Default:  "{{ 'control_center' in groups }}"
 
 Use to set custom kafka properties. This variable is a dictionary. Put values true/false in quotation marks to perserve case. NOTE- kafka_broker.properties is deprecated.
 
-Default:  "{{ kafka_broker.properties }}"
+Default:  {}
 
 ***
 
@@ -1096,7 +1096,7 @@ Default:  "{{ 'mtls' if schema_registry_ssl_mutual_auth_enabled else 'none' }}"
 
 Set this variable to customize the directory that the Schema Registry writes log files to. Default location is /var/log/confluent/schema-registry. NOTE- schema_registry.appender_log_path is deprecated.
 
-Default:  "{{schema_registry.appender_log_path}}"
+Default:  "{{schema_registry_default_log_dir}}"
 
 ***
 
@@ -1200,7 +1200,7 @@ Default:  []
 
 Use to set custom schema registry properties. This variable is a dictionary. Put values true/false in quotation marks to perserve case. NOTE- kafka_broker.properties is deprecated.
 
-Default:  "{{ schema_registry.properties }}"
+Default:  {}
 
 ***
 
@@ -1280,7 +1280,7 @@ Default:  "{{ 'mtls' if kafka_rest_ssl_mutual_auth_enabled else 'none' }}"
 
 Set this variable to customize the directory that the Rest Proxy writes log files to. Default location is /var/log/confluent/kafka-rest. NOTE- kafka_rest.appender_log_path is deprecated.
 
-Default:  "{{kafka_rest.appender_log_path}}"
+Default:  "{{kafka_rest_default_log_dir}}"
 
 ***
 
@@ -1384,7 +1384,7 @@ Default:  []
 
 Use to set custom Rest Proxy properties. This variable is a dictionary. Put values true/false in quotation marks to perserve case. NOTE- kafka_rest.properties is deprecated.
 
-Default:  "{{ kafka_rest.properties }}"
+Default:  {}
 
 ***
 
@@ -1480,7 +1480,7 @@ Default:  "{{ 'mtls' if kafka_connect_ssl_mutual_auth_enabled|bool else 'none' }
 
 Set this variable to customize the directory that Kafka Connect writes log files to. Default location is /var/log/kafka. NOTE- kafka_connect.appender_log_path is deprecated.
 
-Default:  "{{kafka_connect.appender_log_path}}"
+Default:  "{{kafka_connect_default_log_dir}}"
 
 ***
 
@@ -1624,7 +1624,7 @@ Default:  39ff95832750c0090d84ddf5344583832efe91ef
 
 Use to set custom Connect properties. This variable is a dictionary. Put values true/false in quotation marks to perserve case. NOTE- kafka_connect.properties is deprecated.
 
-Default:  "{{ kafka_connect.properties }}"
+Default:  {}
 
 ***
 
@@ -1712,7 +1712,7 @@ Default:  "{{ 'mtls' if ksql_ssl_mutual_auth_enabled|bool else 'none' }}"
 
 Set this variable to customize the directory that ksqlDB writes log files to. Default location is /var/log/confluent/ksql. NOTE- ksql.appender_log_path is deprecated.
 
-Default:  "{{ksql.appender_log_path}}"
+Default:  "{{ksql_default_log_dir}}"
 
 ***
 
@@ -1832,7 +1832,7 @@ Default:  default_
 
 Use to set custom ksqlDB properties. This variable is a dictionary. Put values true/false in quotation marks to perserve case. NOTE- ksql.properties is deprecated.
 
-Default:  "{{ ksql.properties }}"
+Default:  {}
 
 ***
 
@@ -1928,7 +1928,7 @@ Default:  none
 
 Set this variable to customize the directory that Control Center writes log files to. Default location is /var/log/confluent/control-center. NOTE- control_center.appender_log_path is deprecated.
 
-Default:  "{{control_center.appender_log_path}}"
+Default:  "{{control_center_default_log_dir}}"
 
 ***
 
@@ -1952,7 +1952,7 @@ Default:  "{{ 3 if ccloud_kafka_enabled|bool else
 
 Use to set custom Control Center properties. This variable is a dictionary. Put values true/false in quotation marks to perserve case. NOTE- control_center.properties is deprecated.
 
-Default:  "{{ control_center.properties }}"
+Default:  {}
 
 ***
 

--- a/roles/kafka_broker/tasks/main.yml
+++ b/roles/kafka_broker/tasks/main.yml
@@ -13,6 +13,7 @@
   loop:
     - ansible_os_family
     - ansible_fqdn
+    - ansible_distribution
 
 - name: Stop Service and Remove Packages on Version Change
   include_role:

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -281,7 +281,7 @@ zookeeper_client_authentication_type: "{{ 'mtls' if zookeeper_ssl_enabled and zo
 zookeeper_client_port: "{{'2182' if zookeeper_ssl_enabled|bool else '2181'}}"
 
 ### Set this variable to customize the directory that Zookeeper writes log files to. Default location is /var/log/kafka. NOTE- zookeeper.log_path is deprecated.
-zookeeper_log_dir: "{{zookeeper.log_path}}"
+zookeeper_log_dir: "{{zookeeper_default_log_dir}}"
 
 ### Chroot path in Zookeeper used by Kafka. Defaults to no chroot. Must begin with a /
 zookeeper_chroot: ""
@@ -306,13 +306,6 @@ zookeeper_cert_path: "{{ ssl_file_dir_final }}/zookeeper.crt"
 zookeeper_key_path: "{{ ssl_file_dir_final }}/zookeeper.key"
 zookeeper_export_certs: "{{ True if zookeeper_client_authentication_type == 'mtls' or zookeeper_quorum_authentication_type == 'mtls' else False }}"
 zookeeper_keytab_path: /etc/security/keytabs/zookeeper.keytab
-
-zookeeper:
-  # TODO deprecate these
-  jaas_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/kafka/zookeeper_jaas.conf"
-  log_path: "{{zookeeper_default_log_dir}}"
-  # Deprecated way of providing custom properties
-  properties: {}
 
 ### Boolean to enable Jolokia Agent installation and configuration on zookeeper
 zookeeper_jolokia_enabled: "{{jolokia_enabled}}"
@@ -372,7 +365,7 @@ zookeeper_copy_files: []
 
 # User provided properties, merged into the final properties dictionary with precedence
 ### Use to set custom zookeeper properties. This variable is a dictionary. Put values true/false in quotation marks to perserve case. NOTE- zookeeper.properties is deprecated.
-zookeeper_custom_properties: "{{ zookeeper.properties }}"
+zookeeper_custom_properties: {}
 
 ### Boolean used for disabling of systemd service restarts when rootless install is executed
 zookeeper_skip_restarts: "{{ skip_restarts }}"
@@ -434,7 +427,7 @@ kafka_broker_user: "{{kafka_broker_default_user}}"
 kafka_broker_group: "{{kafka_broker_default_group}}"
 
 ### Set this variable to customize the directory that the Kafka Broker writes log files to. Default location is /var/log/kafka. NOTE- kafka_broker.appender_log_path is deprecated.
-kafka_broker_log_dir: "{{kafka_broker.appender_log_path}}"
+kafka_broker_log_dir: "{{kafka_broker_default_log_dir}}"
 
 kafka_broker_packages:
   - confluent-common
@@ -465,14 +458,6 @@ kafka_broker_cert_path: "{{ ssl_file_dir_final }}/kafka_broker.crt"
 kafka_broker_key_path: "{{ ssl_file_dir_final }}/kafka_broker.key"
 kafka_broker_export_certs: "{{ssl_mutual_auth_enabled}}"
 kafka_broker_keytab_path: /etc/security/keytabs/kafka_broker.keytab
-
-kafka_broker:
-  # TODO deprecate these variables
-  jaas_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/kafka/kafka_server_jaas.conf"
-  rest_proxy_password_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/kafka/password.properties"
-  appender_log_path: "{{kafka_broker_default_log_dir}}"
-  # Deprecated way of providing custom properties
-  properties: {}
 
 ### Boolean to configure Schema Validation on Kafka
 kafka_broker_schema_validation_enabled: true
@@ -526,7 +511,7 @@ kafka_broker_default_internal_replication_factor: "{{ [ groups['kafka_broker'] |
 kafka_broker_metrics_reporter_enabled: "{{ 'control_center' in groups }}"
 
 ### Use to set custom kafka properties. This variable is a dictionary. Put values true/false in quotation marks to perserve case. NOTE- kafka_broker.properties is deprecated.
-kafka_broker_custom_properties: "{{ kafka_broker.properties }}"
+kafka_broker_custom_properties: {}
 
 ### Boolean to enable the embedded rest proxy within Kafka. NOTE- Embedded Rest Proxy must be enabled if RBAC is enabled and Confluent Server must be enabled
 kafka_broker_rest_proxy_enabled: "{{confluent_server_enabled and not ccloud_kafka_enabled}}"
@@ -568,7 +553,7 @@ schema_registry_ssl_mutual_auth_enabled: "{{ ssl_mutual_auth_enabled }}"
 schema_registry_authentication_type: "{{ 'mtls' if schema_registry_ssl_mutual_auth_enabled else 'none' }}"
 
 ### Set this variable to customize the directory that the Schema Registry writes log files to. Default location is /var/log/confluent/schema-registry. NOTE- schema_registry.appender_log_path is deprecated.
-schema_registry_log_dir: "{{schema_registry.appender_log_path}}"
+schema_registry_log_dir: "{{schema_registry_default_log_dir}}"
 
 schema_registry_packages:
   - confluent-common
@@ -594,12 +579,6 @@ schema_registry_key_path: "{{ ssl_file_dir_final }}/schema_registry.key"
 schema_registry_export_certs: "{{ True if schema_registry_authentication_type == 'mtls' else False }}"
 schema_registry_keytab_path: /etc/security/keytabs/schema_registry.keytab
 schema_registry_kafka_listener_name: internal
-schema_registry:
-  jaas_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/schema-registry/jaas.conf"
-  password_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/schema-registry/password.properties"
-  appender_log_path: "{{schema_registry_default_log_dir}}"
-  # Deprecated way of providing custom properties
-  properties: {}
 
 ### Boolean to enable Jolokia Agent installation and configuration on schema registry
 schema_registry_jolokia_enabled: "{{jolokia_enabled}}"
@@ -638,7 +617,7 @@ schema_registry_jmxexporter_port: 8078
 schema_registry_copy_files: []
 
 ### Use to set custom schema registry properties. This variable is a dictionary. Put values true/false in quotation marks to perserve case. NOTE- kafka_broker.properties is deprecated.
-schema_registry_custom_properties: "{{ schema_registry.properties }}"
+schema_registry_custom_properties: {}
 
 ### Use to register and identify your Schema Registry cluster in the MDS.
 schema_registry_cluster_name: ""
@@ -670,7 +649,7 @@ kafka_rest_ssl_mutual_auth_enabled: "{{ ssl_mutual_auth_enabled }}"
 kafka_rest_authentication_type: "{{ 'mtls' if kafka_rest_ssl_mutual_auth_enabled else 'none' }}"
 
 ### Set this variable to customize the directory that the Rest Proxy writes log files to. Default location is /var/log/confluent/kafka-rest. NOTE- kafka_rest.appender_log_path is deprecated.
-kafka_rest_log_dir: "{{kafka_rest.appender_log_path}}"
+kafka_rest_log_dir: "{{kafka_rest_default_log_dir}}"
 
 kafka_rest_packages:
   - confluent-common
@@ -697,12 +676,6 @@ kafka_rest_key_path: "{{ ssl_file_dir_final }}/kafka_rest.key"
 kafka_rest_export_certs: "{{ True if kafka_rest_authentication_type == 'mtls' else False }}"
 kafka_rest_keytab_path: /etc/security/keytabs/kafka_rest.keytab
 kafka_rest_kafka_listener_name: internal
-kafka_rest:
-  jaas_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/kafka-rest/jaas.conf"
-  password_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/kafka-rest/password.properties"
-  appender_log_path: "{{kafka_rest_default_log_dir}}"
-  # Deprecated way of providing custom properties
-  properties: {}
 
 ### Boolean to enable Jolokia Agent installation and configuration on Rest Proxy
 kafka_rest_jolokia_enabled: "{{jolokia_enabled}}"
@@ -741,7 +714,7 @@ kafka_rest_jmxexporter_port: 8075
 kafka_rest_copy_files: []
 
 ### Use to set custom Rest Proxy properties. This variable is a dictionary. Put values true/false in quotation marks to perserve case. NOTE- kafka_rest.properties is deprecated.
-kafka_rest_custom_properties: "{{ kafka_rest.properties }}"
+kafka_rest_custom_properties: {}
 
 ### Boolean to configure Monitoring Interceptors on Rest Proxy.
 kafka_rest_monitoring_interceptors_enabled: "{{ monitoring_interceptors_enabled }}"
@@ -779,7 +752,7 @@ kafka_connect_ssl_mutual_auth_enabled: "{{ ssl_mutual_auth_enabled }}"
 kafka_connect_authentication_type: "{{ 'mtls' if kafka_connect_ssl_mutual_auth_enabled|bool else 'none' }}"
 
 ### Set this variable to customize the directory that Kafka Connect writes log files to. Default location is /var/log/kafka. NOTE- kafka_connect.appender_log_path is deprecated.
-kafka_connect_log_dir: "{{kafka_connect.appender_log_path}}"
+kafka_connect_log_dir: "{{kafka_connect_default_log_dir}}"
 
 kafka_connect_packages:
   - confluent-common
@@ -812,13 +785,6 @@ kafka_connect_kafka_listener_name: internal
 
 ### Additional set of Connect extension classes.
 kafka_connect_custom_rest_extension_classes: []
-
-kafka_connect:
-  jaas_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/kafka/connect-jaas.conf"
-  password_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/kafka/connect-password.properties"
-  appender_log_path: "{{kafka_connect_default_log_dir}}"
-  # Deprecated way of providing custom properties
-  properties: {}
 
 ### Boolean to enable Jolokia Agent installation and configuration on Connect
 kafka_connect_jolokia_enabled: "{{jolokia_enabled}}"
@@ -883,7 +849,7 @@ kafka_connect_plugins_remote: []
 kafka_connect_plugins_dest: /usr/share/java
 
 ### Use to set custom Connect properties. This variable is a dictionary. Put values true/false in quotation marks to perserve case. NOTE- kafka_connect.properties is deprecated.
-kafka_connect_custom_properties: "{{ kafka_connect.properties }}"
+kafka_connect_custom_properties: {}
 
 ### Boolean to configure Monitoring Interceptors on Connect.
 kafka_connect_monitoring_interceptors_enabled: "{{ monitoring_interceptors_enabled }}"
@@ -918,7 +884,7 @@ ksql_ssl_mutual_auth_enabled: "{{ ssl_mutual_auth_enabled }}"
 ksql_authentication_type: "{{ 'mtls' if ksql_ssl_mutual_auth_enabled|bool else 'none' }}"
 
 ### Set this variable to customize the directory that ksqlDB writes log files to. Default location is /var/log/confluent/ksql. NOTE- ksql.appender_log_path is deprecated.
-ksql_log_dir: "{{ksql.appender_log_path}}"
+ksql_log_dir: "{{ksql_default_log_dir}}"
 
 ksql_packages:
   - confluent-common
@@ -947,11 +913,6 @@ ksql_export_certs: "{{ True if ksql_authentication_type == 'mtls' else False }}"
 ksql_keytab_path: /etc/security/keytabs/ksql.keytab
 ksql_kafka_listener_name: internal
 ksql_processing_log_kafka_listener_name: "{{kafka_broker_inter_broker_listener_name if rbac_enabled else ksql_kafka_listener_name}}"
-ksql:
-  jaas_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/ksql{{ 'db' if (confluent_package_version is version('5.5.0', '>=')) else '' }}/jaas.conf"
-  password_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/ksql{{ 'db' if (confluent_package_version is version('5.5.0', '>=')) else '' }}/password.properties"
-  appender_log_path: "{{ksql_default_log_dir}}"
-  properties: {}
 
 ### Boolean to enable Jolokia Agent installation and configuration on ksqlDB
 ksql_jolokia_enabled: "{{jolokia_enabled}}"
@@ -997,7 +958,7 @@ ksql_default_internal_replication_factor: "{{ 3 if ccloud_kafka_enabled|bool els
 ksql_service_id: default_
 
 ### Use to set custom ksqlDB properties. This variable is a dictionary. Put values true/false in quotation marks to perserve case. NOTE- ksql.properties is deprecated.
-ksql_custom_properties: "{{ ksql.properties }}"
+ksql_custom_properties: {}
 
 ### Boolean to configure Monitoring Interceptors on ksqlDB.
 ksql_monitoring_interceptors_enabled: "{{ monitoring_interceptors_enabled }}"
@@ -1037,7 +998,7 @@ control_center_ssl_enabled: "{{ssl_enabled}}"
 control_center_authentication_type: none
 
 ### Set this variable to customize the directory that Control Center writes log files to. Default location is /var/log/confluent/control-center. NOTE- control_center.appender_log_path is deprecated.
-control_center_log_dir: "{{control_center.appender_log_path}}"
+control_center_log_dir: "{{control_center_default_log_dir}}"
 
 control_center_packages:
   - confluent-common
@@ -1064,12 +1025,6 @@ control_center_key_path: "{{ ssl_file_dir_final }}/control_center.key"
 control_center_export_certs: "{{ssl_mutual_auth_enabled}}"
 control_center_keytab_path: /etc/security/keytabs/control_center.keytab
 control_center_kafka_listener_name: internal
-control_center:
-  jaas_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/confluent-control-center/jaas.conf"
-  password_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/confluent-control-center/password.properties"
-  appender_log_path: "{{control_center_default_log_dir}}"
-  # Deprecated way of providing custom properties
-  properties: {}
 
 ### Use to copy files from control node to Control Center hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode (default: '0640') to set directory and file permissions.
 control_center_copy_files: []
@@ -1079,7 +1034,7 @@ control_center_default_internal_replication_factor: "{{ 3 if ccloud_kafka_enable
   [ groups['kafka_broker'] | default(['localhost']) | length, default_internal_replication_factor ] | min }}"
 
 ### Use to set custom Control Center properties. This variable is a dictionary. Put values true/false in quotation marks to perserve case. NOTE- control_center.properties is deprecated.
-control_center_custom_properties: "{{ control_center.properties }}"
+control_center_custom_properties: {}
 
 ### Boolean used for disabling of systemd service restarts when rootless install is executed
 control_center_skip_restarts: "{{ skip_restarts }}"

--- a/roles/variables/vars/main.yml
+++ b/roles/variables/vars/main.yml
@@ -19,7 +19,8 @@ zookeeper:
   config_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}{{ zookeeper_config_prefix }}/zookeeper.properties"
   systemd_file: "{{systemd_base_dir}}/{{zookeeper_service_name}}.service"
   systemd_override: /etc/systemd/system/{{zookeeper_service_name}}.service.d/override.conf
-  log4j_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}{{ zookeeper_config_prefix }}/zookeeper-log4j.properties"
+  log4j_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/kafka/zookeeper-log4j.properties"
+  jaas_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/kafka/zookeeper_jaas.conf"
 
 zookeeper_properties:
   defaults:
@@ -98,6 +99,10 @@ kafka_broker:
   systemd_file: "{{systemd_base_dir}}/{{kafka_broker_service_name}}.service"
   systemd_override: /etc/systemd/system/{{kafka_broker_service_name}}.service.d/override.conf
   log4j_file: "{% if installation_method == 'archive' %}{{archive_destination_path}}/confluent-{{confluent_package_version}}{% endif %}/etc/kafka/log4j.properties"
+  jaas_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/kafka/kafka_server_jaas.conf"
+  rest_proxy_password_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/kafka/password.properties"
+  datadir:
+    - /var/lib/kafka/data
 
 mds_http_protocol: "{{ 'https' if kafka_broker_rest_ssl_enabled|bool else 'http' }}"
 mds_tls_enabled: "{{true if 'https' in mds_bootstrap_server_urls else false}}"
@@ -408,6 +413,8 @@ schema_registry:
   systemd_file: "{{systemd_base_dir}}/{{schema_registry_service_name}}.service"
   systemd_override: /etc/systemd/system/{{schema_registry_service_name}}.service.d/override.conf
   log4j_file: "{% if installation_method == 'archive' %}{{archive_destination_path}}/confluent-{{confluent_package_version}}{% endif %}/etc/schema-registry/log4j.properties"
+  jaas_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/schema-registry/jaas.conf"
+  password_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/schema-registry/password.properties"
 
 schema_registry_http_protocol: "{{ 'https' if schema_registry_ssl_enabled|bool else 'http' }}"
 
@@ -522,6 +529,8 @@ kafka_connect:
   systemd_file: "{{systemd_base_dir}}/{{kafka_connect_service_name}}.service"
   systemd_override: /etc/systemd/system/{{kafka_connect_service_name}}.service.d/override.conf
   log4j_file: "{% if installation_method == 'archive' %}{{archive_destination_path}}/confluent-{{confluent_package_version}}{% endif %}/etc/kafka/connect-log4j.properties"
+  jaas_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/kafka/connect-jaas.conf"
+  password_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/kafka/connect-password.properties"
 
 kafka_connect_http_protocol: "{{ 'https' if kafka_connect_ssl_enabled|bool else 'http' }}"
 
@@ -728,6 +737,8 @@ ksql:
   systemd_file: "{{systemd_base_dir}}/{{ksql_service_name}}.service"
   systemd_override: /etc/systemd/system/{{ksql_service_name}}.service.d/override.conf
   log4j_file: "{% if installation_method == 'archive' %}{{archive_destination_path}}/confluent-{{confluent_package_version}}{% endif %}/etc/ksqldb/ksqldb-log4j.properties"
+  jaas_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/ksql{{ 'db' if (confluent_package_version is version('5.5.0', '>=')) else '' }}/jaas.conf"
+  password_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/ksql{{ 'db' if (confluent_package_version is version('5.5.0', '>=')) else '' }}/password.properties"
 
 ksql_http_protocol: "{{ 'https' if ksql_ssl_enabled|bool else 'http' }}"
 
@@ -898,6 +909,8 @@ kafka_rest:
   systemd_file: "{{systemd_base_dir}}/{{kafka_rest_service_name}}.service"
   systemd_override: /etc/systemd/system/{{kafka_rest_service_name}}.service.d/override.conf
   log4j_file: "{% if installation_method == 'archive' %}{{archive_destination_path}}/confluent-{{confluent_package_version}}{% endif %}/etc/kafka-rest/log4j.properties"
+  jaas_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/kafka-rest/jaas.conf"
+  password_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/kafka-rest/password.properties"
 
 kafka_rest_http_protocol: "{{ 'https' if kafka_rest_ssl_enabled|bool else 'http' }}"
 
@@ -1041,6 +1054,8 @@ control_center:
   systemd_file: "{{systemd_base_dir}}/{{control_center_service_name}}.service"
   systemd_override: /etc/systemd/system/{{control_center_service_name}}.service.d/override.conf
   log4j_file: "{% if installation_method == 'archive' %}{{archive_destination_path}}/confluent-{{confluent_package_version}}{% endif %}/etc/confluent-control-center/log4j-rolling.properties"
+  jaas_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/confluent-control-center/jaas.conf"
+  password_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/confluent-control-center/password.properties"
 
 control_center_http_protocol: "{{ 'https' if control_center_ssl_enabled|bool else 'http' }}"
 


### PR DESCRIPTION
# Description

We have variable `kafka_broker` defined in vars as well as in default. Since vars has higher precedence then default, the resultant dictionary doesn't have any `properties` key. This causes the play to fail with error 
```
fatal: [zookeeper1]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: {{ zookeeper_combined_properties | combine(zookeeper_custom_properties) }}: {{ zookeeper.properties }}: 'dict object' has no attribute 'properties'\n
```

Fixes #[RCCA-6061](https://confluentinc.atlassian.net/browse/RCCA-6061)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

` ansible-playbook -i ../../hosts.ini ../../all.yml `
Since the user was trying out with ini file, we have verified with an ini file

**Test Configuration**:
Local environment

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Any variable changes have been validated to be backwards compatible