### PR TITLE
Set ansible_become to false when delegating to localhost

### DIFF
--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -4,6 +4,14 @@ Below are the supported variables for the role confluent.variables
 
 ***
 
+### ansible_become_localhost
+
+Boolean to specify the become value for localhost, used when dealing with any file present on localhost/controller.
+
+Default:  false
+
+***
+
 ### mask_sensitive_logs
 
 Boolean to mask secrets in playbook output, defaults to true

--- a/roles/confluent.kafka_broker/tasks/rbac.yml
+++ b/roles/confluent.kafka_broker/tasks/rbac.yml
@@ -36,6 +36,9 @@
     path: "{{ token_services_public_pem_file }}"
   register: broker_public_pem_file
   delegate_to: localhost
+  vars:
+    ansible_connection: local
+    ansible_become: "{{ ansible_become_localhost }}"
 
 - name: Debug
   ansible.builtin.debug:
@@ -57,6 +60,9 @@
     path: "{{ token_services_private_pem_file }}"
   register: broker_private_pem_file
   delegate_to: localhost
+  vars:
+    ansible_connection: local
+    ansible_become: "{{ ansible_become_localhost }}"
 
 - name: Debug
   ansible.builtin.debug:

--- a/roles/confluent.kafka_rest/tasks/main.yml
+++ b/roles/confluent.kafka_rest/tasks/main.yml
@@ -122,6 +122,9 @@
     path: "{{ token_services_public_pem_file }}"
   register: krest_public_pem_file
   delegate_to: localhost
+  vars:
+    ansible_connection: local
+    ansible_become: "{{ ansible_become_localhost }}"
 
 - name: Debug
   ansible.builtin.debug:

--- a/roles/confluent.variables/defaults/main.yml
+++ b/roles/confluent.variables/defaults/main.yml
@@ -10,6 +10,9 @@ confluent_package_debian_suffix: "{{ '=' + confluent_full_package_version if con
 # Deprecated, see mask_sensitive_logs
 mask_secrets: true
 
+### Boolean to specify the become value for localhost, used when dealing with any file present on localhost/controller.
+ansible_become_localhost: false
+
 ### Boolean to mask secrets in playbook output, defaults to true
 mask_sensitive_logs: "{{mask_secrets}}"
 

--- a/tasks/rbac_setup.yml
+++ b/tasks/rbac_setup.yml
@@ -47,6 +47,9 @@
     path: "{{ token_services_public_pem_file }}"
   register: public_pem_file
   delegate_to: localhost
+  vars:
+    ansible_connection: local
+    ansible_become: "{{ ansible_become_localhost }}"
 
 - name: Debug
   ansible.builtin.debug:

--- a/tasks/secrets_protection.yml
+++ b/tasks/secrets_protection.yml
@@ -44,7 +44,7 @@
   delegate_to: localhost
   vars:
     ansible_connection: local
-    ansible_become: false
+    ansible_become: "{{ ansible_become_localhost }}"
   register: slurped_masterkey
   when: not secrets_protection_masterkey
 


### PR DESCRIPTION
# Description

For all places where we are delegating to localhost to read/check a file (anything to do with a file), it looks for root permission on the controller node (which might not be required)
This causes issues when user doesn't have root permissions when running the playbooks.
Hence, we are explicitly setting ansible_become to false for such tasks (using a new var - ansible_become_localhost) 

Fixes # (ANSIENG-1801)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

All pass
https://jenkins.confluent.io/job/cp-ansible-on-demand/597/


**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible