### PR TITLE
Fix ksql scale up test failures

### DIFF
--- a/molecule/ksql-scale-up/converge.yml
+++ b/molecule/ksql-scale-up/converge.yml
@@ -18,7 +18,7 @@
       vars:
         file_path: /etc/confluent-control-center/control-center-production.properties
         property: confluent.controlcenter.ksql.ksql.advertised.url
-        expected_value: https://ksql1:8088,https://ksql2:8088
+        expected_value: https://ksql1:8088,https://ksql2.confluent:8088
 
 - name: Add new KSQL nodes in in-memory inventory
   hosts: all


### PR DESCRIPTION
# Description

The inventory file in this test has `ksql_advertised_listener_hostname: ksql2.confluent` . Updating the verify step accordingly.

Fixes # ([ANSIENG-1484](https://confluentinc.atlassian.net/browse/ANSIENG-1484))

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Local verification 
` molecule converge -s ksql-scale-up`

```
PLAY RECAP *********************************************************************
control-center1            : ok=56   changed=4    unreachable=0    failed=0    skipped=53   rescued=0    ignored=0
kafka-broker1              : ok=53   changed=0    unreachable=0    failed=0    skipped=62   rescued=0    ignored=0
kafka-broker2              : ok=53   changed=0    unreachable=0    failed=0    skipped=59   rescued=0    ignored=0
kafka-broker3              : ok=53   changed=0    unreachable=0    failed=0    skipped=59   rescued=0    ignored=0
kafka-connect1             : ok=47   changed=0    unreachable=0    failed=0    skipped=62   rescued=0    ignored=0
ksql1                      : ok=46   changed=0    unreachable=0    failed=0    skipped=63   rescued=0    ignored=0
ksql2                      : ok=44   changed=0    unreachable=0    failed=0    skipped=55   rescued=0    ignored=0
ksql3                      : ok=73   changed=31   unreachable=0    failed=0    skipped=56   rescued=0    ignored=0
ksql4                      : ok=73   changed=31   unreachable=0    failed=0    skipped=56   rescued=0    ignored=0
zookeeper1                 : ok=50   changed=0    unreachable=0    failed=0    skipped=62   rescued=0    ignored=0
```

On demand job id: 362

**Test Configuration**:
Local molecule scenario

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible