### PR TITLE
Fix ability to have custom filename for kafka connect config/properties

### DIFF
--- a/roles/variables/vars/main.yml
+++ b/roles/variables/vars/main.yml
@@ -524,7 +524,7 @@ kafka_connect_default_log_dir: /var/log/kafka
 kafka_connect:
   server_start_file: "{{ binary_base_path }}/bin/connect-distributed"
   systemd_file: "{{systemd_base_dir}}/{{kafka_connect_service_name}}.service"
-  config_file: "{{ (config_base_path,'etc/kafka/connect-distributed.properties') | community.general.path_join }}"
+  config_file: "{{ (config_base_path,'etc/kafka',kafka_connect_config_filename) | community.general.path_join }}"
   systemd_override: /etc/systemd/system/{{kafka_connect_service_name}}.service.d/override.conf
   log4j_file: "{{ (base_path, 'etc/kafka/connect-log4j.properties') | community.general.path_join }}"
 


### PR DESCRIPTION
# Description

The ability to have a custom name for the Kafka Connect properties file is broken in 7.0.x after adding "community.general.path_join" to create the path.

The introduced bug is on roles/variables/vars/main.yml | kafka_connect>config_file ... the file name is hardcoded

`config_file: "{{ (config_base_path,'etc/kafka/connect-distributed.properties') | community.general.path_join }}"`

As an example, the line from 7.0.1-post looks like

`config_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/kafka/{{kafka_connect_config_filename}}"`

The missing part is in fact a reference to  `{{kafka_connect_config_filename}}`

Being consequent with the removal of 'archive_config_base_path' I've just changed the line to
`config_file: "{{ (config_base_path,'etc/kafka',kafka_connect_config_filename) | community.general.path_join }}"`

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible