### PR TITLE
Fixing Multi Connector Groups issue

### DIFF
--- a/roles/confluent.kafka_connect/tasks/deploy_connectors.yml
+++ b/roles/confluent.kafka_connect/tasks/deploy_connectors.yml
@@ -1,6 +1,6 @@
 ---
 - name: Register Kafka Connect Subgroups
-  set_fact: subgroups="{{ ((subgroups | default([])) + hostvars[item].group_names) | difference('kafka_connect') }}"
+  set_fact: subgroups="{{ ((subgroups | default([])) + hostvars[item].group_names) | difference('kafka_broker, ksql, kafka_connect, kafka_rest, kerberos, ksql, schema_registry, zookeeper, kafka_broker_parallel, ksql_parallel, kafka_connect_parallel, kafka_rest_parallel, kerberos_parallel, ksql_parallel, schema_registry_parallel, zookeeper_parallel') }}"
   with_items: "{{groups['kafka_connect']}}"
 
 - name: Register connector configs and remove deleted connectors for single cluster


### PR DESCRIPTION
# Description
Fixes issue -> Connection refused error at task "Register connector configs and remove deleted connectors for Multiple Clusters"

Fixes # (issue)
ANSIENG-1206 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Tested by running a reproducible scenario

**Test Configuration**:
```
PLAY [Kafka Connect Replicator Serial Provisioning] ****************************
skipping: no hosts matched

PLAY RECAP *********************************************************************
control-center1            : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
kafka-broker1              : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
kafka-broker2              : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
kafka-broker3              : ok=48   changed=0    unreachable=0    failed=0    skipped=51   rescued=0    ignored=0
kafka-rest1                : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
schema-registry1           : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
zookeeper1                 : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible