### PR TITLE
Enable running fetch logs playbooks standalone

### DIFF
--- a/playbooks/fetch_logs.yml
+++ b/playbooks/fetch_logs.yml
@@ -1,4 +1,10 @@
 ---
+- name: Import all variables
+  hosts: all
+  tasks:
+    - import_role:
+        name: variables
+
 - name: Zookeeper Provisioning
   hosts: zookeeper
   gather_facts: false


### PR DESCRIPTION
# Description

This PR will enable running fetch_logs playbook standalone. Earlier, it was failing due to undefined variables. 
This'll help us to collect all logs from all components using a single playbook.
To be used as: `ansible-playbook -i hosts.yml confluent.platform.fetch_logs`

Fixes # (ANSIENG-1311)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update. `This change doesn't. But this feature in itself is not documented anywhere. Will raise a doc ticket post review.`

# How Has This Been Tested?

Tested locally. 


**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible