### PR TITLE
Add "sasl_protocol: oauthbearer" which does not add default handlers

### DIFF
--- a/docs/MOLECULE_SCENARIOS.md
+++ b/docs/MOLECULE_SCENARIOS.md
@@ -1200,6 +1200,22 @@ Validates that Confluent CLI is installed.
 
 ***
 
+### molecule/oauthbearer-rhel
+
+#### Scenario oauthbearer-rhel test's the following:
+
+Installation of Confluent Community Edition on CentOS7.
+
+SASL OAUTHBEARER Auth.
+
+#### Scenario oauthbearer-rhel verify test's the following:
+
+Validates that SASL OAUTHBEARER protocol is set.
+
+Validates that properties for callback handlers are not set.
+
+***
+
 ### molecule/archive-plain-debian
 
 #### Scenario archive-plain-debian test's the following:

--- a/docs/VARIABLES.md
+++ b/docs/VARIABLES.md
@@ -390,7 +390,7 @@ Default:  3
 
 ### sasl_protocol
 
-SASL Mechanism to set on all Kafka Listeners. Configures all components to use that mechanism for authentication. Possible options none, kerberos, plain, scram, scram256
+SASL Mechanism to set on all Kafka Listeners. Configures all components to use that mechanism for authentication. Possible options none, kerberos, plain, scram, scram256, oauthbearer
 
 Default:  none
 

--- a/molecule/oauthbearer-rhel/molecule.yml
+++ b/molecule/oauthbearer-rhel/molecule.yml
@@ -1,0 +1,52 @@
+---
+### Installation of Confluent Community Edition on CentOS7.
+### SASL OAUTHBEARER Auth.
+
+driver:
+  name: docker
+platforms:
+  - name: zookeeper1
+    hostname: zookeeper1.confluent
+    groups:
+      - zookeeper
+    image: geerlingguy/docker-centos7-ansible
+    dockerfile: ../Dockerfile.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    networks:
+      - name: confluent
+  - name: kafka-broker1
+    hostname: kafka-broker1.confluent
+    groups:
+      - kafka_broker
+    image: geerlingguy/docker-centos7-ansible
+    dockerfile: ../Dockerfile.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    networks:
+      - name: confluent
+provisioner:
+  inventory:
+    group_vars:
+      all:
+        confluent_server_enabled: false
+        sasl_protocol: plain
+        kafka_broker_custom_listeners:
+          broker:
+            name: BROKER
+            port: 9091
+            sasl_protocol: plain
+          internal:
+            name: INTERNAL
+            port: 9092
+            sasl_protocol: plain
+          ob:
+            name: OB
+            port: 9096
+            sasl_protocol: oauthbearer
+        kafka_broker_custom_properties:
+          listener.name.ob.oauthbearer.sasl.jaas.config: org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required;

--- a/molecule/oauthbearer-rhel/verify.yml
+++ b/molecule/oauthbearer-rhel/verify.yml
@@ -1,0 +1,27 @@
+---
+### Validates that SASL OAUTHBEARER protocol is set.
+### Validates that properties for callback handlers are not set.
+
+- name: Verify - kafka_broker
+  hosts: kafka_broker
+  gather_facts: false
+  tasks:
+    - import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: /etc/kafka/server.properties
+        property: listener.name.ob.sasl.enabled.mechanisms
+        expected_value: OAUTHBEARER
+    - import_role:
+        name: confluent.test
+        tasks_from: check_property_unset.yml
+      vars:
+        file_path: /etc/kafka/server.properties
+        property: listener.name.ob.oauthbearer.sasl.login.callback.handler.class
+    - import_role:
+        name: confluent.test
+        tasks_from: check_property_unset.yml
+      vars:
+        file_path: /etc/kafka/server.properties
+        property: listener.name.ob.oauthbearer.sasl.server.callback.handler.class

--- a/plugins/filter/filters.py
+++ b/plugins/filter/filters.py
@@ -35,7 +35,7 @@ class FilterModule(object):
             else 'SCRAM-SHA-512' if protocol.upper() == 'SCRAM' \
             else 'SCRAM-SHA-256' if protocol.lower() == 'scram256' \
             else 'PLAIN' if protocol.upper() == 'PLAIN' \
-            else 'OAUTHBEARER' if protocol.upper() == 'OAUTH' \
+            else 'OAUTHBEARER' if protocol.upper() == 'OAUTH' or protocol.upper() == 'OAUTHBEARER' \
             else 'none'
         return normalized
 
@@ -211,12 +211,13 @@ class FilterModule(object):
 
             if self.normalize_sasl_protocol(listeners_dict[listener].get('sasl_protocol', default_sasl_protocol)) == 'OAUTHBEARER':
                 final_dict['listener.name.' + listener_name + '.sasl.enabled.mechanisms'] = 'OAUTHBEARER'
-                final_dict['listener.name.' + listener_name + '.oauthbearer.sasl.server.callback.handler.class'] =\
-                    'io.confluent.kafka.server.plugins.auth.token.TokenBearerValidatorCallbackHandler'
-                final_dict['listener.name.' + listener_name + '.oauthbearer.sasl.login.callback.handler.class'] =\
-                    'io.confluent.kafka.server.plugins.auth.token.TokenBearerServerLoginCallbackHandler'
-                final_dict['listener.name.' + listener_name + '.oauthbearer.sasl.jaas.config'] =\
-                    'org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required publicKeyPath=\"' + oauth_pem_path + '\";'
+                if listeners_dict[listener].get('sasl_protocol', default_sasl_protocol).upper() == 'OAUTH':
+                    final_dict['listener.name.' + listener_name + '.oauthbearer.sasl.server.callback.handler.class'] =\
+                        'io.confluent.kafka.server.plugins.auth.token.TokenBearerValidatorCallbackHandler'
+                    final_dict['listener.name.' + listener_name + '.oauthbearer.sasl.login.callback.handler.class'] =\
+                        'io.confluent.kafka.server.plugins.auth.token.TokenBearerServerLoginCallbackHandler'
+                    final_dict['listener.name.' + listener_name + '.oauthbearer.sasl.jaas.config'] =\
+                        'org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required publicKeyPath=\"' + oauth_pem_path + '\";'
 
         return final_dict
 

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -172,7 +172,7 @@ confluent_cli_version: 2.3.1
 ### Recommended replication factor, defaults to 3. When splitting your cluster across 2 DCs with 4 or more Brokers, this should be increased to 4 to balance topic replicas.
 default_internal_replication_factor: 3
 
-### SASL Mechanism to set on all Kafka Listeners. Configures all components to use that mechanism for authentication. Possible options none, kerberos, plain, scram, scram256
+### SASL Mechanism to set on all Kafka Listeners. Configures all components to use that mechanism for authentication. Possible options none, kerberos, plain, scram, scram256, oauthbearer
 sasl_protocol: none
 
 ### Boolean to configure components with TLS Encryption. Also manages Java Keystore creation

--- a/test_roles/confluent.test/tasks/check_property_unset.yml
+++ b/test_roles/confluent.test/tasks/check_property_unset.yml
@@ -1,0 +1,6 @@
+---
+- name: Fail if property found in file
+  shell: "egrep '^{{property}}[ ]?=' {{file_path}}"
+  register: grep
+  changed_when: false
+  failed_when: grep.rc == 0


### PR DESCRIPTION
# Description

Using the existing `sasl_protocol: oauth` will add callback handlers for Confluent-provided classes. This PR adds a similar `sasl_protocol: oauthbearer` that will not automatically set up any callback handlers.

Fixes #1089

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Molecule test, and test in our local cluster.

**Test Configuration**:


# Checklist:

- [x ] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible