### PR TITLE
Remove hardcoded path in molecule files 61x

### DIFF
--- a/roles/confluent.test/molecule/kafka-connect-replicator-mtls-scram-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/kafka-connect-replicator-mtls-scram-rhel/molecule.yml
@@ -152,9 +152,9 @@ provisioner:
         ssl_custom_certs: true
         ssl_mutual_auth_enabled: true
         # Paths relative to all.yml
-        ssl_ca_cert_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/ca.crt"
-        ssl_signed_cert_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
-        ssl_key_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-key.pem"
+        ssl_ca_cert_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/ca.crt"
+        ssl_signed_cert_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
+        ssl_key_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-key.pem"
         ssl_key_password: keypass
 
 
@@ -164,9 +164,9 @@ provisioner:
         ssl_enabled: true
         ssl_custom_certs: true
         # Paths relative to all.yml
-        ssl_ca_cert_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/ca.crt"
-        ssl_signed_cert_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
-        ssl_key_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-key.pem"
+        ssl_ca_cert_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/ca.crt"
+        ssl_signed_cert_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
+        ssl_key_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-key.pem"
         ssl_key_password: keypass
 
 
@@ -179,9 +179,9 @@ provisioner:
 
         kafka_connect_replicator_white_list: test-replicator-source
         kafka_connect_replicator_bootstrap_servers: kafka-broker1:9092
-        kafka_connect_replicator_ssl_ca_cert_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/ca.crt"
-        kafka_connect_replicator_ssl_cert_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
-        kafka_connect_replicator_ssl_key_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-key.pem"
+        kafka_connect_replicator_ssl_ca_cert_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/ca.crt"
+        kafka_connect_replicator_ssl_cert_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
+        kafka_connect_replicator_ssl_key_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-key.pem"
         kafka_connect_replicator_ssl_key_password: keypass
         kafka_connect_replicator_truststore_storepass: confluenttruststorepass
         kafka_connect_replicator_keystore_storepass: confluentkeystorestorepass
@@ -194,9 +194,9 @@ provisioner:
 
         kafka_connect_replicator_consumer_bootstrap_servers: mds-kafka-broker1:9092
         # Validating these vars default properly
-        # kafka_connect_replicator_consumer_ssl_ca_cert_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/ca.crt"
-        # kafka_connect_replicator_consumer_ssl_cert_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
-        # kafka_connect_replicator_consumer_ssl_key_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-key.pem"
+        # kafka_connect_replicator_consumer_ssl_ca_cert_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/ca.crt"
+        # kafka_connect_replicator_consumer_ssl_cert_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
+        # kafka_connect_replicator_consumer_ssl_key_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-key.pem"
         # kafka_connect_replicator_consumer_ssl_key_password: keypass
         # kafka_connect_replicator_truststore_storepass: confluenttruststorepass
         # kafka_connect_replicator_keystore_storepass: confluentkeystorestorepass
@@ -209,9 +209,9 @@ provisioner:
           sasl_protocol: scram
 
         kafka_connect_replicator_producer_bootstrap_servers: kafka-broker1:9092
-        kafka_connect_replicator_producer_ssl_ca_cert_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/ca.crt"
-        kafka_connect_replicator_producer_ssl_cert_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
-        kafka_connect_replicator_producer_ssl_key_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-key.pem"
+        kafka_connect_replicator_producer_ssl_ca_cert_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/ca.crt"
+        kafka_connect_replicator_producer_ssl_cert_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
+        kafka_connect_replicator_producer_ssl_key_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-key.pem"
         kafka_connect_replicator_producer_ssl_key_password: keypass
         kafka_connect_replicator_producer_custom_properties:
           client.id: producer-test
@@ -223,9 +223,9 @@ provisioner:
 
         kafka_connect_replicator_monitoring_interceptor_bootstrap_servers: kafka-broker1:9092
         # Testing these variables default properly
-        # kafka_connect_replicator_monitoring_interceptor_ssl_ca_cert_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/ca.crt"
-        # kafka_connect_replicator_monitoring_interceptor_ssl_cert_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
-        # kafka_connect_replicator_monitoring_interceptor_ssl_key_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-key.pem"
+        # kafka_connect_replicator_monitoring_interceptor_ssl_ca_cert_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/ca.crt"
+        # kafka_connect_replicator_monitoring_interceptor_ssl_cert_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
+        # kafka_connect_replicator_monitoring_interceptor_ssl_key_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-key.pem"
         # kafka_connect_replicator_monitoring_interceptor_ssl_key_password: keypass
 
 verifier:

--- a/roles/confluent.test/molecule/kafka-connect-replicator-plain-kerberos-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/kafka-connect-replicator-plain-kerberos-rhel/molecule.yml
@@ -154,8 +154,8 @@ provisioner:
 
         zookeeper_kerberos_principal: "zookeeper/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
         kafka_broker_kerberos_principal: "{{kerberos_kafka_broker_primary}}/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
-        zookeeper_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/zookeeper-{{inventory_hostname}}.keytab"
-        kafka_broker_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/kafka_broker-{{inventory_hostname}}.keytab"
+        zookeeper_kerberos_keytab_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs/zookeeper-{{inventory_hostname}}.keytab"
+        kafka_broker_kerberos_keytab_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs/kafka_broker-{{inventory_hostname}}.keytab"
 
       mds:
         _sasl_plain_users:
@@ -172,9 +172,9 @@ provisioner:
         ssl_enabled: true
         ssl_custom_certs: true
         # Paths relative to all.yml
-        ssl_ca_cert_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/ca.crt"
-        ssl_signed_cert_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
-        ssl_key_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-key.pem"
+        ssl_ca_cert_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/ca.crt"
+        ssl_signed_cert_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
+        ssl_key_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-key.pem"
         ssl_key_password: keypass
 
       cluster2:
@@ -193,16 +193,16 @@ provisioner:
           sasl_protocol: plain
 
         # Paths relative to all.yml
-        ssl_ca_cert_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/ca.crt"
-        ssl_signed_cert_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
-        ssl_key_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-key.pem"
+        ssl_ca_cert_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/ca.crt"
+        ssl_signed_cert_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
+        ssl_key_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-key.pem"
         ssl_key_password: keypass
 
         zookeeper_kerberos_principal: "zookeeper/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
-        zookeeper_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/zookeeper-{{inventory_hostname}}.keytab"
+        zookeeper_kerberos_keytab_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs/zookeeper-{{inventory_hostname}}.keytab"
 
         kafka_broker_kerberos_principal: "{{kerberos_kafka_broker_primary}}/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
-        kafka_broker_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/kafka_broker-{{inventory_hostname}}.keytab"
+        kafka_broker_kerberos_keytab_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs/kafka_broker-{{inventory_hostname}}.keytab"
 
       kafka_connect_replicator:
 
@@ -216,10 +216,10 @@ provisioner:
         kafka_connect_replicator_white_list: test-replicator-source
         kafka_connect_replicator_bootstrap_servers: kafka-broker1:9092
         kafka_connect_replicator_kerberos_principal: "replicator/kafka-connect-replicator1.confluent@{{kerberos.realm | upper}}"
-        kafka_connect_replicator_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/kafka-connect-replicator1.keytab"
-        kafka_connect_replicator_ssl_ca_cert_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/ca.crt"
-        kafka_connect_replicator_ssl_cert_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
-        kafka_connect_replicator_ssl_key_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-key.pem"
+        kafka_connect_replicator_kerberos_keytab_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs/kafka-connect-replicator1.keytab"
+        kafka_connect_replicator_ssl_ca_cert_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/ca.crt"
+        kafka_connect_replicator_ssl_cert_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
+        kafka_connect_replicator_ssl_key_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-key.pem"
         kafka_connect_replicator_ssl_key_password: keypass
         kafka_connect_replicator_truststore_storepass: confluenttruststorepass
         kafka_connect_replicator_keystore_storepass: confluentkeystorestorepass
@@ -230,9 +230,9 @@ provisioner:
           sasl_protocol: plain
 
         kafka_connect_replicator_consumer_bootstrap_servers: mds-kafka-broker1:9092
-        kafka_connect_replicator_consumer_ssl_ca_cert_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/ca.crt"
-        kafka_connect_replicator_consumer_ssl_cert_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
-        kafka_connect_replicator_consumer_ssl_key_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-key.pem"
+        kafka_connect_replicator_consumer_ssl_ca_cert_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/ca.crt"
+        kafka_connect_replicator_consumer_ssl_cert_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
+        kafka_connect_replicator_consumer_ssl_key_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-key.pem"
         kafka_connect_replicator_consumer_ssl_key_password: keypass
         kafka_connect_replicator_consumer_custom_properties:
           client.id: consumer-test
@@ -244,10 +244,10 @@ provisioner:
 
         kafka_connect_replicator_producer_bootstrap_servers: kafka-broker1:9092
         kafka_connect_replicator_producer_kerberos_principal: "replicator/kafka-connect-replicator1.confluent@{{kerberos.realm | upper}}"
-        kafka_connect_replicator_producer_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/kafka-connect-replicator1.keytab"
-        kafka_connect_replicator_producer_ssl_ca_cert_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/ca.crt"
-        kafka_connect_replicator_producer_ssl_cert_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
-        kafka_connect_replicator_producer_ssl_key_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-key.pem"
+        kafka_connect_replicator_producer_kerberos_keytab_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs/kafka-connect-replicator1.keytab"
+        kafka_connect_replicator_producer_ssl_ca_cert_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/ca.crt"
+        kafka_connect_replicator_producer_ssl_cert_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
+        kafka_connect_replicator_producer_ssl_key_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-key.pem"
         kafka_connect_replicator_producer_ssl_key_password: keypass
         kafka_connect_replicator_producer_custom_properties:
           client.id: producer-test
@@ -259,10 +259,10 @@ provisioner:
 
         kafka_connect_replicator_monitoring_interceptor_bootstrap_servers: kafka-broker1:9092
         kafka_connect_replicator_monitoring_interceptor_kerberos_principal: "replicator/kafka-connect-replicator1.confluent@{{kerberos.realm | upper}}"
-        kafka_connect_replicator_monitoring_interceptor_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/kafka-connect-replicator1.keytab"
-        kafka_connect_replicator_monitoring_interceptor_ssl_ca_cert_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/ca.crt"
-        kafka_connect_replicator_monitoring_interceptor_ssl_cert_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
-        kafka_connect_replicator_monitoring_interceptor_ssl_key_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-key.pem"
+        kafka_connect_replicator_monitoring_interceptor_kerberos_keytab_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs/kafka-connect-replicator1.keytab"
+        kafka_connect_replicator_monitoring_interceptor_ssl_ca_cert_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/ca.crt"
+        kafka_connect_replicator_monitoring_interceptor_ssl_cert_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
+        kafka_connect_replicator_monitoring_interceptor_ssl_key_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-key.pem"
         kafka_connect_replicator_monitoring_interceptor_ssl_key_password: keypass
 
       kerberos_server:

--- a/roles/confluent.test/molecule/provided-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/provided-rhel/molecule.yml
@@ -140,9 +140,9 @@ provisioner:
         ssl_enabled: true
 
         # ssl_custom_certs: true
-        # ssl_ca_cert_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/ca.crt"
-        # ssl_signed_cert_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
-        # ssl_key_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-key.pem"
+        # ssl_ca_cert_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/ca.crt"
+        # ssl_signed_cert_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
+        # ssl_key_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-key.pem"
         # ssl_key_password: keypass
 
         # Variable to have prepare playbook add extra cert to
@@ -150,10 +150,10 @@ provisioner:
         molecule_certs_format: jks
 
         ssl_provided_keystore_and_truststore: true
-        ssl_keystore_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}.keystore.jks"
+        ssl_keystore_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}.keystore.jks"
         ssl_keystore_key_password: keystorepass
         ssl_keystore_store_password: keystorepass
-        ssl_truststore_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/truststore.jks"
+        ssl_truststore_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/truststore.jks"
         ssl_truststore_password: truststorepass
         ssl_truststore_ca_cert_alias: CARoot
 

--- a/roles/confluent.test/molecule/rbac-kafka-connect-replicator-kerberos-mtls-custom-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/rbac-kafka-connect-replicator-kerberos-mtls-custom-rhel/molecule.yml
@@ -163,8 +163,8 @@ provisioner:
         rbac_enabled: true
 
         create_mds_certs: false
-        token_services_public_pem_file: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/public.pem"
-        token_services_private_pem_file: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/tokenKeypair.pem"
+        token_services_public_pem_file: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/public.pem"
+        token_services_private_pem_file: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/tokenKeypair.pem"
 
         kafka_broker_custom_listeners:
           client_listener:
@@ -191,8 +191,8 @@ provisioner:
 
         zookeeper_kerberos_principal: "zookeeper/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
         kafka_broker_kerberos_principal: "{{kerberos_kafka_broker_primary}}/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
-        zookeeper_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/zookeeper-{{inventory_hostname}}.keytab"
-        kafka_broker_kerberos_keytab_path: "roles/confluent.test/molecule/{{scenario_name}}/keytabs/kafka_broker-{{inventory_hostname}}.keytab"
+        zookeeper_kerberos_keytab_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs/zookeeper-{{inventory_hostname}}.keytab"
+        kafka_broker_kerberos_keytab_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs/kafka_broker-{{inventory_hostname}}.keytab"
 
       mds:
         ssl_enabled: false
@@ -232,9 +232,9 @@ provisioner:
 
         ssl_custom_certs: true
         # Paths relative to all.yml
-        ssl_ca_cert_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/ca.crt"
-        ssl_signed_cert_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
-        ssl_key_filepath: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-key.pem"
+        ssl_ca_cert_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/ca.crt"
+        ssl_signed_cert_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
+        ssl_key_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-key.pem"
         ssl_key_password: keypass
 
         external_mds_enabled: true
@@ -255,9 +255,9 @@ provisioner:
         kafka_connect_replicator_cluster_name: replicator
         kafka_connect_replicator_white_list: test-replicator-source
         kafka_connect_replicator_bootstrap_servers: kafka-broker1:9092
-        kafka_connect_replicator_ssl_ca_cert_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/ca.crt"
-        kafka_connect_replicator_ssl_cert_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
-        kafka_connect_replicator_ssl_key_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-key.pem"
+        kafka_connect_replicator_ssl_ca_cert_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/ca.crt"
+        kafka_connect_replicator_ssl_cert_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
+        kafka_connect_replicator_ssl_key_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-key.pem"
         kafka_connect_replicator_ssl_key_password: keypass
         kafka_connect_replicator_truststore_storepass: confluenttruststorepass
         kafka_connect_replicator_keystore_storepass: confluentkeystorestorepass
@@ -269,7 +269,7 @@ provisioner:
         kafka_connect_replicator_erp_admin_password: password
         # kafka_connect_replicator_kafka_cluster_id: destination_cluster
         kafka_connect_replicator_kafka_cluster_name: destination_cluster
-        kafka_connect_replicator_erp_pem_file: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/public.pem"
+        kafka_connect_replicator_erp_pem_file: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/public.pem"
 
         kafka_connect_replicator_consumer_listener:
           ssl_enabled: false
@@ -278,9 +278,9 @@ provisioner:
 
         kafka_connect_replicator_consumer_bootstrap_servers: mds-kafka-broker1:9092
         # Validating these vars default properly
-        # kafka_connect_replicator_consumer_ssl_ca_cert_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/ca.crt"
-        # kafka_connect_replicator_consumer_ssl_cert_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
-        # kafka_connect_replicator_consumer_ssl_key_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-key.pem"
+        # kafka_connect_replicator_consumer_ssl_ca_cert_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/ca.crt"
+        # kafka_connect_replicator_consumer_ssl_cert_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
+        # kafka_connect_replicator_consumer_ssl_key_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-key.pem"
         # kafka_connect_replicator_consumer_ssl_key_password: keypass
         # kafka_connect_replicator_truststore_storepass: confluenttruststorepass
         # kafka_connect_replicator_keystore_storepass: confluentkeystorestorepass
@@ -294,7 +294,7 @@ provisioner:
         kafka_connect_replicator_consumer_erp_admin_password: password
         # kafka_connect_replicator_consumer_kafka_cluster_id: mds
         kafka_connect_replicator_consumer_kafka_cluster_name: mds
-        kafka_connect_replicator_consumer_erp_pem_file: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/public.pem"
+        kafka_connect_replicator_consumer_erp_pem_file: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/public.pem"
 
         kafka_connect_replicator_producer_listener:
           ssl_enabled: true
@@ -302,9 +302,9 @@ provisioner:
           sasl_protocol: oauth
 
         kafka_connect_replicator_producer_bootstrap_servers: kafka-broker1:9092
-        kafka_connect_replicator_producer_ssl_ca_cert_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/ca.crt"
-        kafka_connect_replicator_producer_ssl_cert_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
-        kafka_connect_replicator_producer_ssl_key_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-key.pem"
+        kafka_connect_replicator_producer_ssl_ca_cert_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/ca.crt"
+        kafka_connect_replicator_producer_ssl_cert_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
+        kafka_connect_replicator_producer_ssl_key_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-key.pem"
         kafka_connect_replicator_producer_ssl_key_password: keypass
         kafka_connect_replicator_producer_custom_properties:
           client.id: producer-test
@@ -316,9 +316,9 @@ provisioner:
 
         kafka_connect_replicator_monitoring_interceptor_bootstrap_servers: kafka-broker1:9092
         # Testing these variables default properly
-        # kafka_connect_replicator_monitoring_interceptor_ssl_ca_cert_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/ca.crt"
-        # kafka_connect_replicator_monitoring_interceptor_ssl_cert_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
-        # kafka_connect_replicator_monitoring_interceptor_ssl_key_path: "roles/confluent.test/molecule/{{scenario_name}}/generated_ssl_files/{{inventory_hostname}}-key.pem"
+        # kafka_connect_replicator_monitoring_interceptor_ssl_ca_cert_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/ca.crt"
+        # kafka_connect_replicator_monitoring_interceptor_ssl_cert_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
+        # kafka_connect_replicator_monitoring_interceptor_ssl_key_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-key.pem"
         # kafka_connect_replicator_monitoring_interceptor_ssl_key_password: keypass
 
       ldap_server:


### PR DESCRIPTION
# Description

https://github.com/confluentinc/cp-ansible/pull/988
Similar to above PR. After pint merging the above PR on 60x to all downstream, some new scenarios in 61x were left with these hardcoded path. Fixing those 4 files here. 

Fixes # (ANSIENG-1222)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?


**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible