### PR TITLE
fix: support running plays in check mode

### DIFF
--- a/roles/common/tasks/debian.yml
+++ b/roles/common/tasks/debian.yml
@@ -219,6 +219,8 @@
 - name: Get Java Version
   shell: java -version
   register: version_output
+  check_mode: false
+  changed_when: false
 
 - name: Print Java Version
   debug:

--- a/roles/common/tasks/redhat.yml
+++ b/roles/common/tasks/redhat.yml
@@ -60,6 +60,8 @@
 - name: Get Java Version
   shell: java -version
   register: version_output
+  check_mode: false
+  changed_when: false
 
 - name: Print Java Version
   debug:

--- a/roles/common/tasks/ubuntu.yml
+++ b/roles/common/tasks/ubuntu.yml
@@ -116,6 +116,8 @@
 - name: Get Java Version
   shell: java -version
   register: version_output
+  check_mode: false
+  changed_when: false
 
 - name: Print Java Version
   debug:


### PR DESCRIPTION
# Description

We always run plays in check mode against our first environment (dev) on feature branches. We just tried out the recent 7.3.0-post branch, and check mode is currently borked with the following error:

````
TASK [confluent.platform.common : Print Java Version] **************************
fatal: [REDACTED]: FAILED! => 
  msg: |-
    The task includes an option with an undefined variable. The error was: list object has no element 0
  
    The error appears to be in '/home/ansible/.ansible/collections/ansible_collections/confluent/platform/roles/common/tasks/redhat.yml': line 64, column 3, but may
    be elsewhere in the file depending on the exact syntax problem.
  
    The offending line appears to be:
  
  
    - name: Print Java Version
      ^ here
````

Intentionally targeting the release branch (7.3.0-post).

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Verified that our check mode run passes the currently failing task with this fix. We are getting a subsequent error that I have to look closer into.

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible