### PR TITLE
Change backup directory location from /tmp

### DIFF
--- a/roles/confluent.variables/defaults/main.yml
+++ b/roles/confluent.variables/defaults/main.yml
@@ -2,7 +2,7 @@
 # Custom filters used in this file are defined in filter_plugins/filters.py
 
 ### Version of Confluent Platform to install
-confluent_package_version: 6.1.1
+confluent_package_version: 7.1.0
 
 confluent_full_package_version: "{{ confluent_package_version + '-1' }}"
 confluent_package_redhat_suffix: "{{ '-' + confluent_full_package_version if confluent_full_package_version != '' else ''}}"
@@ -91,6 +91,9 @@ installation_method: "package"
 
 ## <deprecated, should be removed> The Scala version of the Confluent Platform archive to download. Possible values: 2.11, 2.12, etc. If you don't have a specific version requirement then use the default.
 confluent_archive_scala_version: 2.12
+
+### Backup location
+backup_location: "/opt/upgrade"
 
 ### The path the downloaded archive is expanded into. Using the default with a `confluent_package_version` of *5.5.1* results in the following installation path `/opt/confluent/confluent-5.5.1/` that contains directories such as `bin` and `share`, but may be overridden usinf the `binary_base_path` property.
 archive_destination_path: "/opt/confluent"
@@ -518,6 +521,7 @@ schema_registry_packages:
   - "{{ kafka_broker_main_package }}"
   - confluent-schema-registry
   - confluent-security
+  - confluent-schema-registry-plugins
 
 schema_registry_truststore_path: "{{ ssl_file_dir_final }}/schema_registry.truststore.jks"
 schema_registry_keystore_path: "{{ ssl_file_dir_final }}/schema_registry.keystore.jks"

--- a/roles/confluent.variables/vars/main.yml
+++ b/roles/confluent.variables/vars/main.yml
@@ -19,7 +19,7 @@ zookeeper:
   config_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/kafka/zookeeper.properties"
   systemd_file: "{{systemd_base_dir}}/{{zookeeper_service_name}}.service"
   systemd_override: /etc/systemd/system/{{zookeeper_service_name}}.service.d/override.conf
-  log4j_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/kafka/zookeeper-log4j.properties"
+  log4j_file: "{{ archive_config_base_path if installation_method == 'archive' else '' }}/etc/kafka/zookeeper_log4j.properties"
 
 zookeeper_properties:
   defaults:

--- a/tasks/reinstall_and_restart_components.yml
+++ b/tasks/reinstall_and_restart_components.yml
@@ -12,7 +12,7 @@
 
 - name: Create Backup Folders
   file:
-    path: "/tmp/upgrade/{{ item | dirname }}"
+    path: "{{ backup_location }}/{{ item | dirname }}"
     state: directory
     mode: 0640
   loop: "{{ backup_files }}"
@@ -21,7 +21,7 @@
   copy:
     src: "{{ item }}"
     remote_src: yes
-    dest: "/tmp/upgrade/{{ item }}-{{timestamp}}"
+    dest: "{{ backup_location }}/{{ item }}-{{timestamp}}"
   loop: "{{ backup_files }}"
 
 - name: Remove the Packages - Red Hat
@@ -57,7 +57,7 @@
   copy:
     dest: "{{ item }}"
     remote_src: yes
-    src: "/tmp/upgrade/{{ item }}-{{timestamp}}"
+    src: "{{ backup_location }}/{{ item }}-{{timestamp}}"
   loop: "{{ backup_files }}"
 
 - name: reload systemd

--- a/tasks/reinstall_components.yml
+++ b/tasks/reinstall_components.yml
@@ -4,7 +4,7 @@
 
 - name: Create Backup Folders
   file:
-    path: "/tmp/upgrade/{{ item | dirname }}"
+    path: "{{ backup_location }}/{{ item | dirname }}"
     state: directory
     mode: 0640
   loop: "{{ backup_files }}"
@@ -13,7 +13,7 @@
   copy:
     src: "{{ item }}"
     remote_src: yes
-    dest: "/tmp/upgrade/{{ item }}-{{timestamp}}"
+    dest: "{{ backup_location }}/{{ item }}-{{timestamp}}"
   loop: "{{ backup_files }}"
 
 - name: Remove the Packages - Red Hat
@@ -49,5 +49,5 @@
   copy:
     dest: "{{ item }}"
     remote_src: yes
-    src: "/tmp/upgrade/{{ item }}-{{timestamp}}"
+    src: "{{ backup_location }}/{{ item }}-{{timestamp}}"
   loop: "{{ backup_files }}"

--- a/tasks/upgrade_component.yml
+++ b/tasks/upgrade_component.yml
@@ -2,7 +2,7 @@
 - name: Create Backup Directory
   file:
     # TODO configurable
-    path: "/tmp/upgrade/{{ service_name }}"
+    path: "{{ backup_location }}/{{ service_name }}"
     state: directory
     mode: 0640
 
@@ -13,7 +13,7 @@
   copy:
     src: "{{ item }}"
     remote_src: true
-    dest: "/tmp/upgrade/{{ service_name }}/{{ item | basename }}-{{timestamp}}"
+    dest: "{{ backup_location }}/{{ service_name }}/{{ item | basename }}-{{timestamp}}"
     owner: "{{ config_owner }}"
     group: "{{ config_group }}"
     mode: 0640
@@ -75,7 +75,7 @@
   copy:
     dest: "{{ item }}"
     remote_src: true
-    src: "/tmp/upgrade/{{ service_name }}/{{ item | basename }}-{{timestamp}}"
+    src: "{{ backup_location }}/{{ service_name }}/{{ item | basename }}-{{timestamp}}"
     owner: "{{ config_owner }}"
     group: "{{ config_group }}"
     mode: 0640

--- a/upgrade_kafka_broker.yml
+++ b/upgrade_kafka_broker.yml
@@ -202,7 +202,7 @@
 
     - name: Create Backup Directory
       file:
-        path: "/tmp/upgrade/{{ kafka_broker_service_name }}"
+        path: "{{ backup_location }}/{{ kafka_broker_service_name }}"
         state: directory
         mode: 0640
       when: installation_method == 'package'
@@ -215,7 +215,7 @@
       copy:
         src: "{{ item }}"
         remote_src: true
-        dest: "/tmp/upgrade/{{ kafka_broker_service_name }}/{{ item | basename }}-{{timestamp}}"
+        dest: "{{ backup_location }}/{{ kafka_broker_service_name }}/{{ item | basename }}-{{timestamp}}"
         owner: "{{kafka_broker_user}}"
         group: "{{kafka_broker_group}}"
         mode: 0640
@@ -287,7 +287,7 @@
       copy:
         dest: "{{ item }}"
         remote_src: true
-        src: "/tmp/upgrade/{{ kafka_broker_service_name }}/{{ item | basename }}-{{timestamp}}"
+        src: "{{ backup_location }}/{{ kafka_broker_service_name }}/{{ item | basename }}-{{timestamp}}"
         owner: "{{kafka_broker_user}}"
         group: "{{kafka_broker_group}}"
         mode: 0640

--- a/upgrade_ksql.yml
+++ b/upgrade_ksql.yml
@@ -60,7 +60,7 @@
     - name: Create Backup Directory
       file:
         # TODO configurable
-        path: "/tmp/upgrade/{{ ksql_service_name }}"
+        path: "{{ backup_location }}/{{ ksql_service_name }}"
         state: directory
         mode: 0640
       when: installation_method == "package"
@@ -73,7 +73,7 @@
       copy:
         src: "{{ item }}"
         remote_src: true
-        dest: "/tmp/upgrade/{{ ksql_service_name }}/{{ item | basename }}-{{timestamp}}"
+        dest: "{{ backup_location }}/{{ ksql_service_name }}/{{ item | basename }}-{{timestamp}}"
         owner: "{{ ksql_user }}"
         group: "{{ ksql_group}}"
         mode: 0640
@@ -144,7 +144,7 @@
       copy:
         dest: "{{ item }}"
         remote_src: true
-        src: "/tmp/upgrade/{{ ksql_service_name }}/{{ item | basename }}-{{timestamp}}"
+        src: "{{ backup_location }}/{{ ksql_service_name }}/{{ item | basename }}-{{timestamp}}"
         owner: "{{ ksql_user }}"
         group: "{{ ksql_group}}"
         mode: 0640

--- a/upgrade_zookeeper.yml
+++ b/upgrade_zookeeper.yml
@@ -116,7 +116,7 @@
 
     - name: Create Backup Directory
       file:
-        path: "/tmp/upgrade/{{ zookeeper_service_name }}"
+        path: "{{ backup_location }}/{{ zookeeper_service_name }}"
         state: directory
         mode: 0640
 
@@ -127,7 +127,7 @@
       copy:
         src: "{{ item }}"
         remote_src: true
-        dest: "/tmp/upgrade/{{ zookeeper_service_name }}/{{ item | basename }}-{{timestamp}}"
+        dest: "{{ backup_location }}/{{ zookeeper_service_name }}/{{ item | basename }}-{{timestamp}}"
         owner: "{{zookeeper_user}}"
         group: "{{zookeeper_group}}"
         mode: 0640
@@ -199,7 +199,7 @@
       copy:
         dest: "{{ item }}"
         remote_src: true
-        src: "/tmp/upgrade/{{ zookeeper_service_name }}/{{ item | basename }}-{{timestamp}}"
+        src: "{{ backup_location }}/{{ zookeeper_service_name }}/{{ item | basename }}-{{timestamp}}"
         owner: "{{zookeeper_user}}"
         group: "{{zookeeper_group}}"
         mode: 0640


### PR DESCRIPTION
# Description

Made changes for backup directory location and schema-registry plugins.
- changed backup directory from /tmp/upgrade to /opt/upgrade
- added confluent-schema-registry-plugins in the list of schema-registry plugins to be installed
- corrected filename for zookeeper_log4j.properties from /etc/kafka/zookeeper-log4j.properties to /etc/kafka/zookeeper_log4j.properties (issue was seen while upgrading soak cluster 1 from 7.1 build to 7.2 RC build)

Fixes #
https://confluentinc.atlassian.net/browse/QEC-7880
https://confluentinc.atlassian.net/browse/QEC-7879