### PR TITLE
Mark shell tasks as idempotent with changed_when: false

### DIFF
--- a/roles/common/tasks/host_validations.yml
+++ b/roles/common/tasks/host_validations.yml
@@ -94,6 +94,7 @@
   shell: openssl rsa -noout -modulus -in {{ ssl_key_filepath }} | openssl md5
   register: key_hash
   delegate_to: localhost
+  changed_when: false
   when: ssl_custom_certs|bool
   tags:
     - validate
@@ -103,6 +104,7 @@
   shell: openssl x509 -noout -modulus -in {{ ssl_signed_cert_filepath }} | openssl md5
   register: cert_hash
   delegate_to: localhost
+  changed_when: false
   when: ssl_custom_certs|bool
   tags:
     - validate


### PR DESCRIPTION
# Description

This marks shell tasks as idempotent by adding `changed_when: false`. Using shell/command tasks in Ansible should be "last resort", and I think replacing these tasks with community.crypto module(s) would be nice. But it seems like there is a need to support pre-historical versions of Python/Ansible - at least for now.

I would also suggest to include the idempotence checks in our molecule tests, to avoid making these errors for the future. But that will slow down the slow CI build even more.....

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Ran our playbook with this change in our local DEV environment.

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible