### PR TITLE
Fixed issue where ksql log4j templating was failing in case of ccloud

### DIFF
--- a/roles/ksql/templates/ksql-server_log4j.properties.j2
+++ b/roles/ksql/templates/ksql-server_log4j.properties.j2
@@ -47,7 +47,11 @@ log4j.appender.kafka.append=true
 
 log4j.appender.kafka_appender=org.apache.kafka.log4jappender.KafkaLog4jAppender
 log4j.appender.kafka_appender.layout=io.confluent.common.logging.log4j.StructuredJsonLayout
+{% if ccloud_kafka_enabled | bool %}
 log4j.appender.kafka_appender.BrokerList={% for host in groups['kafka_broker'] %}{% if loop.index > 1%},{% endif %}{{ host }}:{{kafka_broker_listeners[ksql_processing_log_kafka_listener_name]['port']}}{% endfor %}
+{% else %}
+log4j.appender.kafka_appender.BrokerList={{ cloud_kafka_bootstrap_servers }}
+{% endif %}
 
 log4j.appender.kafka_appender.Topic={{ksql_service_id}}{{ksql_processing_log}}
 {% set listener = kafka_broker_listeners[ksql_processing_log_kafka_listener_name] %}


### PR DESCRIPTION
Fixed issue where ksql log4j templating was failing in case of ccloud…

# Description
In case if broker list is missing, template engine fails to find the `kafka_broker` dict.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
By running a non ccloud scenario.

**Test Configuration**:


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible