### PR TITLE
GH issue #891 Fix proxy settings for yum repo

### DIFF
--- a/docs/hosts_example.yml
+++ b/docs/hosts_example.yml
@@ -10,9 +10,9 @@ all:
     ## To set proxy env vars for the duration of playbook run, uncomment below block and set as necessary
     # proxy_env:
     #   http_proxy: http://proxy.example.com:8080
-    #   https_proxy: http://proxy.example.com:8080
+    #   https_proxy: https://proxy.example.com:8080
     ## Note: You must use Hostnames or IPs to define your no_proxy server addresses, CIDR ranges are not supported.
-    #   no_proxy: http://proxy.example.com:8080
+    #   no_proxy: http://10.198.0.0:8080
 
     #### SASL Authentication Configuration ####
     ## By default there will be no SASL Authentication

--- a/roles/common/tasks/host_validations.yml
+++ b/roles/common/tasks/host_validations.yml
@@ -53,7 +53,12 @@
   tags:
     - validate
     - validate_internet_access
-  environment: "{ {% if 'http_proxy' in proxy_env %} 'http_proxy': '{{ proxy_env.http_proxy }}', 'https_proxy': '{{ proxy_env.http_proxy }}' {% endif %} }"
+  environment: "{
+    {% if 'http_proxy' in proxy_env or 'https_proxy' in proxy_env %}
+      'http_proxy': '{{ proxy_env.http_proxy if 'http_proxy' in proxy_env else proxy_env.https_proxy}}',
+      'https_proxy': '{{ proxy_env.https_proxy if 'https_proxy' in proxy_env else proxy_env.http_proxy }}'
+    {% endif %}
+  }"
 
 - name: Fail Provisioning because No Network Connectivity
   fail:

--- a/roles/common/templates/confluent.repo.j2
+++ b/roles/common/templates/confluent.repo.j2
@@ -7,7 +7,9 @@ enabled = {{ repo.enabled | int }}
 gpgcheck = {{ repo.gpgcheck | int }}
 gpgkey = {{ repo.gpgkey }}
 name = {{ repo.description }}
-{% if 'http_proxy' in proxy_env %}
+{% if 'https_proxy' in proxy_env %}
+proxy = {{ proxy_env.https_proxy }}
+{% elif 'http_proxy' in proxy_env %}
 proxy = {{ proxy_env.http_proxy }}
 {% endif %}
 {% endfor %}


### PR DESCRIPTION
# Description
https://confluentinc.atlassian.net/browse/ANSIENG-1515
Supports both https_proxy and http_proxy for yum repo

Fixes 
Github issue #891

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This was tested by spinning up a fresh redhat EC2 instance, and running playbook with above fix.
/etc/yum.repos.d/confluent.repo will now appropriately set proxy using fall back chain from https -> http-> none.


**Test Configuration**:

https://jenkins.confluent.io/job/cp-ansible-on-demand/652/


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible