### PR TITLE
Add Sid Repo variable for Debain 10

### DIFF
--- a/roles/confluent.common/defaults/main.yml
+++ b/roles/confluent.common/defaults/main.yml
@@ -45,6 +45,9 @@ ubuntu_java_package_name: openjdk-8-jdk
 ### Deb Repository to use for Java Installation
 ubuntu_java_repository: ppa:openjdk-r/ppa
 
+### Boolean to add Sid Repo for JAVA Buster
+add_sid_repo: false
+
 ### Version of Jolokia Agent Jar to Download
 jolokia_version: 1.6.2
 

--- a/roles/confluent.common/tasks/debian.yml
+++ b/roles/confluent.common/tasks/debian.yml
@@ -107,6 +107,7 @@
     - install_java|bool
     - repository_configuration == 'confluent'
     - ansible_distribution_release == "buster"
+    - add_sid_repo|bool
 
 - meta: flush_handlers
 


### PR DESCRIPTION
# Description

This PR aims to provide a custom variable for adding Sid Repo. The default value for add_sid_repo is false. This change would stabilize Java 11 installation on Debian 10 

Fixes # [ANSIENG-1650](https://confluentinc.atlassian.net/browse/ANSIENG-1650)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I have tested both locally and on jenkins for all debian scenarios. The changes have been made on base 6.1.x Here are the test Results [test1](https://jenkins.confluent.io/job/cp-ansible-on-demand/480/) [test2](https://jenkins.confluent.io/job/cp-ansible-on-demand/481/) 



**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible