### PR TITLE
Fixed Kafka Connect children registration with MDS

### DIFF
--- a/roles/kafka_connect/tasks/main.yml
+++ b/roles/kafka_connect/tasks/main.yml
@@ -275,9 +275,21 @@
     - not ansible_check_mode
   tags: health_check
 
+# Set a host fact with the direct cluster parent group
+# Host of the same cluster have the same group.id
+- name: Set parent Cluster
+  vars:
+    keywords:
+      - kafka_connect
+      - kafka_connect_parallel
+      - kafka_connect_serial
+  set_fact:
+    parent_kafka_connect_cluster_group: "{{ (group_names | difference(keywords))[0] | default('kafka_connect') }}"
+    parent_kafka_connect_cluster_id: "{{ kafka_connect_final_properties['group.id'] }}"
+
 - name: Register Cluster
   include_tasks: register_cluster.yml
-  when: kafka_connect_cluster_name|length > 0 and rbac_enabled|bool
+  run_once: true
 
 - name: Deploy Connectors
   include_tasks: deploy_connectors.yml

--- a/roles/kafka_connect/tasks/register_cluster.yml
+++ b/roles/kafka_connect/tasks/register_cluster.yml
@@ -3,10 +3,20 @@
   import_role:
     name: common
     tasks_from: rbac_setup.yml
+  when: rbac_enabled
   vars:
     copy_certs: false
 
+- name: Fetch Kafka Connect Cluster Groups
+  set_fact: active_kafka_connect_groups="{{ (((active_kafka_connect_groups | default([])) + hostvars[item].group_names) | difference('kafka_connect'+'kafka_connect_parallel'+'kafka_connect_serial')) | default(['kafka_connect'], true) }}"
+  with_items: "{{ ansible_play_hosts }}"
+
 - name: Register Kafka Connect Cluster
+  vars:
+    cluster_host_delegates: "{{ active_kafka_connect_groups | map('extract', groups, 0)| list }}"
+    cluster_group: "{{ hostvars[item].parent_kafka_connect_cluster_group }}"
+    cluster_name: "{{ hostvars[item].kafka_connect_cluster_name }}"
+    cluster_id: "{{ hostvars[item].parent_kafka_connect_cluster_id }}"
   uri:
     url: "{{mds_bootstrap_server_urls.split(',')[0]}}/security/1.0/registry/clusters"
     method: POST
@@ -20,18 +30,21 @@
     body: >
       [
           {
-              "clusterName": "{{kafka_connect_cluster_name}}",
+              "clusterName": "{{cluster_name}}",
               "scope": {
                   "clusters": {
                       "kafka-cluster": "{{kafka_cluster_id}}",
-                      "connect-cluster": "{{kafka_connect_final_properties['group.id']}}"
+                      "connect-cluster": "{{cluster_id}}"
                   }
               },
-              "hosts": [ {% for host in groups['kafka_connect'] %}{% if loop.index > 1%},{% endif %}{ "host": "{{host}}", "port": {{kafka_connect_rest_port}} }{% endfor %}
-              ],
+              "hosts": [ {% for inv_host in groups[cluster_group] %}{% if loop.index > 1%},{% endif %}{ "host": "{{hostvars[inv_host]|confluent.platform.resolve_hostname}}", "port": {% if hostvars[inv_host].kafka_connect_rest_port is defined %} {{hostvars[inv_host].kafka_connect_rest_port}} {% else %} {{kafka_connect_rest_port}} {% endif %} }{% endfor %} ],
               "protocol": "{{kafka_connect_http_protocol | upper}}"
           }
       ]
     status_code: 204
-  run_once: true
   register: output
+  when:
+    - hostvars[item].get("rbac_enabled", false)|bool
+    - hostvars[item].kafka_connect_cluster_name is defined
+    - hostvars[item].parent_kafka_connect_cluster_id is defined
+  with_items: "{{ cluster_host_delegates }}"


### PR DESCRIPTION
# Description

Kafka Connect Cluster registration against MDS is not working properly when multiple kafka connect clusters are defined in the inventory (children). The registration is done only once and for the first cluster sub-group, moreover it includes all the hosts of the other groups too. I've followed the same approach of PR #991, with the addition of resolving the hostname using 'confluent.platform.resolve_hostname' in case 'hostname_aliasing_enabled: true' 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Using a connect an inventory with a kafka_connect similar to this one:
`
kafka_connect:
  vars:
    hostname_aliasing_enabled: true
  children: 
    connect-main:
      vars:
        kafka_connect_cluster_name: connect-main 
        kafka_connect_group_id: connect-main
        kafka_connect_service_name: connect-main
        kafka_connect_config_filename: connect-main-distributed.properties
        kafka_connect_log_dir: "{{ kafka_connect_default_log_dir }}/connect-main"
      hosts:
        dfederico-demo-connect-0:
        dfederico-demo-connect-1:

    connect-spawn1:
      vars:
        kafka_connect_cluster_name: connect-spawn1
        kafka_connect_group_id: connect-spawn1
        kafka_connect_service_name: connect-spawn1
        kafka_connect_config_filename: connect-spawn1-distributed.properties
        kafka_connect_log_dir: "{{ kafka_connect_default_log_dir }}/connect-spawn1"
      hosts:
        dfederico-demo-connect-2.A:
          ansible_host: dfederico-demo-connect-2
          hostname: dfederico-demo-connect-2
        dfederico-demo-connect-3.A:
          ansible_host: dfederico-demo-connect-3
          hostname: dfederico-demo-connect-3

    connect-spawn2:
      vars:
        kafka_connect_cluster_name: connect-spawn2 
        kafka_connect_group_id: connect-spawn2
        kafka_connect_service_name: connect-spawn2
        kafka_connect_config_filename: connect-spawn2-distributed.properties
        kafka_connect_rest_port: 8084
        kafka_connect_jmxexporter_port: 8078
        kafka_connect_log_dir: "{{ kafka_connect_default_log_dir }}/connect-spawn2"
      hosts:
        dfederico-demo-connect-2.B:
          ansible_host: dfederico-demo-connect-2
          hostname: dfederico-demo-connect-2
        dfederico-demo-connect-3.B:
          ansible_host: dfederico-demo-connect-3
          hostname: dfederico-demo-connect-3
`

Without the change the registration end like this... Only one cluster gets registered with every "inventory" hostname (note the suffix) for every child cluster
<img width="1768" alt="Screenshot 2022-06-08 at 18 26 33" src="https://user-images.githubusercontent.com/1193234/172687456-f43636bc-1732-48b5-b418-c526a722dc6e.png">

With the fix it seems to work as expected... Each child cluster is registered with their intended host resolved to the real hostname and port (note spawn2)
<img width="1268" alt="Screenshot 2022-06-08 at 20 27 03" src="https://user-images.githubusercontent.com/1193234/172690695-8f1291f7-a4c5-4202-b59a-99717bf16c5b.png">

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible