### PR TITLE
Improve logic for identifying whether a custom key needs to be decrypted

### DIFF
--- a/roles/ssl/tasks/custom_certs.yml
+++ b/roles/ssl/tasks/custom_certs.yml
@@ -42,7 +42,7 @@
   shell: |
     openssl rsa -in {{ ssl_file_dir_final }}/generation/{{service_name}}.key \
       -out {{key_path}} {% if ssl_key_password is defined %}-passin pass:{{ssl_key_password}} -passout pass:{{ssl_key_password}}{% endif %}
-  when: "'BEGIN ENCRYPTED PRIVATE KEY' in slurped_private_key.content|b64decode"
+  when: "'ENCRYPTED' in slurped_private_key.content|b64decode"
   no_log: "{{mask_secrets|bool}}"
 
 - name: Create Keystore and Truststore from Certs


### PR DESCRIPTION
# Description

The string that we were searching for in the slurped private key content to evaluate whether it's encrypted or not is not deterministic. 
Based on some online references like [this](https://serverfault.com/questions/628921/how-do-i-know-if-pem-is-password-protected-using-ssh-keygen), there are some more deterministic ways to evaluate whether a key is encrypted or not. 
Searching for string 'ENCRYPTED' covers more use cases. 

A customer hit some issues due to the logic in the mentioned RCCA

Fixes # (issue)
RCCA-8063

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?



**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible