### PR TITLE
Add ssl.* props for kafka broker

### DIFF
--- a/roles/confluent.variables/vars/main.yml
+++ b/roles/confluent.variables/vars/main.yml
@@ -135,6 +135,19 @@ kafka_broker_properties:
     properties:
       # broker.id logic depends on inventory hostname being in kafka_broker host list, defaulting to 0 if non kafka host
       broker.id: "{{ broker_id | default( groups.kafka_broker.index(inventory_hostname) + 1 ) if inventory_hostname in groups.kafka_broker else 0 }}"
+  ssl:
+    enabled: "{{ zookeeper_ssl_enabled|bool or
+    kafka_broker_listeners | ssl_required(ssl_enabled) or
+    kafka_broker_rest_ssl_enabled|bool or
+    mds_broker_listener.ssl_enabled|bool or
+    mds_tls_enabled|bool or
+    ( kafka_broker_schema_validation_enabled and 'schema_registry' in groups and schema_registry_ssl_enabled ) }}"
+    properties:
+      ssl.truststore.location: "{{kafka_broker_truststore_path}}"
+      ssl.truststore.password: "{{kafka_broker_truststore_storepass}}"
+      ssl.keystore.location: "{{kafka_broker_keystore_path}}"
+      ssl.keystore.password: "{{kafka_broker_keystore_storepass}}"
+      ssl.key.password: "{{kafka_broker_keystore_storepass}}"
   fips:
     enabled: "{{fips_enabled}}"
     properties:


### PR DESCRIPTION
# Description

After removal of unused confluent.ssl.* props, we explored the ssl.* properties
https://docs.confluent.io/platform/current/kafka/encryption.html#brokers talks about the usage of ssl.* properties for broker
https://docs.confluent.io/platform/current/installation/configuration/broker-configs.html#ak-broker-configurations-for-cp
The enable condition for these properties have been kept the same as ssl role for kafka brokers, which'll ensure that these properties show up only and whenever required.

Fixes # (ANSIENG-1826)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

On 6.0.x - https://jenkins.confluent.io/job/cp-ansible-on-demand/665/
On 7.3.x - https://jenkins.confluent.io/job/cp-ansible-on-demand/662/


**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible