### PR TITLE
6.1.x pint

### DIFF
--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -236,11 +236,11 @@ Default:  ""
 
 ***
 
-### archive_config_base_path
+### config_base_path
 
 If the installation_method is 'archive' then this will be the base path for the configuration files, otherwise configuration files are in the default /etc locations. For example, configuration files may be placed in `/opt/confluent/etc` using this variable.
 
-Default:  "{{ archive_destination_path }}"
+Default:  {{ (archive_destination_path | regex_replace('\\/$','')) if installation_method == 'archive' else '' }}
 
 ***
 
@@ -544,7 +544,7 @@ Default:  "{{ zookeeper_ssl_enabled }}"
 
 Path on Zookeeper host for Jolokia Configuration file
 
-Default:  "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/kafka/zookeeper_jolokia.properties"
+Default:  "{{ (config_base_path, '/etc/kafka/zookeeper_jolokia.properties' ) | path_join }}"
 
 ***
 
@@ -728,7 +728,7 @@ Default:  "{{ ssl_enabled }}"
 
 Path on Kafka host for Jolokia Configuration file
 
-Default:  "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/kafka/kafka_jolokia.properties"
+Default:  "{{ (config_base_path,'/etc/kafka/kafka_jolokia.properties') | path_join }}"
 
 ***
 
@@ -920,7 +920,7 @@ Default:  "{{ schema_registry_ssl_enabled }}"
 
 Path on Schema Registry host for Jolokia Configuration file
 
-Default:  "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/schema-registry/schema_registry_jolokia.properties"
+Default:  "{{ (config_base_path,'/etc/schema-registry/schema_registry_jolokia.properties') | path_join }}"
 
 ***
 
@@ -1080,7 +1080,7 @@ Default:  "{{ kafka_rest_ssl_enabled }}"
 
 Path on Rest Proxy host for Jolokia Configuration file
 
-Default:  "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/kafka-rest/kafka_rest_jolokia.properties"
+Default:  "{{ (config_base_path,'/etc/kafka-rest/kafka_rest_jolokia.properties') | path_join }}"
 
 ***
 
@@ -1248,7 +1248,7 @@ Default:  "{{ kafka_connect_ssl_enabled }}"
 
 Path on Connect host for Jolokia Configuration file
 
-Default:  "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/kafka/kafka_connect_jolokia.properties"
+Default:  "{{ (config_base_path,'/etc/kafka/kafka_connect_jolokia.properties') | path_join }}"
 
 ***
 
@@ -1448,7 +1448,7 @@ Default:  "{{ ksql_ssl_enabled }}"
 
 Path on ksqlDB host for Jolokia Configuration file
 
-Default:  "{{ archive_config_base_path if installation_method == 'archive' else '' }}{{(confluent_package_version is version('5.5.0', '>=')) | ternary('/etc/ksqldb/ksql_jolokia.properties' , '/etc/ksql/ksql_jolokia.properties')}}"
+Default:  "{{ (config_base_path,((confluent_package_version is version('5.5.0', '>=')) | ternary('/etc/ksqldb/ksql_jolokia.properties' , '/etc/ksql/ksql_jolokia.properties')) | path_join }}"
 
 ***
 

--- a/roles/confluent.common/tasks/main.yml
+++ b/roles/confluent.common/tasks/main.yml
@@ -45,7 +45,7 @@
     group: "{{ omit if archive_group == '' else archive_group }}"
     owner: "{{ omit if archive_owner == '' else archive_owner }}"
     mode: 0755
-    creates: "{{archive_destination_path}}/confluent-{{confluent_package_version}}"
+    creates: "{{binary_base_path}}"
   when: installation_method == "archive"
 
 - name: Create Jolokia directory

--- a/roles/confluent.kafka_broker/tasks/dynamic_groups.yml
+++ b/roles/confluent.kafka_broker/tasks/dynamic_groups.yml
@@ -37,7 +37,7 @@
 - name: Set kafka_broker_current_version variable - Archive Installer
   set_fact:
     kafka_broker_current_version: "{{ (slurped_override.content|b64decode) .split('\n') |
-      select('match', '^ExecStart=' + archive_config_base_path + '/confluent-(.*)/bin/kafka-server-start ' + kafka_broker.config_file) |
+      select('match', '^ExecStart=' + config_base_path + '/confluent-(.*)/bin/kafka-server-start ' + kafka_broker.config_file) |
       list | first | regex_search('confluent-([0-9]+(.[0-9]+)+)/bin/', '\\1') | first }}"
   when: installation_method == "archive"
 

--- a/roles/confluent.ssl/tasks/create_keystores_from_certs.yml
+++ b/roles/confluent.ssl/tasks/create_keystores_from_certs.yml
@@ -34,7 +34,7 @@
       -storepass {{truststore_storepass}} \
       -keypass {{truststore_storepass}} \
       -providerclass org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider \
-      -providerpath {% if installation_method == 'archive' %}{{archive_destination_path}}/confluent-{{confluent_package_version}}/{% else %}/usr/{% endif %}share/java/kafka/bc-fips-*.jar
+      -providerpath {{ (binary_base_path, 'share/java/kafka/bc-fips-*.jar') | path_join }}
   when:
     - cert_count|int == 1
     - create_bouncy_castle_keystore|bool
@@ -75,7 +75,7 @@
       -deststoretype BCFKS \
       -providername BCFIPS \
       -providerclass org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider \
-      -providerpath {% if installation_method == 'archive' %}{{archive_destination_path}}/confluent-{{confluent_package_version}}/{% else %}/usr/{% endif %}share/java/kafka/bc-fips-*.jar
+      -providerpath {{ (binary_base_path, 'share/java/kafka/bc-fips-*.jar') | path_join }}
   when: create_bouncy_castle_keystore|bool
   no_log: "{{mask_secrets|bool}}"
 
@@ -96,6 +96,6 @@
       -import -file {{ca_cert_path}} \
       -storepass {{keystore_storepass}} \
       -providerclass org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider \
-      -providerpath {% if installation_method == 'archive' %}{{archive_destination_path}}/confluent-{{confluent_package_version}}/{% else %}/usr/{% endif %}share/java/kafka/bc-fips-*.jar
+      -providerpath {{ (binary_base_path, 'share/java/kafka/bc-fips-*.jar') | path_join }}
   when: create_bouncy_castle_keystore|bool
   no_log: "{{mask_secrets|bool}}"

--- a/roles/confluent.ssl/tasks/import_ca_chain.yml
+++ b/roles/confluent.ssl/tasks/import_ca_chain.yml
@@ -31,6 +31,6 @@
             -deststorepass {{truststore_storepass}} \
             -providername BCFIPS \
             -providerclass org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider \
-            -providerpath {% if installation_method == 'archive' %}{{archive_destination_path}}/confluent-{{confluent_package_version}}/{% else %}/usr/{% endif %}share/java/kafka/bc-fips-*.jar
+            -providerpath {{ (binary_base_path, 'share/java/kafka/bc-fips-*.jar') | path_join }}
     done
   when: create_bouncy_castle_keystore|bool

--- a/roles/confluent.test/molecule/mtls-custombundle-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/mtls-custombundle-rhel/molecule.yml
@@ -144,6 +144,12 @@ provisioner:
         kafka_rest_secrets_protection_encrypt_passwords: false
         kafka_rest_secrets_protection_encrypt_properties: [listeners, bootstrap.servers]
 
+        kafka_broker_secrets_protection_encrypt_properties: [advertised.listeners, broker.id, ssl.key.password]
+        schema_registry_secrets_protection_encrypt_properties: [ssl.keystore.location]
+        kafka_rest_secrets_protection_encrypt_passwords: false
+        kafka_rest_secrets_protection_encrypt_properties: [listeners, bootstrap.servers]
+
+
         # cert creation script does not use fqdn, which is a requirement for zk ssl
         zookeeper_ssl_enabled: false
 

--- a/roles/confluent.test/molecule/mtls-custombundle-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/mtls-custombundle-rhel/molecule.yml
@@ -139,16 +139,10 @@ provisioner:
         secrets_protection_masterkey: "UWQYODNQVqwbQeFgytYYoMr+FjK9Q6I0F6r16u6Z0EI="
         secrets_protection_security_file: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/security.properties"
         # Test the unique filter by adding a prop containing password
-        kafka_broker_secrets_protection_encrypt_properties: [advertised.listeners, broker.id, ssl.key.password]
         schema_registry_secrets_protection_encrypt_properties: [ssl.keystore.location]
-        kafka_rest_secrets_protection_encrypt_passwords: false
         kafka_rest_secrets_protection_encrypt_properties: [listeners, bootstrap.servers]
-
+        kafka_rest_secrets_protection_encrypt_passwords: false
         kafka_broker_secrets_protection_encrypt_properties: [advertised.listeners, broker.id, ssl.key.password]
-        schema_registry_secrets_protection_encrypt_properties: [ssl.keystore.location]
-        kafka_rest_secrets_protection_encrypt_passwords: false
-        kafka_rest_secrets_protection_encrypt_properties: [listeners, bootstrap.servers]
-
 
         # cert creation script does not use fqdn, which is a requirement for zk ssl
         zookeeper_ssl_enabled: false

--- a/roles/confluent.variables/defaults/main.yml
+++ b/roles/confluent.variables/defaults/main.yml
@@ -1527,7 +1527,7 @@ kafka_connect_replicator_jolokia_password: "{{jolokia_password}}"
 ### Port for Jolokia agent for Kafka Connect Replicator.
 kafka_connect_replicator_jolokia_port: 7777
 
-kafka_connect_replicator_jolokia_config: "{{ (config_base_path ,'etc/kafka-connect-replicator/confluent-replicator-jolokia.properties' ) path_join }}"
+kafka_connect_replicator_jolokia_config: "{{ (config_base_path ,'etc/kafka-connect-replicator/confluent-replicator-jolokia.properties' ) | path_join }}"
 
 ### Full path to download the Jolokia Agent Jar.
 kafka_connect_replicator_jolokia_jar_path: /opt/jolokia/jolokia.jar

--- a/roles/confluent.variables/defaults/main.yml
+++ b/roles/confluent.variables/defaults/main.yml
@@ -1527,7 +1527,7 @@ kafka_connect_replicator_jolokia_password: "{{jolokia_password}}"
 ### Port for Jolokia agent for Kafka Connect Replicator.
 kafka_connect_replicator_jolokia_port: 7777
 
-kafka_connect_replicator_jolokia_config: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/kafka-connect-replicator/confluent-replicator-jolokia.properties"
+kafka_connect_replicator_jolokia_config: "{{ (config_base_path ,'etc/kafka-connect-replicator/confluent-replicator-jolokia.properties' ) path_join }}"
 
 ### Full path to download the Jolokia Agent Jar.
 kafka_connect_replicator_jolokia_jar_path: /opt/jolokia/jolokia.jar

--- a/roles/confluent.variables/defaults/main.yml
+++ b/roles/confluent.variables/defaults/main.yml
@@ -113,7 +113,7 @@ archive_owner: ""
 archive_group: ""
 
 ### If the installation_method is 'archive' then this will be the base path for the configuration files, otherwise configuration files are in the default /etc locations. For example, configuration files may be placed in `/opt/confluent/etc` using this variable.
-archive_config_base_path: "{{ archive_destination_path }}"
+config_base_path: "{{ (archive_destination_path | regex_replace('\\/$','')) if installation_method == 'archive' else '/' }}"
 
 ### Boolean to have cp-ansible download the Confluent CLI
 confluent_cli_download_enabled: "{{rbac_enabled or secrets_protection_enabled}}"
@@ -249,8 +249,8 @@ zookeeper_keytab_path: /etc/security/keytabs/zookeeper.keytab
 
 zookeeper:
   # TODO deprecate these
-  jaas_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/kafka/zookeeper_jaas.conf"
   log_path: "{{zookeeper_default_log_dir}}"
+  jaas_file: "{{ (config_base_path,'etc/kafka/zookeeper_jaas.conf') | path_join }}"
   # Deprecated way of providing custom properties
   properties: {}
 
@@ -264,7 +264,7 @@ zookeeper_jolokia_port: 7770
 zookeeper_jolokia_ssl_enabled: "{{ zookeeper_ssl_enabled }}"
 
 ### Path on Zookeeper host for Jolokia Configuration file
-zookeeper_jolokia_config: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/kafka/zookeeper_jolokia.properties"
+zookeeper_jolokia_config: "{{ (config_base_path, 'etc/kafka/zookeeper_jolokia.properties' ) | path_join }}"
 
 ### Authentication Mode for Zookeeper's Jolokia Agent. Possible values: none, basic. If selecting basic, you must set zookeeper_jolokia_user and zookeeper_jolokia_password
 zookeeper_jolokia_auth_mode: "{{jolokia_auth_mode}}"
@@ -404,8 +404,8 @@ kafka_broker_keytab_path: /etc/security/keytabs/kafka_broker.keytab
 
 kafka_broker:
   # TODO deprecate these variables
-  jaas_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/kafka/kafka_server_jaas.conf"
   appender_log_path: "{{kafka_broker_default_log_dir}}"
+  jaas_file: "{{ (config_base_path,'etc/kafka/kafka_server_jaas.conf') | path_join }}"
   # Deprecated way of providing custom properties
   properties: {}
   # Deprecated way of setting kafkas log.dirs property, use kafka_broker_custom_properties:
@@ -426,7 +426,7 @@ kafka_broker_jolokia_port: 7771
 kafka_broker_jolokia_ssl_enabled: "{{ ssl_enabled }}"
 
 ### Path on Kafka host for Jolokia Configuration file
-kafka_broker_jolokia_config: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/kafka/kafka_jolokia.properties"
+kafka_broker_jolokia_config: "{{ (config_base_path,'etc/kafka/kafka_jolokia.properties') | path_join }}"
 
 ### Authentication Mode for Kafka's Jolokia Agent. Possible values: none, basic. If selecting basic, you must set kafka_broker_jolokia_user and kafka_broker_jolokia_password
 kafka_broker_jolokia_auth_mode: "{{jolokia_auth_mode}}"
@@ -534,7 +534,7 @@ schema_registry_jolokia_port: 7772
 schema_registry_jolokia_ssl_enabled: "{{ schema_registry_ssl_enabled }}"
 
 ### Path on Schema Registry host for Jolokia Configuration file
-schema_registry_jolokia_config: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/schema-registry/schema_registry_jolokia.properties"
+schema_registry_jolokia_config: "{{ (config_base_path,'etc/schema-registry/schema_registry_jolokia.properties') | path_join }}"
 
 ### Authentication Mode for Schema Registry's Jolokia Agent. Possible values: none, basic. If selecting basic, you must set schema_registry_jolokia_user and schema_registry_jolokia_password
 schema_registry_jolokia_auth_mode: "{{jolokia_auth_mode}}"
@@ -626,7 +626,7 @@ kafka_rest_jolokia_port: 7775
 kafka_rest_jolokia_ssl_enabled: "{{ kafka_rest_ssl_enabled }}"
 
 ### Path on Rest Proxy host for Jolokia Configuration file
-kafka_rest_jolokia_config: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/kafka-rest/kafka_rest_jolokia.properties"
+kafka_rest_jolokia_config: "{{ (config_base_path,'etc/kafka-rest/kafka_rest_jolokia.properties') | path_join }}"
 
 ### Authentication Mode for Rest Proxy's Jolokia Agent. Possible values: none, basic. If selecting basic, you must set schema_registry_jolokia_user and schema_registry_jolokia_password
 kafka_rest_jolokia_auth_mode: "{{jolokia_auth_mode}}"
@@ -726,7 +726,7 @@ kafka_connect_jolokia_port: 7773
 kafka_connect_jolokia_ssl_enabled: "{{ kafka_connect_ssl_enabled }}"
 
 ### Path on Connect host for Jolokia Configuration file
-kafka_connect_jolokia_config: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/kafka/kafka_connect_jolokia.properties"
+kafka_connect_jolokia_config: "{{ (config_base_path,'etc/kafka/kafka_connect_jolokia.properties') | path_join }}"
 
 ### Authentication Mode for Connect's Jolokia Agent. Possible values: none, basic. If selecting basic, you must set schema_registry_jolokia_user and schema_registry_jolokia_password
 kafka_connect_jolokia_auth_mode: "{{jolokia_auth_mode}}"
@@ -767,7 +767,7 @@ kafka_connect_secret_registry_key: 39ff95832750c0090d84ddf5344583832efe91ef
 kafka_connect_secret_registry_default_replication_factor:  "{{ [ groups['kafka_broker'] | default(['localhost']) | length, default_internal_replication_factor ] | min }}"
 
 kafka_connect_plugins_path:
-  - "{% if installation_method == 'archive' %}{{archive_destination_path}}/confluent-{{confluent_package_version}}/{% else %}/usr/{% endif %}share/java"
+  - "{{ (binary_base_path, 'share/java') | path_join }}"
 
 
 kafka_connect_confluent_hub_plugins: []
@@ -847,7 +847,7 @@ ksql_jolokia_port: 7774
 ksql_jolokia_ssl_enabled: "{{ ksql_ssl_enabled }}"
 
 ### Path on ksqlDB host for Jolokia Configuration file
-ksql_jolokia_config: "{{ archive_config_base_path if installation_method == 'archive' else '' }}{{(confluent_package_version is version('5.5.0', '>=')) | ternary('/etc/ksqldb/ksql_jolokia.properties' , '/etc/ksql/ksql_jolokia.properties')}}"
+ksql_jolokia_config: "{{ (config_base_path,((confluent_package_version is version('5.5.0', '>=')) | ternary('etc/ksqldb/ksql_jolokia.properties' , 'etc/ksql/ksql_jolokia.properties'))) | path_join }}"
 
 ### Authentication Mode for ksqlDB's Jolokia Agent. Possible values: none, basic. If selecting basic, you must set schema_registry_jolokia_user and schema_registry_jolokia_password
 ksql_jolokia_auth_mode: "{{jolokia_auth_mode}}"

--- a/roles/confluent.variables/vars/main.yml
+++ b/roles/confluent.variables/vars/main.yml
@@ -1038,10 +1038,6 @@ control_center_combined_properties: "{{control_center_properties | combine_prope
 
 control_center_final_properties: "{{ control_center_combined_properties | combine(control_center_custom_properties) }}"
 
-### The base path for the binary files. When in Archive File deployment mode this results in binary files being based in, for example `/opt/confluent/confluent-5.5.1/bin`, otherwise they are based in `/usr/bin`.
-binary_base_path: "{{ ((config_base_path,('confluent-',confluent_package_version) | join) | path_join) if installation_method == 'archive' else '/usr' }}"
-
-
 #### Kafka Connect Replicator Variables ####
 kafka_connect_replicator_service_name: kafka-connect-replicator
 kafka_connect_replicator_default_user: cp-kafka-connect-replicator

--- a/roles/confluent.variables/vars/main.yml
+++ b/roles/confluent.variables/vars/main.yml
@@ -21,7 +21,7 @@ zookeeper:
   systemd_file: "{{systemd_base_dir}}/{{zookeeper_service_name}}.service"
   config_file: "{{ (config_base_path , 'etc/kafka/zookeeper.properties') | path_join }}"
   systemd_override: /etc/systemd/system/{{zookeeper_service_name}}.service.d/override.conf
-  log4j_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/kafka/zookeeper-log4j.properties"
+  log4j_file: "{{ (config_base_path, '/etc/kafka/zookeeper-log4j.properties' ) | path_join }}"
 
 zookeeper_properties:
   defaults:
@@ -1039,7 +1039,7 @@ control_center_combined_properties: "{{control_center_properties | combine_prope
 control_center_final_properties: "{{ control_center_combined_properties | combine(control_center_custom_properties) }}"
 
 ### The base path for the binary files. When in Archive File deployment mode this results in binary files being based in, for example `/opt/confluent/confluent-5.5.1/bin`, otherwise they are based in `/usr/bin`.
-binary_base_path: "{{ archive_config_base_path+'/confluent-'+archive_version if installation_method == 'archive' else '/usr' }}"
+binary_base_path: "{{ ((config_base_path,('confluent-',confluent_package_version) | join) | path_join) if installation_method == 'archive' else '/usr' }}"
 
 
 #### Kafka Connect Replicator Variables ####
@@ -1049,10 +1049,10 @@ kafka_connect_replicator_default_group: confluent
 
 kafka_connect_replicator:
   server_start_file: "{{ binary_base_path }}/bin/kafka-connect-replicator-start"
-  replication_config_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/kafka-connect-replicator/kafka-connect-replicator.properties"
-  consumer_config_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/kafka-connect-replicator/kafka-connect-replicator-consumer.properties"
-  producer_config_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/kafka-connect-replicator/kafka-connect-replicator-producer.properties"
-  interceptors_config_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/kafka-connect-replicator/kafka-connect-replicator-interceptors.properties"
+  replication_config_file: "{{ (config_base_path, 'etc/kafka-connect-replicator/kafka-connect-replicator.properties') | path_join }}"
+  consumer_config_file: "{{ (config_base_path, 'etc/kafka-connect-replicator/kafka-connect-replicator-consumer.properties') | path_join }}"
+  producer_config_file: "{{ (config_base_path, 'etc/kafka-connect-replicator/kafka-connect-replicator-producer.properties') | path_join }}"
+  interceptors_config_file: "{{ (config_base_path, 'etc/kafka-connect-replicator/kafka-connect-replicator-interceptors.properties') | path_join }}"
   systemd_file: "{{systemd_base_dir}}/{{kafka_connect_replicator_service_name}}.service"
   systemd_override: /etc/systemd/system/{{kafka_connect_replicator_service_name}}.service.d/override.conf
   log4j_file: "{% if installation_method == 'archive' %}{{archive_destination_path}}/confluent-{{confluent_package_version}}{% endif %}/etc/kafka-connect-replicator/replicator-log4j.properties"

--- a/roles/confluent.variables/vars/main.yml
+++ b/roles/confluent.variables/vars/main.yml
@@ -944,7 +944,6 @@ control_center:
   systemd_file: "{{systemd_base_dir}}/{{control_center_service_name}}.service"
   config_file: "{{ (config_base_path,'etc/confluent-control-center/control-center-production.properties') | path_join }}"
   systemd_override: /etc/systemd/system/{{control_center_service_name}}.service.d/override.conf
-  log4j_file: "{% if installation_method == 'archive' %}{{archive_destination_path}}/confluent-{{confluent_package_version}}{% endif %}/etc/confluent-control-center/log4j-rolling.properties"
   log4j_file: "{{ (base_path, '/etc/confluent-control-center/log4j-rolling.properties') | path_join }}"
 
 control_center_http_protocol: "{{ 'https' if control_center_ssl_enabled|bool else 'http' }}"

--- a/roles/confluent.variables/vars/main.yml
+++ b/roles/confluent.variables/vars/main.yml
@@ -481,7 +481,7 @@ kafka_connect:
   systemd_file: "{{systemd_base_dir}}/{{kafka_connect_service_name}}.service"
   config_file: "{{ (config_base_path,'etc/kafka/connect-distributed.properties') | path_join }}"
   systemd_override: /etc/systemd/system/{{kafka_connect_service_name}}.service.d/override.conf
-  log4j_file: "{{ (base_path, '/etc/kafka/connect-log4j.properties') | path_join }}"
+  log4j_file: "{{ (base_path, 'etc/kafka/connect-log4j.properties') | path_join }}"
 
 kafka_connect_http_protocol: "{{ 'https' if kafka_connect_ssl_enabled|bool else 'http' }}"
 
@@ -670,7 +670,7 @@ ksql:
   systemd_file: "{{systemd_base_dir}}/{{ksql_service_name}}.service"
   config_file: "{{ (config_base_path, (confluent_package_version is version('5.5.0', '>=')) | ternary('etc/ksqldb/ksql-server.properties','etc/ksql/ksql-server.properties') ) | path_join }}"
   systemd_override: /etc/systemd/system/{{ksql_service_name}}.service.d/override.conf
-  log4j_file: "{{ (base_path, '/etc/ksqldb/ksqldb-log4j.properties') | path_join }}"
+  log4j_file: "{{ (base_path, 'etc/ksqldb/ksqldb-log4j.properties') | path_join }}"
 
 ksql_http_protocol: "{{ 'https' if ksql_ssl_enabled|bool else 'http' }}"
 
@@ -821,7 +821,7 @@ kafka_rest:
   systemd_file: "{{systemd_base_dir}}/{{kafka_rest_service_name}}.service"
   config_file: "{{ (config_base_path,'etc/kafka-rest/kafka-rest.properties') | path_join }}"
   systemd_override: /etc/systemd/system/{{kafka_rest_service_name}}.service.d/override.conf
-  log4j_file: "{{ (base_path, '/etc/kafka-rest/log4j.properties') | path_join }}"
+  log4j_file: "{{ (base_path, 'etc/kafka-rest/log4j.properties') | path_join }}"
 
 kafka_rest_http_protocol: "{{ 'https' if kafka_rest_ssl_enabled|bool else 'http' }}"
 
@@ -944,7 +944,7 @@ control_center:
   systemd_file: "{{systemd_base_dir}}/{{control_center_service_name}}.service"
   config_file: "{{ (config_base_path,'etc/confluent-control-center/control-center-production.properties') | path_join }}"
   systemd_override: /etc/systemd/system/{{control_center_service_name}}.service.d/override.conf
-  log4j_file: "{{ (base_path, '/etc/confluent-control-center/log4j-rolling.properties') | path_join }}"
+  log4j_file: "{{ (base_path, 'etc/confluent-control-center/log4j-rolling.properties') | path_join }}"
 
 control_center_http_protocol: "{{ 'https' if control_center_ssl_enabled|bool else 'http' }}"
 
@@ -1052,7 +1052,7 @@ kafka_connect_replicator:
   interceptors_config_file: "{{ (config_base_path, 'etc/kafka-connect-replicator/kafka-connect-replicator-interceptors.properties') | path_join }}"
   systemd_file: "{{systemd_base_dir}}/{{kafka_connect_replicator_service_name}}.service"
   systemd_override: /etc/systemd/system/{{kafka_connect_replicator_service_name}}.service.d/override.conf
-  log4j_file: "{{ (base_path, '/etc/kafka-connect-replicator/replicator-log4j.properties') | path_join }}"
+  log4j_file: "{{ (base_path, 'etc/kafka-connect-replicator/replicator-log4j.properties') | path_join }}"
 
 kafka_connect_replicator_properties:
   defaults:

--- a/roles/confluent.variables/vars/main.yml
+++ b/roles/confluent.variables/vars/main.yml
@@ -9,6 +9,7 @@ confluent_repo_version: "{{ confluent_package_version | regex_replace('^([0-9])\
 ssl_file_dir_final: "{{ ssl_file_dir |regex_replace('\\/$', '') }}"
 ### The base path for the binary files. When in Archive File deployment mode this results in binary files being based in, for example `/opt/confluent/confluent-5.5.1/bin`, otherwise they are based in `/usr/bin`.
 binary_base_path: "{{ ((config_base_path,('confluent-',confluent_package_version) | join) | path_join) if installation_method == 'archive' else '/usr' }}"
+base_path: "{{ ((config_base_path,('confluent-',confluent_package_version) | join) | path_join) if installation_method == 'archive' else '/' }}"
 
 #### Zookeeper Variables ####
 zookeeper_service_name: confluent-zookeeper
@@ -21,7 +22,7 @@ zookeeper:
   systemd_file: "{{systemd_base_dir}}/{{zookeeper_service_name}}.service"
   config_file: "{{ (config_base_path , 'etc/kafka/zookeeper.properties') | path_join }}"
   systemd_override: /etc/systemd/system/{{zookeeper_service_name}}.service.d/override.conf
-  log4j_file: "{{ (config_base_path, '/etc/kafka/zookeeper-log4j.properties' ) | path_join }}"
+  log4j_file: "{{ (base_path, 'etc/kafka/zookeeper-log4j.properties' ) | path_join }}"
 
 zookeeper_properties:
   defaults:
@@ -88,7 +89,7 @@ kafka_broker:
   zookeeper_tls_client_config_file: "{{ (config_base_path, 'etc/kafka/zookeeper-tls-client.properties') | path_join }}"
   systemd_file: "{{systemd_base_dir}}/{{kafka_broker_service_name}}.service"
   systemd_override: /etc/systemd/system/{{kafka_broker_service_name}}.service.d/override.conf
-  log4j_file: "{{ ((config_base_path,('confluent-',confluent_package_version) | join) if installation_method == 'archive' else '/','etc/kafka/log4j.properties') | path_join  }}"
+  log4j_file: "{{ (base_path, 'etc/kafka/log4j.properties') | path_join }}"
 
 mds_http_protocol: "{{ 'https' if kafka_broker_rest_ssl_enabled|bool else 'http' }}"
 mds_tls_enabled: "{{true if 'https' in mds_bootstrap_server_urls else false}}"
@@ -385,7 +386,7 @@ schema_registry:
   systemd_file: "{{systemd_base_dir}}/{{schema_registry_service_name}}.service"
   config_file: "{{ (config_base_path,'etc/schema-registry/schema-registry.properties') | path_join }}"
   systemd_override: /etc/systemd/system/{{schema_registry_service_name}}.service.d/override.conf
-  log4j_file: "{% if installation_method == 'archive' %}{{archive_destination_path}}/confluent-{{confluent_package_version}}{% endif %}/etc/schema-registry/log4j.properties"
+  log4j_file: "{{ (base_path, 'etc/schema-registry/log4j.properties') | path_join }}"
 
 schema_registry_http_protocol: "{{ 'https' if schema_registry_ssl_enabled|bool else 'http' }}"
 
@@ -480,7 +481,7 @@ kafka_connect:
   systemd_file: "{{systemd_base_dir}}/{{kafka_connect_service_name}}.service"
   config_file: "{{ (config_base_path,'etc/kafka/connect-distributed.properties') | path_join }}"
   systemd_override: /etc/systemd/system/{{kafka_connect_service_name}}.service.d/override.conf
-  log4j_file: "{% if installation_method == 'archive' %}{{archive_destination_path}}/confluent-{{confluent_package_version}}{% endif %}/etc/kafka/connect-log4j.properties"
+  log4j_file: "{{ (base_path, '/etc/kafka/connect-log4j.properties') | path_join }}"
 
 kafka_connect_http_protocol: "{{ 'https' if kafka_connect_ssl_enabled|bool else 'http' }}"
 
@@ -669,7 +670,7 @@ ksql:
   systemd_file: "{{systemd_base_dir}}/{{ksql_service_name}}.service"
   config_file: "{{ (config_base_path, (confluent_package_version is version('5.5.0', '>=')) | ternary('etc/ksqldb/ksql-server.properties','etc/ksql/ksql-server.properties') ) | path_join }}"
   systemd_override: /etc/systemd/system/{{ksql_service_name}}.service.d/override.conf
-  log4j_file: "{% if installation_method == 'archive' %}{{archive_destination_path}}/confluent-{{confluent_package_version}}{% endif %}/etc/ksqldb/ksqldb-log4j.properties"
+  log4j_file: "{{ (base_path, '/etc/ksqldb/ksqldb-log4j.properties') | path_join }}"
 
 ksql_http_protocol: "{{ 'https' if ksql_ssl_enabled|bool else 'http' }}"
 
@@ -820,7 +821,7 @@ kafka_rest:
   systemd_file: "{{systemd_base_dir}}/{{kafka_rest_service_name}}.service"
   config_file: "{{ (config_base_path,'etc/kafka-rest/kafka-rest.properties') | path_join }}"
   systemd_override: /etc/systemd/system/{{kafka_rest_service_name}}.service.d/override.conf
-  log4j_file: "{% if installation_method == 'archive' %}{{archive_destination_path}}/confluent-{{confluent_package_version}}{% endif %}/etc/kafka-rest/log4j.properties"
+  log4j_file: "{{ (base_path, '/etc/kafka-rest/log4j.properties') | path_join }}"
 
 kafka_rest_http_protocol: "{{ 'https' if kafka_rest_ssl_enabled|bool else 'http' }}"
 
@@ -944,6 +945,7 @@ control_center:
   config_file: "{{ (config_base_path,'etc/confluent-control-center/control-center-production.properties') | path_join }}"
   systemd_override: /etc/systemd/system/{{control_center_service_name}}.service.d/override.conf
   log4j_file: "{% if installation_method == 'archive' %}{{archive_destination_path}}/confluent-{{confluent_package_version}}{% endif %}/etc/confluent-control-center/log4j-rolling.properties"
+  log4j_file: "{{ (base_path, '/etc/confluent-control-center/log4j-rolling.properties') | path_join }}"
 
 control_center_http_protocol: "{{ 'https' if control_center_ssl_enabled|bool else 'http' }}"
 
@@ -1051,7 +1053,7 @@ kafka_connect_replicator:
   interceptors_config_file: "{{ (config_base_path, 'etc/kafka-connect-replicator/kafka-connect-replicator-interceptors.properties') | path_join }}"
   systemd_file: "{{systemd_base_dir}}/{{kafka_connect_replicator_service_name}}.service"
   systemd_override: /etc/systemd/system/{{kafka_connect_replicator_service_name}}.service.d/override.conf
-  log4j_file: "{% if installation_method == 'archive' %}{{archive_destination_path}}/confluent-{{confluent_package_version}}{% endif %}/etc/kafka-connect-replicator/replicator-log4j.properties"
+  log4j_file: "{{ (base_path, '/etc/kafka-connect-replicator/replicator-log4j.properties') | path_join }}"
 
 kafka_connect_replicator_properties:
   defaults:

--- a/roles/confluent.variables/vars/main.yml
+++ b/roles/confluent.variables/vars/main.yml
@@ -7,6 +7,8 @@ confluent_repo_version: "{{ confluent_package_version | regex_replace('^([0-9])\
 
 # Confirm no trailing / on the ssl file directory path
 ssl_file_dir_final: "{{ ssl_file_dir |regex_replace('\\/$', '') }}"
+### The base path for the binary files. When in Archive File deployment mode this results in binary files being based in, for example `/opt/confluent/confluent-5.5.1/bin`, otherwise they are based in `/usr/bin`.
+binary_base_path: "{{ ((config_base_path,('confluent-',confluent_package_version) | join) | path_join) if installation_method == 'archive' else '/usr' }}"
 
 #### Zookeeper Variables ####
 zookeeper_service_name: confluent-zookeeper
@@ -16,8 +18,8 @@ zookeeper_default_group: confluent
 zookeeper_default_log_dir: /var/log/kafka
 zookeeper:
   server_start_file: "{{ binary_base_path }}/bin/zookeeper-server-start"
-  config_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/kafka/zookeeper.properties"
   systemd_file: "{{systemd_base_dir}}/{{zookeeper_service_name}}.service"
+  config_file: "{{ (config_base_path , 'etc/kafka/zookeeper.properties') | path_join }}"
   systemd_override: /etc/systemd/system/{{zookeeper_service_name}}.service.d/override.conf
   log4j_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/kafka/zookeeper-log4j.properties"
 
@@ -81,12 +83,12 @@ kafka_broker_default_group: confluent
 kafka_broker_default_log_dir: /var/log/kafka
 kafka_broker:
   server_start_file: "{{ binary_base_path }}/bin/kafka-server-start"
-  config_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/kafka/server.properties"
-  client_config_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/kafka/client.properties"
-  zookeeper_tls_client_config_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/kafka/zookeeper-tls-client.properties"
+  config_file: "{{ (config_base_path , 'etc/kafka/server.properties')| path_join }}"
+  client_config_file: "{{ (config_base_path , 'etc/kafka/client.properties')| path_join }}"
+  zookeeper_tls_client_config_file: "{{ (config_base_path, 'etc/kafka/zookeeper-tls-client.properties') | path_join }}"
   systemd_file: "{{systemd_base_dir}}/{{kafka_broker_service_name}}.service"
   systemd_override: /etc/systemd/system/{{kafka_broker_service_name}}.service.d/override.conf
-  log4j_file: "{% if installation_method == 'archive' %}{{archive_destination_path}}/confluent-{{confluent_package_version}}{% endif %}/etc/kafka/log4j.properties"
+  log4j_file: "{{ ((config_base_path,('confluent-',confluent_package_version) | join) if installation_method == 'archive' else '/','etc/kafka/log4j.properties') | path_join  }}"
 
 mds_http_protocol: "{{ 'https' if kafka_broker_rest_ssl_enabled|bool else 'http' }}"
 mds_tls_enabled: "{{true if 'https' in mds_bootstrap_server_urls else false}}"
@@ -380,8 +382,8 @@ schema_registry_default_group: confluent
 schema_registry_default_log_dir: /var/log/confluent/schema-registry
 schema_registry:
   server_start_file: "{{ binary_base_path }}/bin/schema-registry-start"
-  config_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/schema-registry/schema-registry.properties"
   systemd_file: "{{systemd_base_dir}}/{{schema_registry_service_name}}.service"
+  config_file: "{{ (config_base_path,'etc/schema-registry/schema-registry.properties') | path_join }}"
   systemd_override: /etc/systemd/system/{{schema_registry_service_name}}.service.d/override.conf
   log4j_file: "{% if installation_method == 'archive' %}{{archive_destination_path}}/confluent-{{confluent_package_version}}{% endif %}/etc/schema-registry/log4j.properties"
 
@@ -475,8 +477,8 @@ kafka_connect_default_group: confluent
 kafka_connect_default_log_dir: /var/log/kafka
 kafka_connect:
   server_start_file: "{{ binary_base_path }}/bin/connect-distributed"
-  config_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/kafka/connect-distributed.properties"
   systemd_file: "{{systemd_base_dir}}/{{kafka_connect_service_name}}.service"
+  config_file: "{{ (config_base_path,'etc/kafka/connect-distributed.properties') | path_join }}"
   systemd_override: /etc/systemd/system/{{kafka_connect_service_name}}.service.d/override.conf
   log4j_file: "{% if installation_method == 'archive' %}{{archive_destination_path}}/confluent-{{confluent_package_version}}{% endif %}/etc/kafka/connect-log4j.properties"
 
@@ -664,8 +666,8 @@ ksql_default_group: confluent
 ksql_default_log_dir: /var/log/confluent/ksql
 ksql:
   server_start_file: "{{ binary_base_path }}/bin/ksql-server-start"
-  config_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}{{(confluent_package_version is version('5.5.0', '>=')) | ternary('/etc/ksqldb/ksql-server.properties' , '/etc/ksql/ksql-server.properties')}}"
   systemd_file: "{{systemd_base_dir}}/{{ksql_service_name}}.service"
+  config_file: "{{ (config_base_path, (confluent_package_version is version('5.5.0', '>=')) | ternary('etc/ksqldb/ksql-server.properties','etc/ksql/ksql-server.properties') ) | path_join }}"
   systemd_override: /etc/systemd/system/{{ksql_service_name}}.service.d/override.conf
   log4j_file: "{% if installation_method == 'archive' %}{{archive_destination_path}}/confluent-{{confluent_package_version}}{% endif %}/etc/ksqldb/ksqldb-log4j.properties"
 
@@ -815,8 +817,8 @@ kafka_rest_default_group: confluent
 kafka_rest_default_log_dir: /var/log/confluent/kafka-rest
 kafka_rest:
   server_start_file: "{{ binary_base_path }}/bin/kafka-rest-start"
-  config_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/kafka-rest/kafka-rest.properties"
   systemd_file: "{{systemd_base_dir}}/{{kafka_rest_service_name}}.service"
+  config_file: "{{ (config_base_path,'etc/kafka-rest/kafka-rest.properties') | path_join }}"
   systemd_override: /etc/systemd/system/{{kafka_rest_service_name}}.service.d/override.conf
   log4j_file: "{% if installation_method == 'archive' %}{{archive_destination_path}}/confluent-{{confluent_package_version}}{% endif %}/etc/kafka-rest/log4j.properties"
 
@@ -938,8 +940,8 @@ control_center_default_group: confluent
 control_center_default_log_dir: /var/log/confluent/control-center
 control_center:
   server_start_file: "{{ binary_base_path }}/bin/control-center-start"
-  config_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/confluent-control-center/control-center-production.properties"
   systemd_file: "{{systemd_base_dir}}/{{control_center_service_name}}.service"
+  config_file: "{{ (config_base_path,'etc/confluent-control-center/control-center-production.properties') | path_join }}"
   systemd_override: /etc/systemd/system/{{control_center_service_name}}.service.d/override.conf
   log4j_file: "{% if installation_method == 'archive' %}{{archive_destination_path}}/confluent-{{confluent_package_version}}{% endif %}/etc/confluent-control-center/log4j-rolling.properties"
 

--- a/roles/confluent.zookeeper/tasks/dynamic_groups.yml
+++ b/roles/confluent.zookeeper/tasks/dynamic_groups.yml
@@ -12,7 +12,7 @@
 - name: Set zookeeper_current_version variable - Archive Installer
   set_fact:
     zookeeper_current_version: "{{ (slurped_override.content|b64decode) .split('\n') |
-      select('match', '^ExecStart=' + archive_config_base_path + '/confluent-(.*)/bin/zookeeper-server-start ' + zookeeper.config_file) |
+      select('match', '^ExecStart=' + config_base_path + '/confluent-(.*)/bin/zookeeper-server-start ' + zookeeper.config_file) |
       list | first | regex_search('confluent-([0-9]+(.[0-9]+)+)/bin/', '\\1') | first }}"
   when: installation_method == "archive"
 

--- a/tasks/upgrade_component_archive.yml
+++ b/tasks/upgrade_component_archive.yml
@@ -21,8 +21,8 @@
 - name: Update Override to Use New Version
   lineinfile:
     path: "{{ systemd_override }}"
-    line: "ExecStart={{archive_config_base_path}}/confluent-{{confluent_package_version}}/bin/{{start_script}} {{config_file}}"
-    regexp: "ExecStart={{archive_config_base_path}}/confluent-(.*)/bin/{{start_script}} {{config_file}}"
+    line: "ExecStart={{config_base_path}}/confluent-{{confluent_package_version}}/bin/{{start_script}} {{config_file}}"
+    regexp: "ExecStart={{config_base_path}}/confluent-(.*)/bin/{{start_script}} {{config_file}}"
 
 - name: Restart Service
   systemd:

--- a/upgrade_control_center.yml
+++ b/upgrade_control_center.yml
@@ -35,7 +35,7 @@
     - name: Set control_center_current_version variable - Archive
       set_fact:
         control_center_current_version: "{{ (slurped_override.content|b64decode) .split('\n') |
-          select('match', '^ExecStart=' + archive_config_base_path + '/confluent-(.*)/bin/control-center-start ' + control_center.config_file) |
+          select('match', '^ExecStart=' + config_base_path + '/confluent-(.*)/bin/control-center-start ' + control_center.config_file) |
           list | first | regex_search('[0-9]+(.[0-9]+)+') }}"
       when: installation_method == "archive"
 

--- a/upgrade_kafka_broker.yml
+++ b/upgrade_kafka_broker.yml
@@ -87,7 +87,7 @@
     - name: Set kafka_broker_current_version variable - Archive Installer
       set_fact:
         kafka_broker_current_version: "{{ (slurped_override.content|b64decode) .split('\n') |
-          select('match', '^ExecStart=' + archive_config_base_path + '/confluent-(.*)/bin/kafka-server-start ' + kafka_broker.config_file) |
+          select('match', '^ExecStart=' + config_base_path + '/confluent-(.*)/bin/kafka-server-start ' + kafka_broker.config_file) |
           list | first | regex_search('[0-9]+(.[0-9]+)+') }}"
       when: installation_method == "archive"
 
@@ -144,7 +144,7 @@
     - name: Set kafka_broker_current_version variable - Archive Installer
       set_fact:
         kafka_broker_current_version: "{{ (slurped_override.content|b64decode) .split('\n') |
-          select('match', '^ExecStart=' + archive_config_base_path + '/confluent-(.*)/bin/kafka-server-start ' + kafka_broker.config_file) |
+          select('match', '^ExecStart=' + config_base_path + '/confluent-(.*)/bin/kafka-server-start ' + kafka_broker.config_file) |
           list | first | regex_search('[0-9]+(.[0-9]+)+') }}"
       when: installation_method == "archive"
 
@@ -296,8 +296,8 @@
     - name: Update Override to Use New Version
       lineinfile:
         path: "{{ kafka_broker.systemd_override }}"
-        line: "ExecStart={{archive_config_base_path}}/confluent-{{confluent_package_version}}/bin/kafka-server-start {{ kafka_broker.config_file }}"
-        regexp: "ExecStart={{archive_config_base_path}}/confluent-(.*)/bin/kafka-server-start {{ kafka_broker.config_file }}"
+        line: "ExecStart={{config_base_path}}/confluent-{{confluent_package_version}}/bin/kafka-server-start {{ kafka_broker.config_file }}"
+        regexp: "ExecStart={{config_base_path}}/confluent-(.*)/bin/kafka-server-start {{ kafka_broker.config_file }}"
       when: installation_method == "archive"
 
     - name: Disable Embedded Rest Proxy

--- a/upgrade_kafka_connect.yml
+++ b/upgrade_kafka_connect.yml
@@ -44,7 +44,7 @@
     - name: Set kafka_connect_current_version variable - Archive
       set_fact:
         kafka_connect_current_version: "{{ (slurped_override.content|b64decode) .split('\n') |
-          select('match', '^ExecStart=' + archive_config_base_path + '/confluent-(.*)/bin/connect-distributed ' + kafka_connect.config_file) |
+          select('match', '^ExecStart=' + config_base_path + '/confluent-(.*)/bin/connect-distributed ' + kafka_connect.config_file) |
           list | first | regex_search('[0-9]+(.[0-9]+)+') }}"
       when: installation_method == "archive"
 

--- a/upgrade_kafka_rest.yml
+++ b/upgrade_kafka_rest.yml
@@ -65,7 +65,7 @@
     - name: Set kafka_rest_current_version variable - Archive
       set_fact:
         kafka_rest_current_version: "{{ (slurped_override.content|b64decode) .split('\n') |
-          select('match', '^ExecStart=' + archive_config_base_path + '/confluent-(.*)/bin/kafka-rest-start ' + kafka_rest.config_file) |
+          select('match', '^ExecStart=' + config_base_path + '/confluent-(.*)/bin/kafka-rest-start ' + kafka_rest.config_file) |
           list | first | regex_search('[0-9]+(.[0-9]+)+') }}"
       when: installation_method == "archive"
 

--- a/upgrade_ksql.yml
+++ b/upgrade_ksql.yml
@@ -44,7 +44,7 @@
     - name: Set ksql_current_version variable - Archive
       set_fact:
         ksql_current_version: "{{ (slurped_override.content|b64decode) .split('\n') |
-          select('match', '^ExecStart=' + archive_config_base_path + '/confluent-(.*)/bin/ksql-server-start ' + ksql.config_file) |
+          select('match', '^ExecStart=' + config_base_path + '/confluent-(.*)/bin/ksql-server-start ' + ksql.config_file) |
           list | first | regex_search('[0-9]+(.[0-9]+)+') }}"
       when: installation_method == "archive"
 
@@ -167,8 +167,8 @@
     - name: Update Override to Use New Version
       lineinfile:
         path: "{{ ksql.systemd_override }}"
-        line: "ExecStart={{archive_config_base_path}}/confluent-{{confluent_package_version}}/bin/ksql-server-start {{ ksql.config_file }}"
-        regexp: "ExecStart={{archive_config_base_path}}/confluent-(.*)/bin/ksql-server-start {{ ksql.config_file }}"
+        line: "ExecStart={{config_base_path}}/confluent-{{confluent_package_version}}/bin/ksql-server-start {{ ksql.config_file }}"
+        regexp: "ExecStart={{config_base_path}}/confluent-(.*)/bin/ksql-server-start {{ ksql.config_file }}"
       when: installation_method == "archive"
 
     - name: Update RBAC Configs

--- a/upgrade_schema_registry.yml
+++ b/upgrade_schema_registry.yml
@@ -67,7 +67,7 @@
     - name: Set schema_registry_current_version variable - Archive
       set_fact:
         schema_registry_current_version: "{{ (slurped_override.content|b64decode) .split('\n') |
-          select('match', '^ExecStart=' + archive_config_base_path + '/confluent-(.*)/bin/schema-registry-start ' + schema_registry.config_file) |
+          select('match', '^ExecStart=' + config_base_path + '/confluent-(.*)/bin/schema-registry-start ' + schema_registry.config_file) |
           list | first | regex_search('[0-9]+(.[0-9]+)+') }}"
       when: installation_method == "archive"
 

--- a/upgrade_zookeeper.yml
+++ b/upgrade_zookeeper.yml
@@ -24,7 +24,7 @@
     - name: Set zookeeper_current_version variable - Archive Installer
       set_fact:
         zookeeper_current_version: "{{ (slurped_override.content|b64decode) .split('\n') |
-          select('match', '^ExecStart=' + archive_config_base_path + '/confluent-(.*)/bin/zookeeper-server-start ' + zookeeper.config_file) |
+          select('match', '^ExecStart=' + config_base_path + '/confluent-(.*)/bin/zookeeper-server-start ' + zookeeper.config_file) |
           list | first | regex_search('[0-9]+(.[0-9]+)+') }}"
       when: installation_method == "archive"
 
@@ -222,8 +222,8 @@
     - name: Update Override to Use New Version
       lineinfile:
         path: "{{ zookeeper.systemd_override }}"
-        line: "ExecStart={{archive_config_base_path}}/confluent-{{confluent_package_version}}/bin/zookeeper-server-start {{ zookeeper.config_file }}"
-        regexp: "ExecStart={{archive_config_base_path}}/confluent-(.*)/bin/zookeeper-server-start {{ zookeeper.config_file }}"
+        line: "ExecStart={{config_base_path}}/confluent-{{confluent_package_version}}/bin/zookeeper-server-start {{ zookeeper.config_file }}"
+        regexp: "ExecStart={{config_base_path}}/confluent-(.*)/bin/zookeeper-server-start {{ zookeeper.config_file }}"
       when: installation_method == "archive"
 
     - name: Add Disable Admin Server Property


### PR DESCRIPTION
# Description
This is a forward pint merge of changes we made in 6.0.x to properly deal the slashes `/` in path variables. We have unified the variables which were getting evaluated at multiple places, hence were creating a chance of error and ambiguity.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested Locally
archive-plain-rhel
archive-scram-rhel
mtls-custombundle-rhel
rbac-kafka-connect-replicator-kerberos-mtls-custom-rhel
multi-ksql-connect-rhel
rbac-mds-kerberos-mtls-custom-rhel

Archive Custom Plain Rhel
https://jenkins.confluent.io/job/cp-ansible-on-demand/271/

Cloud Kafka rest
https://jenkins.confluent.io/job/cp-ansible-on-demand/272/

Kerberos customcerts rhel
https://jenkins.confluent.io/job/cp-ansible-on-demand/273/

mtls-customcerts-rhel
https://jenkins.confluent.io/job/cp-ansible-on-demand/276/

cp-kafka-plain-rhel
https://jenkins.confluent.io/job/cp-ansible-on-demand/277/

zookeeper-plain-rhel
https://jenkins.confluent.io/job/cp-ansible-on-demand/278/



**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Any variable changes have been validated to be backwards compatible