### PR TITLE
first fix registering multiple ksql with MDS

### DIFF
--- a/roles/confluent.ksql/tasks/main.yml
+++ b/roles/confluent.ksql/tasks/main.yml
@@ -295,6 +295,15 @@
     - not ansible_check_mode
   tags: health_check
 
+# Set a host fact with the direct cluster parent group
+- name: Set parent Cluster
+  vars:
+    keywords:
+    - ksql
+    - ksql_parallel
+    - ksql_serial
+  set_fact: parent_ksql_cluster={{ (group_names | difference(keywords))[0] | default('ksql') }}
+
 - name: Register Cluster
   include_tasks: register_cluster.yml
   when: ksql_cluster_name | length >0 and rbac_enabled|bool

--- a/roles/confluent.ksql/tasks/main.yml
+++ b/roles/confluent.ksql/tasks/main.yml
@@ -302,8 +302,10 @@
     - ksql
     - ksql_parallel
     - ksql_serial
-  set_fact: parent_ksql_cluster={{ (group_names | difference(keywords))[0] | default('ksql') }}
+  set_fact: 
+    parent_ksql_cluster_group: "{{ (group_names | difference(keywords))[0] | default('ksql') }}"
+    parent_ksql_cluster_id: "{{ ksql_final_properties['ksql.service.id'] }}"
 
 - name: Register Cluster
   include_tasks: register_cluster.yml
-  when: ksql_cluster_name | length >0 and rbac_enabled|bool
+  run_once: True

--- a/roles/confluent.ksql/tasks/register_cluster.yml
+++ b/roles/confluent.ksql/tasks/register_cluster.yml
@@ -6,7 +6,16 @@
   vars:
     copy_certs: false
 
+- name: Fetch KSQL Cluster Groups
+  set_fact: active_ksql_groups="{{ (((active_ksql_groups | default([])) + hostvars[item].group_names) | difference('ksql'+'ksql_parallel'+'ksql_serial')) | default(['ksql'], true) }}"
+  with_items: "{{ ansible_play_hosts }}"
+
 - name: Register KSQL Cluster
+  vars:
+    cluster_host_delegates: "{{ active_ksql_groups | map('extract', groups, 0)  }}"
+    cluster_group: "{{ hostvars[item].parent_ksql_cluster_group }}"
+    cluster_name: "{{ hostvars[item].ksql_cluster_name }}"
+    cluster_id: "{{ hostvars[item].parent_ksql_cluster_id }}"
   uri:
     url: "{{mds_bootstrap_server_urls.split(',')[0]}}/security/1.0/registry/clusters"
     method: POST
@@ -20,17 +29,21 @@
     body: >
       [
           {
-              "clusterName": "{{ksql_cluster_name}}",
+              "clusterName": "{{ cluster_name }}",
               "scope": {
                   "clusters": {
                       "kafka-cluster": "{{kafka_cluster_id}}",
-                      "ksql-cluster": "{{ksql_final_properties['ksql.service.id']}}"
+                      "ksql-cluster": "{{ cluster_id }}"
                   }
               },
-              "hosts": [ {% for host in groups[parent_ksql_cluster] %}{% if loop.index > 1%},{% endif %}{ "host": "{{host}}", "port": {{ksql_listener_port}} }{% endfor %}
+              "hosts": [ {% for host in groups[cluster_group] %}{% if loop.index > 1%},{% endif %}{ "host": "{{host}}", "port": {{ksql_listener_port}} }{% endfor %}
               ],
               "protocol": "{{ksql_http_protocol | upper}}"
           }
       ]
     status_code: 204
   register: output
+  when: (hostvars[item].rbac_enabled|bool) and
+        (hostvars[item].ksql_cluster_name is defined) and 
+        (hostvars[item].parent_ksql_cluster_id is defined) 
+  with_items: "{{ cluster_host_delegates }}"

--- a/roles/confluent.ksql/tasks/register_cluster.yml
+++ b/roles/confluent.ksql/tasks/register_cluster.yml
@@ -27,11 +27,10 @@
                       "ksql-cluster": "{{ksql_final_properties['ksql.service.id']}}"
                   }
               },
-              "hosts": [ {% for host in groups['ksql'] %}{% if loop.index > 1%},{% endif %}{ "host": "{{host}}", "port": {{ksql_listener_port}} }{% endfor %}
+              "hosts": [ {% for host in groups[parent_ksql_cluster] %}{% if loop.index > 1%},{% endif %}{ "host": "{{host}}", "port": {{ksql_listener_port}} }{% endfor %}
               ],
               "protocol": "{{ksql_http_protocol | upper}}"
           }
       ]
     status_code: 204
-  run_once: true
   register: output

--- a/sample_inventories/rbac_mutiple_ksql.yml
+++ b/sample_inventories/rbac_mutiple_ksql.yml
@@ -1,0 +1,139 @@
+---
+### RBAC SSL - Multiple KSQL Clusters
+##
+## The following is an example inventory file of the configuration required for setting up Confluent Platform with:
+# RBAC enabled, mTLS enabled, and Kerberos authentication on the Interbroker and external client listeners.
+
+all:
+  vars:
+    ansible_connection: ssh
+    ansible_user: ec2-user
+    ansible_become: true
+    ansible_ssh_private_key_file: /home/ec2-user/guest.pem
+
+    ## TLS Configuration - Custom Certificates
+    ssl_enabled: true
+    ssl_custom_certs: true
+    ssl_ca_cert_filepath: "/home/ec2-user/repos/tools/generated_ssl_files/confluent-root-certificate.crt"
+    # If these three vars can't follow a pattern, or the password is different per host, move them under each host
+    ssl_signed_cert_filepath: "/home/ec2-user/repos/tls_generation/generated_ssl_files/{{inventory_hostname}}-server.crt"
+    ssl_key_filepath: "/home/ec2-user/repos/tls_generation/generated_ssl_files/{{inventory_hostname}}-server-private-key.key"
+    ssl_key_password: password
+
+    #### SASL Authentication Configuration - Choose the one that suit your requirements and configure according ####
+    ## By default there will be no SASL Authentication
+    ## For SASL/PLAIN uncomment this line:
+    # sasl_protocol: plain
+    ## For SASL/SCRAM uncomment this line:
+    # sasl_protocol: scram
+    ## For SASL/GSSAPI uncomment this line and see Kerberos Configuration properties below
+    # sasl_protocol: kerberos
+
+    ## RBAC Configuration
+    rbac_enabled: true
+
+    create_mds_certs: false
+    token_services_public_pem_file: /home/ec2-user/keys/public.pem
+    token_services_private_pem_file: /home/ec2-user/keys/tokenKeypair.pem
+
+    ## LDAP CONFIGURATION
+    kafka_broker_custom_properties:
+      ldap.java.naming.factory.initial: com.sun.jndi.ldap.LdapCtxFactory
+      ldap.com.sun.jndi.ldap.read.timeout: 3000
+      ldap.java.naming.provider.url: ldaps://ldap1:636
+      ldap.java.naming.security.principal: uid=mds,OU=rbac,DC=example,DC=com
+      ldap.java.naming.security.credentials: password
+      ldap.java.naming.security.authentication: simple
+      ldap.user.search.base: OU=rbac,DC=example,DC=com
+      ldap.group.search.base: OU=rbac,DC=example,DC=com
+      ldap.user.name.attribute: uid
+      ldap.user.memberof.attribute.pattern: CN=(.*),OU=rbac,DC=example,DC=com
+      ldap.group.name.attribute: cn
+      ldap.group.member.attribute.pattern: CN=(.*),OU=rbac,DC=example,DC=com
+      ldap.user.object.class: account
+
+    ## LDAP USERS
+    mds_super_user: mds
+    mds_super_user_password: password
+    kafka_broker_ldap_user: kafka_broker
+    kafka_broker_ldap_password: password
+    schema_registry_ldap_user: schema_registry
+    schema_registry_ldap_password: password
+    kafka_connect_ldap_user: connect_worker
+    kafka_connect_ldap_password: password
+    ksql_ldap_user: ksql
+    ksql_ldap_password: password
+    kafka_rest_ldap_user: rest_proxy
+    kafka_rest_ldap_password: password
+    control_center_ldap_user: control_center
+    control_center_ldap_password: password
+
+    ## (OPTIONAL) SYSTEM ADMINS (SYSTEM ADMIN ROLEBINDINGS)
+    # A list of users can be specified for all the componentes using 'rbac_component_additional_system_admins:'
+    # Or individual components [component]_additional_system_admins (i.e. schema_registry_additional_system_admins)
+
+zookeeper:
+  hosts:
+    demo-zk-0:
+    demo-zk-1:
+    demo-zk-2:
+
+kafka_broker:
+  hosts:
+    demo-broker-0:
+    demo-broker-1:
+    demo-broker-2:
+
+schema_registry:
+  hosts:
+    demo-sr-0:
+
+kafka_connect:
+  hosts:
+    demo-connect-0:    
+
+kafka_rest:
+  hosts:
+    demo-rest-0:
+
+#### To configure multiple ksql clusters, make use of child groups
+## Note: There can only be one ksql group (parent). So decide on other group names that are not 'ksql'
+## IMPORTANT: There are two vars that must be defined when configuring multiple ksql cluster
+## 'ksql_service_id' - This is mandatory but has a single default value, thus must be override and be unique for each cluster 
+##                     It also used as prefix of the command topics and log topic when 'ksql_log_streaming_enabled: true'
+##                     By convetion it should end with and underscore sign
+## 'ksql_cluster_name' - This is the value used to register the cluster in MDS
+##                       Proper registration will only occur if a name is given (the value exists)
+##                       uniqueness is not required but recommended
+##                       Its the 'firendly' name used in the Role Management GUIs in Control Center
+##                       Name can be changed in succesive runs but the clsuter must be unregister "manually" before hand
+ksql_wraggle:
+  vars:
+    ksql_cluster_name: ksql-wraggle
+    ksql_service_id: wraggle-ksql_
+  hosts:
+    demo-ksql-0:
+    demo-ksql-2:
+
+ksql_analytics:
+  vars:
+    ksql_cluster_name: anaytics-ksql-cluster
+    ksql_service_id: analytics-ksql_
+  hosts:
+    demo-ksql-1:
+
+ksql:
+  children:
+    ksql_wraggle:
+    ksql_analytics:
+
+control_center:
+  # ## When configuring multiple ksql clusters, the below variables are mandatory
+  # # The group names must match the group names as they are in your inventory
+  # # The group names are currently used as "cluster names" in Control Center KSQL tab
+  vars:
+    ksql_cluster_ansible_group_names:
+      - ksql_analytics
+      - ksql_wraggle
+  hosts:
+    demo-c3-0:


### PR DESCRIPTION
# Description

Cluster registration against MDS is not working properly when multiple ksql clusters are defined in the inventory. The registration is done only once and for the first cluster sub-group, moreover it includes all the hosts of the other groups too.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I've tested this deploying against a group of VM's in GCP. With and without ksql subgroups. The relevant parts of the inventory files are these...

```yaml
## Without Groups
ksql:
  vars: 
    ksql_cluster_name: ksql
    # ksql_service_id: default_
  hosts:
    dfederico-demo-ksql-0:
    dfederico-demo-ksql-1:
    dfederico-demo-ksql-2:
``` 
Works as expected!
![Pasted image 20220325105702](https://user-images.githubusercontent.com/1193234/160133482-a2f0ebdb-435d-4b53-889f-32bbc8451336.png)

```
ksql_default:
  vars:
    ksql_cluster_name: ksql
    ksql_service_id: default_
  hosts:
    dfederico-demo-ksql-0:

ksql_wraggle:
  vars:
    ksql_cluster_name: ksql-wraggle
    ksql_service_id: wraggle-ksql_
  hosts:
    dfederico-demo-ksql-1:    

ksql_analytics:
  vars:
    ksql_cluster_name: ksql-analytics
    ksql_service_id: analytics-ksql_
  hosts:
    dfederico-demo-ksql-2:

ksql:
  children:
    ksql_default:
    ksql_wraggle:
    ksql_analytics:
```
Without the proposed fix, the end result registration is always the whole list of hosts for the first group, even playing with the limits... note the that 'register_cluster.yml' in the ksql builds the host list from the "ksql" root group
```yaml
 "hosts": [ {% for host in groups['ksql'] %}{% if loop.index > 1%},{% endif %}{ "host": "{{host}}", "port": {{ksql_listener_port}} }{% endfor %}
```

I ran my fix proposal in several ways, using different `--limit`, commenting out the `ksql_cluster_name` of some and all groups, and the registration were what I expected, new clusters registered as long as the had a name, existing cluster had they host override when applicable, of course that "deleted" clusters are not unregistered, that I'll do by CLI 

IHAC that is planning to upgrade all clusters and "re-distribute" the nodes in new groups and I've also ran this as such scenario and found the expected result.

![Pasted image 20220325113214](https://user-images.githubusercontent.com/1193234/160135748-c1e75042-f272-432d-87fb-fa31ea301ced.png)

***NOTE***: This scenario applies to Connect and other clusters that can form cluster group (i.e. Replicator) 
The process now runs in all hosts, as I removed the 'run_once: true' from the registering task, but it needs to run at least in one host of each group. Such optimization is arguable, and perhaps I'll give it try, to make it run only in one host for each subgroup.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible