### PR TITLE
accept ssl key file in ansible-vault format

### DIFF
--- a/roles/common/tasks/host_validations.yml
+++ b/roles/common/tasks/host_validations.yml
@@ -91,7 +91,9 @@
     - validate_disk_usage
 
 - name: Retrieve SSL key hash
-  shell: openssl rsa -noout -modulus -in {{ ssl_key_filepath }} | openssl md5
+  shell:
+    cmd: openssl rsa -noout -modulus | openssl md5
+    stdin: "{{ lookup('file', ssl_key_filepath) }}"
   register: key_hash
   delegate_to: localhost
   changed_when: false


### PR DESCRIPTION
# Description

SSL key file may be stored in ansible inventory as ansible-vault file.
In this case, check between key and certificate fails because shell task doesn't decrypt file

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

 - set `ssl_custom_certs` true
 - Store ssl key in a vault file
 - set `ssl_key_filepath` to this file path

**Test Configuration**:
cp-ansible 7.2.1-post with 7.2 cluster : step doesn't fails anymore
