### PR TITLE
Make filter code python2 compatible

### DIFF
--- a/plugins/filter/filters.py
+++ b/plugins/filter/filters.py
@@ -316,7 +316,7 @@ class FilterModule(object):
 
         return final_dict
 
-    def resolve_principal(self, common_names:str, rules:str):
+    def resolve_principal(self, common_names, rules):
         """
         This filter is to extract principle from the keystore based on the provided rule. This filter should be
         used when we have ssl.principal.mapping.rules variable set to some value.
@@ -340,22 +340,30 @@ class FilterModule(object):
         list_of_rules = [i for i in list_of_rules if i]
 
         for rule_str in list_of_rules:
-            mapping_pattern, mapping_value, *case = rule_str.split('/')
+            tokens = rule_str.split('/')
+            if len(tokens) < 2:
+                raise "Invalid rule format. Please ensure the rule has Mapping pattern and Mapping replacement.\n" \
+                      "For details, please refer to https://cwiki.apache.org/confluence/display/KAFKA/KIP-371%3A+Add+a+configuration+to+build+custom+SSL+principal+name"
+
+            mapping_pattern = tokens[0]
+            mapping_value = tokens[1]
+            case = tokens[2] if len(tokens) > 2 else None
+
             for common_name in common_names:
                 matched = re.match(mapping_pattern, common_name)
                 if bool(matched):
                     index =1
                     for match_str in matched.groups():
-                        mapping_value = mapping_value.replace(f"${index}", match_str)
+                        mapping_value = mapping_value.replace("${0}".format(index), match_str)
                         index = index+1
 
                     # Remove leading and trailing whitespaces
                     mapping_value = mapping_value.strip()
                     principal_mapping_value = mapping_value
 
-                    if case[0] == 'L':
+                    if case and case == 'L':
                         principal_mapping_value = mapping_value.lower()
-                    elif case[0] == 'U':
+                    elif case and case == 'U':
                         principal_mapping_value = mapping_value.upper()
                     break
 


### PR DESCRIPTION
# Description

CP-Ansbile 7.1 does support python2.7 This PR removes python 3 specific code from filters plugin. 

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Verified with `rbac-mtls-rhel` molecule scenario


**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible