### PR TITLE
Create broker jaas file when client sasl authentication is enabled

### DIFF
--- a/roles/confluent.kafka_broker/tasks/main.yml
+++ b/roles/confluent.kafka_broker/tasks/main.yml
@@ -273,6 +273,7 @@
     group: "{{kafka_broker_group}}"
   when: "'GSSAPI' in kafka_broker_sasl_enabled_mechanisms or
           zookeeper_sasl_protocol in ['kerberos', 'digest'] or
+          zookeeper_client_authentication_type in ['kerberos', 'digest'] or
           (kafka_broker_rest_proxy_enabled and (not rbac_enabled or (rbac_enabled and external_mds_enabled)) and kafka_broker_rest_proxy_authentication_type == 'basic')"
   notify: restart kafka
 


### PR DESCRIPTION
# Description

Ensure `kafka_server_jaas.conf` file is created when `zookeeper_client_authentication_type` is set to `kerberos` or `digest`.

Fixes #733 
Closes #733 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested on local development cluster.

**Test Configuration**:

```yaml
zookeeper_quorum_authentication_type: digest_over_tls
zookeeper_client_authentication_type: digest
```
Did not set `zookeeper_sasl_protocol`.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible