### PR TITLE
Check Internet Access thru proxy if any

### DIFF
--- a/roles/common/tasks/host_validations.yml
+++ b/roles/common/tasks/host_validations.yml
@@ -53,7 +53,7 @@
   tags:
     - validate
     - validate_internet_access
-  environment: "{ {% if proxy_env.http_proxy|length != 0 %} 'http_proxy': '{{ proxy_env.http_proxy }}', 'https_proxy': '{{ proxy_env.http_proxy }}' {% endif %} }"
+  environment: "{ {% if 'http_proxy' in proxy_env %} 'http_proxy': '{{ proxy_env.http_proxy }}', 'https_proxy': '{{ proxy_env.http_proxy }}' {% endif %} }"
 
 - name: Fail Provisioning because No Network Connectivity
   fail:

--- a/roles/common/tasks/host_validations.yml
+++ b/roles/common/tasks/host_validations.yml
@@ -53,6 +53,7 @@
   tags:
     - validate
     - validate_internet_access
+  environment: "{ {% if proxy_env.http_proxy|length != 0 %} 'http_proxy': '{{ proxy_env.http_proxy }}', 'https_proxy': '{{ proxy_env.http_proxy }}' {% endif %} }"
 
 - name: Fail Provisioning because No Network Connectivity
   fail:


### PR DESCRIPTION
# Description

When broker server accesses internet thru a proxy, the step `Check Internet Access for Confluent Packages/Archive` fails, while the generated configuration is correct

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

just addind a "when" to set proxy n environment solves the issue

**Test Configuration**:
cp-ansible 7.2.1-post with 6.1 and 7.2 cluster : step doesn't fail anymore
