### PR TITLE
Fix kafka connect service name when copying from archive install

### DIFF
--- a/roles/kafka_connect/tasks/main.yml
+++ b/roles/kafka_connect/tasks/main.yml
@@ -67,7 +67,7 @@
 # Copy the tarball's systemd service to the system
 - name: Copy Kafka Connect Service from archive file to system
   copy:
-    src: "{{binary_base_path}}/lib/systemd/system/{{kafka_connect.systemd_file|basename}}"
+    src: "{{binary_base_path}}/lib/systemd/system/{{kafka_connect_default_service_name}}.service"
     remote_src: true
     dest: "{{kafka_connect.systemd_file}}"
     mode: 0644


### PR DESCRIPTION
# Description

Using `installation_method: archive`, when configuring the kafka connect service a "template" file needs to be fetched from the binary_base_path ... the file is named by default 'confluent-kafka-connect.service' which is already defined by `kafka_connect_default_service_name`

The proposed change is consistent with the default install mechanism a couple of lines below in the same changed file

Without this change, on an "archive" install and using a custom service name for connect in the inventory (i.e kafka_connect_default_service_name: my-kafka-connect) you get an error at the `TASK [confluent.platform.kafka_connect : Copy Kafka Connect Service from archive file to system]`

FAILED! => {"changed": false, "msg": "Source /opt/confluent/confluent-7.1.1/lib/systemd/system/my-kafka-connect.service not found"}

This is kind of important to setup multiple connect workers in the same host. (along with the naming of the properties file PR #1084)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Specifying a value for the kafka connect service name using the  var `kafka_connect_service_name` and checking:
* folder - /etc/systemd/system/[servicename] - gets created
* file - /usr/lib/systemd/system/[servicename].service - gets created
* Running the command 'systemctl status [servicename] - displays that the service is running


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible