### PR TITLE
Separate trustore/keystore creation for multple service in the same host

### DIFF
--- a/roles/kafka_connect/tasks/main.yml
+++ b/roles/kafka_connect/tasks/main.yml
@@ -92,7 +92,7 @@
     keystore_path: "{{kafka_connect_keystore_path}}"
     keystore_storepass: "{{kafka_connect_keystore_storepass}}"
     keystore_keypass: "{{kafka_connect_keystore_keypass}}"
-    service_name: kafka_connect
+    service_name: "{{ kafka_connect_service_name if kafka_connect_service_name != kafka_connect_default_service_name else 'kafka_connect' }}"
     user: "{{kafka_connect_user}}"
     group: "{{kafka_connect_group}}"
     hostnames: "{{ [inventory_hostname, ansible_fqdn, ansible_host, ansible_ssh_host, hostname|default(omit)] | unique }}"

--- a/roles/ssl/tasks/create_keystores_from_certs.yml
+++ b/roles/ssl/tasks/create_keystores_from_certs.yml
@@ -46,7 +46,7 @@
       -in {{ ssl_file_dir_final }}/{{service_name}}.chain \
       -inkey {{key_path}} \
       {% if ssl_key_password is defined %}-passin pass:{{ssl_key_password}}{% endif %} \
-      -out {{ ssl_file_dir_final }}/generation/client.p12 \
+      -out {{ ssl_file_dir_final }}/generation/{{service_name}}.p12 \
       -name localhost \
       -passout pass:mykeypassword
   no_log: "{{mask_secrets|bool}}"
@@ -54,7 +54,7 @@
 - name: Create Keystore
   shell: |
     keytool -importkeystore \
-      -srckeystore {{ ssl_file_dir_final }}/generation/client.p12 \
+      -srckeystore {{ ssl_file_dir_final }}/generation/{{service_name}}.p12 \
       -srcstoretype pkcs12 \
       -srcstorepass mykeypassword \
       -destkeystore {{keystore_path}} \
@@ -66,7 +66,7 @@
 - name: Create BCFKS Keystore
   shell: |
     keytool -importkeystore \
-      -srckeystore {{ ssl_file_dir_final }}/generation/client.p12 \
+      -srckeystore {{ ssl_file_dir_final }}/generation/{{service_name}}.p12 \
       -srcstoretype pkcs12 \
       -srcstorepass mykeypassword \
       -destkeystore {{bcfks_keystore_path}} \

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -745,14 +745,14 @@ kafka_connect_packages:
   - confluent-control-center
   - confluent-schema-registry
 
-kafka_connect_truststore_path: "{{ ssl_file_dir_final }}/kafka_connect.truststore.jks"
-kafka_connect_keystore_path: "{{ ssl_file_dir_final }}/kafka_connect.keystore.jks"
+kafka_connect_truststore_path: "{{ ssl_file_dir_final }}/{{ kafka_connect_service_name + '.truststore.jks' if kafka_connect_service_name != kafka_connect_default_service_name else 'kafka_connect.truststore.jks'}}"
+kafka_connect_keystore_path: "{{ ssl_file_dir_final }}/{{ kafka_connect_service_name + '.keystore.jks' if kafka_connect_service_name != kafka_connect_default_service_name else 'kafka_connect.keystore.jks'}}"
 kafka_connect_truststore_storepass: "{{ ssl_truststore_password if ssl_provided_keystore_and_truststore|bool else 'confluenttruststorepass'}}"
 kafka_connect_keystore_storepass: "{{ ssl_keystore_store_password if ssl_provided_keystore_and_truststore|bool else 'confluentkeystorestorepass'}}"
 kafka_connect_keystore_keypass: "{{ ssl_keystore_key_password if ssl_provided_keystore_and_truststore|bool else kafka_connect_keystore_storepass }}"
-kafka_connect_ca_cert_path: "{{ ssl_file_dir_final }}/ca.crt"
-kafka_connect_cert_path: "{{ ssl_file_dir_final }}/kafka_connect.crt"
-kafka_connect_key_path: "{{ ssl_file_dir_final }}/kafka_connect.key"
+kafka_connect_ca_cert_path: "{{ ssl_file_dir_final }}/{{ kafka_connect_service_name + '.ca.crt' if kafka_connect_service_name != kafka_connect_default_service_name else 'ca.crt'}}"
+kafka_connect_cert_path: "{{ ssl_file_dir_final }}/{{ kafka_connect_service_name + '.crt' if kafka_connect_service_name != kafka_connect_default_service_name else 'kafka_connect.crt'}}"
+kafka_connect_key_path: "{{ ssl_file_dir_final }}/{{ kafka_connect_service_name + '.key' if kafka_connect_service_name != kafka_connect_default_service_name else 'kafka_connect.key'}}"
 kafka_connect_export_certs: "{{ True if kafka_connect_authentication_type == 'mtls' else False }}"
 kafka_connect_keytab_path: /etc/security/keytabs/kafka_connect.keytab
 kafka_connect_kafka_listener_name: internal


### PR DESCRIPTION
# Description
When running multiple services in the same host, in particular for multiple connect workers, there is concurrency and race conditions can happen when manipulating the certificate files and keystores

(attaching picture of the error) 
<img width="1920" alt="Ansible error creating stores" src="https://user-images.githubusercontent.com/1193234/172634395-caac01e0-31e2-4375-b031-0b0beae0fa50.png">

Using the following host section example for sharing the host between connect services

`
all:
  vars:
   
    ...
    
    ssl_enabled: true
    ssl_custom_certs: true
    ssl_ca_cert_filepath: ~/inventories/gcp-sandbox/ssl/generated/CAcert.pem
    ssl_signed_cert_filepath: ~/inventories/gcp-sandbox/ssl/generated/server.pem
    ssl_key_filepath: ~/inventories/gcp-sandbox/ssl/generated/server-key.pem
    regenerate_keystore_and_truststore: true
    
    ...

kafka_connect:
  vars:
    hostname_aliasing_enabled: true
  children: 
    connect-main:
      vars:
        kafka_connect_cluster_name: connect-main 
        kafka_connect_group_id: connect-main
        #kafka_connect_service_name: connect-main
        kafka_connect_config_filename: connect-main-distributed.properties
        kafka_connect_log_dir: "{{ kafka_connect_default_log_dir }}/connect-main"
      hosts:
        dfederico-demo-connect-0:
        dfederico-demo-connect-1:

    connect-spawn1:
      vars:
        kafka_connect_cluster_name: connect-spawn1
        kafka_connect_group_id: connect-spawn1
        kafka_connect_service_name: connect-spawn1
        kafka_connect_config_filename: connect-spawn1-distributed.properties
        kafka_connect_log_dir: "{{ kafka_connect_default_log_dir }}/connect-spawn1"
      hosts:
        dfederico-demo-connect-2.A:
          ansible_host: dfederico-demo-connect-2
          hostname: dfederico-demo-connect-2
        dfederico-demo-connect-3.A:
          ansible_host: dfederico-demo-connect-3
          hostname: dfederico-demo-connect-3

    connect-spawn2:
      vars:
        kafka_connect_cluster_name: connect-spawn2 
        kafka_connect_group_id: connect-spawn2
        kafka_connect_service_name: connect-spawn2
        kafka_connect_config_filename: connect-spawn2-distributed.properties
        kafka_connect_rest_port: 8084
        kafka_connect_jmxexporter_port: 8078
        kafka_connect_log_dir: "{{ kafka_connect_default_log_dir }}/connect-spawn2"
      hosts:
        dfederico-demo-connect-2.B:
          ansible_host: dfederico-demo-connect-2
          hostname: dfederico-demo-connect-2
        dfederico-demo-connect-3.B:
          ansible_host: dfederico-demo-connect-3
          hostname: dfederico-demo-connect-3
`

With the proposed change the service_name will be used as the filename prefix for all related artifacts when manipulating custom certificates and stores in the ssl role.

As stated, this change is important to properly install multiple services in the same host, although it's targeted to kafka_connect, as the only service with such example 'sample_invetories/multi_connect_workers_on_single_node.yml'

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Run in a cluster with different custom certificates, both encrypted and non-encrypted and checked the results in the '/var/ssl/private' folder as well as the generated properties for the services (both standard and host sharing)
(see image)
<img width="539" alt="generated stores per service" src="https://user-images.githubusercontent.com/1193234/172639396-903bca7a-5267-4a6f-9815-7bba74948fab.png">

Also checked that control center can see the clusters properly

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible