### PR TITLE
Add retry to some tasks

### DIFF
--- a/roles/common/tasks/rbac_setup.yml
+++ b/roles/common/tasks/rbac_setup.yml
@@ -11,6 +11,9 @@
     url_password: "{{mds_super_user_password}}"
     force_basic_auth: true
   register: cluster_id_query
+  until: cluster_id_query.status == 200
+  retries: 5
+  delay: 10
   when: cluster_id_source | default('erp') == 'erp'
 
 - name: Parse Kafka Cluster ID from json query

--- a/roles/control_center/tasks/rbac.yml
+++ b/roles/control_center/tasks/rbac.yml
@@ -25,6 +25,10 @@
         }
       }
     status_code: 204
+  register: admin_role_response
+  until: admin_role_response.status == 204
+  retries: 5
+  delay: 10
   loop: "{{control_center_additional_system_admins}}"
   when: not ansible_check_mode
 

--- a/roles/kafka_broker/tasks/rbac_rolebindings.yml
+++ b/roles/kafka_broker/tasks/rbac_rolebindings.yml
@@ -25,6 +25,10 @@
         }
       }
     status_code: 204
+  register: admin_role_response
+  until: admin_role_response.status == 204
+  retries: 5
+  delay: 10
   loop: "{{kafka_broker_additional_system_admins}}"
   when: not ansible_check_mode
 

--- a/roles/kafka_connect/tasks/rbac.yml
+++ b/roles/kafka_connect/tasks/rbac.yml
@@ -26,6 +26,10 @@
         }
       }
     status_code: 204
+  register: admin_role_response
+  until: admin_role_response.status == 204
+  retries: 5
+  delay: 10
   loop: "{{kafka_connect_additional_system_admins}}"
   when: not ansible_check_mode
 

--- a/roles/ksql/tasks/rbac.yml
+++ b/roles/ksql/tasks/rbac.yml
@@ -30,6 +30,10 @@
         }
       }
     status_code: 204
+  register: admin_role_response
+  until: admin_role_response.status == 204
+  retries: 5
+  delay: 10
   loop: "{{ksql_additional_system_admins}}"
   when: not ansible_check_mode
 

--- a/roles/schema_registry/tasks/rbac.yml
+++ b/roles/schema_registry/tasks/rbac.yml
@@ -26,6 +26,10 @@
         }
       }
     status_code: 204
+  register: admin_role_response
+  until: admin_role_response.status == 204
+  retries: 5
+  delay: 10
   loop: "{{schema_registry_additional_system_admins}}"
   when: not ansible_check_mode
 


### PR DESCRIPTION
# Description

Add a retry to certain tasks which we have recently seen failing intermittently with message - 
```
{"error_code": 50003, "message": "For requests intended only for the leader, this error indicates that the broker is not the current leader. For requests intended for any replica, this error indicates that the broker is not a replica of the topic partition."}
```
The error has been discussed at multiple places including users setups. The mitigation of this error is to wait till leader selection process is complete. 
In our tests this has been failing intermittently for different CP component ( i.e SR, Ksql ). This changes fixes the issue when we try to do some write operation when leader selection is in process. 

Fixes # ([ANSIENG-1162](https://confluentinc.atlassian.net/browse/ANSIENG-1162))

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

[On demand job](https://jenkins.confluent.io/job/cp-ansible-on-demand/131)

**Test Configuration**:
` molecule --debug converge -s rbac-plain-provided-debian`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible