### PR TITLE
Remove component where redacted word unavailable

### DIFF
--- a/molecule/archive-plain-rhel/verify.yml
+++ b/molecule/archive-plain-rhel/verify.yml
@@ -93,7 +93,7 @@
         tasks_from: check_log4j.yml
 
 - name: Verify logredactor
-  hosts: zookeeper:kafka_broker:schema_registry:kafka_connect:ksql:kafka_rest:control_center
+  hosts: zookeeper:kafka_broker:schema_registry:ksql:kafka_rest:control_center
   gather_facts: false
   tasks:
     - name: Create a mapping of component and log file


### PR DESCRIPTION
# Description

With #1091, default redactor being used with connect would remove the word being redacted, hence removing it from the verification stage.

Fixes # (weekly test failure)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Ran local verify


**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible