### PR TITLE
use separate var to register output of each health check task

### DIFF
--- a/roles/confluent.kafka_broker/tasks/health_check.yml
+++ b/roles/confluent.kafka_broker/tasks/health_check.yml
@@ -3,9 +3,9 @@
   shell: |
     {{ binary_base_path }}/bin/kafka-topics --bootstrap-server {{inventory_hostname}}:{{kafka_broker_listeners[kafka_broker_inter_broker_listener_name]['port']}} \
       --describe --under-replicated-partitions --command-config {{kafka_broker.client_config_file}}
-  register: topics1
+  register: urp_topics
   # stdout_lines will have topics with URPs and stderr has WARN and ERROR level logs
-  until: topics1.stdout_lines|length == 0 and 'ERROR' not in topics1.stderr
+  until: urp_topics.stdout_lines|length == 0 and 'ERROR' not in urp_topics.stderr
   retries: 15
   delay: 5
   ignore_errors: true
@@ -19,9 +19,9 @@
       --describe --under-replicated-partitions --command-config {{kafka_broker.client_config_file}}
   environment:
     CONFLUENT_SECURITY_MASTER_KEY: "{{ secrets_protection_masterkey }}"
-  register: topics2
+  register: urp_topics_secrets_protection
   # stdout_lines will have topics with URPs and stderr has WARN and ERROR level logs
-  until: topics2.stdout_lines|length == 0 and 'ERROR' not in topics2.stderr
+  until: urp_topics_secrets_protection.stdout_lines|length == 0 and 'ERROR' not in urp_topics_secrets_protection.stderr
   retries: 15
   delay: 5
   ignore_errors: true
@@ -46,7 +46,7 @@
   when:
     - rbac_enabled|bool and not external_mds_enabled|bool
     # Skip if any previous check failed
-    - not topics1.failed|default(False) and not topics2.failed|default(False)
+    - not urp_topics.failed|default(False) and not urp_topics_secrets_protection.failed|default(False)
     - not fips_enabled|bool
 
 - name: Wait for Embedded Rest Proxy to start
@@ -66,7 +66,7 @@
   when:
     - kafka_broker_rest_proxy_enabled|bool
     # Skip if any previous checks failed
-    - not topics1.failed|default(False) and not topics2.failed|default(False) and not mds_result.failed|default(False)
+    - not urp_topics.failed|default(False) and not urp_topics_secrets_protection.failed|default(False) and not mds_result.failed|default(False)
     - not fips_enabled|bool
 
 - name: Fetch Log Files and Error out
@@ -85,4 +85,4 @@
       fail:
         msg: Health checks failed. Review exported files.
   # When only one health check runs, only one will have a 'failed' field. For skipped checks, defaulting 'failed' to False
-  when: topics1.failed|default(False) or topics2.failed|default(False) or mds_result.failed|default(False) or erp_result.failed|default(False)
+  when: urp_topics.failed|default(False) or urp_topics_secrets_protection.failed|default(False) or mds_result.failed|default(False) or erp_result.failed|default(False)

--- a/roles/confluent.kafka_broker/tasks/health_check.yml
+++ b/roles/confluent.kafka_broker/tasks/health_check.yml
@@ -3,9 +3,9 @@
   shell: |
     {{ binary_base_path }}/bin/kafka-topics --bootstrap-server {{inventory_hostname}}:{{kafka_broker_listeners[kafka_broker_inter_broker_listener_name]['port']}} \
       --describe --under-replicated-partitions --command-config {{kafka_broker.client_config_file}}
-  register: topics
+  register: topics1
   # stdout_lines will have topics with URPs and stderr has WARN and ERROR level logs
-  until: topics.stdout_lines|length == 0 and 'ERROR' not in topics.stderr
+  until: topics1.stdout_lines|length == 0 and 'ERROR' not in topics1.stderr
   retries: 15
   delay: 5
   ignore_errors: true
@@ -19,9 +19,9 @@
       --describe --under-replicated-partitions --command-config {{kafka_broker.client_config_file}}
   environment:
     CONFLUENT_SECURITY_MASTER_KEY: "{{ secrets_protection_masterkey }}"
-  register: topics
+  register: topics2
   # stdout_lines will have topics with URPs and stderr has WARN and ERROR level logs
-  until: topics.stdout_lines|length == 0 and 'ERROR' not in topics.stderr
+  until: topics2.stdout_lines|length == 0 and 'ERROR' not in topics2.stderr
   retries: 15
   delay: 5
   ignore_errors: true
@@ -46,7 +46,7 @@
   when:
     - rbac_enabled|bool and not external_mds_enabled|bool
     # Skip if any previous check failed
-    - not topics.failed|default(False)
+    - not topics1.failed|default(False) and not topics2.failed|default(False)
     - not fips_enabled|bool
 
 - name: Wait for Embedded Rest Proxy to start
@@ -66,7 +66,7 @@
   when:
     - kafka_broker_rest_proxy_enabled|bool
     # Skip if any previous checks failed
-    - not topics.failed|default(False) and not mds_result.failed|default(False)
+    - not topics1.failed|default(False) and not topics2.failed|default(False) and not mds_result.failed|default(False)
     - not fips_enabled|bool
 
 - name: Fetch Log Files and Error out
@@ -85,4 +85,4 @@
       fail:
         msg: Health checks failed. Review exported files.
   # When only one health check runs, only one will have a 'failed' field. For skipped checks, defaulting 'failed' to False
-  when: topics.failed|default(False) or mds_result.failed|default(False) or erp_result.failed|default(False)
+  when: topics1.failed|default(False) or topics2.failed|default(False) or mds_result.failed|default(False) or erp_result.failed|default(False)


### PR DESCRIPTION
# Description

Our code fell prey to an infamous ansible default behaviour - registering vars even for skipped tasks. 
Refer https://github.com/ansible/ansible/issues/17500 or https://github.com/ansible/ansible/issues/4297
The suggested solution is to use separate variables to register output of separate tasks. 

Fixes # https://github.com/confluentinc/cp-ansible/issues/954 and https://github.com/confluentinc/cp-ansible/issues/1041

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested locally with the fix. 


**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible