### PR TITLE
fix typo which made additional + on the begining of the line

### DIFF
--- a/molecule/multi-ksql-connect-rhel/verify.yml
+++ b/molecule/multi-ksql-connect-rhel/verify.yml
@@ -77,7 +77,7 @@
       uri:
         url: "https://kafka-connect3:8083/connectors"
         client_cert: /var/ssl/private/kafka_connect.crt
-+       client_key: /var/ssl/private/kafka_connect.key
+        client_key: /var/ssl/private/kafka_connect.key
         status_code: 200
         validate_certs: false
       register: connectors


### PR DESCRIPTION
# Description

Fixing an issue where a plus sign (+) was mistakenly left due to copy paste from github.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

By running the same scenario `multi-ksql-rhel`

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible