### PR TITLE
Add always tag to import var task

### DIFF
--- a/playbooks/fetch_logs.yml
+++ b/playbooks/fetch_logs.yml
@@ -1,6 +1,7 @@
 ---
 - name: Import all variables
   hosts: all
+  tags: always
   tasks:
     - import_role:
         name: variables


### PR DESCRIPTION
# Description

Something missed in https://github.com/confluentinc/cp-ansible/pull/1025
Adding tag `always` to import variables play, so that we can run with any component specific tag without failure. 

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?



**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible