### PR TITLE
Install pip and cryptography on managed nodes for community.crypto module

### DIFF
--- a/molecule/mtls-customcerts-rhel/molecule.yml
+++ b/molecule/mtls-customcerts-rhel/molecule.yml
@@ -9,7 +9,7 @@ platforms:
     hostname: zookeeper1.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-centos7-ansible
+    image: wadhwa1/docker-centos7:v2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -20,7 +20,7 @@ platforms:
     hostname: kafka-broker1.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: wadhwa1/docker-centos7:v2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -31,7 +31,7 @@ platforms:
     hostname: kafka-broker2.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: wadhwa1/docker-centos7:v2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -42,7 +42,7 @@ platforms:
     hostname: kafka-broker3.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: wadhwa1/docker-centos7:v2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -53,7 +53,7 @@ platforms:
     hostname: schema-registry1.confluent
     groups:
       - schema_registry
-    image: geerlingguy/docker-centos7-ansible
+    image: wadhwa1/docker-centos7:v2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -64,7 +64,7 @@ platforms:
     hostname: kafka-rest1.confluent
     groups:
       - kafka_rest
-    image: geerlingguy/docker-centos7-ansible
+    image: wadhwa1/docker-centos7:v2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -75,7 +75,7 @@ platforms:
     hostname: kafka-connect1.confluent
     groups:
       - kafka_connect
-    image: geerlingguy/docker-centos7-ansible
+    image: wadhwa1/docker-centos7:v2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -86,7 +86,7 @@ platforms:
     hostname: ksql1.confluent
     groups:
       - ksql
-    image: geerlingguy/docker-centos7-ansible
+    image: wadhwa1/docker-centos7:v2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -97,7 +97,7 @@ platforms:
     hostname: control-center1.confluent
     groups:
       - control_center
-    image: geerlingguy/docker-centos7-ansible
+    image: wadhwa1/docker-centos7:v2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/molecule/mtls-customcerts-rhel/molecule.yml
+++ b/molecule/mtls-customcerts-rhel/molecule.yml
@@ -9,7 +9,7 @@ platforms:
     hostname: zookeeper1.confluent
     groups:
       - zookeeper
-    image: wadhwa1/docker-centos7:v2
+    image: geerlingguy/docker-centos7-ansible
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -20,7 +20,7 @@ platforms:
     hostname: kafka-broker1.confluent
     groups:
       - kafka_broker
-    image: wadhwa1/docker-centos7:v2
+    image: geerlingguy/docker-centos7-ansible
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -31,7 +31,7 @@ platforms:
     hostname: kafka-broker2.confluent
     groups:
       - kafka_broker
-    image: wadhwa1/docker-centos7:v2
+    image: geerlingguy/docker-centos7-ansible
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -42,7 +42,7 @@ platforms:
     hostname: kafka-broker3.confluent
     groups:
       - kafka_broker
-    image: wadhwa1/docker-centos7:v2
+    image: geerlingguy/docker-centos7-ansible
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -53,7 +53,7 @@ platforms:
     hostname: schema-registry1.confluent
     groups:
       - schema_registry
-    image: wadhwa1/docker-centos7:v2
+    image: geerlingguy/docker-centos7-ansible
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -64,7 +64,7 @@ platforms:
     hostname: kafka-rest1.confluent
     groups:
       - kafka_rest
-    image: wadhwa1/docker-centos7:v2
+    image: geerlingguy/docker-centos7-ansible
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -75,7 +75,7 @@ platforms:
     hostname: kafka-connect1.confluent
     groups:
       - kafka_connect
-    image: wadhwa1/docker-centos7:v2
+    image: geerlingguy/docker-centos7-ansible
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -86,7 +86,7 @@ platforms:
     hostname: ksql1.confluent
     groups:
       - ksql
-    image: wadhwa1/docker-centos7:v2
+    image: geerlingguy/docker-centos7-ansible
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -97,7 +97,7 @@ platforms:
     hostname: control-center1.confluent
     groups:
       - control_center
-    image: wadhwa1/docker-centos7:v2
+    image: geerlingguy/docker-centos7-ansible
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/roles/common/tasks/debian.yml
+++ b/roles/common/tasks/debian.yml
@@ -212,3 +212,22 @@
       - unzip
       - curl
   tags: package
+
+- set_fact:
+    pip_package_name: "{{ 'python-pip' if ansible_python_version is match('2.*') else 'python3-pip' }}"
+
+- name: Install pip
+  apt:
+    name:
+      - "{{ pip_package_name }}"
+    state: present
+  become: true
+
+- name: Upgrade pip
+  ansible.builtin.pip:
+    name: pip
+    extra_args: --upgrade
+
+- name: Install cryptography
+  ansible.builtin.pip:
+    name: cryptography

--- a/roles/common/tasks/redhat.yml
+++ b/roles/common/tasks/redhat.yml
@@ -54,18 +54,21 @@
       - unzip
   tags: package
 
+- set_fact:
+    pip_package_name: "{{ 'python-pip' if ansible_python_version is match('2.*') else 'python3-pip' }}"
+    pip_version: "{{ 'pip==20.3.4' if ansible_python_version is match('2.*') else 'pip' }}"
+
 - name: Install pip
   yum:
     name:
       - epel-release
-      - python-pip
+      - "{{ pip_package_name }}"
     state: present
   become: true
-  when: ansible_python_version == "2.7.5"
 
 - name: Upgrade pip
   ansible.builtin.pip:
-    name: pip==20.3.4
+    name: "{{ pip_version }}"
     extra_args: --upgrade
 
 - name: Install cryptography

--- a/roles/common/tasks/redhat.yml
+++ b/roles/common/tasks/redhat.yml
@@ -53,3 +53,21 @@
       - openssl
       - unzip
   tags: package
+
+- name: Install pip
+  yum:
+    name:
+      - epel-release
+      - python-pip
+    state: present
+  become: true
+  when: ansible_python_version == "2.7.5"
+
+- name: Upgrade pip
+  ansible.builtin.pip:
+    name: pip==20.3.4
+    extra_args: --upgrade
+
+- name: Install cryptography
+  ansible.builtin.pip:
+    name: cryptography

--- a/roles/common/tasks/ubuntu.yml
+++ b/roles/common/tasks/ubuntu.yml
@@ -109,3 +109,22 @@
   apt:
     name: openssl
   tags: package
+
+- set_fact:
+    pip_package_name: "{{ 'python-pip' if ansible_python_version is match('2.*') else 'python3-pip' }}"
+
+- name: Install pip
+  apt:
+    name:
+      - "{{ pip_package_name }}"
+    state: present
+  become: true
+
+- name: Upgrade pip
+  ansible.builtin.pip:
+    name: pip
+    extra_args: --upgrade
+
+- name: Install cryptography
+  ansible.builtin.pip:
+    name: cryptography


### PR DESCRIPTION
# Description

Installing pip and cryptography on managed nodes via playbooks itself. This is needed for ansible community.crypto module to work.

Fixes # 
Background - https://github.com/confluentinc/cp-ansible/pull/1214

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Created custom docker image wadhwa1/docker-centos7:v2 so as to first reproduce the cp-env issue via molecule tests and make our tests fail.

Verified via cp-ansible-ondemand-job (Test failed as expected) https://jenkins.confluent.io/job/cp-ansible-on-demand/656/testReport/molecule.mtls-customcerts-rhel.molecule/yml/test/

After fix, here are on demand job run- https://jenkins.confluent.io/job/cp-ansible-on-demand/660/

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible