### PR TITLE
Fetch logs path added as var 

### DIFF
--- a/docs/VARIABLES.md
+++ b/docs/VARIABLES.md
@@ -28,6 +28,14 @@ Default:  true
 
 ***
 
+### fetch_logs_path
+
+Path on component to store logs collected during fetch_logs playbook
+
+Default: /tmp
+
+***
+
 ### jolokia_url_remote
 
 To copy from Ansible control host or download

--- a/roles/common/tasks/fetch_logs.yml
+++ b/roles/common/tasks/fetch_logs.yml
@@ -17,12 +17,12 @@
 
 - name: Remove directory
   file:
-    path: "/tmp/troubleshooting/{{inventory_hostname}}/"
+    path: "{{fetch_logs_path}}/troubleshooting/{{inventory_hostname}}/"
     state: absent
 
 - name: Recreate directory
   file:
-    path: "/tmp/troubleshooting/{{inventory_hostname}}/"
+    path: "{{fetch_logs_path}}/troubleshooting/{{inventory_hostname}}/"
     state: directory
     mode: 0750
     owner: "{{user}}"
@@ -30,7 +30,7 @@
 
 - name: Copy Config and Log Files to tmp dir
   copy:
-    dest: "/tmp/troubleshooting/{{inventory_hostname}}/"
+    dest: "{{fetch_logs_path}}/troubleshooting/{{inventory_hostname}}/"
     src: "{{ item }}"
     remote_src: true
     mode: 0750
@@ -40,8 +40,8 @@
 
 - name: Archive log files
   archive:
-    path: "/tmp/troubleshooting/{{inventory_hostname}}"
-    dest: "/tmp/troubleshooting/{{inventory_hostname}}.tar.gz"
+    path: "{{fetch_logs_path}}/troubleshooting/{{inventory_hostname}}"
+    dest: "{{fetch_logs_path}}/troubleshooting/{{inventory_hostname}}.tar.gz"
     remove: true
     format: gz
     force_archive: true
@@ -51,13 +51,13 @@
 
 - name: Fetch Config and Log Files
   fetch:
-    src: "/tmp/troubleshooting/{{inventory_hostname}}.tar.gz"
+    src: "{{fetch_logs_path}}/troubleshooting/{{inventory_hostname}}.tar.gz"
     dest: "troubleshooting/"
     flat: true
 
 - name: Clean temp directory
   file:
-    path: "/tmp/troubleshooting/{{inventory_hostname}}/"
+    path: "{{fetch_logs_path}}/troubleshooting/{{inventory_hostname}}/"
     state: absent
 
 - name: Review logs message

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -12,7 +12,7 @@ confluent_common_repository_debian_release_version: "{{ansible_distribution_rele
 
 # Deprecated, see mask_sensitive_logs
 mask_secrets: true
-
+fetch_logs_path: /tmp
 ### Boolean to mask secrets in playbook output, defaults to true
 mask_sensitive_logs: "{{mask_secrets}}"
 

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -12,7 +12,10 @@ confluent_common_repository_debian_release_version: "{{ansible_distribution_rele
 
 # Deprecated, see mask_sensitive_logs
 mask_secrets: true
+
+### Path on component to store logs collected during fetch_logs playbook
 fetch_logs_path: /tmp
+
 ### Boolean to mask secrets in playbook output, defaults to true
 mask_sensitive_logs: "{{mask_secrets}}"
 


### PR DESCRIPTION
# Description

adding the ability to control the path of the on controlled nodes logs fetching directory, currently set to `/tmp`
