### PR TITLE
Add playbook to force service restart manually

### DIFF
--- a/molecule/plaintext-rhel/verify.yml
+++ b/molecule/plaintext-rhel/verify.yml
@@ -284,3 +284,6 @@
       with_items:
         - "http://{{inventory_hostname}}:7775/jolokia/list"
         - "http://{{inventory_hostname}}:8075"
+
+- name: Verify - Restart Services
+  import_playbook: ../../playbooks/restart.yml

--- a/playbooks/restart.yml
+++ b/playbooks/restart.yml
@@ -17,6 +17,10 @@
     - include_role:
         name: zookeeper
         tasks_from: restart_and_wait.yml
+    - include_role:
+        name: zookeeper
+        tasks_from: health_check.yml
+      tags: health_check
 
 - name: Kafka Broker Restart
   hosts: kafka_broker
@@ -27,6 +31,10 @@
     - include_role:
         name: kafka_broker
         tasks_from: restart_and_wait.yml
+    - include_role:
+        name: kafka_broker
+        tasks_from: health_check.yml
+      tags: health_check
 
 - name: Schema Registry Restart
   hosts: schema_registry
@@ -37,6 +45,10 @@
     - include_role:
         name: schema_registry
         tasks_from: restart_and_wait.yml
+    - include_role:
+        name: schema_registry
+        tasks_from: health_check.yml
+      tags: health_check
 
 - name: Kafka Connect Restart
   hosts: kafka_connect
@@ -47,6 +59,10 @@
     - include_role:
         name: kafka_connect
         tasks_from: restart_and_wait.yml
+    - include_role:
+        name: kafka_connect
+        tasks_from: health_check.yml
+      tags: health_check
 
 - name: Kafka Connect Restart
   hosts: kafka_connect_replicator
@@ -57,6 +73,10 @@
     - include_role:
         name: kafka_connect_replicator
         tasks_from: restart_and_wait.yml
+    - include_role:
+        name: kafka_connect_replicator
+        tasks_from: health_check.yml
+      tags: health_check
 
 - name: KSQL Restart
   hosts: ksql
@@ -67,6 +87,10 @@
     - include_role:
         name: ksql
         tasks_from: restart_and_wait.yml
+    - include_role:
+        name: ksql
+        tasks_from: health_check.yml
+      tags: health_check
 
 - name: Kafka Rest Restart
   hosts: kafka_rest
@@ -77,6 +101,10 @@
     - include_role:
         name: kafka_rest
         tasks_from: restart_and_wait.yml
+    - include_role:
+        name: kafka_rest
+        tasks_from: health_check.yml
+      tags: health_check
 
 - name: Control Center Restart
   hosts: control_center
@@ -87,3 +115,7 @@
     - include_role:
         name: control_center
         tasks_from: restart_and_wait.yml
+    - include_role:
+        name: control_center
+        tasks_from: health_check.yml
+      tags: health_check

--- a/playbooks/restart.yml
+++ b/playbooks/restart.yml
@@ -1,0 +1,89 @@
+---
+### to use restart_strategy as parallel, provide restart_strategy=parallel in --extra-vars
+
+- name: Import all variables
+  hosts: all
+  tags: always
+  tasks:
+    - import_role:
+        name: variables
+
+- name: Zookeeper Restart
+  hosts: zookeeper
+  gather_facts: false
+  serial: "{{ '100%' if restart_strategy | default('rolling')  == 'parallel' else '1' }}"
+  tags: zookeeper
+  tasks:
+    - include_role:
+        name: zookeeper
+        tasks_from: restart_and_wait.yml
+
+- name: Kafka Broker Restart
+  hosts: kafka_broker
+  gather_facts: false
+  serial: "{{ '100%' if restart_strategy | default('rolling')  == 'parallel' else '1' }}"
+  tags: kafka_broker
+  tasks:
+    - include_role:
+        name: kafka_broker
+        tasks_from: restart_and_wait.yml
+
+- name: Schema Registry Restart
+  hosts: schema_registry
+  gather_facts: false
+  serial: "{{ '100%' if restart_strategy | default('rolling')  == 'parallel' else '1' }}"
+  tags: schema_registry
+  tasks:
+    - include_role:
+        name: schema_registry
+        tasks_from: restart_and_wait.yml
+
+- name: Kafka Connect Restart
+  hosts: kafka_connect
+  gather_facts: false
+  serial: "{{ '100%' if restart_strategy | default('rolling')  == 'parallel' else '1' }}"
+  tags: kafka_connect
+  tasks:
+    - include_role:
+        name: kafka_connect
+        tasks_from: restart_and_wait.yml
+
+- name: Kafka Connect Restart
+  hosts: kafka_connect_replicator
+  gather_facts: false
+  serial: "{{ '100%' if restart_strategy | default('rolling')  == 'parallel' else '1' }}"
+  tags: kafka_connect_replicator
+  tasks:
+    - include_role:
+        name: kafka_connect_replicator
+        tasks_from: restart_and_wait.yml
+
+- name: KSQL Restart
+  hosts: ksql
+  gather_facts: false
+  serial: "{{ '100%' if restart_strategy | default('rolling')  == 'parallel' else '1' }}"
+  tags: ksql
+  tasks:
+    - include_role:
+        name: ksql
+        tasks_from: restart_and_wait.yml
+
+- name: Kafka Rest Restart
+  hosts: kafka_rest
+  gather_facts: false
+  serial: "{{ '100%' if restart_strategy | default('rolling')  == 'parallel' else '1' }}"
+  tags: kafka_rest
+  tasks:
+    - include_role:
+        name: kafka_rest
+        tasks_from: restart_and_wait.yml
+
+- name: Control Center Restart
+  hosts: control_center
+  gather_facts: false
+  serial: "{{ '100%' if restart_strategy | default('rolling')  == 'parallel' else '1' }}"
+  tags: control_center
+  tasks:
+    - include_role:
+        name: control_center
+        tasks_from: restart_and_wait.yml


### PR DESCRIPTION
# Description

This PR aims to provide the feature to restart services manually via cp-ansible. A new playbook has been added for that purpose. This issue was raised in [721](https://github.com/confluentinc/cp-ansible/issues/721) and [806](https://github.com/confluentinc/cp-ansible/issues/806)

Fixes # [ANSIENG-1517](https://confluentinc.atlassian.net/browse/ANSIENG-1517)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Tested the playbook locally to check if the deployed components are able to restart and also on the scenario plaintext-rhel [here](https://jenkins.confluent.io/job/cp-ansible-on-demand/600/)



**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible