### PR TITLE
Update Confluent CLI based on provided version

### DIFF
--- a/docs/VARIABLES.md
+++ b/docs/VARIABLES.md
@@ -324,11 +324,19 @@ Default:  ""
 
 ***
 
+### archive_config_base_path
+
+If the installation_method is 'archive' then this will be the base path for the configuration files, otherwise configuration files are in the default /etc locations. For example, configuration files may be placed in `/opt/confluent/etc` using this variable.
+
+Default:  "{{ archive_destination_path }}"
+
+***
+
 ### config_base_path
 
 If the installation_method is 'archive' then this will be the base path for the configuration files, otherwise configuration files are in the default /etc locations. For example, configuration files may be placed in `/opt/confluent/etc` using this variable.
 
-Default:  "{{ (archive_destination_path | regex_replace('\\/$','')) if installation_method == 'archive' else '/' }}"
+Default:  "{{ (archive_config_base_path | regex_replace('\\/$','')) if installation_method == 'archive' else '/' }}"
 
 ***
 

--- a/molecule/archive-plain-debian/molecule.yml
+++ b/molecule/archive-plain-debian/molecule.yml
@@ -98,6 +98,7 @@ provisioner:
   inventory:
     group_vars:
       all:
+        confluent_cli_download_enabled: true
         sasl_protocol: plain
         ssl_enabled: true
         installation_method: "archive"

--- a/molecule/archive-plain-debian/verify.yml
+++ b/molecule/archive-plain-debian/verify.yml
@@ -81,3 +81,20 @@
     - import_role:
         name: confluent.test
         tasks_from: check_log4j.yml
+
+### Validates that Confluent CLI is installed.
+- name: Verify - Confluent CLI
+  hosts: all
+  gather_facts: false
+  tasks:
+    - import_role:
+        name: variables
+
+    - name: Check confluent cli is installed
+      command: "/usr/local/bin/confluent version"
+      register: confluent_cli_output
+
+    - name: Validate the cli version
+      assert:
+        that:
+          - "{{confluent_cli_version in confluent_cli_output.stdout}}"

--- a/roles/common/tasks/confluent_cli.yml
+++ b/roles/common/tasks/confluent_cli.yml
@@ -11,30 +11,33 @@
     fail_msg: "Confluent CLI architecture not supported"
     quiet: true
 
+- name: Directory name for the Confluent CLI version
+  set_fact:
+    confluent_cli_dir: "v{{ confluent_cli_version|replace('.', '_') }}"
+
 - name: Confluent CLI create base path
   file:
-    path: "{{item}}"
+    path: "{{confluent_cli_base_path}}/{{confluent_cli_dir}}"
     state: directory
     mode: '0755'
-  loop:
-    - "{{confluent_cli_base_path}}"
-    - "{{confluent_cli_base_path}}/{{confluent_cli_binary}}"
+    recurse: true
 
 - name: Expand remote Confluent CLI archive
   unarchive:
     src: "{{ confluent_cli_archive_file_source }}"
     remote_src: "{{ confluent_cli_archive_file_remote }}"
-    dest: "{{confluent_cli_base_path}}"
+    dest: "{{confluent_cli_base_path}}/{{confluent_cli_dir}}"
     group: "{{ omit if archive_group == '' else archive_group }}"
     owner: "{{ omit if archive_owner == '' else archive_owner }}"
     mode: 0755
-    creates: "{{confluent_cli_base_path}}/{{confluent_cli_binary}}/{{confluent_cli_binary}}"
+    extra_opts: [--strip-components=1]
+    creates: "{{confluent_cli_base_path}}/{{confluent_cli_dir}}/{{confluent_cli_binary}}"
   when: confluent_cli_custom_download_url is not defined
 
 - name: Download Confluent CLI - Custom URL
   get_url:
     url: "{{ confluent_cli_custom_download_url }}"
-    dest: "{{confluent_cli_base_path}}/{{confluent_cli_binary}}/{{confluent_cli_binary}}"
+    dest: "{{confluent_cli_base_path}}/{{confluent_cli_dir}}/{{confluent_cli_binary}}"
     mode: 0755
   register: cli_download_result
   until: cli_download_result is success
@@ -42,9 +45,14 @@
   delay: 5
   when: confluent_cli_custom_download_url is defined
 
+- name: Delete any existing symlink for confluent cli
+  file:
+    path: "{{confluent_cli_path}}"
+    state: absent
+
 - name: "Confluent CLI create symlink in {{confluent_cli_path}}"
   file:
-    src: "{{confluent_cli_base_path}}/{{confluent_cli_binary}}/{{confluent_cli_binary}}"
+    src: "{{confluent_cli_base_path}}/{{confluent_cli_dir}}/{{confluent_cli_binary}}"
     dest: "{{confluent_cli_path}}"
     state: link
     force: true


### PR DESCRIPTION
# Description

We need to update the Confluent CLI client based on the variable `confluent_cli_version`. This change creates a new directory based on the cli version defined. The task gets skipped if the CLI of the given version is already present ( current behaviour )

Fixes # (ANSIENG-1532)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Verified the changes with molecule scenarios 
https://jenkins.confluent.io/job/cp-ansible-on-demand/389/

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible