### PR TITLE
Resolve test failure in rbac-mtls-rhel

### DIFF
--- a/roles/kafka_broker/tasks/health_check.yml
+++ b/roles/kafka_broker/tasks/health_check.yml
@@ -3,8 +3,6 @@
   shell: |
     {{ binary_base_path }}/bin/kafka-topics --bootstrap-server {{ hostvars[inventory_hostname]|confluent.platform.resolve_hostname }}:{{kafka_broker_listeners[kafka_broker_inter_broker_listener_name]['port']}} \
       --describe --under-replicated-partitions --command-config {{kafka_broker.client_config_file}}
-  environment:
-    KAFKA_OPTS: "-Xlog:all=error"
   register: urp_topics
   # stdout_lines will have topics with URPs and stderr has WARN and ERROR level logs
   until: urp_topics.stdout_lines|length == 0 and 'ERROR' not in urp_topics.stderr

--- a/roles/kafka_broker/tasks/health_check.yml
+++ b/roles/kafka_broker/tasks/health_check.yml
@@ -3,6 +3,8 @@
   shell: |
     {{ binary_base_path }}/bin/kafka-topics --bootstrap-server {{ hostvars[inventory_hostname]|confluent.platform.resolve_hostname }}:{{kafka_broker_listeners[kafka_broker_inter_broker_listener_name]['port']}} \
       --describe --under-replicated-partitions --command-config {{kafka_broker.client_config_file}}
+  environment:
+    KAFKA_OPTS: "-Xlog:all=error -XX:+IgnoreUnrecognizedVMOptions"
   register: urp_topics
   # stdout_lines will have topics with URPs and stderr has WARN and ERROR level logs
   until: urp_topics.stdout_lines|length == 0 and 'ERROR' not in urp_topics.stderr
@@ -19,7 +21,7 @@
       --describe --under-replicated-partitions --command-config {{kafka_broker.client_config_file}}
   environment:
     CONFLUENT_SECURITY_MASTER_KEY: "{{ secrets_protection_masterkey }}"
-    KAFKA_OPTS: "-Xlog:all=error"
+    KAFKA_OPTS: "-Xlog:all=error -XX:+IgnoreUnrecognizedVMOptions"
   register: urp_topics_secrets_protection
   # stdout_lines will have topics with URPs and stderr has WARN and ERROR level logs
   until: urp_topics_secrets_protection.stdout_lines|length == 0 and 'ERROR' not in urp_topics_secrets_protection.stderr

--- a/roles/kafka_broker/tasks/health_check.yml
+++ b/roles/kafka_broker/tasks/health_check.yml
@@ -3,6 +3,8 @@
   shell: |
     {{ binary_base_path }}/bin/kafka-topics --bootstrap-server {{ hostvars[inventory_hostname]|confluent.platform.resolve_hostname }}:{{kafka_broker_listeners[kafka_broker_inter_broker_listener_name]['port']}} \
       --describe --under-replicated-partitions --command-config {{kafka_broker.client_config_file}}
+  environment:
+    KAFKA_OPTS: "-Xlog:all=error"
   register: urp_topics
   # stdout_lines will have topics with URPs and stderr has WARN and ERROR level logs
   until: urp_topics.stdout_lines|length == 0 and 'ERROR' not in urp_topics.stderr
@@ -19,6 +21,7 @@
       --describe --under-replicated-partitions --command-config {{kafka_broker.client_config_file}}
   environment:
     CONFLUENT_SECURITY_MASTER_KEY: "{{ secrets_protection_masterkey }}"
+    KAFKA_OPTS: "-Xlog:all=error"
   register: urp_topics_secrets_protection
   # stdout_lines will have topics with URPs and stderr has WARN and ERROR level logs
   until: urp_topics_secrets_protection.stdout_lines|length == 0 and 'ERROR' not in urp_topics_secrets_protection.stderr


### PR DESCRIPTION
# Description

This PR aims to resolve rbac-mtls-rhel test failure. rbac-mtls-rhel was failing on branch 7.2.x due to a warning message in Health Check. This warning message was coming in the newer versions of Java.

Fixes # [ANSIENG-1572](https://confluentinc.atlassian.net/browse/ANSIENG-1572)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

rbac scenario has been tested locally and all scenarios were tested on cp-ansible-on-demand. This is the result [Result](https://jenkins.confluent.io/job/cp-ansible-on-demand/455/)



**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible