### PR TITLE
Remove unused confluent.ssl.* prop

### DIFF
--- a/roles/confluent.variables/vars/main.yml
+++ b/roles/confluent.variables/vars/main.yml
@@ -182,14 +182,6 @@ kafka_broker_properties:
     enabled: "{{ kafka_broker_schema_validation_enabled and 'schema_registry' in groups }}"
     properties:
       confluent.schema.registry.url: "{{schema_registry_url}}"
-  sr_ssl:
-    enabled: "{{ kafka_broker_schema_validation_enabled and 'schema_registry' in groups and schema_registry_ssl_enabled }}"
-    properties:
-      confluent.ssl.truststore.location: "{{kafka_broker_truststore_path}}"
-      confluent.ssl.truststore.password: "{{kafka_broker_truststore_storepass}}"
-      confluent.ssl.keystore.location: "{{kafka_broker_keystore_path}}"
-      confluent.ssl.keystore.password: "{{kafka_broker_keystore_storepass}}"
-      confluent.ssl.key.password: "{{kafka_broker_keystore_keypass}}"
   sr_ssl_fips:
     enabled: "{{ kafka_broker_schema_validation_enabled and 'schema_registry' in groups and schema_registry_ssl_enabled and fips_enabled }}"
     properties:


### PR DESCRIPTION
# Description

Removing some unused properties. Replacing these confluent.ssl.* with ssl.* props also worked fine. 

Fixes # ([issue](https://github.com/confluentinc/cp-ansible/issues/1193))

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

https://jenkins.confluent.io/job/cp-ansible-on-demand/605/testReport/
Tested all scenarios on 6.0.x - nothing breaks after removing these properties
Will test on 7.3.x too to be more sure.


**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible