### PR TITLE
Remove hardcoded path in molecule files 60x

### DIFF
--- a/roles/confluent.test/molecule/mtls-custombundle-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/mtls-custombundle-rhel/molecule.yml
@@ -136,7 +136,7 @@ provisioner:
         kafka_rest_secrets_protection_encrypt_passwords: false
         kafka_rest_secrets_protection_encrypt_properties: [listeners, bootstrap.servers]
         secrets_protection_masterkey: "UWQYODNQVqwbQeFgytYYoMr+FjK9Q6I0F6r16u6Z0EI="
-        secrets_protection_security_file: "roles/confluent.test/molecule/{{scenario_name}}/security.properties"
+        secrets_protection_security_file: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/security.properties"
 
         # cert creation script does not use fqdn, which is a requirement for zk ssl
         zookeeper_ssl_enabled: false

--- a/roles/confluent.test/molecule/plaintext-basic-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/plaintext-basic-rhel/molecule.yml
@@ -107,9 +107,9 @@ provisioner:
 
         # Kafka Rest API Basic Auth
         kafka_broker_copy_files:
-          - source_path: "roles/confluent.test/molecule/{{scenario_name}}/password.properties"
+          - source_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/password.properties"
             destination_path: /etc/kafka-rest/password.properties
-          - source_path: "roles/confluent.test/molecule/{{scenario_name}}/rest-jaas.properties"
+          - source_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/rest-jaas.properties"
             destination_path: /etc/kafka-rest/rest-jaas.properties
 
         kafka_broker_custom_properties:
@@ -127,9 +127,9 @@ provisioner:
 
         # Schema Registry Basic Auth
         schema_registry_copy_files:
-          - source_path: "roles/confluent.test/molecule/{{scenario_name}}/password.properties"
+          - source_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/password.properties"
             destination_path: /etc/kafka-rest/password.properties
-          - source_path: "roles/confluent.test/molecule/{{scenario_name}}/rest-jaas.properties"
+          - source_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/rest-jaas.properties"
             destination_path: /etc/kafka-rest/rest-jaas.properties
 
         schema_registry_custom_properties:
@@ -144,9 +144,9 @@ provisioner:
 
         # Connect Basic Auth Not working
         # kafka_connect_copy_files:
-        #   - source_path: "roles/confluent.test/molecule/{{scenario_name}}/connect.password"
+        #   - source_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/connect.password"
         #     destination_path: /etc/kafka-connect/connect.password
-        #   - source_path: "roles/confluent.test/molecule/{{scenario_name}}/connect-jaas.properties"
+        #   - source_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/connect-jaas.properties"
         #     destination_path: /etc/kafka-connect/connect-jaas.properties
         #
         # kafka_connect_custom_properties:
@@ -164,9 +164,9 @@ provisioner:
 
         # ksqlDB Basic Auth
         ksql_copy_files:
-          - source_path: "roles/confluent.test/molecule/{{scenario_name}}/password.properties"
+          - source_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/password.properties"
             destination_path: /etc/kafka-rest/password.properties
-          - source_path: "roles/confluent.test/molecule/{{scenario_name}}/rest-jaas.properties"
+          - source_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/rest-jaas.properties"
             destination_path: /etc/kafka-rest/rest-jaas.properties
 
         ksql_custom_properties:
@@ -181,9 +181,9 @@ provisioner:
 
         # Rest Proxy Basic Auth
         kafka_rest_copy_files:
-          - source_path: "roles/confluent.test/molecule/{{scenario_name}}/password.properties"
+          - source_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/password.properties"
             destination_path: /etc/kafka-rest/password.properties
-          - source_path: "roles/confluent.test/molecule/{{scenario_name}}/rest-jaas.properties"
+          - source_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/rest-jaas.properties"
             destination_path: /etc/kafka-rest/rest-jaas.properties
 
         kafka_rest_custom_properties:
@@ -201,9 +201,9 @@ provisioner:
 
         # C3 Basic Auth
         control_center_copy_files:
-          - source_path: "roles/confluent.test/molecule/{{scenario_name}}/password.properties"
+          - source_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/password.properties"
             destination_path: /etc/kafka-rest/password.properties
-          - source_path: "roles/confluent.test/molecule/{{scenario_name}}/rest-jaas.properties"
+          - source_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/rest-jaas.properties"
             destination_path: /etc/kafka-rest/rest-jaas.properties
 
         control_center_custom_properties:

--- a/roles/confluent.test/molecule/plaintext-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/plaintext-rhel/molecule.yml
@@ -135,9 +135,9 @@ provisioner:
 
         # Testing the copy files feature
         zookeeper_copy_files:
-          - source_path: "roles/confluent.test/molecule/{{scenario_name}}/molecule.yml"
+          - source_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/molecule.yml"
             destination_path: /tmp/molecule.yml
-          - source_path: "roles/confluent.test/molecule/{{scenario_name}}/molecule.yml"
+          - source_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/molecule.yml"
             destination_path: /tmp/molecule2.yml
             file_mode: '0666'
 

--- a/roles/confluent.test/molecule/rbac-mds-kerberos-debian/molecule.yml
+++ b/roles/confluent.test/molecule/rbac-mds-kerberos-debian/molecule.yml
@@ -211,8 +211,8 @@ provisioner:
         rbac_enabled: true
 
         create_mds_certs: false
-        token_services_public_pem_file: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/public.pem"
-        token_services_private_pem_file: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/tokenKeypair.pem"
+        token_services_public_pem_file: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/public.pem"
+        token_services_private_pem_file: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/tokenKeypair.pem"
 
         kafka_broker_custom_listeners:
           client_listener:
@@ -250,9 +250,9 @@ provisioner:
           admin_hostname: mds-kerberos1
 
         zookeeper_kerberos_principal: "zookeeper/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
-        zookeeper_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/zookeeper-{{inventory_hostname}}.keytab"
+        zookeeper_kerberos_keytab_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs/zookeeper-{{inventory_hostname}}.keytab"
         kafka_broker_kerberos_principal: "{{kerberos_kafka_broker_primary}}/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
-        kafka_broker_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/kafka_broker-{{inventory_hostname}}.keytab"
+        kafka_broker_kerberos_keytab_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs/kafka_broker-{{inventory_hostname}}.keytab"
 
       mds:
         kafka_broker_custom_properties:

--- a/roles/confluent.test/molecule/rbac-mds-kerberos-mtls-custom-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/rbac-mds-kerberos-mtls-custom-rhel/molecule.yml
@@ -207,8 +207,8 @@ provisioner:
         rbac_enabled: true
 
         create_mds_certs: false
-        token_services_public_pem_file: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/public.pem"
-        token_services_private_pem_file: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/tokenKeypair.pem"
+        token_services_public_pem_file: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/public.pem"
+        token_services_private_pem_file: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/tokenKeypair.pem"
 
         kafka_broker_custom_listeners:
           client_listener:
@@ -247,8 +247,8 @@ provisioner:
 
         zookeeper_kerberos_principal: "zookeeper/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
         kafka_broker_kerberos_principal: "{{kerberos_kafka_broker_primary}}/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
-        zookeeper_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/zookeeper-{{inventory_hostname}}.keytab"
-        kafka_broker_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/kafka_broker-{{inventory_hostname}}.keytab"
+        zookeeper_kerberos_keytab_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs/zookeeper-{{inventory_hostname}}.keytab"
+        kafka_broker_kerberos_keytab_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs/kafka_broker-{{inventory_hostname}}.keytab"
 
       mds:
         ssl_enabled: false
@@ -276,9 +276,9 @@ provisioner:
 
         ssl_custom_certs: true
         # Paths relative to all.yml
-        ssl_ca_cert_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/ca.crt"
-        ssl_signed_cert_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
-        ssl_key_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-key.pem"
+        ssl_ca_cert_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/ca.crt"
+        ssl_signed_cert_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
+        ssl_key_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-key.pem"
         ssl_key_password: keypass
 
         external_mds_enabled: true

--- a/roles/confluent.test/molecule/rbac-mds-mtls-custom-kerberos-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/rbac-mds-mtls-custom-kerberos-rhel/molecule.yml
@@ -206,13 +206,13 @@ provisioner:
         rbac_enabled: true
 
         create_mds_certs: false
-        token_services_public_pem_file: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/public.pem"
-        token_services_private_pem_file: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/tokenKeypair.pem"
+        token_services_public_pem_file: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/public.pem"
+        token_services_private_pem_file: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/tokenKeypair.pem"
 
         ssl_custom_certs: true
-        ssl_ca_cert_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/ca.crt"
-        ssl_signed_cert_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
-        ssl_key_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-key.pem"
+        ssl_ca_cert_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/ca.crt"
+        ssl_signed_cert_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
+        ssl_key_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-key.pem"
         ssl_key_password: keypass
 
         kafka_broker_custom_listeners:
@@ -289,10 +289,10 @@ provisioner:
           sasl_protocol: none
 
         zookeeper_kerberos_principal: "zookeeper/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
-        zookeeper_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/zookeeper-{{inventory_hostname}}.keytab"
+        zookeeper_kerberos_keytab_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs/zookeeper-{{inventory_hostname}}.keytab"
 
         kafka_broker_kerberos_principal: "{{kerberos_kafka_broker_primary}}/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
-        kafka_broker_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/kafka_broker-{{inventory_hostname}}.keytab"
+        kafka_broker_kerberos_keytab_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs/kafka_broker-{{inventory_hostname}}.keytab"
 
       ldap_server:
         ldaps_enabled: true

--- a/roles/confluent.test/molecule/rbac-mds-mtls-custom-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/rbac-mds-mtls-custom-rhel/molecule.yml
@@ -194,16 +194,16 @@ provisioner:
         ssl_mutual_auth_enabled: true
 
         ssl_custom_certs: true
-        ssl_ca_cert_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/ca.crt"
-        ssl_signed_cert_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
-        ssl_key_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-key.pem"
+        ssl_ca_cert_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/ca.crt"
+        ssl_signed_cert_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
+        ssl_key_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-key.pem"
         ssl_key_password: keypass
 
         rbac_enabled: true
 
         create_mds_certs: false
-        token_services_public_pem_file: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/public.pem"
-        token_services_private_pem_file: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/tokenKeypair.pem"
+        token_services_public_pem_file: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/public.pem"
+        token_services_private_pem_file: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/tokenKeypair.pem"
 
         kafka_broker_custom_listeners:
           client_listener:

--- a/roles/confluent.test/molecule/rbac-mds-plain-custom-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/rbac-mds-plain-custom-rhel/molecule.yml
@@ -195,9 +195,9 @@ provisioner:
 
         ssl_custom_certs: true
         # Paths relative to all.yml
-        ssl_ca_cert_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/ca.crt"
-        ssl_signed_cert_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
-        ssl_key_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-key.pem"
+        ssl_ca_cert_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/ca.crt"
+        ssl_signed_cert_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
+        ssl_key_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-key.pem"
         ssl_key_password: keypass
 
         rbac_enabled: true
@@ -205,8 +205,8 @@ provisioner:
         kafka_broker_custom_log4j: false
 
         create_mds_certs: false
-        token_services_public_pem_file: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/public.pem"
-        token_services_private_pem_file: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/tokenKeypair.pem"
+        token_services_public_pem_file: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/public.pem"
+        token_services_private_pem_file: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/tokenKeypair.pem"
 
         kafka_broker_custom_listeners:
           client_listener:

--- a/roles/confluent.test/molecule/rbac-mds-scram-custom-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/rbac-mds-scram-custom-rhel/molecule.yml
@@ -195,16 +195,16 @@ provisioner:
         sasl_protocol: scram
 
         ssl_custom_certs: true
-        ssl_ca_cert_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/ca.crt"
-        ssl_signed_cert_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
-        ssl_key_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-key.pem"
+        ssl_ca_cert_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/ca.crt"
+        ssl_signed_cert_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
+        ssl_key_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-key.pem"
         ssl_key_password: keypass
 
         rbac_enabled: true
 
         create_mds_certs: false
-        token_services_public_pem_file: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/public.pem"
-        token_services_private_pem_file: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/tokenKeypair.pem"
+        token_services_public_pem_file: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/public.pem"
+        token_services_private_pem_file: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/tokenKeypair.pem"
 
         kafka_broker_custom_listeners:
           client_listener:


### PR DESCRIPTION
# Description

https://github.com/confluentinc/cp-ansible/pull/979
Similar to above PR. After pint merging the above PR to all downstream, some new scenarios in 60x were left with these hardcoded path. Fixing those here

Fixes # (ANSIENG-1222)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?


**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible