### PR TITLE
add sanity test to ci builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -111,6 +111,9 @@ cd ansible_collections/confluent/platform
 python3 -m pip install yamllint --upgrade
 python3 -m yamllint .
 
+pip3 install pylint voluptuous
+ansible-test sanity
+
 molecule ${molecule_args} test -s ${params.SCENARIO_NAME}
             """
         }


### PR DESCRIPTION
# Description

Adding sanity test on the CI runs. To always be certification ready.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

tested with cp-ansible-internal. We'll only know more once it's merged. 


**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible