### PR TITLE
Fix issues with provided cert and secrets enabled

### DIFF
--- a/roles/common/tasks/secrets_protection.yml
+++ b/roles/common/tasks/secrets_protection.yml
@@ -7,7 +7,6 @@
     CONFLUENT_PLATFORM_USERNAME: "{{ mds_super_user }}"
     CONFLUENT_PLATFORM_PASSWORD: "{{ mds_super_user_password }}"
     CONFLUENT_PLATFORM_MDS_URL: "{{mds_bootstrap_server_urls.split(',')[0]}}"
-  run_once: true
   register: mds_login_result
   until: mds_login_result.rc == 0
   retries: 30

--- a/roles/kafka_broker/tasks/secrets_protection.yml
+++ b/roles/kafka_broker/tasks/secrets_protection.yml
@@ -12,6 +12,7 @@
     secrets_file_owner: "{{ kafka_broker_user }}"
     secrets_file_group: "{{ kafka_broker_group }}"
     ca_cert_path: "{{ kafka_broker_ca_cert_path if ssl_enabled|bool else '' }}"
+    handler: "restart kafka"
   tags:
     - configuration
 
@@ -28,6 +29,7 @@
     secrets_file_owner: "{{ kafka_broker_user }}"
     secrets_file_group: "{{ kafka_broker_group }}"
     ca_cert_path: "{{ kafka_broker_ca_cert_path if ssl_enabled|bool else '' }}"
+    handler: "restart kafka"
   tags:
     - configuration
 

--- a/roles/ssl/tasks/provided_keystore_and_truststore.yml
+++ b/roles/ssl/tasks/provided_keystore_and_truststore.yml
@@ -11,4 +11,5 @@
 
 - name: Export Certs from Keystore and Truststore
   include_tasks: export_certs_from_keystore_and_truststore.yml
-  when: export_certs|bool
+  when: export_certs|bool or
+        ( (secrets_protection_enabled|bool) and (rbac_enabled|bool) )


### PR DESCRIPTION
# Description

For Secrets Protection, confluent client need to connect to MDS and if TLS is enabled, it need ca.crt to be available. So far we were not copying the certs until MTLS is enabled. This commit makes the condition to copy the ca.crt to host wider, and also includes the situation where RBAC and secrets_protection are enabled.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This is fixing the following 2 test cases
 - rbac-plain-provided-debian
 - rbac-mtls-rhel

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible