### PR TITLE
Fix get leader/follower task when using TLS

### DIFF
--- a/roles/confluent.zookeeper/tasks/dynamic_groups.yml
+++ b/roles/confluent.zookeeper/tasks/dynamic_groups.yml
@@ -30,7 +30,7 @@
   vars:
     archive_version: "{{ zookeeper_current_version | default(confluent_package_version) }}"
     zookeeper_ssl_enabled: "{{ (slurped_properties.content|b64decode).split('\n') |
-      select('match', '^ssl.clientAuth=need') | list | length > 0 }}"
+      select('match', '^secureClientPort') | list | length > 0 }}"
   register: leader_query
   changed_when: false
   check_mode: false


### PR DESCRIPTION
# Description

If brokers are configured with sasl over tls, the Get leader/follower task will fail because it will attempt to talk to zookeeper on the unsecured port. This PR fixes that.

Fixes #1018
Closes #1018 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested in our development cluster.

**Test Configuration**:
```yaml
  zookeeper_ssl_enabled: true
  zookeeper_client_authentication_type: digest
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible