### PR TITLE
Fix schema registry url

### DIFF
--- a/roles/variables/vars/main.yml
+++ b/roles/variables/vars/main.yml
@@ -425,7 +425,7 @@ schema_registry:
 
 schema_registry_http_protocol: "{{ 'https' if schema_registry_ssl_enabled|bool else 'http' }}"
 
-_schema_registry_url: "{{schema_registry_http_protocol}}://{{ groups['schema_registry'] | default(['localhost']) | confluent.platform.resolve_hostnames(hostvars) | join(':' + schema_registry_listener_port|string + ',' + schema_registry_http_protocol + '://') }}:{{schema_registry_listener_port}}"
+_schema_registry_url: "{{schema_registry_http_protocol}}://{{ (groups.get('schema_registry') if groups.get('schema_registry') else ['localhost']) | confluent.platform.resolve_hostnames(hostvars) | join(':' + schema_registry_listener_port|string + ',' + schema_registry_http_protocol + '://') }}:{{schema_registry_listener_port}}"
 
 schema_registry_url: "{{ ccloud_schema_registry_url if ccloud_schema_registry_enabled else _schema_registry_url }}"
 


### PR DESCRIPTION
# Description

Earlier [PR](https://github.com/confluentinc/cp-ansible/pull/1221) had fixed the issue https://confluentinc.atlassian.net/browse/ANSIENG-1764 schema registry url being wrongly generated
`confluent.controlcenter.schema.registry.url = [http://:8081]`
but it broke few molecule scenarios.

Raising another PR, have tested this fix with both - 
- Executing ansible playbook with manually generated inventory.yml file
- All failed molecule scenarios are passing now https://jenkins.confluent.io/job/cp-ansible-on-demand/679/

Fixes # (issue)
https://confluentinc.atlassian.net/browse/ANSIENG-1764

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
https://jenkins.confluent.io/job/cp-ansible-on-demand/679/



**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible