### PR TITLE
Ensure granting of role admin to additional broker admins run once

### DIFF
--- a/roles/confluent.kafka_broker/tasks/rbac_rolebindings.yml
+++ b/roles/confluent.kafka_broker/tasks/rbac_rolebindings.yml
@@ -24,3 +24,4 @@
       }
     status_code: 204
   loop: "{{kafka_broker_additional_system_admins}}"
+  run_once: true


### PR DESCRIPTION
# Description

Ensure granting of role admin to additional broker admins run once and not for every host. 
Can't run on rbac_rolebindings playbook level since rbac_setup.yml needs to run for every broker node (and not just once for a cluster)

Fixes # (GH issue https://github.com/confluentinc/cp-ansible/issues/892) and ANSIENG-1466

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration



**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible