### PR TITLE
Update cli version to 2.28.1 from 2.19

### DIFF
--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -182,7 +182,7 @@ confluent_cli_base_path: /opt/confluent-cli
 confluent_cli_path: "/usr/local/bin/confluent"
 
 ### Confluent CLI version to download (e.g. "1.9.0"). Support matrix https://docs.confluent.io/platform/current/installation/versions-interoperability.html#confluent-cli
-confluent_cli_version: 2.19.0
+confluent_cli_version: 2.28.1
 
 ### Recommended replication factor, defaults to 3. When splitting your cluster across 2 DCs with 4 or more Brokers, this should be increased to 4 to balance topic replicas.
 default_internal_replication_factor: 3


### PR DESCRIPTION
# Description

https://github.com/confluentinc/packaging/pull/1018 - After we raised a question about pinned cli version for cp 7.3, this PR was raised. Hence, we're now updating default cli version to 2.28.1
Another relevant PR - https://github.com/confluentinc/muckrake/pull/1841

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

https://jenkins.confluent.io/job/cp-ansible-on-demand/589/
Ran all rbac scenarios which has confluent cli enabled

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible