### PR TITLE
Deprecate community.general

### DIFF
--- a/docs/VARIABLES.md
+++ b/docs/VARIABLES.md
@@ -644,19 +644,19 @@ Default:  false
 
 ***
 
-### zookeeper_config_prefix
-
-Default Zookeeper config prefix. Note - Only valid to customize when installation_method: archive
-
-Default:  "{{ config_prefix }}/kafka"
-
-***
-
 ### user_login_shell
 
 Variable to set the user login shell for all custom user created per component by cp-ansible.
 
 Default:  /sbin/nologin
+
+***
+
+### zookeeper_config_prefix
+
+Default Zookeeper config prefix. Note - Only valid to customize when installation_method: archive
+
+Default:  "{{ config_prefix }}/kafka"
 
 ***
 
@@ -768,7 +768,7 @@ Default:  "{{ zookeeper_ssl_enabled }}"
 
 Path on Zookeeper host for Jolokia Configuration file
 
-Default:  "{{ (config_base_path, 'etc/kafka/zookeeper_jolokia.properties' ) | community.general.path_join }}"
+Default:  "{{ (config_base_path, 'etc/kafka/zookeeper_jolokia.properties' ) | path_join }}"
 
 ***
 
@@ -968,7 +968,7 @@ Default:  "{{ ssl_enabled }}"
 
 Path on Kafka host for Jolokia Configuration file
 
-Default:  "{{ (config_base_path,'etc/kafka/kafka_jolokia.properties') | community.general.path_join }}"
+Default:  "{{ (config_base_path,'etc/kafka/kafka_jolokia.properties') | path_join }}"
 
 ***
 
@@ -1200,7 +1200,7 @@ Default:  "{{ schema_registry_ssl_enabled }}"
 
 Path on Schema Registry host for Jolokia Configuration file
 
-Default:  "{{ (config_base_path,'etc/schema-registry/schema_registry_jolokia.properties') | community.general.path_join }}"
+Default:  "{{ (config_base_path,'etc/schema-registry/schema_registry_jolokia.properties') | path_join }}"
 
 ***
 
@@ -1384,7 +1384,7 @@ Default:  "{{ kafka_rest_ssl_enabled }}"
 
 Path on Rest Proxy host for Jolokia Configuration file
 
-Default:  "{{ (config_base_path,'etc/kafka-rest/kafka_rest_jolokia.properties') | community.general.path_join }}"
+Default:  "{{ (config_base_path,'etc/kafka-rest/kafka_rest_jolokia.properties') | path_join }}"
 
 ***
 
@@ -1608,7 +1608,7 @@ Default:  "{{ kafka_connect_ssl_enabled }}"
 
 Path on Connect host for Jolokia Configuration file
 
-Default:  "{{ (config_base_path,'etc/kafka/kafka_connect_jolokia.properties') | community.general.path_join }}"
+Default:  "{{ (config_base_path,'etc/kafka/kafka_connect_jolokia.properties') | path_join }}"
 
 ***
 
@@ -1832,7 +1832,7 @@ Default:  "{{ ksql_ssl_enabled }}"
 
 Path on ksqlDB host for Jolokia Configuration file
 
-Default:  "{{ (config_base_path,((confluent_package_version is version('5.5.0', '>=')) | ternary('etc/ksqldb/ksql_jolokia.properties' , 'etc/ksql/ksql_jolokia.properties'))) | community.general.path_join }}"
+Default:  "{{ (config_base_path,((confluent_package_version is version('5.5.0', '>=')) | ternary('etc/ksqldb/ksql_jolokia.properties' , 'etc/ksql/ksql_jolokia.properties'))) | path_join }}"
 
 ***
 

--- a/roles/kafka_broker/tasks/set_principal.yml
+++ b/roles/kafka_broker/tasks/set_principal.yml
@@ -31,7 +31,7 @@
         {% if fips_enabled|bool %}
         -storetype BCFKS \
         -providerclass org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider \
-        -providerpath {{ (binary_base_path, 'share/java/kafka/bc-fips-*.jar') | community.general.path_join }} \
+        -providerpath {{ (binary_base_path, 'share/java/kafka/bc-fips-*.jar') | path_join }} \
         {% endif %}
         -v \
         | grep PrivateKeyEntry -A1000 \

--- a/roles/ssl/tasks/create_keystores_from_certs.yml
+++ b/roles/ssl/tasks/create_keystores_from_certs.yml
@@ -34,7 +34,7 @@
       -storepass {{truststore_storepass}} \
       -keypass {{truststore_storepass}} \
       -providerclass org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider \
-      -providerpath {{ (binary_base_path, 'share/java/kafka/bc-fips-*.jar') | community.general.path_join }}
+      -providerpath {{ (binary_base_path, 'share/java/kafka/bc-fips-*.jar') | path_join }}
   when:
     - cert_count|int == 1
     - create_bouncy_castle_keystore|bool
@@ -75,7 +75,7 @@
       -deststoretype BCFKS \
       -providername BCFIPS \
       -providerclass org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider \
-      -providerpath {{ (binary_base_path, 'share/java/kafka/bc-fips-*.jar') | community.general.path_join }}
+      -providerpath {{ (binary_base_path, 'share/java/kafka/bc-fips-*.jar') | path_join }}
   when: create_bouncy_castle_keystore|bool
   no_log: "{{mask_secrets|bool}}"
 
@@ -96,6 +96,6 @@
       -import -file {{ca_cert_path}} \
       -storepass {{keystore_storepass}} \
       -providerclass org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider \
-      -providerpath {{ (binary_base_path, 'share/java/kafka/bc-fips-*.jar') | community.general.path_join }}
+      -providerpath {{ (binary_base_path, 'share/java/kafka/bc-fips-*.jar') | path_join }}
   when: create_bouncy_castle_keystore|bool
   no_log: "{{mask_secrets|bool}}"

--- a/roles/ssl/tasks/import_ca_chain.yml
+++ b/roles/ssl/tasks/import_ca_chain.yml
@@ -31,6 +31,6 @@
             -deststorepass {{truststore_storepass}} \
             -providername BCFIPS \
             -providerclass org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider \
-            -providerpath {{ (binary_base_path, 'share/java/kafka/bc-fips-*.jar') | community.general.path_join }}
+            -providerpath {{ (binary_base_path, 'share/java/kafka/bc-fips-*.jar') | path_join }}
     done
   when: create_bouncy_castle_keystore|bool

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -342,7 +342,7 @@ zookeeper_jolokia_port: 7770
 zookeeper_jolokia_ssl_enabled: "{{ zookeeper_ssl_enabled }}"
 
 ### Path on Zookeeper host for Jolokia Configuration file
-zookeeper_jolokia_config: "{{ (config_base_path, 'etc/kafka/zookeeper_jolokia.properties' ) | community.general.path_join }}"
+zookeeper_jolokia_config: "{{ (config_base_path, 'etc/kafka/zookeeper_jolokia.properties' ) | path_join }}"
 
 ### Authentication Mode for Zookeeper's Jolokia Agent. Possible values: none, basic. If selecting basic, you must set zookeeper_jolokia_user and zookeeper_jolokia_password
 zookeeper_jolokia_auth_mode: "{{jolokia_auth_mode}}"
@@ -497,7 +497,7 @@ kafka_broker_jolokia_port: 7771
 kafka_broker_jolokia_ssl_enabled: "{{ ssl_enabled }}"
 
 ### Path on Kafka host for Jolokia Configuration file
-kafka_broker_jolokia_config: "{{ (config_base_path,'etc/kafka/kafka_jolokia.properties') | community.general.path_join }}"
+kafka_broker_jolokia_config: "{{ (config_base_path,'etc/kafka/kafka_jolokia.properties') | path_join }}"
 
 ### Authentication Mode for Kafka's Jolokia Agent. Possible values: none, basic. If selecting basic, you must set kafka_broker_jolokia_user and kafka_broker_jolokia_password
 kafka_broker_jolokia_auth_mode: "{{jolokia_auth_mode}}"
@@ -618,7 +618,7 @@ schema_registry_jolokia_port: 7772
 schema_registry_jolokia_ssl_enabled: "{{ schema_registry_ssl_enabled }}"
 
 ### Path on Schema Registry host for Jolokia Configuration file
-schema_registry_jolokia_config: "{{ (config_base_path,'etc/schema-registry/schema_registry_jolokia.properties') | community.general.path_join }}"
+schema_registry_jolokia_config: "{{ (config_base_path,'etc/schema-registry/schema_registry_jolokia.properties') | path_join }}"
 
 ### Authentication Mode for Schema Registry's Jolokia Agent. Possible values: none, basic. If selecting basic, you must set schema_registry_jolokia_user and schema_registry_jolokia_password
 schema_registry_jolokia_auth_mode: "{{jolokia_auth_mode}}"
@@ -715,7 +715,7 @@ kafka_rest_jolokia_port: 7775
 kafka_rest_jolokia_ssl_enabled: "{{ kafka_rest_ssl_enabled }}"
 
 ### Path on Rest Proxy host for Jolokia Configuration file
-kafka_rest_jolokia_config: "{{ (config_base_path,'etc/kafka-rest/kafka_rest_jolokia.properties') | community.general.path_join }}"
+kafka_rest_jolokia_config: "{{ (config_base_path,'etc/kafka-rest/kafka_rest_jolokia.properties') | path_join }}"
 
 ### Authentication Mode for Rest Proxy's Jolokia Agent. Possible values: none, basic. If selecting basic, you must set schema_registry_jolokia_user and schema_registry_jolokia_password
 kafka_rest_jolokia_auth_mode: "{{jolokia_auth_mode}}"
@@ -830,7 +830,7 @@ kafka_connect_jolokia_port: 7773
 kafka_connect_jolokia_ssl_enabled: "{{ kafka_connect_ssl_enabled }}"
 
 ### Path on Connect host for Jolokia Configuration file
-kafka_connect_jolokia_config: "{{ (config_base_path,'etc/kafka/kafka_connect_jolokia.properties') | community.general.path_join }}"
+kafka_connect_jolokia_config: "{{ (config_base_path,'etc/kafka/kafka_connect_jolokia.properties') | path_join }}"
 
 ### Authentication Mode for Connect's Jolokia Agent. Possible values: none, basic. If selecting basic, you must set schema_registry_jolokia_user and schema_registry_jolokia_password
 kafka_connect_jolokia_auth_mode: "{{jolokia_auth_mode}}"
@@ -873,7 +873,7 @@ kafka_connect_secret_registry_default_replication_factor:  "{{ 3 if ccloud_kafka
   [ groups['kafka_broker'] | default(['localhost']) | length, default_internal_replication_factor ] | min }}"
 
 kafka_connect_plugins_path:
-  - "{{ (binary_base_path, 'share/java') | community.general.path_join }}"
+  - "{{ (binary_base_path, 'share/java') | path_join }}"
 
 
 kafka_connect_confluent_hub_plugins: []
@@ -958,7 +958,7 @@ ksql_jolokia_port: 7774
 ksql_jolokia_ssl_enabled: "{{ ksql_ssl_enabled }}"
 
 ### Path on ksqlDB host for Jolokia Configuration file
-ksql_jolokia_config: "{{ (config_base_path,((confluent_package_version is version('5.5.0', '>=')) | ternary('etc/ksqldb/ksql_jolokia.properties' , 'etc/ksql/ksql_jolokia.properties'))) | community.general.path_join }}"
+ksql_jolokia_config: "{{ (config_base_path,((confluent_package_version is version('5.5.0', '>=')) | ternary('etc/ksqldb/ksql_jolokia.properties' , 'etc/ksql/ksql_jolokia.properties'))) | path_join }}"
 
 ### Authentication Mode for ksqlDB's Jolokia Agent. Possible values: none, basic. If selecting basic, you must set schema_registry_jolokia_user and schema_registry_jolokia_password
 ksql_jolokia_auth_mode: "{{jolokia_auth_mode}}"
@@ -1710,7 +1710,7 @@ kafka_connect_replicator_jolokia_password: "{{jolokia_password}}"
 ### Port for Jolokia agent for Kafka Connect Replicator.
 kafka_connect_replicator_jolokia_port: 7777
 
-kafka_connect_replicator_jolokia_config: "{{ (config_base_path ,'etc/kafka-connect-replicator/confluent-replicator-jolokia.properties' ) | community.general.path_join }}"
+kafka_connect_replicator_jolokia_config: "{{ (config_base_path ,'etc/kafka-connect-replicator/confluent-replicator-jolokia.properties' ) | path_join }}"
 
 ### Full path to download the Jolokia Agent Jar.
 kafka_connect_replicator_jolokia_jar_path: /opt/jolokia/jolokia.jar

--- a/roles/variables/vars/main.yml
+++ b/roles/variables/vars/main.yml
@@ -9,9 +9,9 @@ confluent_repo_version: "{{ confluent_package_version | regex_replace('^([0-9])\
 ssl_file_dir_final: "{{ ssl_file_dir |regex_replace('\\/$', '') }}"
 
 ### The base path for the binary files. When in Archive File deployment mode this results in binary files being based in, for example `/opt/confluent/confluent-5.5.1/bin`, otherwise they are based in `/usr/bin`.
-base_path: "{{ ((config_base_path,('confluent-',confluent_package_version) | join) | community.general.path_join) if installation_method == 'archive' else '/' }}"
+base_path: "{{ ((config_base_path,('confluent-',confluent_package_version) | join) | path_join) if installation_method == 'archive' else '/' }}"
 
-binary_base_path: "{{ ((config_base_path,('confluent-',confluent_package_version) | join) | community.general.path_join) if installation_method == 'archive' else '/usr' }}"
+binary_base_path: "{{ ((config_base_path,('confluent-',confluent_package_version) | join) | path_join) if installation_method == 'archive' else '/usr' }}"
 
 #### Zookeeper Variables ####
 zookeeper_service_name: confluent-zookeeper
@@ -21,11 +21,11 @@ zookeeper_default_group: confluent
 zookeeper_default_log_dir: /var/log/kafka
 zookeeper:
   server_start_file: "{{ binary_base_path }}/bin/zookeeper-server-start"
-  config_file: "{{ (config_base_path , 'etc/kafka/zookeeper.properties') | community.general.path_join }}"
+  config_file: "{{ (config_base_path , 'etc/kafka/zookeeper.properties') | path_join }}"
   systemd_file: "{{systemd_base_dir}}/{{zookeeper_service_name}}.service"
   systemd_override: /etc/systemd/system/{{zookeeper_service_name}}.service.d/override.conf
-  log4j_file: "{{ (base_path, 'etc/kafka/zookeeper-log4j.properties' ) | community.general.path_join }}"
-  jaas_file: "{{ (config_base_path, 'etc/kafka/zookeeper_jaas.conf') | community.general.path_join }}"
+  log4j_file: "{{ (base_path, 'etc/kafka/zookeeper-log4j.properties' ) | path_join }}"
+  jaas_file: "{{ (config_base_path, 'etc/kafka/zookeeper_jaas.conf') | path_join }}"
 
 zookeeper_properties:
   defaults:
@@ -98,14 +98,14 @@ kafka_broker_default_group: confluent
 kafka_broker_default_log_dir: /var/log/kafka
 kafka_broker:
   server_start_file: "{{ binary_base_path }}/bin/kafka-server-start"
-  config_file: "{{ (config_base_path , 'etc/kafka/server.properties')| community.general.path_join }}"
-  client_config_file: "{{ (config_base_path , 'etc/kafka/client.properties')| community.general.path_join }}"
-  zookeeper_tls_client_config_file: "{{ (config_base_path, 'etc/kafka/zookeeper-tls-client.properties') | community.general.path_join }}"
+  config_file: "{{ (config_base_path , 'etc/kafka/server.properties')| path_join }}"
+  client_config_file: "{{ (config_base_path , 'etc/kafka/client.properties')| path_join }}"
+  zookeeper_tls_client_config_file: "{{ (config_base_path, 'etc/kafka/zookeeper-tls-client.properties') | path_join }}"
   systemd_file: "{{systemd_base_dir}}/{{kafka_broker_service_name}}.service"
   systemd_override: /etc/systemd/system/{{kafka_broker_service_name}}.service.d/override.conf
-  log4j_file: "{{ (base_path, 'etc/kafka/log4j.properties') | community.general.path_join }}"
-  jaas_file: "{{ (config_base_path, 'etc/kafka/kafka_server_jaas.conf') | community.general.path_join }}"
-  rest_proxy_password_file: "{{ (config_base_path, 'etc/kafka/password.properties') | community.general.path_join }}"
+  log4j_file: "{{ (base_path, 'etc/kafka/log4j.properties') | path_join }}"
+  jaas_file: "{{ (config_base_path, 'etc/kafka/kafka_server_jaas.conf') | path_join }}"
+  rest_proxy_password_file: "{{ (config_base_path, 'etc/kafka/password.properties') | path_join }}"
 
 mds_http_protocol: "{{ 'https' if kafka_broker_rest_ssl_enabled|bool else 'http' }}"
 mds_tls_enabled: "{{true if 'https' in mds_bootstrap_server_urls else false}}"
@@ -412,11 +412,11 @@ schema_registry_default_log_dir: /var/log/confluent/schema-registry
 schema_registry:
   server_start_file: "{{ binary_base_path }}/bin/schema-registry-start"
   systemd_file: "{{systemd_base_dir}}/{{schema_registry_service_name}}.service"
-  config_file: "{{ (config_base_path,'etc/schema-registry/schema-registry.properties') | community.general.path_join }}"
+  config_file: "{{ (config_base_path,'etc/schema-registry/schema-registry.properties') | path_join }}"
   systemd_override: /etc/systemd/system/{{schema_registry_service_name}}.service.d/override.conf
-  log4j_file: "{{ (base_path, 'etc/schema-registry/log4j.properties') | community.general.path_join }}"
-  jaas_file: "{{ (config_base_path,'etc/schema-registry/jaas.conf') | community.general.path_join }}"
-  password_file: "{{ (config_base_path, 'etc/schema-registry/password.properties') | community.general.path_join }}"
+  log4j_file: "{{ (base_path, 'etc/schema-registry/log4j.properties') | path_join }}"
+  jaas_file: "{{ (config_base_path,'etc/schema-registry/jaas.conf') | path_join }}"
+  password_file: "{{ (config_base_path, 'etc/schema-registry/password.properties') | path_join }}"
 
 schema_registry_http_protocol: "{{ 'https' if schema_registry_ssl_enabled|bool else 'http' }}"
 
@@ -528,11 +528,11 @@ kafka_connect_default_log_dir: /var/log/kafka
 kafka_connect:
   server_start_file: "{{ binary_base_path }}/bin/connect-distributed"
   systemd_file: "{{systemd_base_dir}}/{{kafka_connect_service_name}}.service"
-  config_file: "{{ (config_base_path,'etc/kafka',kafka_connect_config_filename) | community.general.path_join }}"
+  config_file: "{{ (config_base_path,'etc/kafka',kafka_connect_config_filename) | path_join }}"
   systemd_override: /etc/systemd/system/{{kafka_connect_service_name}}.service.d/override.conf
-  log4j_file: "{{ (base_path, 'etc/kafka/connect-log4j.properties') | community.general.path_join }}"
-  jaas_file: "{{ (config_base_path, 'etc/kafka/connect-jaas.conf' ) | community.general.path_join }}"
-  password_file: "{{ (config_base_path, 'etc/kafka/connect-password.properties') | community.general.path_join }}"
+  log4j_file: "{{ (base_path, 'etc/kafka/connect-log4j.properties') | path_join }}"
+  jaas_file: "{{ (config_base_path, 'etc/kafka/connect-jaas.conf' ) | path_join }}"
+  password_file: "{{ (config_base_path, 'etc/kafka/connect-password.properties') | path_join }}"
 
 kafka_connect_http_protocol: "{{ 'https' if kafka_connect_ssl_enabled|bool else 'http' }}"
 
@@ -737,12 +737,12 @@ ksql_default_group: confluent
 ksql_default_log_dir: /var/log/confluent/ksql
 ksql:
   server_start_file: "{{ binary_base_path }}/bin/ksql-server-start"
-  config_file: "{{ ((config_base_path, ksql_config_prefix) | join , 'ksql-server.properties') | community.general.path_join }}"
-  systemd_file: "{{ (systemd_base_dir, (ksql_service_name, '.service') | join) | community.general.path_join }}"
-  systemd_override: "{{ ('/etc/systemd/system', (ksql_service_name, '.service.d') | join , 'override.conf') | community.general.path_join }}"
-  log4j_file: "{{ (base_path, 'etc/ksqldb/ksqldb-log4j.properties') | community.general.path_join }}"
-  jaas_file: "{{ (config_base_path, ('etc/ksql', ('db' if (confluent_package_version is version('5.5.0', '>=')) else '')) | join, 'jaas.conf' ) | community.general.path_join }}"
-  password_file: "{{ (config_base_path, ('etc/ksql', ('db' if (confluent_package_version is version('5.5.0', '>=')) else '')) | join, 'password.properties') | community.general.path_join }}"
+  config_file: "{{ ((config_base_path, ksql_config_prefix) | join , 'ksql-server.properties') | path_join }}"
+  systemd_file: "{{ (systemd_base_dir, (ksql_service_name, '.service') | join) | path_join }}"
+  systemd_override: "{{ ('/etc/systemd/system', (ksql_service_name, '.service.d') | join , 'override.conf') | path_join }}"
+  log4j_file: "{{ (base_path, 'etc/ksqldb/ksqldb-log4j.properties') | path_join }}"
+  jaas_file: "{{ (config_base_path, ('etc/ksql', ('db' if (confluent_package_version is version('5.5.0', '>=')) else '')) | join, 'jaas.conf' ) | path_join }}"
+  password_file: "{{ (config_base_path, ('etc/ksql', ('db' if (confluent_package_version is version('5.5.0', '>=')) else '')) | join, 'password.properties') | path_join }}"
 
 ksql_http_protocol: "{{ 'https' if ksql_ssl_enabled|bool else 'http' }}"
 
@@ -909,12 +909,12 @@ kafka_rest_default_group: confluent
 kafka_rest_default_log_dir: /var/log/confluent/kafka-rest
 kafka_rest:
   server_start_file: "{{ binary_base_path }}/bin/kafka-rest-start"
-  config_file: "{{ ((config_base_path, kafka_rest_config_prefix) | join, 'kafka-rest.properties') | community.general.path_join }}"
-  systemd_file: "{{ (systemd_base_dir, (kafka_rest_service_name, '.service') | join) | community.general.path_join }}"
-  systemd_override: "{{ ('/etc/systemd/system', (kafka_rest_service_name, '.service.d') | join , 'override.conf') | community.general.path_join }}"
-  log4j_file: "{{ (base_path, 'etc/kafka-rest/log4j.properties') | community.general.path_join }}"
-  jaas_file: "{{ (config_base_path, 'etc/kafka-rest/jaas.conf') | community.general.path_join }}"
-  password_file: "{{ (config_base_path, 'etc/kafka-rest/password.properties') | community.general.path_join }}"
+  config_file: "{{ ((config_base_path, kafka_rest_config_prefix) | join, 'kafka-rest.properties') | path_join }}"
+  systemd_file: "{{ (systemd_base_dir, (kafka_rest_service_name, '.service') | join) | path_join }}"
+  systemd_override: "{{ ('/etc/systemd/system', (kafka_rest_service_name, '.service.d') | join , 'override.conf') | path_join }}"
+  log4j_file: "{{ (base_path, 'etc/kafka-rest/log4j.properties') | path_join }}"
+  jaas_file: "{{ (config_base_path, 'etc/kafka-rest/jaas.conf') | path_join }}"
+  password_file: "{{ (config_base_path, 'etc/kafka-rest/password.properties') | path_join }}"
 
 kafka_rest_http_protocol: "{{ 'https' if kafka_rest_ssl_enabled|bool else 'http' }}"
 
@@ -1054,12 +1054,12 @@ control_center_default_group: confluent
 control_center_default_log_dir: /var/log/confluent/control-center
 control_center:
   server_start_file: "{{ binary_base_path }}/bin/control-center-start"
-  config_file: "{{ ((config_base_path, control_center_config_prefix) | join, 'control-center-production.properties') | community.general.path_join }}"
-  systemd_file: "{{ (systemd_base_dir, (control_center_service_name, '.service') | join) | community.general.path_join }}"
-  systemd_override: "{{ ('/etc/systemd/system', (control_center_service_name, '.service.d') | join , 'override.conf') | community.general.path_join }}"
-  log4j_file: "{{ (base_path, 'etc/confluent-control-center/log4j-rolling.properties') | community.general.path_join }}"
-  jaas_file: "{{ (config_base_path, 'etc/confluent-control-center/jaas.conf') | community.general.path_join }}"
-  password_file: "{{ (config_base_path, 'etc/confluent-control-center/password.properties') | community.general.path_join }}"
+  config_file: "{{ ((config_base_path, control_center_config_prefix) | join, 'control-center-production.properties') | path_join }}"
+  systemd_file: "{{ (systemd_base_dir, (control_center_service_name, '.service') | join) | path_join }}"
+  systemd_override: "{{ ('/etc/systemd/system', (control_center_service_name, '.service.d') | join , 'override.conf') | path_join }}"
+  log4j_file: "{{ (base_path, 'etc/confluent-control-center/log4j-rolling.properties') | path_join }}"
+  jaas_file: "{{ (config_base_path, 'etc/confluent-control-center/jaas.conf') | path_join }}"
+  password_file: "{{ (config_base_path, 'etc/confluent-control-center/password.properties') | path_join }}"
 
 control_center_http_protocol: "{{ 'https' if control_center_ssl_enabled|bool else 'http' }}"
 
@@ -1194,13 +1194,13 @@ kafka_connect_replicator_default_group: confluent
 
 kafka_connect_replicator:
   server_start_file: "{{ binary_base_path }}/bin/kafka-connect-replicator-start"
-  replication_config_file: "{{ (( config_base_path, kafka_connect_replicator_config_prefix) | join, 'kafka-connect-replicator.properties') | community.general.path_join }}"
-  consumer_config_file: "{{ ((config_base_path, kafka_connect_replicator_config_prefix) | join, 'kafka-connect-replicator-consumer.properties') | community.general.path_join }}"
-  producer_config_file: "{{ ((config_base_path, kafka_connect_replicator_config_prefix) | join, 'kafka-connect-replicator-producer.properties') | community.general.path_join }}"
-  interceptors_config_file: "{{ ((config_base_path, kafka_connect_replicator_config_prefix) | join, 'kafka-connect-replicator-interceptors.properties') | community.general.path_join }}"
-  systemd_file: "{{ (systemd_base_dir, (kafka_connect_replicator_service_name, '.service') | join) | community.general.path_join }}"
-  systemd_override: "{{ ('/etc/systemd/system', (kafka_connect_replicator_service_name, '.service.d') | join , 'override.conf') | community.general.path_join }}"
-  log4j_file: "{{ (base_path, 'etc/kafka-connect-replicator/replicator-log4j.properties') | community.general.path_join }}"
+  replication_config_file: "{{ (( config_base_path, kafka_connect_replicator_config_prefix) | join, 'kafka-connect-replicator.properties') | path_join }}"
+  consumer_config_file: "{{ ((config_base_path, kafka_connect_replicator_config_prefix) | join, 'kafka-connect-replicator-consumer.properties') | path_join }}"
+  producer_config_file: "{{ ((config_base_path, kafka_connect_replicator_config_prefix) | join, 'kafka-connect-replicator-producer.properties') | path_join }}"
+  interceptors_config_file: "{{ ((config_base_path, kafka_connect_replicator_config_prefix) | join, 'kafka-connect-replicator-interceptors.properties') | path_join }}"
+  systemd_file: "{{ (systemd_base_dir, (kafka_connect_replicator_service_name, '.service') | join) | path_join }}"
+  systemd_override: "{{ ('/etc/systemd/system', (kafka_connect_replicator_service_name, '.service.d') | join , 'override.conf') | path_join }}"
+  log4j_file: "{{ (base_path, 'etc/kafka-connect-replicator/replicator-log4j.properties') | path_join }}"
 
 kafka_connect_replicator_properties:
   defaults:


### PR DESCRIPTION
# Description

The community.general was used in cp-ansible to support 2.9 since path_join filter was introduced from 2.10 onwards. 
Since cp-ansible 7.2 and up don't support 2.9 anymore, we are deprecating the use of community.general 

Fixes # (ANSIENG-1589)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

https://jenkins.confluent.io/job/cp-ansible-on-demand/508/testReport/
In above test, mtls-custombundle-rhel and connect-scale-up, both are unrelated failure

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible