### PR TITLE
Change condition for including metric reporter

### DIFF
--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -530,7 +530,7 @@ kafka_broker_copy_files: []
 kafka_broker_default_internal_replication_factor: "{{ [ groups['kafka_broker'] | default(['localhost']) | length, default_internal_replication_factor ] | min }}"
 
 ### Boolean to enable the kafka's metrics reporter. Defaults to true if Control Center in inventory. Enable if you wish to have metrics reported to a centralized monitoring cluster.
-kafka_broker_metrics_reporter_enabled: "{{ false if not confluent_server_enabled|bool else 'control_center' in groups }}"
+kafka_broker_metrics_reporter_enabled: "{{ confluent_server_enabled and 'control_center' in groups }}"
 
 ### Use to set custom kafka properties. This variable is a dictionary. Put values true/false in quotation marks to perserve case. NOTE- kafka_broker.properties is deprecated.
 kafka_broker_custom_properties: {}

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -530,7 +530,7 @@ kafka_broker_copy_files: []
 kafka_broker_default_internal_replication_factor: "{{ [ groups['kafka_broker'] | default(['localhost']) | length, default_internal_replication_factor ] | min }}"
 
 ### Boolean to enable the kafka's metrics reporter. Defaults to true if Control Center in inventory. Enable if you wish to have metrics reported to a centralized monitoring cluster.
-kafka_broker_metrics_reporter_enabled: "{{ 'control_center' in groups }}"
+kafka_broker_metrics_reporter_enabled: "{{ false if not confluent_server_enabled|bool else 'control_center' in groups }}"
 
 ### Use to set custom kafka properties. This variable is a dictionary. Put values true/false in quotation marks to perserve case. NOTE- kafka_broker.properties is deprecated.
 kafka_broker_custom_properties: {}


### PR DESCRIPTION
# Description

Fixes failing weekly jobs cp-kafka-plain-rhel and confluent-kafka-kerberos-customcerts-rhel
Root cause - from 7.2 onwards, confluent community packages will fail if confluent metrics reporter is enabled. 
We have a flag `kafka_broker_metrics_reporter_enabled` controlling properties related to metric reporter.
If ccs used, this will be defaulting to false. If ce kafka used, this will check if control center is available or not. 

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Locally.


**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible