### PR TITLE
Add masterkey tags in masterkey.yml

### DIFF
--- a/tasks/masterkey.yml
+++ b/tasks/masterkey.yml
@@ -1,9 +1,11 @@
 ---
 - name: Create Passphrase File
+  tags: masterkey
   shell: "openssl rand -base64 14 > /tmp/passphrase.txt"
   diff: "{{ not mask_sensitive_diff|bool }}"
 
 - name: Generate Master Encryption Key and File
+  tags: masterkey
   shell: |
     {{ confluent_cli_path }} secret master-key generate \
       --local-secrets-file /tmp/security.properties \
@@ -12,12 +14,14 @@
   diff: "{{ not mask_sensitive_diff|bool }}"
 
 - name: Write Master Key to File
+  tags: masterkey
   copy:
     content: "{{ masterkey.stdout }}"
     dest: /tmp/masterkey
   diff: "{{ not mask_sensitive_diff|bool }}"
 
 - name: Copy Security File Back to Ansible Host
+  tags: masterkey
   fetch:
     src: "/tmp/security.properties"
     dest: "{{secrets_protection_security_file}}"
@@ -25,6 +29,7 @@
   diff: "{{ not mask_sensitive_diff|bool }}"
 
 - name: Copy Master Key Back to Ansible Host
+  tags: masterkey
   fetch:
     src: /tmp/masterkey
     dest: "generated_ssl_files/"
@@ -32,6 +37,7 @@
   diff: "{{ not mask_sensitive_diff|bool }}"
 
 - name: Remove Set Up Files
+  tags: masterkey
   file:
     path: "/tmp/{{item}}"
     state: absent


### PR DESCRIPTION
# Description

No tasks are run for masterkey tag if we follow the cp installation using tags as mentioned [here](https://docs.confluent.io/ansible/7.1.1/ansible-install.html)
To fix this and also to make it consistent with tasks in certificate_authority.yml, we need to add the tag. 
The tag based installation using masterkey is used 6.2.x onwards, but I've targeted it on 6.0.x to make it consistent with certificate_authority.yml

Fixes # (ANSIENG-1320)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested locally.


**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible