### PR TITLE
Fix system restart after secret protection tasks

### DIFF
--- a/roles/kafka_broker/tasks/main.yml
+++ b/roles/kafka_broker/tasks/main.yml
@@ -421,7 +421,9 @@
     - kafka_broker_secrets_protection_enabled|bool or kafka_broker_client_secrets_protection_enabled|bool
     - rbac_enabled|bool
 
-- name: Start kafka
+- meta: flush_handlers
+
+- name: Kafka Started
   systemd:
     name: "{{kafka_broker_service_name}}"
     enabled: true

--- a/roles/kafka_broker/tasks/secrets_protection.yml
+++ b/roles/kafka_broker/tasks/secrets_protection.yml
@@ -44,11 +44,9 @@
   tags:
     - systemd
 
-- name: Restart kafka
-  systemd:
-    name: "{{kafka_broker_service_name}}"
-    enabled: true
-    daemon_reload: true
-    state: restarted
+- name: Restart kafka broker
+  ansible.builtin.debug:
+    msg: "restarting kafka broker"
+  notify: restart kafka
   tags:
     - systemd


### PR DESCRIPTION
# Description

We were missing flushing the handlers after all secrets protections task. This fixes that. 

Fixes # (ANSIENG-1524)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

(https://jenkins.confluent.io/job/cp-ansible-on-demand/378/)

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible