### PR TITLE
Prefix confluent.platform to filter resolve_principal

### DIFF
--- a/molecule/rbac-mtls-rhel/verify.yml
+++ b/molecule/rbac-mtls-rhel/verify.yml
@@ -344,7 +344,7 @@
     - name: Validate mapping rule with Upper case single match
       assert:
         that:
-          - dname == "{{ common_names|resolve_principal(rules) }}"
+          - dname == "{{ common_names|confluent.platform.resolve_principal(rules) }}"
       vars:
         rules: "^CN=(.*?), OU=(.*?)$/$1/U"
         common_names: "CN=kafka-server1, OU=KAFKA"
@@ -353,7 +353,7 @@
     - name: Validate mapping rule with multiple match
       assert:
         that:
-          - dname == "{{ common_names|resolve_principal(rules) }}"
+          - dname == "{{ common_names|confluent.platform.resolve_principal(rules) }}"
       vars:
         rules: "RULE:^CN=(.*?), OU=(.*?), O=(.*?), L=(.*?), ST=(.*?), C=(.*?)$/$1@$2/"
         common_names: "CN=kafka1, OU=SME, O=mycp, L=Fulton, ST=MD, C=US"
@@ -362,7 +362,7 @@
     - name: Validate mapping rule with lowercase single match
       assert:
         that:
-          - dname == "{{ common_names|resolve_principal(rules) }}"
+          - dname == "{{ common_names|confluent.platform.resolve_principal(rules) }}"
       vars:
         rules: "RULE:^cn=(.*?),ou=(.*?),dc=(.*?),dc=(.*?)$/$1/L"
         common_names: "cn=kafka1,ou=SME,dc=mycp,dc=com"
@@ -371,7 +371,7 @@
     - name: Validate multiple mapping rule
       assert:
         that:
-          - dname == "{{ common_names|resolve_principal(rules) }}"
+          - dname == "{{ common_names|confluent.platform.resolve_principal(rules) }}"
       vars:
         rules: "RULE:^cn=(.*?),ou=(.*?),dc=(.*?),dc=(.*?)$/$1/LRULE:^CN=(.*?), OU=(.*?), O=(.*?), L=(.*?), ST=(.*?), C=(.*?)$/$1@$2/"
         common_names: "cn=kafka1,ou=SME,dc=mycp,dc=com"

--- a/roles/kafka_broker/tasks/set_principal.yml
+++ b/roles/kafka_broker/tasks/set_principal.yml
@@ -46,7 +46,7 @@
     kafka_broker_principal: "User:{{ extracted_principal }}"
   vars:
     extracted_principal: "{{distinguished_name_from_keystore.stdout if kafka_broker_final_properties['ssl.principal.mapping.rules'] is not defined \
-                             else distinguished_name_from_keystore.stdout|resolve_principal(kafka_broker_final_properties['ssl.principal.mapping.rules'])}}"
+                             else distinguished_name_from_keystore.stdout|confluent.platform.resolve_principal(kafka_broker_final_properties['ssl.principal.mapping.rules'])}}"
   when:
     - listener['sasl_protocol'] | default(sasl_protocol) | confluent.platform.normalize_sasl_protocol == 'none'
     - listener['ssl_enabled'] | default(ssl_enabled) | bool


### PR DESCRIPTION
# Description

To make filters work with collections and ansible 2.9, we need to prefix them with confluent.platform

Fixes # (ANSIENG-1334)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?



**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible