### PR TITLE
Custom user log dir fix

### DIFF
--- a/molecule/custom-user-plaintext-rhel/molecule.yml
+++ b/molecule/custom-user-plaintext-rhel/molecule.yml
@@ -99,28 +99,21 @@ provisioner:
       zookeeper:
         zookeeper_user: cp-test
         zookeeper_group: cp-test-group
-        zookeeper:
       kafka_broker:
         kafka_broker_user: broker-test
         kafka_broker_group: cp-test-group
-        kafka_broker:
       schema_registry:
         schema_registry_user: sr-custom
         schema_registry_group: sr-custom-group
-        schema_registry:
       kafka_rest:
         kafka_rest_user: rest-custom
         kafka_rest_group: rest-custom-group
-        kafka_rest:
       ksql:
         ksql_user: ksql-custom
         ksql_group: ksql-custom-group
-        ksql:
       kafka_connect:
         kafka_connect_user: connect-custom
         kafka_connect_group: connect-custom-group
-        kafka_connect:
       control_center:
         control_center_user: c3-custom
         control_center_group: c3-custom-group
-        control_center:

--- a/molecule/custom-user-plaintext-rhel/molecule.yml
+++ b/molecule/custom-user-plaintext-rhel/molecule.yml
@@ -89,38 +89,38 @@ provisioner:
     group_vars:
       all:
         scenario_name: custom-user-plaintext-rhel
+        zookeeper_log_dir: /kafka/logs/
+        kafka_broker_log_dir: /kafka/logs/
+        schema_registry_log_dir: /kafka/logs/schemaregistry/
+        kafka_rest_log_dir: /kafka/logs/kafkarest/
+        ksql_log_dir: /kafka/logs/ksql/
+        kafka_connect_log_dir: /kafka/logs/kafkaconnect/
+        control_center_log_dir: /kafka/logs/controlcenter/
       zookeeper:
         zookeeper_user: cp-test
         zookeeper_group: cp-test-group
         zookeeper:
-          log_path: /kafka/logs/
       kafka_broker:
         kafka_broker_user: broker-test
         kafka_broker_group: cp-test-group
         kafka_broker:
-          appender_log_path: /kafka/logs/
       schema_registry:
         schema_registry_user: sr-custom
         schema_registry_group: sr-custom-group
         schema_registry:
-          appender_log_path: /kafka/logs/schemaregistry/
       kafka_rest:
         kafka_rest_user: rest-custom
         kafka_rest_group: rest-custom-group
         kafka_rest:
-          appender_log_path: /kafka/logs/kafkarest/
       ksql:
         ksql_user: ksql-custom
         ksql_group: ksql-custom-group
         ksql:
-          appender_log_path: /kafka/logs/ksql/
       kafka_connect:
         kafka_connect_user: connect-custom
         kafka_connect_group: connect-custom-group
         kafka_connect:
-          appender_log_path: /kafka/logs/kafkaconnect/
       control_center:
         control_center_user: c3-custom
         control_center_group: c3-custom-group
         control_center:
-          appender_log_path: /kafka/logs/controlcenter/

--- a/roles/kafka_broker/tasks/secrets_protection.yml
+++ b/roles/kafka_broker/tasks/secrets_protection.yml
@@ -48,7 +48,7 @@
   systemd:
     name: "{{kafka_broker_service_name}}"
     enabled: true
-    daemon_reload: yes
+    daemon_reload: true
     state: restarted
   tags:
     - systemd


### PR DESCRIPTION
# Description

Custom user scenario was using a very old and deprecated key appender_log_dir, which is no more supported.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Successfully running with scenario `custom-user-plaintext-rhel`


**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible