### PR TITLE
Remove hardcoded path in molecule files

### DIFF
--- a/roles/confluent.test/molecule/confluent-kafka-kerberos-customcerts-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/confluent-kafka-kerberos-customcerts-rhel/molecule.yml
@@ -165,9 +165,9 @@ provisioner:
         ssl_enabled: true
 
         ssl_custom_certs: true
-        ssl_ca_cert_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/ca.crt"
-        ssl_signed_cert_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
-        ssl_key_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-key.pem"
+        ssl_ca_cert_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/ca.crt"
+        ssl_signed_cert_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
+        ssl_key_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-key.pem"
         ssl_key_password: keypass
 
         sasl_protocol: kerberos
@@ -181,25 +181,25 @@ provisioner:
       zookeeper:
         # Paths are relative to all.yml
         zookeeper_kerberos_principal: "zookeeper/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
-        zookeeper_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/zookeeper-{{inventory_hostname}}.keytab"
+        zookeeper_kerberos_keytab_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs/zookeeper-{{inventory_hostname}}.keytab"
       kafka_broker:
         kafka_broker_kerberos_principal: "{{kerberos_kafka_broker_primary}}/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
-        kafka_broker_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/kafka_broker-{{inventory_hostname}}.keytab"
+        kafka_broker_kerberos_keytab_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs/kafka_broker-{{inventory_hostname}}.keytab"
       schema_registry:
         schema_registry_kerberos_principal: "schema_registry/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
-        schema_registry_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/schema_registry-{{inventory_hostname}}.keytab"
+        schema_registry_kerberos_keytab_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs/schema_registry-{{inventory_hostname}}.keytab"
       kafka_rest:
         kafka_rest_kerberos_principal: "kafka_rest/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
-        kafka_rest_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/kafka_rest-{{inventory_hostname}}.keytab"
+        kafka_rest_kerberos_keytab_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs/kafka_rest-{{inventory_hostname}}.keytab"
       kafka_connect:
         kafka_connect_kerberos_principal: "kafka_connect/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
-        kafka_connect_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/kafka_connect-{{inventory_hostname}}.keytab"
+        kafka_connect_kerberos_keytab_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs/kafka_connect-{{inventory_hostname}}.keytab"
       ksql:
         ksql_kerberos_principal: "ksql/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
-        ksql_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/ksql-{{inventory_hostname}}.keytab"
+        ksql_kerberos_keytab_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs/ksql-{{inventory_hostname}}.keytab"
       control_center:
         control_center_kerberos_principal: "control_center/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
-        control_center_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/control_center-{{inventory_hostname}}.keytab"
+        control_center_kerberos_keytab_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs/control_center-{{inventory_hostname}}.keytab"
 
       kerberos_server:
         realm_name: "{{ kerberos.realm | upper }}"

--- a/roles/confluent.test/molecule/customcerts-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/customcerts-rhel/molecule.yml
@@ -128,9 +128,9 @@ provisioner:
         ssl_enabled: true
 
         ssl_custom_certs: true
-        ssl_ca_cert_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/ca.crt"
-        ssl_signed_cert_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
-        ssl_key_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-key.pem"
+        ssl_ca_cert_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/ca.crt"
+        ssl_signed_cert_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
+        ssl_key_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-key.pem"
         ssl_key_password: keypass
 
 verifier:

--- a/roles/confluent.test/molecule/kerberos-customcerts-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/kerberos-customcerts-rhel/molecule.yml
@@ -139,9 +139,9 @@ provisioner:
         ssl_enabled: true
 
         ssl_custom_certs: true
-        ssl_ca_cert_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/ca.crt"
-        ssl_signed_cert_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
-        ssl_key_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-key.pem"
+        ssl_ca_cert_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/ca.crt"
+        ssl_signed_cert_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
+        ssl_key_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-key.pem"
         ssl_key_password: keypass
 
         sasl_protocol: kerberos
@@ -155,25 +155,25 @@ provisioner:
       zookeeper:
         # Paths are relative to all.yml
         zookeeper_kerberos_principal: "zookeeper/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
-        zookeeper_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/zookeeper-{{inventory_hostname}}.keytab"
+        zookeeper_kerberos_keytab_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs/zookeeper-{{inventory_hostname}}.keytab"
       kafka_broker:
         kafka_broker_kerberos_principal: "{{kerberos_kafka_broker_primary}}/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
-        kafka_broker_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/kafka_broker-{{inventory_hostname}}.keytab"
+        kafka_broker_kerberos_keytab_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs/kafka_broker-{{inventory_hostname}}.keytab"
       schema_registry:
         schema_registry_kerberos_principal: "schema_registry/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
-        schema_registry_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/schema_registry-{{inventory_hostname}}.keytab"
+        schema_registry_kerberos_keytab_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs/schema_registry-{{inventory_hostname}}.keytab"
       kafka_rest:
         kafka_rest_kerberos_principal: "kafka_rest/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
-        kafka_rest_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/kafka_rest-{{inventory_hostname}}.keytab"
+        kafka_rest_kerberos_keytab_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs/kafka_rest-{{inventory_hostname}}.keytab"
       kafka_connect:
         kafka_connect_kerberos_principal: "kafka_connect/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
-        kafka_connect_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/kafka_connect-{{inventory_hostname}}.keytab"
+        kafka_connect_kerberos_keytab_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs/kafka_connect-{{inventory_hostname}}.keytab"
       ksql:
         ksql_kerberos_principal: "ksql/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
-        ksql_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/ksql-{{inventory_hostname}}.keytab"
+        ksql_kerberos_keytab_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs/ksql-{{inventory_hostname}}.keytab"
       control_center:
         control_center_kerberos_principal: "control_center/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
-        control_center_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/control_center-{{inventory_hostname}}.keytab"
+        control_center_kerberos_keytab_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs/control_center-{{inventory_hostname}}.keytab"
 
       kerberos_server:
         realm_name: "{{ kerberos.realm | upper }}"

--- a/roles/confluent.test/molecule/kerberos-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/kerberos-rhel/molecule.yml
@@ -149,25 +149,25 @@ provisioner:
       zookeeper:
         # Paths are relative to all.yml
         zookeeper_kerberos_principal: "zk/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
-        zookeeper_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/zookeeper-{{inventory_hostname}}.keytab"
+        zookeeper_kerberos_keytab_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs/zookeeper-{{inventory_hostname}}.keytab"
       kafka_broker:
         kafka_broker_kerberos_principal: "{{kerberos_kafka_broker_primary}}/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
-        kafka_broker_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/kafka_broker-{{inventory_hostname}}.keytab"
+        kafka_broker_kerberos_keytab_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs/kafka_broker-{{inventory_hostname}}.keytab"
       schema_registry:
         schema_registry_kerberos_principal: "schema_registry/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
-        schema_registry_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/schema_registry-{{inventory_hostname}}.keytab"
+        schema_registry_kerberos_keytab_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs/schema_registry-{{inventory_hostname}}.keytab"
       kafka_rest:
         kafka_rest_kerberos_principal: "kafka_rest/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
-        kafka_rest_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/kafka_rest-{{inventory_hostname}}.keytab"
+        kafka_rest_kerberos_keytab_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs/kafka_rest-{{inventory_hostname}}.keytab"
       kafka_connect:
         kafka_connect_kerberos_principal: "kafka_connect/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
-        kafka_connect_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/kafka_connect-{{inventory_hostname}}.keytab"
+        kafka_connect_kerberos_keytab_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs/kafka_connect-{{inventory_hostname}}.keytab"
       ksql:
         ksql_kerberos_principal: "ksql/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
-        ksql_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/ksql-{{inventory_hostname}}.keytab"
+        ksql_kerberos_keytab_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs/ksql-{{inventory_hostname}}.keytab"
       control_center:
         control_center_kerberos_principal: "control_center/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
-        control_center_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/control_center-{{inventory_hostname}}.keytab"
+        control_center_kerberos_keytab_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs/control_center-{{inventory_hostname}}.keytab"
 
       kerberos_server:
         realm_name: "{{ kerberos.realm | upper }}"

--- a/roles/confluent.test/molecule/mtls-custombundle-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/mtls-custombundle-rhel/molecule.yml
@@ -129,9 +129,9 @@ provisioner:
         ssl_mutual_auth_enabled: true
 
         ssl_custom_certs: true
-        ssl_ca_cert_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/caBundle.pem"
-        ssl_signed_cert_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}.chain"
-        ssl_key_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}.key"
+        ssl_ca_cert_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/caBundle.pem"
+        ssl_signed_cert_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}.chain"
+        ssl_key_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}.key"
         # ssl_key_password: keypass
 
 verifier:

--- a/roles/confluent.test/molecule/mtls-customcerts-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/mtls-customcerts-rhel/molecule.yml
@@ -122,9 +122,9 @@ provisioner:
         ssl_mutual_auth_enabled: true
 
         ssl_custom_certs: true
-        ssl_ca_cert_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/ca.crt"
-        ssl_signed_cert_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
-        ssl_key_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-key.pem"
+        ssl_ca_cert_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/ca.crt"
+        ssl_signed_cert_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
+        ssl_key_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-key.pem"
         ssl_key_password: keypass
 
 verifier:

--- a/roles/confluent.test/molecule/plain-customcerts-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/plain-customcerts-rhel/molecule.yml
@@ -130,9 +130,9 @@ provisioner:
         ssl_enabled: true
 
         ssl_custom_certs: true
-        ssl_ca_cert_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/ca.crt"
-        ssl_signed_cert_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
-        ssl_key_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-key.pem"
+        ssl_ca_cert_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/ca.crt"
+        ssl_signed_cert_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
+        ssl_key_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-key.pem"
         ssl_key_password: keypass
 
 verifier:

--- a/roles/confluent.test/molecule/rbac-kerberos-debian/molecule.yml
+++ b/roles/confluent.test/molecule/rbac-kerberos-debian/molecule.yml
@@ -188,11 +188,11 @@ provisioner:
 
       zookeeper:
         zookeeper_kerberos_principal: "zookeeper/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
-        zookeeper_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/zookeeper-{{inventory_hostname}}.keytab"
+        zookeeper_kerberos_keytab_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs/zookeeper-{{inventory_hostname}}.keytab"
 
       kafka_broker:
         kafka_broker_kerberos_principal: "{{kerberos_kafka_broker_primary}}/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
-        kafka_broker_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/kafka_broker-{{inventory_hostname}}.keytab"
+        kafka_broker_kerberos_keytab_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs/kafka_broker-{{inventory_hostname}}.keytab"
 
         ldap_config: |
           ldap.java.naming.factory.initial=com.sun.jndi.ldap.LdapCtxFactory
@@ -212,7 +212,7 @@ provisioner:
       ksql:
         ksql_log_streaming_enabled: true
         ksql_kerberos_principal: "ksql/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
-        ksql_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/ksql-{{inventory_hostname}}.keytab"
+        ksql_kerberos_keytab_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs/ksql-{{inventory_hostname}}.keytab"
 
       kerberos_server:
         realm_name: "{{ kerberos.realm | upper }}"

--- a/roles/confluent.test/molecule/rbac-mtls-provided-ubuntu/molecule.yml
+++ b/roles/confluent.test/molecule/rbac-mtls-provided-ubuntu/molecule.yml
@@ -140,18 +140,18 @@ provisioner:
         ssl_mutual_auth_enabled: true
 
         ssl_provided_keystore_and_truststore: true
-        ssl_keystore_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}.keystore.jks"
+        ssl_keystore_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}.keystore.jks"
         ssl_keystore_key_password: keystorepass
         ssl_keystore_store_password: keystorepass
-        ssl_truststore_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/truststore.jks"
+        ssl_truststore_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/truststore.jks"
         ssl_truststore_password: truststorepass
         ssl_truststore_ca_cert_alias: CARoot
 
         rbac_enabled: true
 
         create_mds_certs: false
-        token_services_public_pem_file: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/public.pem"
-        token_services_private_pem_file: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/tokenKeypair.pem"
+        token_services_public_pem_file: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/public.pem"
+        token_services_private_pem_file: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/tokenKeypair.pem"
 
         kafka_broker_custom_listeners:
           client_listener:

--- a/roles/confluent.test/molecule/rbac-scram-custom-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/rbac-scram-custom-rhel/molecule.yml
@@ -166,16 +166,16 @@ provisioner:
         sasl_protocol: scram
 
         ssl_custom_certs: true
-        ssl_ca_cert_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/ca.crt"
-        ssl_signed_cert_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
-        ssl_key_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-key.pem"
+        ssl_ca_cert_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/ca.crt"
+        ssl_signed_cert_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
+        ssl_key_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-key.pem"
         ssl_key_password: keypass
 
         rbac_enabled: true
 
         create_mds_certs: false
-        token_services_public_pem_file: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/public.pem"
-        token_services_private_pem_file: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/tokenKeypair.pem"
+        token_services_public_pem_file: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/public.pem"
+        token_services_private_pem_file: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/tokenKeypair.pem"
 
         kafka_broker_custom_listeners:
           client_listener:

--- a/roles/confluent.test/molecule/rbac-scram-provided-debian/molecule.yml
+++ b/roles/confluent.test/molecule/rbac-scram-provided-debian/molecule.yml
@@ -165,10 +165,10 @@ provisioner:
         ssl_enabled: true
 
         ssl_provided_keystore_and_truststore: true
-        ssl_keystore_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}.keystore.jks"
+        ssl_keystore_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}.keystore.jks"
         ssl_keystore_key_password: keystorepass
         ssl_keystore_store_password: keystorepass
-        ssl_truststore_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/truststore.jks"
+        ssl_truststore_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/truststore.jks"
         ssl_truststore_password: truststorepass
         ssl_truststore_ca_cert_alias: CARoot
 

--- a/roles/confluent.test/molecule/zookeeper-kerberos/molecule.yml
+++ b/roles/confluent.test/molecule/zookeeper-kerberos/molecule.yml
@@ -123,16 +123,16 @@ provisioner:
       zookeeper:
         # Paths are relative to all.yml
         zookeeper_kerberos_principal: "zookeeper/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
-        zookeeper_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/zookeeper-{{inventory_hostname}}.keytab"
+        zookeeper_kerberos_keytab_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs/zookeeper-{{inventory_hostname}}.keytab"
       kafka_broker:
         kafka_broker_kerberos_principal: "{{kerberos_kafka_broker_primary}}/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
-        kafka_broker_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/kafka_broker-{{inventory_hostname}}.keytab"
+        kafka_broker_kerberos_keytab_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs/kafka_broker-{{inventory_hostname}}.keytab"
 
         kafka_broker_custom_java_args: "-Dsun.security.krb5.debug=true"
 
       schema_registry:
         schema_registry_kerberos_principal: "schema_registry/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
-        schema_registry_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/schema_registry-{{inventory_hostname}}.keytab"
+        schema_registry_kerberos_keytab_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs/schema_registry-{{inventory_hostname}}.keytab"
 
       kerberos_server:
         realm_name: "{{ kerberos.realm | upper }}"


### PR DESCRIPTION
# Description

As part of upgrade automation, we use the inventory file created by the molecule run of scenarios. These inventory files with all variables are based out of molecule.yml files. 
When upgrades are run with starting branches below 7xy and end branches above 7xy, we aren't able to resolve the correct location/path of the these variables, since there path have been hardcoded in molecule.yml files for starting branches. This PR aims to resolve the path from env variables. 

Fixes # (ANSIENG-1222)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

https://jenkins.confluent.io/job/cp-ansible-on-demand/146/

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible