### PR TITLE
Make ansible takeover work for 6x

### DIFF
--- a/roles/confluent.kafka_broker/tasks/rbac.yml
+++ b/roles/confluent.kafka_broker/tasks/rbac.yml
@@ -38,6 +38,7 @@
     mode: 0640
     owner: "{{kafka_broker_user}}"
     group: "{{kafka_broker_group}}"
+  when: copy_certs | default(True)
   diff: "{{ not mask_sensitive_diff|bool }}"
 
 - name: Copy in private pem files
@@ -47,4 +48,5 @@
     mode: 0640
     owner: "{{kafka_broker_user}}"
     group: "{{kafka_broker_group}}"
+  when: copy_certs | default(True)
   diff: "{{ not mask_sensitive_diff|bool }}"

--- a/roles/confluent.kafka_broker/tasks/rbac.yml
+++ b/roles/confluent.kafka_broker/tasks/rbac.yml
@@ -31,6 +31,17 @@
     state: directory
     mode: 0755
 
+- name: Check if MDS public pem file exists on Ansible Controller
+  stat:
+    path: "{{ token_services_public_pem_file }}"
+  register: broker_public_pem_file
+  delegate_to: localhost
+
+- name: Debug
+  ansible.builtin.debug:
+    msg: WARNING - The file {{token_services_public_pem_file}} doesn't exist on the control node
+  when: not broker_public_pem_file.stat.exists|bool
+
 - name: Copy in public pem files
   copy:
     src: "{{token_services_public_pem_file}}"
@@ -38,8 +49,19 @@
     mode: 0640
     owner: "{{kafka_broker_user}}"
     group: "{{kafka_broker_group}}"
-  when: copy_certs | default(True)
+  when: broker_public_pem_file.stat.exists|bool
   diff: "{{ not mask_sensitive_diff|bool }}"
+
+- name: Check if MDS private pem file exists on Ansible Controller
+  stat:
+    path: "{{ token_services_private_pem_file }}"
+  register: broker_private_pem_file
+  delegate_to: localhost
+
+- name: Debug
+  ansible.builtin.debug:
+    msg: WARNING - The file {{token_services_private_pem_file}} doesn't exist on the control node
+  when: not broker_private_pem_file.stat.exists|bool
 
 - name: Copy in private pem files
   copy:
@@ -48,5 +70,5 @@
     mode: 0640
     owner: "{{kafka_broker_user}}"
     group: "{{kafka_broker_group}}"
-  when: copy_certs | default(True)
+  when: broker_private_pem_file.stat.exists|bool
   diff: "{{ not mask_sensitive_diff|bool }}"

--- a/roles/confluent.kafka_rest/tasks/main.yml
+++ b/roles/confluent.kafka_rest/tasks/main.yml
@@ -116,7 +116,9 @@
     mode: '755'
     owner: "{{kafka_rest_user}}"
     group: "{{kafka_rest_group}}"
-  when: rbac_enabled|bool
+  when:
+    - rbac_enabled|bool
+    - copy_certs | default(True)
   diff: "{{ not mask_sensitive_diff|bool }}"
 
 - name: Create Kafka Rest Config directory

--- a/roles/confluent.kafka_rest/tasks/main.yml
+++ b/roles/confluent.kafka_rest/tasks/main.yml
@@ -109,6 +109,17 @@
     mode: 0755
   when: rbac_enabled|bool
 
+- name: Check if MDS public pem file exists on Ansible Controller
+  stat:
+    path: "{{ token_services_public_pem_file }}"
+  register: krest_public_pem_file
+  delegate_to: localhost
+
+- name: Debug
+  ansible.builtin.debug:
+    msg: WARNING - The file {{token_services_public_pem_file}} doesn't exist on the control node
+  when: not krest_public_pem_file.stat.exists|bool
+
 - name: Copy in MDS Public Pem File
   copy:
     src: "{{token_services_public_pem_file}}"
@@ -118,7 +129,7 @@
     group: "{{kafka_rest_group}}"
   when:
     - rbac_enabled|bool
-    - copy_certs | default(True)
+    - krest_public_pem_file.stat.exists|bool
   diff: "{{ not mask_sensitive_diff|bool }}"
 
 - name: Create Kafka Rest Config directory

--- a/roles/confluent.ssl/tasks/export_certs_from_keystore_and_truststore.yml
+++ b/roles/confluent.ssl/tasks/export_certs_from_keystore_and_truststore.yml
@@ -53,3 +53,7 @@
         openssl pkcs12 -in /var/ssl/private/generation/{{service_name}}.p12 \
           -nodes -nocerts -out {{key_path}} \
           -passin pass:{{keystore_storepass}}
+
+- name: Unset export certs var
+  set_fact:
+    export_certs: false

--- a/roles/confluent.ssl/tasks/main.yml
+++ b/roles/confluent.ssl/tasks/main.yml
@@ -13,6 +13,12 @@
   include_tasks: create_keystore_and_truststore.yml
   when: not keystore.stat.exists|bool or not truststore.stat.exists|bool or regenerate_keystore_and_truststore|bool
 
+- name: Export Certs from Keystore and Truststore
+  include_tasks: export_certs_from_keystore_and_truststore.yml
+  when:
+    - export_certs|bool
+    - ssl_provided_keystore_and_truststore|bool
+
 - name: Set Truststore and Keystore File Permissions
   file:
     path: "{{item}}"

--- a/tasks/rbac_setup.yml
+++ b/tasks/rbac_setup.yml
@@ -41,7 +41,17 @@
     path: /var/ssl/private
     state: directory
     mode: 0755
-  when: copy_certs | default(True)
+
+- name: Check if MDS public pem file exists on Ansible Controller
+  stat:
+    path: "{{ token_services_public_pem_file }}"
+  register: public_pem_file
+  delegate_to: localhost
+
+- name: Debug
+  ansible.builtin.debug:
+    msg: WARNING - The file {{token_services_public_pem_file}} doesn't exist on the control node
+  when: not public_pem_file.stat.exists|bool
 
 - name: Copy in MDS Public Pem File
   copy:
@@ -50,5 +60,5 @@
     mode: 0640
     owner: "{{user}}"
     group: "{{group}}"
-  when: copy_certs | default(True)
+  when: public_pem_file.stat.exists|bool
   diff: "{{ not mask_sensitive_diff|bool }}"


### PR DESCRIPTION
# Description

The inventory file generated from ansible takeover will assume all existing clusters to be a case where keystores and truststores and mds-pem files will already be present on the host nodes. 
If the playbook is then run with the generated inventory file, some mandatory steps might get skipped and some unneeded ones might get executed and error out. This PR fixes those problems. 

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

https://jenkins.confluent.io/job/cp-ansible-on-demand/473/
With the latest changes - https://jenkins.confluent.io/job/cp-ansible-on-demand/511/

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible