### PR TITLE
Made parity with 6.1.x onwards branches to make mtls-custombundle

### DIFF
--- a/roles/confluent.test/molecule/mtls-custombundle-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/mtls-custombundle-rhel/molecule.yml
@@ -128,15 +128,17 @@ provisioner:
         scenario_name: mtls-custombundle-rhel
 
         ssl_enabled: true
-        ssl_mutual_auth_enabled: true
-
         fips_enabled: true
 
         secrets_protection_enabled: true
-        kafka_rest_secrets_protection_encrypt_passwords: false
-        kafka_rest_secrets_protection_encrypt_properties: [listeners, bootstrap.servers]
         secrets_protection_masterkey: "UWQYODNQVqwbQeFgytYYoMr+FjK9Q6I0F6r16u6Z0EI="
         secrets_protection_security_file: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/security.properties"
+
+        kafka_broker_secrets_protection_encrypt_properties: [advertised.listeners, broker.id, ssl.key.password]
+        schema_registry_secrets_protection_encrypt_properties: [ssl.keystore.location]
+        kafka_rest_secrets_protection_encrypt_passwords: false
+        kafka_rest_secrets_protection_encrypt_properties: [listeners, bootstrap.servers]
+
 
         # cert creation script does not use fqdn, which is a requirement for zk ssl
         zookeeper_ssl_enabled: false

--- a/roles/confluent.test/molecule/mtls-custombundle-rhel/verify.yml
+++ b/roles/confluent.test/molecule/mtls-custombundle-rhel/verify.yml
@@ -30,16 +30,15 @@
       vars:
         file_path: /etc/schema-registry/schema-registry.properties
         property: ssl.keystore.location
-        expected_value: /var/ssl/private/schema_registry.keystore.jks
-
+        expected_value: ${securepass:/var/ssl/private/schema-registry-security.properties:schema-registry.properties/ssl.keystore.location}
     - name: Secrets Protection Test
       import_role:
         name: confluent.test
         tasks_from: check_property.yml
       vars:
         file_path: /etc/schema-registry/schema-registry.properties
-        property: kafkastore.ssl.key.password
-        expected_value: ${securepass:/var/ssl/private/schema-registry-security.properties:schema-registry.properties/kafkastore.ssl.key.password}
+        property: ssl.key.password
+        expected_value: ${securepass:/var/ssl/private/schema-registry-security.properties:schema-registry.properties/ssl.key.password}
 
 - name: Verify - kafka_rest
   hosts: kafka_rest
@@ -62,8 +61,8 @@
         tasks_from: check_property.yml
       vars:
         file_path: /etc/kafka/connect-distributed.properties
-        property: ssl.keystore.location
-        expected_value: /var/ssl/private/kafka_connect.keystore.jks
+        property: ssl.truststore.location
+        expected_value: /var/ssl/private/kafka_connect.truststore.jks
 
     - name: Secrets Protection Test
       import_role:
@@ -104,5 +103,5 @@
         tasks_from: check_property.yml
       vars:
         file_path: /etc/confluent-control-center/control-center-production.properties
-        property: confluent.controlcenter.streams.ssl.keystore.location
-        expected_value: /var/ssl/private/control_center.keystore.jks
+        property: confluent.controlcenter.streams.ssl.truststore.location
+        expected_value: /var/ssl/private/control_center.truststore.jks


### PR DESCRIPTION
# Description

This `mtls-custombundle-rhel` scenario was failing only on 6.0.x. It turned out that mutual auth doesn't work well with fips enabled. Same changes has been done on 6.1.x branches onwards.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

`molecule converge -s mtls-custombundle-rhel`
`molecule verify -s mtls-custombundle-rhel`


**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible