### PR TITLE
Add test that use LdapAuthenticateCallbackHandler for authentication

### DIFF
--- a/molecule/rbac-mtls-provided-ubuntu/molecule.yml
+++ b/molecule/rbac-mtls-provided-ubuntu/molecule.yml
@@ -182,6 +182,8 @@ provisioner:
 
       kafka_broker:
         ldap_config: |
+          listener.name.broker.plain.sasl.server.callback.handler.class=io.confluent.security.auth.provider.ldap.LdapAuthenticateCallbackHandler
+          listener.name.client.plain.sasl.server.callback.handler.class=io.confluent.security.auth.provider.ldap.LdapAuthenticateCallbackHandler
           ldap.java.naming.factory.initial=com.sun.jndi.ldap.LdapCtxFactory
           ldap.com.sun.jndi.ldap.read.timeout=3000
           ldap.java.naming.provider.url=ldaps://ldap1:636

--- a/molecule/rbac-mtls-provided-ubuntu/verify.yml
+++ b/molecule/rbac-mtls-provided-ubuntu/verify.yml
@@ -23,6 +23,22 @@
         property: ldap.java.naming.provider.url
         expected_value: ldaps://ldap1:636
 
+    - import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: /etc/kafka/server.properties
+        property: listener.name.broker.plain.sasl.server.callback.handler.class
+        expected_value: io.confluent.security.auth.provider.ldap.LdapAuthenticateCallbackHandler
+
+    - import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: /etc/kafka/server.properties
+        property: listener.name.client.plain.sasl.server.callback.handler.class
+        expected_value: io.confluent.security.auth.provider.ldap.LdapAuthenticateCallbackHandler
+
     - name: Get super.users
       shell: grep "super.users" /etc/kafka/server.properties
       register: super_users_grep


### PR DESCRIPTION
# Description

This PR aims to Add test that use LdapAuthenticateCallbackHandler for authentication via LDAP. The test has been added in the scenario rbac-mtls-provided-ubuntu
This issue was reported in [764](https://github.com/confluentinc/cp-ansible/issues/764)

Fixes # [ANSIENG-1821](https://confluentinc.atlassian.net/browse/ANSIENG-1821)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This has been tested locally as well as [here](https://jenkins.confluent.io/job/cp-ansible-on-demand/629/console)



**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible