### PR TITLE
fix(ksql): align processing log topic

### DIFF
--- a/roles/ksql/templates/ksql-server_log4j.properties.j2
+++ b/roles/ksql/templates/ksql-server_log4j.properties.j2
@@ -49,7 +49,7 @@ log4j.appender.kafka_appender=org.apache.kafka.log4jappender.KafkaLog4jAppender
 log4j.appender.kafka_appender.layout=io.confluent.common.logging.log4j.StructuredJsonLayout
 log4j.appender.kafka_appender.BrokerList={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ host }}:{{kafka_broker_listeners[ksql_processing_log_kafka_listener_name]['port']}}{% endfor %}
 
-log4j.appender.kafka_appender.Topic={{ksql_processing_log}}
+log4j.appender.kafka_appender.Topic={{ksql_service_id}}{{ksql_processing_log}}
 {% set listener = kafka_broker_listeners[ksql_processing_log_kafka_listener_name] %}
 
 log4j.appender.kafka_appender.SecurityProtocol={{listener | confluent.platform.kafka_protocol_defaults(sasl_protocol, ssl_enabled) }}


### PR DESCRIPTION
# Description

ksqlDB property is defined [here](https://github.com/confluentinc/cp-ansible/blob/fa209b47eb0b2f4b3cd6642c183f1fec95d60680/roles/variables/vars/main.yml#L882) as  `ksql.logging.processing.topic.name: "{{ksql_service_id}}{{ksql_processing_log}}"` 
But log4j properties [here](https://github.com/confluentinc/cp-ansible/blob/fa209b47eb0b2f4b3cd6642c183f1fec95d60680/roles/ksql/templates/ksql-server_log4j.properties.j2#L52) is defined: `log4j.appender.kafka_appender.Topic={{ksql_processing_log}}`

These should be the same, based on https://docs.ksqldb.io/en/latest/reference/processing-log/#configuration-using-log4j

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

**Test Configuration**:


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible