### PR TITLE
Fixing zookeeper logs issue and yaml lint issues

### DIFF
--- a/roles/confluent.zookeeper/templates/zookeeper_log4j.properties.j2
+++ b/roles/confluent.zookeeper/templates/zookeeper_log4j.properties.j2
@@ -20,10 +20,9 @@ log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c)%n
 
- 
-log4j.appender.zkAppender=org.apache.log4j.RollingFileAppender 
-log4j.appender.zkAppender.File={{zookeeper.log_path}}{{zookeeper.log_name}} 
-log4j.appender.zkAppender.layout=org.apache.log4j.PatternLayout 
+log4j.appender.zkAppender=org.apache.log4j.RollingFileAppender
+log4j.appender.zkAppender.File={{zookeeper.log_path}}{{zookeeper.log_name}}
+log4j.appender.zkAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.zkAppender.layout.ConversionPattern=[%d] %p %m (%c)%n
 log4j.appender.zkAppender.Append=true
 log4j.appender.zkAppender.MaxBackupIndex={{zookeeper.max_log_files}}


### PR DESCRIPTION
# Description

Zookeeper server was not able to load the log Appender class due to trailing spaces in ap[pender class name.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Scenario `custom-user-plaintext-rhel` is runninng successul now

```
molecule verify -s custom-user-plaintext-rhel

PLAY RECAP *********************************************************************
control-center1            : ok=6    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
kafka-connect1             : ok=6    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
kafka-rest1                : ok=6    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
ksql1                      : ok=6    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
schema-registry1           : ok=6    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
zookeeper1-kafka-broker1   : ok=13   changed=4    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0

INFO     Verifier completed successfully.
```


**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible