### PR TITLE
Remove Deprecated Properties from Kafka Broker

### DIFF
--- a/roles/confluent.variables/vars/main.yml
+++ b/roles/confluent.variables/vars/main.yml
@@ -208,10 +208,8 @@ kafka_broker_properties:
     properties:
       confluent.metadata.server.advertised.listeners: "{{mds_http_protocol}}://{{ mds_advertised_listener_hostname | default(inventory_hostname, True) }}:{{mds_port}}"
       confluent.metadata.server.listeners: "{{mds_http_protocol}}://0.0.0.0:{{mds_port}}"
-      confluent.metadata.server.token.auth.enable: "true"
       confluent.metadata.server.token.max.lifetime.ms: 3600000
       confluent.metadata.server.token.key.path: "{{rbac_enabled_private_pem_path}}"
-      confluent.metadata.server.public.key.path: "{{rbac_enabled_public_pem_path}}"
       confluent.metadata.server.token.signature.algorithm: RS256
       confluent.metadata.server.authentication.method: BEARER
   rbac_mds_ldap:


### PR DESCRIPTION
# Description

This PR aims to remove deprecated properties from Kafka Broker properties. RBAC related configs i.e. `confluent.metadata.server.token.auth.enable` and `confluent.metadata.server.public.key.path` are removed in this PR. 

Fixes # [ANSIENG-1600](https://confluentinc.atlassian.net/browse/ANSIENG-1600)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This was tested in cp-ansible-on-demand on all rbac scenarios. Here is the result [Test Report](https://jenkins.confluent.io/job/cp-ansible-on-demand/414/testReport/)



**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible