### PR TITLE
Support for Ansible 2.13

### DIFF
--- a/docs/HOW_TO_TEST.md
+++ b/docs/HOW_TO_TEST.md
@@ -15,6 +15,13 @@ Due to some changes in Docker wrt systemd, the latest versions of Docker won't w
 ```
 python3 -m pip install --user "molecule[docker,lint]"
 ```
+ 
+Note:
+There’s this [recent issue](https://github.com/ansible-community/molecule-docker/issues/184) with latest molecule-docker version `2.1.0` which broke env var interpolation.
+Please downgrade it to 2.0.0 for time being until fix is available and above issue is closed.
+```
+python3 -m pip install "molecule-docker<=2.0.0"
+```
 
 ## Cloning CP-Ansible
 

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -11,9 +11,8 @@
   assert:
     that:
       - "ansible_version.full is version('2.11', '>=')"
-      - "ansible_version.full is version('2.13', '<')"
     fail_msg: >-
-      "You must update Ansible to 2.11 or 2.12 to use these playbooks."
+      "You must update Ansible to at least 2.11 to use these playbooks."
   tags:
     - validate
     - validate_ansi_version

--- a/roles/control_center/tasks/main.yml
+++ b/roles/control_center/tasks/main.yml
@@ -121,7 +121,7 @@
     service_name: control_center
     user: "{{control_center_user}}"
     group: "{{control_center_group}}"
-    hostnames: "{{ [inventory_hostname, ansible_fqdn, ansible_host, ansible_ssh_host, hostname|default(omit)] | unique }}"
+    hostnames: "{{ [inventory_hostname, ansible_fqdn, ansible_host, ansible_ssh_host|default(omit), hostname|default(omit)] | unique }}"
     ca_cert_path: "{{control_center_ca_cert_path}}"
     cert_path: "{{control_center_cert_path}}"
     key_path: "{{control_center_key_path}}"

--- a/roles/kafka_broker/tasks/main.yml
+++ b/roles/kafka_broker/tasks/main.yml
@@ -122,7 +122,7 @@
     service_name: kafka_broker
     user: "{{kafka_broker_user}}"
     group: "{{kafka_broker_group}}"
-    hostnames: "{{ ([inventory_hostname, ansible_fqdn, ansible_host, ansible_ssh_host, hostname|default(omit)] + kafka_broker_listeners | confluent.platform.get_hostnames(inventory_hostname)) | unique }}"
+    hostnames: "{{ ([inventory_hostname, ansible_fqdn, ansible_host, ansible_ssh_host|default(omit), hostname|default(omit)] + kafka_broker_listeners | confluent.platform.get_hostnames(inventory_hostname)) | unique }}"
     ca_cert_path: "{{kafka_broker_ca_cert_path}}"
     cert_path: "{{kafka_broker_cert_path}}"
     key_path: "{{kafka_broker_key_path}}"

--- a/roles/kafka_broker/tasks/rbac.yml
+++ b/roles/kafka_broker/tasks/rbac.yml
@@ -21,13 +21,22 @@
 # Take super.users property, split into list, remove empty string from list, and add in mds_super_user
 - name: Initialize Super Users List
   set_fact:
-    super_users: "{{ (kafka_broker_final_properties['super.users'] | default('')).split(';') | difference(['']) }} + [ 'User:{{ mds_super_user }}' ]"
+    super_users: "{{ (kafka_broker_final_properties['super.users'] | default('')).split(';') | difference(['']) }}"
+    mds_super_users: [ "User:{{ mds_super_user }}" ]
 
 # Loop over each brokers principal and add to list
 - name: Add Each Broker's Principal to Super Users List
   set_fact:
-    super_users: "{{super_users}}  + [ '{{ hostvars[item]['kafka_broker_principal'] }}' ]"
-  loop: "{{ groups['kafka_broker'] }}"
+    broker_principals: |-
+      [
+      {% for host in groups.kafka_broker %}
+        "{{ hostvars[host]['kafka_broker_principal'] }}",
+      {% endfor %}
+      ]
+
+- name: Combine and form super users list
+  set_fact:
+    super_users: "{{ super_users + mds_super_users + broker_principals }}"
 
 - name: Remove Duplicates and Convert to String
   set_fact:

--- a/roles/kafka_broker/tasks/rbac.yml
+++ b/roles/kafka_broker/tasks/rbac.yml
@@ -21,22 +21,13 @@
 # Take super.users property, split into list, remove empty string from list, and add in mds_super_user
 - name: Initialize Super Users List
   set_fact:
-    super_users: "{{ (kafka_broker_final_properties['super.users'] | default('')).split(';') | difference(['']) }}"
-    mds_super_users: [ "User:{{ mds_super_user }}" ]
+    super_users: "{{ (kafka_broker_final_properties['super.users'] | default('')).split(';') | difference(['']) + [ 'User:' + lookup('vars', 'mds_super_user', default=mds_super_user) ]}}"
 
 # Loop over each brokers principal and add to list
 - name: Add Each Broker's Principal to Super Users List
   set_fact:
-    broker_principals: |-
-      [
-      {% for host in groups.kafka_broker %}
-        "{{ hostvars[host]['kafka_broker_principal'] }}",
-      {% endfor %}
-      ]
-
-- name: Combine and form super users list
-  set_fact:
-    super_users: "{{ super_users + mds_super_users + broker_principals }}"
+    super_users: "{{ super_users + [ hostvars[item]['kafka_broker_principal'] ] }}"
+  loop: "{{ groups['kafka_broker'] }}"
 
 - name: Remove Duplicates and Convert to String
   set_fact:

--- a/roles/kafka_broker/tasks/rbac.yml
+++ b/roles/kafka_broker/tasks/rbac.yml
@@ -21,7 +21,7 @@
 # Take super.users property, split into list, remove empty string from list, and add in mds_super_user
 - name: Initialize Super Users List
   set_fact:
-    super_users: "{{ (kafka_broker_final_properties['super.users'] | default('')).split(';') | difference(['']) + [ 'User:' + lookup('vars', 'mds_super_user', default=mds_super_user) ]}}"
+    super_users: "{{ (kafka_broker_final_properties['super.users'] | default('')).split(';') | difference(['']) + [ 'User:' + lookup('vars', 'mds_super_user') ]}}"
 
 # Loop over each brokers principal and add to list
 - name: Add Each Broker's Principal to Super Users List

--- a/roles/kafka_connect/tasks/main.yml
+++ b/roles/kafka_connect/tasks/main.yml
@@ -112,7 +112,7 @@
     service_name: "{{ kafka_connect_service_name if kafka_connect_service_name != kafka_connect_default_service_name else 'kafka_connect' }}"
     user: "{{kafka_connect_user}}"
     group: "{{kafka_connect_group}}"
-    hostnames: "{{ [inventory_hostname, ansible_fqdn, ansible_host, ansible_ssh_host, hostname|default(omit)] | unique }}"
+    hostnames: "{{ [inventory_hostname, ansible_fqdn, ansible_host, ansible_ssh_host|default(omit), hostname|default(omit)] | unique }}"
     ca_cert_path: "{{kafka_connect_ca_cert_path}}"
     cert_path: "{{kafka_connect_cert_path}}"
     key_path: "{{kafka_connect_key_path}}"

--- a/roles/kafka_connect_replicator/tasks/main.yml
+++ b/roles/kafka_connect_replicator/tasks/main.yml
@@ -80,7 +80,7 @@
     service_name: confluent-replicator
     user: "{{kafka_connect_replicator_user}}"
     group: "{{kafka_connect_replicator_group}}"
-    hostnames: "{{ [inventory_hostname, ansible_fqdn, ansible_host, ansible_ssh_host, hostname|default(omit)] | unique }}"
+    hostnames: "{{ [inventory_hostname, ansible_fqdn, ansible_host, ansible_ssh_host|default(omit), hostname|default(omit)] | unique }}"
     ca_cert_path: "{{kafka_connect_replicator_ca_cert_path}}"
     cert_path: "{{kafka_connect_replicator_cert_path}}"
     key_path: "{{kafka_connect_replicator_key_path}}"
@@ -109,7 +109,7 @@
     service_name: kafka-connect-replicator
     user: "{{kafka_connect_replicator_user}}"
     group: "{{kafka_connect_replicator_group}}"
-    hostnames: "{{ [inventory_hostname, ansible_fqdn, ansible_host, ansible_ssh_host, hostname|default(omit)] | unique }}"
+    hostnames: "{{ [inventory_hostname, ansible_fqdn, ansible_host, ansible_ssh_host|default(omit), hostname|default(omit)] | unique }}"
     ca_cert_path: "{{kafka_connect_replicator_consumer_ca_cert_path}}"
     cert_path: "{{kafka_connect_replicator_consumer_cert_path}}"
     key_path: "{{kafka_connect_replicator_consumer_key_path}}"
@@ -136,7 +136,7 @@
     service_name: kafka-connect-replicator
     user: "{{kafka_connect_replicator_user}}"
     group: "{{kafka_connect_replicator_group}}"
-    hostnames: "{{ [inventory_hostname, ansible_fqdn, ansible_host, ansible_ssh_host, hostname|default(omit)] | unique }}"
+    hostnames: "{{ [inventory_hostname, ansible_fqdn, ansible_host, ansible_ssh_host|default(omit), hostname|default(omit)] | unique }}"
     ca_cert_path: "{{kafka_connect_replicator_producer_ca_cert_path}}"
     cert_path: "{{kafka_connect_replicator_producer_cert_path}}"
     key_path: "{{kafka_connect_replicator_producer_key_path}}"
@@ -163,7 +163,7 @@
     service_name: kafka-connect-replicator
     user: "{{kafka_connect_replicator_user}}"
     group: "{{kafka_connect_replicator_group}}"
-    hostnames: "{{ [inventory_hostname, ansible_fqdn, ansible_host, ansible_ssh_host, hostname|default(omit)] | unique }}"
+    hostnames: "{{ [inventory_hostname, ansible_fqdn, ansible_host, ansible_ssh_host|default(omit), hostname|default(omit)] | unique }}"
     ca_cert_path: "{{kafka_connect_replicator_monitoring_interceptor_ca_cert_path}}"
     cert_path: "{{kafka_connect_replicator_monitoring_interceptor_cert_path}}"
     key_path: "{{kafka_connect_replicator_monitoring_interceptor_key_path}}"

--- a/roles/kafka_rest/tasks/main.yml
+++ b/roles/kafka_rest/tasks/main.yml
@@ -102,7 +102,7 @@
     service_name: kafka_rest
     user: "{{kafka_rest_user}}"
     group: "{{kafka_rest_group}}"
-    hostnames: "{{ [inventory_hostname, ansible_fqdn, ansible_host, ansible_ssh_host, hostname|default(omit)] | unique }}"
+    hostnames: "{{ [inventory_hostname, ansible_fqdn, ansible_host, ansible_ssh_host|default(omit), hostname|default(omit)] | unique }}"
     ca_cert_path: "{{kafka_rest_ca_cert_path}}"
     cert_path: "{{kafka_rest_cert_path}}"
     key_path: "{{kafka_rest_key_path}}"

--- a/roles/ksql/tasks/main.yml
+++ b/roles/ksql/tasks/main.yml
@@ -112,7 +112,7 @@
     service_name: ksql
     user: "{{ksql_user}}"
     group: "{{ksql_group}}"
-    hostnames: "{{ [inventory_hostname, ansible_fqdn, ansible_host, ansible_ssh_host, hostname|default(omit)] | unique }}"
+    hostnames: "{{ [inventory_hostname, ansible_fqdn, ansible_host, ansible_ssh_host|default(omit), hostname|default(omit)] | unique }}"
     ca_cert_path: "{{ksql_ca_cert_path}}"
     cert_path: "{{ksql_cert_path}}"
     key_path: "{{ksql_key_path}}"

--- a/roles/schema_registry/tasks/main.yml
+++ b/roles/schema_registry/tasks/main.yml
@@ -103,7 +103,7 @@
     service_name: schema_registry
     user: "{{schema_registry_user}}"
     group: "{{schema_registry_group}}"
-    hostnames: "{{ [inventory_hostname, ansible_fqdn, ansible_host, ansible_ssh_host, hostname|default(omit)] | unique }}"
+    hostnames: "{{ [inventory_hostname, ansible_fqdn, ansible_host, ansible_ssh_host|default(omit), hostname|default(omit)] | unique }}"
     ca_cert_path: "{{schema_registry_ca_cert_path}}"
     cert_path: "{{schema_registry_cert_path}}"
     key_path: "{{schema_registry_key_path}}"

--- a/roles/zookeeper/tasks/main.yml
+++ b/roles/zookeeper/tasks/main.yml
@@ -103,7 +103,7 @@
     service_name: zookeeper
     user: "{{zookeeper_user}}"
     group: "{{zookeeper_group}}"
-    hostnames: "{{ [inventory_hostname, ansible_fqdn, ansible_host, ansible_ssh_host, hostname|default(omit)] | unique }}"
+    hostnames: "{{ [inventory_hostname, ansible_fqdn, ansible_host, ansible_ssh_host|default(omit), hostname|default(omit)] | unique }}"
     ca_cert_path: "{{zookeeper_ca_cert_path}}"
     cert_path: "{{zookeeper_cert_path}}"
     key_path: "{{zookeeper_key_path}}"


### PR DESCRIPTION
# Description

This PR fixes couple of problems working with Ansible 2.13 -
1. `ansible_ssh_host` being undefined in ansible 2.13
2. Templating issue in rbac.yml while appending items to list
3. There's recent issue with molecule-docker 2.1.0 latest version, Added a note in HOW_TO_TEST.md for the same

This PR should now support both Ansible 2.13 and 2.12 versions.
**Note:** Jenkins on demand job has been updated to accept ansible version as configurable parameter. 

Fixes # 
https://confluentinc.atlassian.net/browse/ANSIENG-1556


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

All rbac scenarios were run and tested on all three ansible versions 2.11, 2.12, 2.13


**Test Configuration**:


# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible