### PR TITLE
fix: remove install of epel-release

### DIFF
--- a/roles/common/tasks/redhat.yml
+++ b/roles/common/tasks/redhat.yml
@@ -72,7 +72,6 @@
 - name: Install pip
   yum:
     name:
-      - epel-release
       - "{{ pip_package_name }}"
     state: present
   become: true


### PR DESCRIPTION
# Description

This removes the installation of the `epel-release` package on RHEL systems. If the package is required for some reason, I think it should be justified, and put behind some kind of conditional logic.

Intentionally targeting the 7.3.0-post branch.

Fixes #1229 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Play runs successfully with this change against our dev environment in check mode.

**Test Configuration**:

N/A

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible