### PR TITLE
Allow creation of keystore and truststore with custom password when using custom or self-signed certs

### DIFF
--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -364,6 +364,14 @@ Default:  false
 
 ***
 
+### ssl_keystore_and_truststore_custom_password
+
+Boolean to provide custom password for keystores and truststore. Enabled with ssl_provided_keystore_and_truststore, but can be enabled independently to set the custom password for generated keystores and truststores when using custom or self-signed certificates
+
+Default:  "{{ssl_provided_keystore_and_truststore}}"
+
+***
+
 ### ssl_keystore_filepath
 
 Full path to host specific keystore on ansible control node. Used with ssl_provided_keystore_and_truststore: true. May set per host, or use inventory_hostname variable eg "/tmp/certs/{{inventory_hostname}}-keystore.jks"
@@ -374,7 +382,7 @@ Default:  ""
 
 ### ssl_keystore_key_password
 
-Keystore Key Password for host specific keystore. Used with ssl_provided_keystore_and_truststore: true. May set per host if keystores have unique passwords
+Keystore Key Password for host specific keystore. Used with ssl_provided_keystore_and_truststore: true. May set per host if keystores have unique passwords. Not to be confused with ssl_key_password when using custom certs
 
 Default:  ""
 
@@ -382,7 +390,7 @@ Default:  ""
 
 ### ssl_keystore_store_password
 
-Keystore Password for host specific keystore. Used with ssl_provided_keystore_and_truststore: true. May set per host if keystores have unique passwords
+Keystore Password for host specific keystore. Used with ssl_provided_keystore_and_truststore: true or ssl_keystore_and_truststore_custom_password: true. May set per host if keystores have unique passwords
 
 Default:  ""
 
@@ -406,7 +414,7 @@ Default:  ""
 
 ### ssl_truststore_password
 
-Keystore Password for host specific truststore. Used with ssl_provided_keystore_and_truststore: true
+Keystore Password for host specific truststore. Used with ssl_provided_keystore_and_truststore: true or ssl_keystore_and_truststore_custom_password: true.
 
 Default:  ""
 

--- a/hosts_example.yml
+++ b/hosts_example.yml
@@ -58,7 +58,7 @@ all:
     ## (Optional) provide custom password for the generated truststores and keystores
     # ssl_keystore_and_truststore_custom_password: true
     # ssl_truststore_password: <mytruststorecustompassword> can be set for each host or service
-    # ssl_keystore_store_password: <mykeystorecustompassword> can be set for each host or service    
+    # ssl_keystore_store_password: <mykeystorecustompassword> can be set for each host or service
     ## Option 2: Custom Keystores and Truststores
     ## CP-Ansible can move keystores/truststores to their corresponding hosts and configure the components to use them. Set These vars
     # ssl_provided_keystore_and_truststore: true

--- a/hosts_example.yml
+++ b/hosts_example.yml
@@ -55,6 +55,10 @@ all:
     # ssl_key_filepath: "/tmp/certs/{{inventory_hostname}}-key.pem"
     # ssl_key_password: <password for key for each host, will be inputting in the form -passin pass:{{ssl_key_password}} >
     # regenerate_keystore_and_truststore: true # Set to true to update certs on hosts. If keystores/truststores exist, they won't be updated without this variable.
+    ## (Optional) provide custom password for the generated truststores and keystores
+    # ssl_keystore_and_truststore_custom_password: true
+    # ssl_truststore_password: <mytruststorecustompassword> can be set for each host or service
+    # ssl_keystore_store_password: <mykeystorecustompassword> can be set for each host or service    
     ## Option 2: Custom Keystores and Truststores
     ## CP-Ansible can move keystores/truststores to their corresponding hosts and configure the components to use them. Set These vars
     # ssl_provided_keystore_and_truststore: true

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -168,13 +168,16 @@ certs_updated: false
 ### Boolean for TLS Encryption option to provide own Host Keystores.
 ssl_provided_keystore_and_truststore: false
 
+### Boolean to provide custom password for keystores and truststore. Enabled with ssl_provided_keystore_and_truststore, but can be enabled independently to set the custom password for generated keystores and truststores when using custom or self-signed certificates
+ssl_keystore_and_truststore_custom_password: "{{ssl_provided_keystore_and_truststore}}"
+
 ### Full path to host specific keystore on ansible control node. Used with ssl_provided_keystore_and_truststore: true. May set per host, or use inventory_hostname variable eg "/tmp/certs/{{inventory_hostname}}-keystore.jks"
 ssl_keystore_filepath: ""
 
-### Keystore Key Password for host specific keystore. Used with ssl_provided_keystore_and_truststore: true. May set per host if keystores have unique passwords
+### Keystore Key Password for host specific keystore. Used with ssl_provided_keystore_and_truststore: true. May set per host if keystores have unique passwords. Not to be confused with ssl_key_password when using custom certs
 ssl_keystore_key_password: ""
 
-### Keystore Password for host specific keystore. Used with ssl_provided_keystore_and_truststore: true. May set per host if keystores have unique passwords
+### Keystore Password for host specific keystore. Used with ssl_provided_keystore_and_truststore: true or ssl_keystore_and_truststore_custom_password: true. May set per host if keystores have unique passwords
 ssl_keystore_store_password: ""
 
 ### Keystore source alias for host specific certificate. Only required if keystore contains more than one certificate. Used with ssl_provided_keystore_and_truststore: true. May set per host, or use inventory_hostname variable eg "{{inventory_hostname}}"
@@ -183,7 +186,7 @@ ssl_keystore_alias: ""
 ### Full path to host specific truststore on ansible control node. Used with ssl_provided_keystore_and_truststore: true. Can share same keystore for all components if it contains all ca certs used to sign host certificates
 ssl_truststore_filepath: ""
 
-### Keystore Password for host specific truststore. Used with ssl_provided_keystore_and_truststore: true
+### Keystore Password for host specific truststore. Used with ssl_provided_keystore_and_truststore: true or ssl_keystore_and_truststore_custom_password: true.
 ssl_truststore_password: ""
 
 ### Keystore alias for ca certificate
@@ -263,8 +266,8 @@ zookeeper_packages:
 
 zookeeper_truststore_path: "{{ ssl_file_dir_final }}/zookeeper.truststore.jks"
 zookeeper_keystore_path: "{{ ssl_file_dir_final }}/zookeeper.keystore.jks"
-zookeeper_truststore_storepass: "{{ ssl_truststore_password if ssl_provided_keystore_and_truststore|bool else 'confluenttruststorepass'}}"
-zookeeper_keystore_storepass: "{{ ssl_keystore_store_password if ssl_provided_keystore_and_truststore|bool else 'confluentkeystorestorepass'}}"
+zookeeper_truststore_storepass: "{{ ssl_truststore_password if ssl_keystore_and_truststore_custom_password|bool else 'confluenttruststorepass'}}"
+zookeeper_keystore_storepass: "{{ ssl_keystore_store_password if ssl_keystore_and_truststore_custom_password|bool else 'confluentkeystorestorepass'}}"
 zookeeper_keystore_keypass: "{{ ssl_keystore_key_password if ssl_provided_keystore_and_truststore|bool else zookeeper_keystore_storepass }}"
 zookeeper_ca_cert_path: "{{ ssl_file_dir_final }}/ca.crt"
 zookeeper_cert_path: "{{ ssl_file_dir_final }}/zookeeper.crt"
@@ -417,8 +420,8 @@ kafka_broker_bcfks_keystore_path: "{{ ssl_file_dir_final }}/kafka_broker.keystor
 kafka_broker_pkcs12_truststore_path: "{{ ssl_file_dir_final }}/kafka_broker.truststore.jks"
 kafka_broker_pkcs12_keystore_path: "{{ ssl_file_dir_final }}/kafka_broker.keystore.jks"
 
-kafka_broker_truststore_storepass: "{{ ssl_truststore_password if ssl_provided_keystore_and_truststore|bool else 'confluenttruststorepass'}}"
-kafka_broker_keystore_storepass: "{{ ssl_keystore_store_password if ssl_provided_keystore_and_truststore|bool else 'confluentkeystorestorepass'}}"
+kafka_broker_truststore_storepass: "{{ ssl_truststore_password if ssl_keystore_and_truststore_custom_password|bool else 'confluenttruststorepass'}}"
+kafka_broker_keystore_storepass: "{{ ssl_keystore_store_password if ssl_keystore_and_truststore_custom_password|bool else 'confluentkeystorestorepass'}}"
 kafka_broker_keystore_keypass: "{{ ssl_keystore_key_password if ssl_provided_keystore_and_truststore|bool else kafka_broker_keystore_storepass }}"
 kafka_broker_ca_cert_path: "{{ ssl_file_dir_final }}/ca.crt"
 kafka_broker_cert_path: "{{ ssl_file_dir_final }}/kafka_broker.crt"
@@ -539,8 +542,8 @@ schema_registry_packages:
 
 schema_registry_truststore_path: "{{ ssl_file_dir_final }}/schema_registry.truststore.jks"
 schema_registry_keystore_path: "{{ ssl_file_dir_final }}/schema_registry.keystore.jks"
-schema_registry_truststore_storepass: "{{ ssl_truststore_password if ssl_provided_keystore_and_truststore|bool else 'confluenttruststorepass'}}"
-schema_registry_keystore_storepass: "{{ ssl_keystore_store_password if ssl_provided_keystore_and_truststore|bool else 'confluentkeystorestorepass'}}"
+schema_registry_truststore_storepass: "{{ ssl_truststore_password if ssl_keystore_and_truststore_custom_password|bool else 'confluenttruststorepass'}}"
+schema_registry_keystore_storepass: "{{ ssl_keystore_store_password if ssl_keystore_and_truststore_custom_password|bool else 'confluentkeystorestorepass'}}"
 schema_registry_keystore_keypass: "{{ ssl_keystore_key_password if ssl_provided_keystore_and_truststore|bool else schema_registry_keystore_storepass }}"
 schema_registry_ca_cert_path: "{{ ssl_file_dir_final }}/ca.crt"
 schema_registry_cert_path: "{{ ssl_file_dir_final }}/schema_registry.crt"
@@ -636,8 +639,8 @@ kafka_rest_packages:
 
 kafka_rest_truststore_path: "{{ ssl_file_dir_final }}/kafka_rest.truststore.jks"
 kafka_rest_keystore_path: "{{ ssl_file_dir_final }}/kafka_rest.keystore.jks"
-kafka_rest_truststore_storepass: "{{ ssl_truststore_password if ssl_provided_keystore_and_truststore|bool else 'confluenttruststorepass'}}"
-kafka_rest_keystore_storepass: "{{ ssl_keystore_store_password if ssl_provided_keystore_and_truststore|bool else 'confluentkeystorestorepass'}}"
+kafka_rest_truststore_storepass: "{{ ssl_truststore_password if ssl_keystore_and_truststore_custom_password|bool else 'confluenttruststorepass'}}"
+kafka_rest_keystore_storepass: "{{ ssl_keystore_store_password if ssl_keystore_and_truststore_custom_password|bool else 'confluentkeystorestorepass'}}"
 kafka_rest_keystore_keypass: "{{ ssl_keystore_key_password if ssl_provided_keystore_and_truststore|bool else kafka_rest_keystore_storepass }}"
 kafka_rest_ca_cert_path: "{{ ssl_file_dir_final }}/ca.crt"
 kafka_rest_cert_path: "{{ ssl_file_dir_final }}/kafka_rest.crt"
@@ -743,8 +746,8 @@ kafka_connect_packages:
 
 kafka_connect_truststore_path: "{{ ssl_file_dir_final }}/kafka_connect.truststore.jks"
 kafka_connect_keystore_path: "{{ ssl_file_dir_final }}/kafka_connect.keystore.jks"
-kafka_connect_truststore_storepass: "{{ ssl_truststore_password if ssl_provided_keystore_and_truststore|bool else 'confluenttruststorepass'}}"
-kafka_connect_keystore_storepass: "{{ ssl_keystore_store_password if ssl_provided_keystore_and_truststore|bool else 'confluentkeystorestorepass'}}"
+kafka_connect_truststore_storepass: "{{ ssl_truststore_password if ssl_keystore_and_truststore_custom_password|bool else 'confluenttruststorepass'}}"
+kafka_connect_keystore_storepass: "{{ ssl_keystore_store_password if ssl_keystore_and_truststore_custom_password|bool else 'confluentkeystorestorepass'}}"
 kafka_connect_keystore_keypass: "{{ ssl_keystore_key_password if ssl_provided_keystore_and_truststore|bool else kafka_connect_keystore_storepass }}"
 kafka_connect_ca_cert_path: "{{ ssl_file_dir_final }}/ca.crt"
 kafka_connect_cert_path: "{{ ssl_file_dir_final }}/kafka_connect.crt"
@@ -880,8 +883,8 @@ ksql_packages:
 
 ksql_truststore_path: "{{ ssl_file_dir_final }}/ksql.truststore.jks"
 ksql_keystore_path: "{{ ssl_file_dir_final }}/ksql.keystore.jks"
-ksql_truststore_storepass: "{{ ssl_truststore_password if ssl_provided_keystore_and_truststore|bool else 'confluenttruststorepass'}}"
-ksql_keystore_storepass: "{{ ssl_keystore_store_password if ssl_provided_keystore_and_truststore|bool else 'confluentkeystorestorepass'}}"
+ksql_truststore_storepass: "{{ ssl_truststore_password if ssl_keystore_and_truststore_custom_password|bool else 'confluenttruststorepass'}}"
+ksql_keystore_storepass: "{{ ssl_keystore_store_password if ssl_keystore_and_truststore_custom_password|bool else 'confluentkeystorestorepass'}}"
 ksql_keystore_keypass: "{{ ssl_keystore_key_password if ssl_provided_keystore_and_truststore|bool else ksql_keystore_storepass }}"
 ksql_ca_cert_path: "{{ ssl_file_dir_final }}/ca.crt"
 ksql_cert_path: "{{ ssl_file_dir_final }}/ksql.crt"
@@ -993,8 +996,8 @@ control_center_packages:
 
 control_center_truststore_path: "{{ ssl_file_dir_final }}/control_center.truststore.jks"
 control_center_keystore_path: "{{ ssl_file_dir_final }}/control_center.keystore.jks"
-control_center_truststore_storepass: "{{ ssl_truststore_password if ssl_provided_keystore_and_truststore|bool else 'confluenttruststorepass'}}"
-control_center_keystore_storepass: "{{ ssl_keystore_store_password if ssl_provided_keystore_and_truststore|bool else 'confluentkeystorestorepass'}}"
+control_center_truststore_storepass: "{{ ssl_truststore_password if ssl_keystore_and_truststore_custom_password|bool else 'confluenttruststorepass'}}"
+control_center_keystore_storepass: "{{ ssl_keystore_store_password if ssl_keystore_and_truststore_custom_password|bool else 'confluentkeystorestorepass'}}"
 control_center_keystore_keypass: "{{ ssl_keystore_key_password if ssl_provided_keystore_and_truststore|bool else control_center_keystore_storepass }}"
 control_center_ca_cert_path: "{{ ssl_file_dir_final }}/ca.crt"
 control_center_cert_path: "{{ ssl_file_dir_final }}/control_center.crt"


### PR DESCRIPTION
# Description

Truststore and Keystores are created using hardcoded visible password in the ssl role when using custom certs or self-signed. This change allow to specify a custom password for those stores in a way compatible with the "provided truststore and keystore" mechanism

This surfaced with deployment using "secrets protection", the customer doesn't want to provide the JKS stores but their custom certificates and the password for the stores via Ansible Vault  

Fixes # (#641)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Sadly I have trouble running molecule, I could use a hand with that and would be able to provide automated tests, in the meantime I've tested this manually with VM's using custom certificated (with encrypted and unencrypted keys) and providing custom stores for all services except replicator.

Besides simple sanity checks via Control Center, with each test scenario/deployment, I double-check the properties file of the services to confirm the expected value of appropriate '*.keystore.password' and '*.trustore.password', and used those to "open" the stores addressed by '*.trustore.location' and '*.keystore.location'

**Test Configuration**:
Custom Certificates and Key for all services
Custom Certificates and Key for each service
Custom Certificates and Encrypted key for all services
Provided Keystore and Truststore for all services

# Checklist:
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] Any variable changes have been validated to be backwards compatible

NOTE: The 'ssl_keystore_key_password' doesn't need to be set with custom certificates as the generated keystore will use the same password for both the key and the store (I'm guessing it's due to the limitation PKCS12)