### PR TITLE
C3 Basic Auth properties fix

### DIFF
--- a/roles/variables/vars/main.yml
+++ b/roles/variables/vars/main.yml
@@ -1043,7 +1043,7 @@ control_center_properties:
       confluent.controlcenter.rest.ssl.truststore.location: "{{control_center_truststore_path}}"
       confluent.controlcenter.rest.ssl.truststore.password: "{{control_center_truststore_storepass}}"
   basic:
-    enabled: "{{ kafka_rest_authentication_type == 'basic' }}"
+    enabled: "{{ control_center_authentication_type == 'basic' }}"
     properties:
       confluent.controlcenter.rest.authentication.method: BASIC
       confluent.controlcenter.rest.authentication.realm: ControlCenter


### PR DESCRIPTION
# Description

The properties to enable basic auth for Control Center should be set when the actual 'control_center_authentication_type' is set to 'basic'
My guess its a typo error inherited by previous versions
I found this since 6.2.x

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I have checked the control center properties and seeing the expected behavior (control center prompting for user/password) 



**Test Configuration**:


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible