### PR TITLE
fix: no diff on JAAS login configuration files (may contain secrets)

### DIFF
--- a/roles/confluent.kafka_broker/tasks/main.yml
+++ b/roles/confluent.kafka_broker/tasks/main.yml
@@ -216,6 +216,7 @@
     group: "{{kafka_broker_group}}"
   when: "'GSSAPI' in kafka_broker_sasl_enabled_mechanisms or zookeeper_sasl_protocol in ['kerberos', 'digest']"
   notify: restart kafka
+  diff: "{{ not mask_sensitive_diff|bool }}"
 
 - name: Create SCRAM Users
   shell: |

--- a/roles/confluent.zookeeper/tasks/main.yml
+++ b/roles/confluent.zookeeper/tasks/main.yml
@@ -182,6 +182,7 @@
     group: "{{zookeeper_group}}"
   when: zookeeper_sasl_protocol in ['kerberos', 'digest']
   notify: restart zookeeper
+  diff: "{{ not mask_sensitive_diff|bool }}"
 
 - name: Deploy JMX Exporter Config File
   copy:


### PR DESCRIPTION
# Description

As JAAS Login Configuration files may contain secrets, they should be diffed - unless configured to do so. We discovered this when attempting to introduce digest authentication between zookeepers.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Not tested with this change, but it follows an established pattern for masking secrets in cp-ansible.

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible