### PR TITLE
Extract DNAME from BCFKS keystore

### DIFF
--- a/roles/confluent.kafka_broker/tasks/set_principal.yml
+++ b/roles/confluent.kafka_broker/tasks/set_principal.yml
@@ -14,7 +14,7 @@
     kafka_broker_principal: "{{ kerberos_kafka_broker_primary }}"
   when: kafka_broker_listeners[kafka_broker_inter_broker_listener_name]['sasl_protocol'] | default(sasl_protocol) | normalize_sasl_protocol == 'GSSAPI'
 
-- name: Extract Common Name from Keystore - SSL Mutual Auth
+- name: Extract Distinguished Name from Keystore - SSL Mutual Auth
   # Examine the keystore
   # Search lines with Entry type: "PrivateKeyEntry" and return that line and all after, ca cert is of type "trustedCertEntry"
   # Search for first "Owner" line
@@ -22,13 +22,20 @@
   # Remove spaces after commas
   shell: |
     keytool -list -keystore {{kafka_broker_keystore_path}} \
-        -storepass {{kafka_broker_keystore_storepass}} -v \
+        -storepass {{kafka_broker_keystore_storepass}} \
+        {% if fips_enabled|bool %}
+        -storetype BCFKS \
+        -providerclass org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider \
+        -providerpath {{ (binary_base_path, 'share/java/kafka/bc-fips-*.jar') | community.general.path_join }} \
+        {% endif %}
+        -v \
         | grep PrivateKeyEntry -A1000 \
         | grep Owner -m1 \
         | cut -d ":" -f2 \
         | cut -c2- \
         | sed 's/\s*,\s*/,/g'
   register: distinguished_name_from_keystore
+  changed_when: false
   when:
     - kafka_broker_listeners[kafka_broker_inter_broker_listener_name]['sasl_protocol'] | default(sasl_protocol) | normalize_sasl_protocol == 'none'
     - kafka_broker_listeners[kafka_broker_inter_broker_listener_name]['ssl_enabled'] | default(ssl_enabled) | bool


### PR DESCRIPTION
# Description

https://github.com/confluentinc/cp-ansible/blob/7.1.1-post/roles/kafka_broker/tasks/set_principal.yml#L29-L30 
This statement fails for fips keystore (.bcfks) with the following error: 
`keytool error: java.io.IOException: Invalid keystore format
java.io.IOException: Invalid keystore format
	at sun.security.provider.JavaKeyStore.engineLoad(JavaKeyStore.java:666)
	at sun.security.provider.JavaKeyStore$JKS.engineLoad(JavaKeyStore.java:57)
	at sun.security.provider.KeyStoreDelegator.engineLoad(KeyStoreDelegator.java:224)
	at sun.security.provider.JavaKeyStore$DualFormatJKS.engineLoad(JavaKeyStore.java:71)
	at java.security.KeyStore.load(KeyStore.java:1445)
	at sun.security.tools.keytool.Main.doCommands(Main.java:839)
	at sun.security.tools.keytool.Main.run(Main.java:380)
	at sun.security.tools.keytool.Main.main(Main.java:373)`

This leads to parsing of wrong value of kafka_broker_principal which is also used to populate super.users property of kafka broker.

Thus, we need a separate parsing and command for bcfks keystores.

Fixes # (ANSIENG-1587)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Locally with bcfks keystores.

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible