### PR TITLE
Disable fips for java11 related scenario

### DIFF
--- a/roles/confluent.test/molecule/mtls-java11-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/mtls-java11-rhel/molecule.yml
@@ -97,8 +97,6 @@ provisioner:
 
         redhat_java_package_name: java-11-openjdk
 
-        fips_enabled: true
-
 verifier:
   name: ansible
 lint: |


### PR DESCRIPTION
# Description

Since it's known that fips doesn't work with java11, this PR disables it for java11 related scenario. Has also been removed in later branches - https://github.com/confluentinc/cp-ansible/blob/6.1.x/roles/confluent.test/molecule/mtls-java11-rhel/molecule.yml#L100

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?


**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible