### PR TITLE
Specify default value of user login shell

### DIFF
--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -508,6 +508,14 @@ Default:  true
 
 ***
 
+### user_login_shell
+
+Variable to set the user login shell for all custom user created per component by cp-ansible.
+
+Default:  /sbin/nologin
+
+***
+
 ### zookeeper_user
 
 Set this variable to customize the Linux User that the Zookeeper Service runs with. Default user is cp-kafka.

--- a/roles/control_center/tasks/main.yml
+++ b/roles/control_center/tasks/main.yml
@@ -60,6 +60,7 @@
     name: "{{control_center_user}}"
     comment: Confluent Control Center
     system: true
+    shell: "{{user_login_shell}}"
     group: "{{control_center_group}}"
   when: (getent_passwd|default({}))[control_center_user] is not defined
 

--- a/roles/kafka_broker/tasks/main.yml
+++ b/roles/kafka_broker/tasks/main.yml
@@ -60,6 +60,7 @@
     name: "{{kafka_broker_user}}"
     comment: Confluent Kafka
     system: true
+    shell: "{{user_login_shell}}"
     group: "{{kafka_broker_group}}"
   when: (getent_passwd|default({}))[kafka_broker_user] is not defined
 

--- a/roles/kafka_connect/tasks/main.yml
+++ b/roles/kafka_connect/tasks/main.yml
@@ -60,6 +60,7 @@
     name: "{{kafka_connect_user}}"
     comment: Confluent Kafka Connect
     system: true
+    shell: "{{user_login_shell}}"
     group: "{{kafka_connect_group}}"
   when: (getent_passwd|default({}))[kafka_connect_user] is not defined
 

--- a/roles/kafka_connect_replicator/tasks/main.yml
+++ b/roles/kafka_connect_replicator/tasks/main.yml
@@ -60,6 +60,7 @@
     name: "{{kafka_connect_replicator_user}}"
     comment: Confluent Kafka Connect Replicator
     system: true
+    shell: "{{user_login_shell}}"
     group: "{{kafka_connect_replicator_group}}"
   when: (getent_passwd|default({}))[kafka_connect_replicator_user] is not defined
 

--- a/roles/kafka_rest/tasks/main.yml
+++ b/roles/kafka_rest/tasks/main.yml
@@ -60,6 +60,7 @@
     name: "{{kafka_rest_user}}"
     comment: Confluent REST proxy
     system: true
+    shell: "{{user_login_shell}}"
     group: "{{kafka_rest_group}}"
   when: (getent_passwd|default({}))[kafka_rest_user] is not defined
 

--- a/roles/ksql/tasks/main.yml
+++ b/roles/ksql/tasks/main.yml
@@ -60,6 +60,7 @@
     name: "{{ksql_user}}"
     comment: Confluent KSQL
     system: true
+    shell: "{{user_login_shell}}"
     group: "{{ksql_group}}"
   when: (getent_passwd|default({}))[ksql_user] is not defined
 

--- a/roles/schema_registry/tasks/main.yml
+++ b/roles/schema_registry/tasks/main.yml
@@ -61,6 +61,7 @@
     name: "{{schema_registry_user}}"
     comment: Confluent Schema Registry
     system: true
+    shell: "{{user_login_shell}}"
     group: "{{schema_registry_group}}"
   when: (getent_passwd|default({}))[schema_registry_user] is not defined
 

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -223,6 +223,9 @@ ksql_cluster_ansible_group_names: "{{ ['ksql'] if 'ksql' in groups else [] }}"
 ### Boolean to Run Host Validations. Validations include OS Version compatibility and Proper Internet Connectivity
 validate_hosts: true
 
+### Variable to set the user login shell for all custom user created per component by cp-ansible.
+user_login_shell: /sbin/nologin
+
 # Zookeeper Variables
 
 ### Set this variable to customize the Linux User that the Zookeeper Service runs with. Default user is cp-kafka.

--- a/roles/zookeeper/tasks/main.yml
+++ b/roles/zookeeper/tasks/main.yml
@@ -61,6 +61,7 @@
     name: "{{zookeeper_user}}"
     comment: Confluent Kafka
     system: true
+    shell: "{{user_login_shell}}"
     group: "{{zookeeper_group}}"
   when: (getent_passwd|default({}))[zookeeper_user] is not defined
 


### PR DESCRIPTION
# Description

cp-ansible creates a custom user for each component which owns the component service. 
This PR aims to introduce a default user login shell for all such created users. It'd be defaulting to /sbin/nologin coz we don't need these users to interactively login. 
This'll enhance security but the users will not be able to login. 

Fixes # (ANSIENG-1590)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested locally on a single scenario
https://jenkins.confluent.io/job/cp-ansible-on-demand/411/ for ALL scenarios.


**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible