### PR TITLE
Remove unused datadir variable

### DIFF
--- a/roles/kafka_broker/tasks/main.yml
+++ b/roles/kafka_broker/tasks/main.yml
@@ -15,6 +15,25 @@
     - ansible_fqdn
     - ansible_distribution
 
+# datadir is not supported way to provide data directories for kafka brokers
+- name: Assert that datadir is not present in the inventory
+  assert:
+    that: >
+      'kafka_broker' not in hostvars[item] or
+      hostvars[item].kafka_broker == None or
+      'datadir' not in hostvars[item].kafka_broker
+    fail_msg: |
+      "Providing 'datadir' in inventory file is no more supported way to configure data directories for kafka brokers."
+      "Please use 'log.dirs' under kafka_broker_custom_properties with comma separated directories."
+  loop: "{{ groups['kafka_broker'] }}"
+
+# To avoid a catastrophic user error where root directory permissions get recursively changed
+- name: Assert log.dirs Property not Misconfigured
+  assert:
+    that:
+      - kafka_broker_final_properties['log.dirs'].split(',')[0] != "/"
+    fail_msg: "If you have log.dirs in kafka_broker_custom_properties, make sure it's comma separated directories."
+
 - name: Stop Service and Remove Packages on Version Change
   include_role:
     name: common
@@ -145,13 +164,6 @@
   tags:
     - privileged
     - filesystem
-
-# To avoid a catastrophic user error where root directory permissions get recursively changed
-- name: Assert log.dirs Property not Misconfigured
-  assert:
-    that:
-      - kafka_broker_final_properties['log.dirs'].split(',')[0] != "/"
-    fail_msg: "Make sure datadir key is set to list of directories, NOT a string or dictionary."
 
 - name: Set Permissions on Data Dirs
   file:

--- a/roles/variables/vars/main.yml
+++ b/roles/variables/vars/main.yml
@@ -101,8 +101,6 @@ kafka_broker:
   log4j_file: "{% if installation_method == 'archive' %}{{archive_destination_path}}/confluent-{{confluent_package_version}}{% endif %}/etc/kafka/log4j.properties"
   jaas_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/kafka/kafka_server_jaas.conf"
   rest_proxy_password_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/kafka/password.properties"
-  datadir:
-    - /var/lib/kafka/data
 
 mds_http_protocol: "{{ 'https' if kafka_broker_rest_ssl_enabled|bool else 'http' }}"
 mds_tls_enabled: "{{true if 'https' in mds_bootstrap_server_urls else false}}"


### PR DESCRIPTION
# Description

dataDir under kafka properties has been obsolete way of providing the data directories. The recommended way is to use `log.dirs` key under `kafka_broker_custom_properties`

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Local molecule scenario


**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible