### PR TITLE
CLI won't be installed if secret_protection is disabled

### DIFF
--- a/molecule/zookeeper-mtls-rhel/verify.yml
+++ b/molecule/zookeeper-mtls-rhel/verify.yml
@@ -4,13 +4,6 @@
 ### Validates that other components are using SCRAM for auth.
 ### Validates that Secrets protection is applied to the correct properties.
 
-- name: Verify - Confluent CLI
-  hosts: all
-  gather_facts: false
-  tasks:
-    - name: Check confluent cli is installed
-      command: "/usr/local/bin/confluent version"
-
 - name: Verify - zookeeper
   hosts: zookeeper
   gather_facts: false

--- a/molecule/zookeeper-mtls-secrets-rhel/verify.yml
+++ b/molecule/zookeeper-mtls-secrets-rhel/verify.yml
@@ -4,13 +4,6 @@
 ### Validates that other components are using SCRAM for auth.
 ### Validates that Secrets protection is applied to the correct properties.
 
-- name: Verify - Confluent CLI
-  hosts: all
-  gather_facts: false
-  tasks:
-    - name: Check confluent cli is installed
-      command: "/usr/local/bin/confluent version"
-
 - name: Verify - zookeeper
   hosts: zookeeper
   gather_facts: false


### PR DESCRIPTION
# Description

Since this was a non-RBAC scenario, secret protection was not enabled by default here. And there will be no CLI installed here.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
By running successfully following molecule scenarios
`zookeeper-mtls-rhel`
`zookeeper-mtls-secrets-rhel`


**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible