### PR TITLE
zookeeper_skip_restart prints message restarting zokeeper

### DIFF
--- a/roles/zookeeper/tasks/main.yml
+++ b/roles/zookeeper/tasks/main.yml
@@ -267,7 +267,7 @@
   ansible.builtin.debug:
     msg: "restarting zookeeper"
   notify: restart zookeeper
-  when: (zookeeper_custom_log4j|bool) and (logredactor_enabled|bool)
+  when: (zookeeper_custom_log4j|bool) and (logredactor_enabled|bool) and (not zookeeper_skip_restarts|default(false)|bool)
   tags:
     - log
 


### PR DESCRIPTION
# Description
When we give variable `zookeeper_skip_restarts=true`, intent is to skip zookeeper restarts. And it happens that we don;t restart zookeeper in such case. But there is a message which gets printed that it's restarting zookeeper, which causes confusions. This fix is to suppress that false message in case of variable `zookeeper_skip_restarts` is given as true.


Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

`ansible-playbook -i ~/.cache/molecule/platform/archive-plain-rhel/inventory confluent.platform.all --tags zookeeper --skip-tags "privileged,sysctl,filesystem,package,systemd,health_check" --limit zookeeper1 -e zookeeper_skip_restarts=true`

```
TASK [confluent.platform.zookeeper : Restart zookeeper] **********************************
Wednesday 07 September 2022  12:44:45 +0000 (0:00:01.363)       0:01:25.189 ***
skipping: [zookeeper1]
```

**Test Configuration**:
`ansible-playbook -i ~/.cache/molecule/platform/archive-plain-rhel/inventory confluent.platform.all --tags zookeeper --skip-tags "privileged,sysctl,filesystem,package,systemd,health_check" --limit zookeeper1 -e zookeeper_skip_restarts=true`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible