### PR TITLE
Add daemon reload after secret protection related tasks

### DIFF
--- a/roles/kafka_broker/tasks/secrets_protection.yml
+++ b/roles/kafka_broker/tasks/secrets_protection.yml
@@ -48,6 +48,7 @@
   systemd:
     name: "{{kafka_broker_service_name}}"
     enabled: true
+    daemon_reload: yes
     state: restarted
   tags:
     - systemd


### PR DESCRIPTION
# Description

When secret protection is enabled, ansible playbook generates the master key and adds it to the systemd as an override, this requires systemd daemon to be reloaded for the changes to be picked up. 

Fixes # (ANSIENG-1327)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Doesn't break anything else - https://jenkins.confluent.io/job/cp-ansible-on-demand/229/
And verified by support team for their use case. 


**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible