### PR TITLE
Fix Zookeeper ssl Test failure on 7.2.x

### DIFF
--- a/roles/common/tasks/host_validations.yml
+++ b/roles/common/tasks/host_validations.yml
@@ -100,10 +100,11 @@
   changed_when: false
   when:
     - ssl_custom_certs|bool
-    - (groups['zookeeper'] is defined and (inventory_hostname in groups['zookeeper'] and zookeeper_ssl_enabled|bool) or (inventory_hostname not in groups['zookeeper'] and ssl_enabled|bool))
+    - lookup('vars', item + '_ssl_enabled', default=ssl_enabled)
   tags:
     - validate
     - validate_ssl_keys_certs
+  loop: "{{group_names}}"
 
 - name: Retrieve SSL cert hash
   shell:
@@ -114,23 +115,25 @@
   changed_when: false
   when:
     - ssl_custom_certs|bool
-    - (groups['zookeeper'] is defined and (inventory_hostname in groups['zookeeper'] and zookeeper_ssl_enabled|bool) or (inventory_hostname not in groups['zookeeper'] and ssl_enabled|bool))
+    - lookup('vars', item + '_ssl_enabled', default=ssl_enabled)
   tags:
     - validate
     - validate_ssl_keys_certs
+  loop: "{{group_names}}"
 
 - name: Assert SSL key hash matches SSL cert hash
   assert:
-    that: key_hash.stdout == cert_hash.stdout
+    that: key_hash['results'][0].stdout == cert_hash['results'][0].stdout
     fail_msg: >-
       "The MD5 value of the custom ssl key does not match the MD5 value of the custom certificate, indicating that the keys do no match
       and are incompatible.  Please review your keys and certs and confirm they are from the same source."
   when:
     - ssl_custom_certs|bool
-    - (groups['zookeeper'] is defined and (inventory_hostname in groups['zookeeper'] and zookeeper_ssl_enabled|bool) or (inventory_hostname not in groups['zookeeper'] and ssl_enabled|bool))
+    - lookup('vars', item + '_ssl_enabled', default=ssl_enabled)
   tags:
     - validate
     - validate_ssl_keys_certs
+  loop: "{{group_names}}"
 
 - name: Validate enough free memory for Zookeeper hosts
   assert:

--- a/roles/common/tasks/host_validations.yml
+++ b/roles/common/tasks/host_validations.yml
@@ -98,7 +98,7 @@
   register: key_hash
   delegate_to: localhost
   changed_when: false
-  when: 
+  when:
     - ssl_custom_certs|bool
     - (groups['zookeeper'] is defined and (inventory_hostname in groups['zookeeper'] and zookeeper_ssl_enabled|bool) or (inventory_hostname not in groups['zookeeper'] and ssl_enabled|bool))
   tags:
@@ -112,7 +112,7 @@
   register: cert_hash
   delegate_to: localhost
   changed_when: false
-  when: 
+  when:
     - ssl_custom_certs|bool
     - (groups['zookeeper'] is defined and (inventory_hostname in groups['zookeeper'] and zookeeper_ssl_enabled|bool) or (inventory_hostname not in groups['zookeeper'] and ssl_enabled|bool))
   tags:
@@ -125,7 +125,7 @@
     fail_msg: >-
       "The MD5 value of the custom ssl key does not match the MD5 value of the custom certificate, indicating that the keys do no match
       and are incompatible.  Please review your keys and certs and confirm they are from the same source."
-  when: 
+  when:
     - ssl_custom_certs|bool
     - (groups['zookeeper'] is defined and (inventory_hostname in groups['zookeeper'] and zookeeper_ssl_enabled|bool) or (inventory_hostname not in groups['zookeeper'] and ssl_enabled|bool))
   tags:

--- a/roles/common/tasks/host_validations.yml
+++ b/roles/common/tasks/host_validations.yml
@@ -98,17 +98,23 @@
   register: key_hash
   delegate_to: localhost
   changed_when: false
-  when: ssl_custom_certs|bool
+  when: 
+    - ssl_custom_certs|bool
+    - (groups['zookeeper'] is defined and (inventory_hostname in groups['zookeeper'] and zookeeper_ssl_enabled|bool) or (inventory_hostname not in groups['zookeeper'] and ssl_enabled|bool))
   tags:
     - validate
     - validate_ssl_keys_certs
 
 - name: Retrieve SSL cert hash
-  shell: openssl x509 -noout -modulus -in {{ ssl_signed_cert_filepath }} | openssl md5
+  shell:
+    cmd: openssl x509 -noout -modulus | openssl md5
+    stdin: "{{ lookup('file', ssl_signed_cert_filepath) }}"
   register: cert_hash
   delegate_to: localhost
   changed_when: false
-  when: ssl_custom_certs|bool
+  when: 
+    - ssl_custom_certs|bool
+    - (groups['zookeeper'] is defined and (inventory_hostname in groups['zookeeper'] and zookeeper_ssl_enabled|bool) or (inventory_hostname not in groups['zookeeper'] and ssl_enabled|bool))
   tags:
     - validate
     - validate_ssl_keys_certs
@@ -119,7 +125,9 @@
     fail_msg: >-
       "The MD5 value of the custom ssl key does not match the MD5 value of the custom certificate, indicating that the keys do no match
       and are incompatible.  Please review your keys and certs and confirm they are from the same source."
-  when: ssl_custom_certs|bool
+  when: 
+    - ssl_custom_certs|bool
+    - (groups['zookeeper'] is defined and (inventory_hostname in groups['zookeeper'] and zookeeper_ssl_enabled|bool) or (inventory_hostname not in groups['zookeeper'] and ssl_enabled|bool))
   tags:
     - validate
     - validate_ssl_keys_certs

--- a/roles/common/tasks/host_validations.yml
+++ b/roles/common/tasks/host_validations.yml
@@ -123,7 +123,7 @@
 
 - name: Assert SSL key hash matches SSL cert hash
   assert:
-    that: key_hash['results'][my_idx].stdout == cert_hash['results'][my_idx].stdout
+    that: key_hash['results'][group_idx].stdout == cert_hash['results'][group_idx].stdout
     fail_msg: >-
       "The MD5 value of the custom ssl key does not match the MD5 value of the custom certificate, indicating that the keys do no match
       and are incompatible.  Please review your keys and certs and confirm they are from the same source."
@@ -135,7 +135,7 @@
     - validate_ssl_keys_certs
   loop: "{{group_names}}"
   loop_control:
-    index_var: my_idx
+    index_var: group_idx
 
 - name: Validate enough free memory for Zookeeper hosts
   assert:

--- a/roles/common/tasks/host_validations.yml
+++ b/roles/common/tasks/host_validations.yml
@@ -100,7 +100,7 @@
   changed_when: false
   when:
     - ssl_custom_certs|bool
-    - lookup('vars', item + '_ssl_enabled', default=ssl_enabled)
+    - lookup('vars', item + '_ssl_enabled', default=ssl_enabled)|bool
   tags:
     - validate
     - validate_ssl_keys_certs
@@ -115,7 +115,7 @@
   changed_when: false
   when:
     - ssl_custom_certs|bool
-    - lookup('vars', item + '_ssl_enabled', default=ssl_enabled)
+    - lookup('vars', item + '_ssl_enabled', default=ssl_enabled)|bool
   tags:
     - validate
     - validate_ssl_keys_certs
@@ -129,7 +129,7 @@
       and are incompatible.  Please review your keys and certs and confirm they are from the same source."
   when:
     - ssl_custom_certs|bool
-    - lookup('vars', item + '_ssl_enabled', default=ssl_enabled)
+    - lookup('vars', item + '_ssl_enabled', default=ssl_enabled)|bool
   tags:
     - validate
     - validate_ssl_keys_certs

--- a/roles/common/tasks/host_validations.yml
+++ b/roles/common/tasks/host_validations.yml
@@ -123,7 +123,7 @@
 
 - name: Assert SSL key hash matches SSL cert hash
   assert:
-    that: key_hash['results'][0].stdout == cert_hash['results'][0].stdout
+    that: key_hash['results'][my_idx].stdout == cert_hash['results'][my_idx].stdout
     fail_msg: >-
       "The MD5 value of the custom ssl key does not match the MD5 value of the custom certificate, indicating that the keys do no match
       and are incompatible.  Please review your keys and certs and confirm they are from the same source."
@@ -134,6 +134,8 @@
     - validate
     - validate_ssl_keys_certs
   loop: "{{group_names}}"
+  loop_control:
+    index_var: my_idx
 
 - name: Validate enough free memory for Zookeeper hosts
   assert:


### PR DESCRIPTION
# Description

Fix zookeeper ssl test failure in mtls-custombundle-rhel on 7.2.x

Fixes # [ANSIENG-1677](https://confluentinc.atlassian.net/browse/ANSIENG-1677)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

tested on jenkins job using 7.2.2 confluent package version [Result](https://jenkins.confluent.io/job/cp-ansible-on-demand/517/)



**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible