### PR TITLE
Change cli download condition to only rbac enabled

### DIFF
--- a/docs/VARIABLES.md
+++ b/docs/VARIABLES.md
@@ -344,7 +344,7 @@ Default:  "/etc"
 
 Boolean to have cp-ansible download the Confluent CLI
 
-Default:  "{{rbac_enabled or secrets_protection_enabled}}"
+Default:  "{{rbac_enabled}}"
 
 ***
 

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -154,7 +154,7 @@ archive_config_base_path: "{{ archive_destination_path }}"
 config_prefix: "/etc"
 
 ### Boolean to have cp-ansible download the Confluent CLI
-confluent_cli_download_enabled: "{{rbac_enabled or secrets_protection_enabled}}"
+confluent_cli_download_enabled: "{{rbac_enabled}}"
 
 ### The path the Confluent CLI archive is expanded into.
 confluent_cli_base_path: /opt/confluent-cli


### PR DESCRIPTION
# Description

Change cli download condition to only rbac enabled.
Since 7.1 onwards, secrets protection enabled is only valid if rbac_enabled
Slack discussion - https://confluent.slack.com/archives/C020B5SDHB5/p1646731249453449?thread_ts=1646659961.309819&cid=C020B5SDHB5

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Haven't tested.


**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible