### PR TITLE
Add quotes to fix the condition when registering ksql cluster

### DIFF
--- a/roles/confluent.ksql/tasks/register_cluster.yml
+++ b/roles/confluent.ksql/tasks/register_cluster.yml
@@ -45,7 +45,7 @@
     status_code: 204
   register: output
   when:
-    - hostvars[item].get(rbac_enabled, false)|bool
+    - hostvars[item].get("rbac_enabled", false)|bool
     - hostvars[item].ksql_cluster_name is defined
     - hostvars[item].parent_ksql_cluster_id is defined
   with_items: "{{ cluster_host_delegates }}"


### PR DESCRIPTION
# Description

Fixing a conditional check in #1004 
Due to missing quotes, the conditional always evaluated to false due to which no ksql cluster was getting registered for any scenario. 

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested locally
and here - https://jenkins.confluent.io/job/cp-ansible-on-demand/183/

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible