### PR TITLE
fixed principal construction causing double User in the principal name

### DIFF
--- a/roles/ksql/tasks/set_principal.yml
+++ b/roles/ksql/tasks/set_principal.yml
@@ -54,7 +54,7 @@
 
 - name: Normalize User Name
   set_fact:
-    ksql_log4j_principal: "User:{{ ksql_log4j_principal }}"
+    ksql_log4j_principal: "{{ ksql_log4j_principal }}"
   when: ksql_log4j_principal is defined
 
 - debug:


### PR DESCRIPTION
# Description

Noticed rolebindings for the ksql processing topic created with **User:User:principal** . This is caused by the following code
```
- name: Normalize User Name
  set_fact:
    ksql_log4j_principal: "User:{{ ksql_log4j_principal }}"
  when: ksql_log4j_principal is defined
```
Fixes # (issue)

Removed the User: prefix as it is added during the rolebinding again.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

Verified the code, the only place this is used is in the rolebinding.

**Test Configuration**:

7.1.x

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible