### PR TITLE
Exclude the version from variable description

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -7,11 +7,11 @@ parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
 serialize = 
 	{major}.{minor}.{patch}
 
-[bumpversion:file:docs/VARIABLES.md]
-
 [bumpversion:file(latest_version):molecule/plaintext-rhel/verify.yml]
 
 [bumpversion:file(package_version):roles/variables/defaults/main.yml]
+search = confluent_package_version: {current_version}
+replace = confluent_package_version: {new_version}
 
 [bumpversion:file:galaxy.yml]
 

--- a/docs/VARIABLES.md
+++ b/docs/VARIABLES.md
@@ -2310,7 +2310,7 @@ Default:  "{{rbac_component_additional_system_admins}}"
 
 ### secrets_protection_enabled
 
-Boolean to enable secrets protection on all components except Zookeeper. Starting form CP 7.1.1 Secrets protection. This works only with RBAC.
+Boolean to enable secrets protection on all components except Zookeeper. Starting from CP 7.1.0, secrets protection will work only with RBAC
 
 Default:  false
 

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -1347,7 +1347,7 @@ control_center_additional_system_admins: "{{rbac_component_additional_system_adm
 
 # Secrets Protection Variables
 
-### Boolean to enable secrets protection on all components except Zookeeper. Starting form CP 7.1.1 Secrets protection. This works only with RBAC.
+### Boolean to enable secrets protection on all components except Zookeeper. Starting from CP 7.1.0, secrets protection will work only with RBAC
 secrets_protection_enabled: false
 
 ### Boolean to Recreate Secrets File and Masterkey. Only set to false AFTER first cp-ansible run.


### PR DESCRIPTION
# Description

The description of `secrets_protection` feature was getting updated because of bumpversion regex match. updated the regex to match the filed which qualifies for version update. 

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Local version update

**Test Configuration**:


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible