### PR TITLE
Revert "add sanity test to ci builds"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -111,9 +111,6 @@ cd ansible_collections/confluent/platform
 python3 -m pip install yamllint --upgrade
 python3 -m yamllint .
 
-pip3 install pylint voluptuous
-ansible-test sanity
-
 molecule ${molecule_args} test -s ${params.SCENARIO_NAME}
             """
         }


### PR DESCRIPTION
Reverts confluentinc/cp-ansible#1079
If we see the latest run logs (https://jenkins.confluent.io/job/confluentinc/job/cp-ansible/job/7.0.x/508/console), we can see that the ansible-test sanity is reading some unexpected files like  /usr/local/lib/python3.9/site-packages/ansible_test/_data/sanity/pylint/config/collection.cfg and also throwing some new errors in the .py files (not visible on local - maybe because of the python version) 
Thus, reverting for now.