### PR TITLE
Replace geerlingguy docker images with our custom images

### DIFF
--- a/molecule/Dockerfile-debian-archive.j2
+++ b/molecule/Dockerfile-debian-archive.j2
@@ -4,4 +4,11 @@ RUN echo 'deb [check-valid-until=no] http://ftp.debian.org/debian stretch-backpo
 
 RUN apt-get update && \
     apt-get install --no-install-recommends --yes \
-      openjdk-11-jdk \
+      apt-transport-https \
+      gnupg \
+      software-properties-common \
+      openjdk-11-jdk
+
+# Hack to fix cacerts on debian hosts, preventing confluenthub installs from working
+RUN /usr/bin/printf '\xfe\xed\xfe\xed\x00\x00\x00\x02\x00\x00\x00\x00\xe2\x68\x6e\x45\xfb\x43\xdf\xa4\xd9\x92\xdd\x41\xce\xb6\xb2\x1c\x63\x30\xd7\x92' > /etc/ssl/certs/java/cacerts && \
+    /var/lib/dpkg/info/ca-certificates-java.postinst configure

--- a/molecule/Dockerfile-debian-archive.j2
+++ b/molecule/Dockerfile-debian-archive.j2
@@ -4,16 +4,9 @@ RUN echo 'deb [check-valid-until=no] http://ftp.debian.org/debian stretch-backpo
 
 RUN apt-get update && \
     apt-get install --no-install-recommends --yes \
-      apt-transport-https \
-      gnupg \
-      software-properties-common \
       openjdk-11-jdk \
-      rsync \
-      ca-certificates \
-      openssl \
-      unzip \
-      curl
 
+RUN mkdir -p /etc/ssl/certs/java/cacerts
 # Hack to fix cacerts on debian hosts, preventing confluenthub installs from working
 RUN /usr/bin/printf '\xfe\xed\xfe\xed\x00\x00\x00\x02\x00\x00\x00\x00\xe2\x68\x6e\x45\xfb\x43\xdf\xa4\xd9\x92\xdd\x41\xce\xb6\xb2\x1c\x63\x30\xd7\x92' > /etc/ssl/certs/java/cacerts && \
     /var/lib/dpkg/info/ca-certificates-java.postinst configure

--- a/molecule/Dockerfile-debian-archive.j2
+++ b/molecule/Dockerfile-debian-archive.j2
@@ -5,8 +5,3 @@ RUN echo 'deb [check-valid-until=no] http://ftp.debian.org/debian stretch-backpo
 RUN apt-get update && \
     apt-get install --no-install-recommends --yes \
       openjdk-11-jdk \
-
-RUN mkdir -p /etc/ssl/certs/java/cacerts
-# Hack to fix cacerts on debian hosts, preventing confluenthub installs from working
-RUN /usr/bin/printf '\xfe\xed\xfe\xed\x00\x00\x00\x02\x00\x00\x00\x00\xe2\x68\x6e\x45\xfb\x43\xdf\xa4\xd9\x92\xdd\x41\xce\xb6\xb2\x1c\x63\x30\xd7\x92' > /etc/ssl/certs/java/cacerts && \
-    /var/lib/dpkg/info/ca-certificates-java.postinst configure

--- a/molecule/Dockerfile-debian-java8.j2
+++ b/molecule/Dockerfile-debian-java8.j2
@@ -4,15 +4,7 @@ RUN echo 'deb [check-valid-until=no] http://ftp.debian.org/debian stretch-backpo
 
 RUN apt-get update && \
     apt-get install --no-install-recommends --yes \
-      apt-transport-https \
-      gnupg \
-      software-properties-common \
-      openjdk-8-jdk \
-      rsync \
-      ca-certificates \
-      openssl \
-      unzip \
-      curl
+      openjdk-8-jdk
 
 # Hack to fix cacerts on debian hosts, preventing confluenthub installs from working
 RUN /usr/bin/printf '\xfe\xed\xfe\xed\x00\x00\x00\x02\x00\x00\x00\x00\xe2\x68\x6e\x45\xfb\x43\xdf\xa4\xd9\x92\xdd\x41\xce\xb6\xb2\x1c\x63\x30\xd7\x92' > /etc/ssl/certs/java/cacerts && \

--- a/molecule/Dockerfile-debian.j2
+++ b/molecule/Dockerfile-debian.j2
@@ -4,6 +4,9 @@ RUN echo 'deb [check-valid-until=no] http://ftp.debian.org/debian stretch-backpo
 
 RUN apt-get update && \
     apt-get install --no-install-recommends --yes \
+      apt-transport-https \
+      gnupg \
+      software-properties-common \
       openjdk-11-jdk
 
 # Hack to fix cacerts on debian hosts, preventing confluenthub installs from working

--- a/molecule/Dockerfile-debian.j2
+++ b/molecule/Dockerfile-debian.j2
@@ -4,15 +4,7 @@ RUN echo 'deb [check-valid-until=no] http://ftp.debian.org/debian stretch-backpo
 
 RUN apt-get update && \
     apt-get install --no-install-recommends --yes \
-      apt-transport-https \
-      gnupg \
-      software-properties-common \
-      openjdk-11-jdk \
-      rsync \
-      ca-certificates \
-      openssl \
-      unzip \
-      curl
+      openjdk-11-jdk
 
 # Hack to fix cacerts on debian hosts, preventing confluenthub installs from working
 RUN /usr/bin/printf '\xfe\xed\xfe\xed\x00\x00\x00\x02\x00\x00\x00\x00\xe2\x68\x6e\x45\xfb\x43\xdf\xa4\xd9\x92\xdd\x41\xce\xb6\xb2\x1c\x63\x30\xd7\x92' > /etc/ssl/certs/java/cacerts && \

--- a/molecule/Dockerfile-debian10-archive.j2
+++ b/molecule/Dockerfile-debian10-archive.j2
@@ -2,16 +2,7 @@ FROM {{ item.image }}
 
 RUN apt-get update && \
     apt-get install --yes \
-      apt-transport-https \
-      gnupg \
-      procps \
-      software-properties-common \
-      openjdk-11-jdk \
-      rsync \
-      ca-certificates \
-      openssl \
-      unzip \
-      curl
+      openjdk-11-jdk
 
 {% set DEFAULT_PACKAGE_VER = lookup('pipe', "awk '/confluent_package_version:/ {print $2}' $MOLECULE_PROJECT_DIRECTORY/roles/variables/defaults/main.yml" ) %}
 {% set PACKAGE_VER = lookup('env', 'VERSION') | default(DEFAULT_PACKAGE_VER, true) %}

--- a/molecule/Dockerfile-debian10.j2
+++ b/molecule/Dockerfile-debian10.j2
@@ -2,16 +2,7 @@ FROM {{ item.image }}
 
 RUN apt-get update && \
     apt-get install --yes \
-      apt-transport-https \
-      gnupg \
-      procps \
-      software-properties-common \
-      openjdk-11-jdk \
-      rsync \
-      ca-certificates \
-      openssl \
-      unzip \
-      curl
+      openjdk-11-jdk
 
 {% set DEFAULT_PACKAGE_VER = lookup('pipe', "awk '/confluent_package_version:/ {print $2}' $MOLECULE_PROJECT_DIRECTORY/roles/variables/defaults/main.yml" ) %}
 {% set PACKAGE_VER = lookup('env', 'VERSION') | default(DEFAULT_PACKAGE_VER, true) %}

--- a/molecule/Dockerfile-rhel-base.j2
+++ b/molecule/Dockerfile-rhel-base.j2
@@ -1,5 +1,3 @@
 FROM {{ item.image }}
 
-RUN yum -y install java-11-openjdk \
-      rsync \
-      openssl
+RUN yum -y install java-11-openjdk

--- a/molecule/Dockerfile-rhel-java8.j2
+++ b/molecule/Dockerfile-rhel-java8.j2
@@ -1,21 +1,7 @@
 FROM {{ item.image }}
 
 RUN yum -y install java-8-openjdk \
-      rsync \
-      openssl \
-      rsyslog \
-      libselinux-python \
-      openldap \
-      openldap-servers \
-      compat-openldap \
-      openldap-clients \
-      openldap-devel \
-      nss-pam-ldapd \
-      libselinux-python \
-      krb5-libs \
-      krb5-server \
-      krb5-workstation \
-      unzip
+      rsync
 
 {% set DEFAULT_PACKAGE_VER = lookup('pipe', "awk '/confluent_package_version:/ {print $2}' $MOLECULE_PROJECT_DIRECTORY/roles/variables/defaults/main.yml" ) %}
 {% set PACKAGE_VER = lookup('env', 'VERSION') | default(DEFAULT_PACKAGE_VER, true) %}

--- a/molecule/Dockerfile-tar.j2
+++ b/molecule/Dockerfile-tar.j2
@@ -1,8 +1,7 @@
 FROM {{ item.image }}
 
 RUN yum -y install java-11-openjdk \
-      rsync \
-      openssl
+      rsync
 
 {% set DEFAULT_PACKAGE_VER = lookup('pipe', "awk '/confluent_package_version:/ {print $2}' $MOLECULE_PROJECT_DIRECTORY/roles/variables/defaults/main.yml" ) %}
 {% set PACKAGE_VER = lookup('env', 'VERSION') | default(DEFAULT_PACKAGE_VER, true) %}

--- a/molecule/Dockerfile-ubuntu-java8.j2
+++ b/molecule/Dockerfile-ubuntu-java8.j2
@@ -1,8 +1,7 @@
 FROM {{ item.image }}
 
-RUN mkdir -p /usr/share/man/man1 && \
-    apt-get update -y && \
-    apt-get install -y openjdk-8-jdk wget gnupg
+RUN apt-get update -y && \
+    apt-get install -y openjdk-8-jdk
 
 {% set DEFAULT_PACKAGE_VER = lookup('pipe', "awk '/confluent_package_version:/ {print $2}' $MOLECULE_PROJECT_DIRECTORY/roles/variables/defaults/main.yml" ) %}
 {% set PACKAGE_VER = lookup('env', 'VERSION') | default(DEFAULT_PACKAGE_VER, true) %}

--- a/molecule/Dockerfile-ubuntu.j2
+++ b/molecule/Dockerfile-ubuntu.j2
@@ -1,8 +1,7 @@
 FROM {{ item.image }}
 
-RUN mkdir -p /usr/share/man/man1 && \
-    apt-get update -y && \
-    apt-get install -y openjdk-11-jdk wget gnupg
+RUN apt-get update -y && \
+    apt-get install -y openjdk-11-jdk
 
 {% set DEFAULT_PACKAGE_VER = lookup('pipe', "awk '/confluent_package_version:/ {print $2}' $MOLECULE_PROJECT_DIRECTORY/roles/variables/defaults/main.yml" ) %}
 {% set PACKAGE_VER = lookup('env', 'VERSION') | default(DEFAULT_PACKAGE_VER, true) %}

--- a/molecule/Dockerfile-ubuntu2004-archive.j2
+++ b/molecule/Dockerfile-ubuntu2004-archive.j2
@@ -1,6 +1,4 @@
 FROM {{ item.image }}
 
-RUN mkdir -p /usr/share/man/man1 && \
-    apt-get update -y && \
-    apt-get install -y openjdk-11-jdk wget gnupg && \
-    apt-get install -y dirmngr
+RUN apt-get update -y && \
+    apt-get install -y openjdk-11-jdk

--- a/molecule/Dockerfile.j2
+++ b/molecule/Dockerfile.j2
@@ -1,21 +1,7 @@
 FROM {{ item.image }}
 
 RUN yum -y install java-11-openjdk \
-      rsync \
-      openssl \
-      rsyslog \
-      libselinux-python \
-      openldap \
-      openldap-servers \
-      compat-openldap \
-      openldap-clients \
-      openldap-devel \
-      nss-pam-ldapd \
-      libselinux-python \
-      krb5-libs \
-      krb5-server \
-      krb5-workstation \
-      unzip
+      rsync
 
 {% set DEFAULT_PACKAGE_VER = lookup('pipe', "awk '/confluent_package_version:/ {print $2}' $MOLECULE_PROJECT_DIRECTORY/roles/variables/defaults/main.yml" ) %}
 {% set PACKAGE_VER = lookup('env', 'VERSION') | default(DEFAULT_PACKAGE_VER, true) %}

--- a/molecule/archive-community-plaintext-rhel/molecule.yml
+++ b/molecule/archive-community-plaintext-rhel/molecule.yml
@@ -12,7 +12,7 @@ platforms:
     hostname: zookeeper1.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile-rhel-base.j2
     command: ""
     volumes:
@@ -24,7 +24,7 @@ platforms:
     hostname: kafka-broker1.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile-rhel-base.j2
     command: ""
     volumes:
@@ -36,7 +36,7 @@ platforms:
     hostname: schema-registry1.confluent
     groups:
       - schema_registry
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile-rhel-base.j2
     command: ""
     volumes:
@@ -48,7 +48,7 @@ platforms:
     hostname: kafka-rest1.confluent
     groups:
       - kafka_rest
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile-rhel-base.j2
     command: ""
     volumes:
@@ -60,7 +60,7 @@ platforms:
     hostname: kafka-connect1.confluent
     groups:
       - kafka_connect
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile-rhel-base.j2
     command: ""
     volumes:
@@ -72,7 +72,7 @@ platforms:
     hostname: ksql1.confluent
     groups:
       - ksql
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile-rhel-base.j2
     command: ""
     volumes:
@@ -91,7 +91,7 @@ provisioner:
         confluent_community_archive_url: "{{ lookup('env', 'COMMON_REPO_URL') | default('http://packages.confluent.io', true) }}/archive/{{confluent_repo_version}}/confluent-community-{{confluent_package_version}}.tar.gz"
         confluent_archive_file_source: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/confluent-community-{{confluent_package_version}}.tar.gz"
         confluent_archive_file_remote: false
-        confluent_cli_archive_url: "https://s3-us-west-2.amazonaws.com/confluent.cloud/confluent-cli/archives/latest/confluent_latest_linux_amd64.tar.gz" # image: geerlingguy/docker-centos7-ansible is for linux/amd64
+        confluent_cli_archive_url: "https://s3-us-west-2.amazonaws.com/confluent.cloud/confluent-cli/archives/latest/confluent_latest_linux_amd64.tar.gz" # image: utkarsh5474/docker-centos7-ansible is for linux/amd64
         confluent_cli_archive_file_source: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/confluent_latest_linux_amd64.tar.gz"
         confluent_cli_archive_file_remote: false
         confluent_cli_download_enabled: true

--- a/molecule/archive-plain-debian/molecule.yml
+++ b/molecule/archive-plain-debian/molecule.yml
@@ -12,7 +12,7 @@ platforms:
     hostname: zookeeper1.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian-archive.j2
     command: ""
     volumes:
@@ -24,7 +24,7 @@ platforms:
     hostname: kafka-broker1.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian-archive.j2
     command: ""
     volumes:
@@ -36,7 +36,7 @@ platforms:
     hostname: schema-registry1.confluent
     groups:
       - schema_registry
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian-archive.j2
     command: ""
     volumes:
@@ -48,7 +48,7 @@ platforms:
     hostname: kafka-rest1.confluent
     groups:
       - kafka_rest
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian-archive.j2
     command: ""
     volumes:
@@ -60,7 +60,7 @@ platforms:
     hostname: kafka-connect1.confluent
     groups:
       - kafka_connect
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian-archive.j2
     command: ""
     volumes:
@@ -72,7 +72,7 @@ platforms:
     hostname: ksql1.confluent
     groups:
       - ksql
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian-archive.j2
     command: ""
     volumes:
@@ -84,7 +84,7 @@ platforms:
     hostname: control-center1.confluent
     groups:
       - control_center
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian-archive.j2
     command: ""
     volumes:

--- a/molecule/archive-plain-debian10/molecule.yml
+++ b/molecule/archive-plain-debian10/molecule.yml
@@ -10,7 +10,7 @@ platforms:
     hostname: zookeeper1.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-debian10-ansible
+    image: utkarsh5474/docker-debian10-ansible
     dockerfile: ../Dockerfile-debian10-archive.j2
     command: ""
     volumes:
@@ -22,7 +22,7 @@ platforms:
     hostname: kafka-broker1.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-debian10-ansible
+    image: utkarsh5474/docker-debian10-ansible
     dockerfile: ../Dockerfile-debian10-archive.j2
     command: ""
     volumes:
@@ -34,7 +34,7 @@ platforms:
     hostname: schema-registry1.confluent
     groups:
       - schema_registry
-    image: geerlingguy/docker-debian10-ansible
+    image: utkarsh5474/docker-debian10-ansible
     dockerfile: ../Dockerfile-debian10-archive.j2
     command: ""
     volumes:
@@ -46,7 +46,7 @@ platforms:
     hostname: kafka-rest1.confluent
     groups:
       - kafka_rest
-    image: geerlingguy/docker-debian10-ansible
+    image: utkarsh5474/docker-debian10-ansible
     dockerfile: ../Dockerfile-debian10-archive.j2
     command: ""
     volumes:
@@ -58,7 +58,7 @@ platforms:
     hostname: kafka-connect1.confluent
     groups:
       - kafka_connect
-    image: geerlingguy/docker-debian10-ansible
+    image: utkarsh5474/docker-debian10-ansible
     dockerfile: ../Dockerfile-debian10-archive.j2
     command: ""
     volumes:
@@ -70,7 +70,7 @@ platforms:
     hostname: ksql1.confluent
     groups:
       - ksql
-    image: geerlingguy/docker-debian10-ansible
+    image: utkarsh5474/docker-debian10-ansible
     dockerfile: ../Dockerfile-debian10-archive.j2
     command: ""
     volumes:
@@ -82,7 +82,7 @@ platforms:
     hostname: control-center1.confluent
     groups:
       - control_center
-    image: geerlingguy/docker-debian10-ansible
+    image: utkarsh5474/docker-debian10-ansible
     dockerfile: ../Dockerfile-debian10-archive.j2
     command: ""
     volumes:

--- a/molecule/archive-plain-rhel/molecule.yml
+++ b/molecule/archive-plain-rhel/molecule.yml
@@ -14,7 +14,7 @@ platforms:
     hostname: zookeeper1.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile-tar.j2
     command: ""
     volumes:
@@ -26,7 +26,7 @@ platforms:
     hostname: kafka-broker1.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile-tar.j2
     command: ""
     volumes:
@@ -38,7 +38,7 @@ platforms:
     hostname: schema-registry1.confluent
     groups:
       - schema_registry
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile-tar.j2
     command: ""
     volumes:
@@ -50,7 +50,7 @@ platforms:
     hostname: kafka-rest1.confluent
     groups:
       - kafka_rest
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile-tar.j2
     command: ""
     volumes:
@@ -62,7 +62,7 @@ platforms:
     hostname: kafka-connect1.confluent
     groups:
       - kafka_connect
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile-tar.j2
     command: ""
     volumes:
@@ -74,7 +74,7 @@ platforms:
     hostname: ksql1.confluent
     groups:
       - ksql
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile-tar.j2
     command: ""
     volumes:
@@ -86,7 +86,7 @@ platforms:
     hostname: control-center1.confluent
     groups:
       - control_center
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile-tar.j2
     command: ""
     volumes:

--- a/molecule/archive-plain-ubuntu/molecule.yml
+++ b/molecule/archive-plain-ubuntu/molecule.yml
@@ -12,7 +12,7 @@ platforms:
     hostname: zookeeper1.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-ubuntu1804-ansible
+    image: utkarsh5474/docker-ubuntu1804-ansible
     dockerfile: ../Dockerfile-ubuntu-archive.j2
     command: ""
     volumes:
@@ -24,7 +24,7 @@ platforms:
     hostname: kafka-broker1.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-ubuntu1804-ansible
+    image: utkarsh5474/docker-ubuntu1804-ansible
     dockerfile: ../Dockerfile-ubuntu-archive.j2
     command: ""
     volumes:
@@ -36,7 +36,7 @@ platforms:
     hostname: schema-registry1.confluent
     groups:
       - schema_registry
-    image: geerlingguy/docker-ubuntu1804-ansible
+    image: utkarsh5474/docker-ubuntu1804-ansible
     dockerfile: ../Dockerfile-ubuntu-archive.j2
     command: ""
     volumes:
@@ -48,7 +48,7 @@ platforms:
     hostname: kafka-rest1.confluent
     groups:
       - kafka_rest
-    image: geerlingguy/docker-ubuntu1804-ansible
+    image: utkarsh5474/docker-ubuntu1804-ansible
     dockerfile: ../Dockerfile-ubuntu-archive.j2
     command: ""
     volumes:
@@ -60,7 +60,7 @@ platforms:
     hostname: kafka-connect1.confluent
     groups:
       - kafka_connect
-    image: geerlingguy/docker-ubuntu1804-ansible
+    image: utkarsh5474/docker-ubuntu1804-ansible
     dockerfile: ../Dockerfile-ubuntu-archive.j2
     command: ""
     volumes:
@@ -72,7 +72,7 @@ platforms:
     hostname: ksql1.confluent
     groups:
       - ksql
-    image: geerlingguy/docker-ubuntu1804-ansible
+    image: utkarsh5474/docker-ubuntu1804-ansible
     dockerfile: ../Dockerfile-ubuntu-archive.j2
     command: ""
     volumes:
@@ -84,7 +84,7 @@ platforms:
     hostname: control-center1.confluent
     groups:
       - control_center
-    image: geerlingguy/docker-ubuntu1804-ansible
+    image: utkarsh5474/docker-ubuntu1804-ansible
     dockerfile: ../Dockerfile-ubuntu-archive.j2
     command: ""
     volumes:

--- a/molecule/archive-plain-ubuntu2004/molecule.yml
+++ b/molecule/archive-plain-ubuntu2004/molecule.yml
@@ -10,7 +10,7 @@ platforms:
     hostname: zookeeper1.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-ubuntu2004-ansible
+    image: utkarsh5474/docker-ubuntu2004-ansible
     dockerfile: ../Dockerfile-ubuntu2004-archive.j2
     command: ""
     volumes:
@@ -22,7 +22,7 @@ platforms:
     hostname: kafka-broker1.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-ubuntu2004-ansible
+    image: utkarsh5474/docker-ubuntu2004-ansible
     dockerfile: ../Dockerfile-ubuntu2004-archive.j2
     command: ""
     volumes:
@@ -34,7 +34,7 @@ platforms:
     hostname: schema-registry1.confluent
     groups:
       - schema_registry
-    image: geerlingguy/docker-ubuntu2004-ansible
+    image: utkarsh5474/docker-ubuntu2004-ansible
     dockerfile: ../Dockerfile-ubuntu2004-archive.j2
     command: ""
     volumes:
@@ -46,7 +46,7 @@ platforms:
     hostname: kafka-rest1.confluent
     groups:
       - kafka_rest
-    image: geerlingguy/docker-ubuntu2004-ansible
+    image: utkarsh5474/docker-ubuntu2004-ansible
     dockerfile: ../Dockerfile-ubuntu2004-archive.j2
     command: ""
     volumes:
@@ -58,7 +58,7 @@ platforms:
     hostname: kafka-connect1.confluent
     groups:
       - kafka_connect
-    image: geerlingguy/docker-ubuntu2004-ansible
+    image: utkarsh5474/docker-ubuntu2004-ansible
     dockerfile: ../Dockerfile-ubuntu2004-archive.j2
     command: ""
     volumes:
@@ -70,7 +70,7 @@ platforms:
     hostname: ksql1.confluent
     groups:
       - ksql
-    image: geerlingguy/docker-ubuntu2004-ansible
+    image: utkarsh5474/docker-ubuntu2004-ansible
     dockerfile: ../Dockerfile-ubuntu2004-archive.j2
     command: ""
     volumes:
@@ -82,7 +82,7 @@ platforms:
     hostname: control-center1.confluent
     groups:
       - control_center
-    image: geerlingguy/docker-ubuntu2004-ansible
+    image: utkarsh5474/docker-ubuntu2004-ansible
     dockerfile: ../Dockerfile-ubuntu2004-archive.j2
     command: ""
     volumes:

--- a/molecule/archive-scram-rhel/molecule.yml
+++ b/molecule/archive-scram-rhel/molecule.yml
@@ -12,7 +12,7 @@ platforms:
     hostname: zookeeper1.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile-tar.j2
     command: ""
     volumes:
@@ -24,7 +24,7 @@ platforms:
     hostname: kafka-broker1.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile-tar.j2
     command: ""
     volumes:
@@ -36,7 +36,7 @@ platforms:
     hostname: schema-registry1.confluent
     groups:
       - schema_registry
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile-tar.j2
     command: ""
     volumes:
@@ -48,7 +48,7 @@ platforms:
     hostname: kafka-rest1.confluent
     groups:
       - kafka_rest
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile-tar.j2
     command: ""
     volumes:
@@ -60,7 +60,7 @@ platforms:
     hostname: kafka-connect1.confluent
     groups:
       - kafka_connect
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile-tar.j2
     command: ""
     volumes:
@@ -72,7 +72,7 @@ platforms:
     hostname: ksql1.confluent
     groups:
       - ksql
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile-tar.j2
     command: ""
     volumes:
@@ -84,7 +84,7 @@ platforms:
     hostname: control-center1.confluent
     groups:
       - control_center
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile-tar.j2
     command: ""
     volumes:

--- a/molecule/ccloud/molecule.yml
+++ b/molecule/ccloud/molecule.yml
@@ -11,7 +11,7 @@ platforms:
     hostname: zookeeper1.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -23,7 +23,7 @@ platforms:
     hostname: kafka-broker1.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -35,7 +35,7 @@ platforms:
     hostname: kafka-broker2.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -47,7 +47,7 @@ platforms:
     hostname: kafka-broker3.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -59,7 +59,7 @@ platforms:
     hostname: ccloud-schema-registry1.confluent
     groups:
       - ccloud_schema_registry
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -71,7 +71,7 @@ platforms:
     hostname: schema-registry1.confluent
     groups:
       - schema_registry
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -83,7 +83,7 @@ platforms:
     hostname: kafka-connect1.confluent
     groups:
       - kafka_connect
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -95,7 +95,7 @@ platforms:
     hostname: ksql1.confluent
     groups:
       - ksql
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -107,7 +107,7 @@ platforms:
     hostname: kafka-rest1.confluent
     groups:
       - kafka_rest
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -119,7 +119,7 @@ platforms:
     hostname: control-center1.confluent
     groups:
       - control_center
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:

--- a/molecule/confluent-kafka-kerberos-customcerts-rhel/molecule.yml
+++ b/molecule/confluent-kafka-kerberos-customcerts-rhel/molecule.yml
@@ -11,7 +11,7 @@ platforms:
     hostname: kerberos1.confluent
     groups:
       - kerberos_server
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -23,7 +23,7 @@ platforms:
     hostname: zookeeper1.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -35,7 +35,7 @@ platforms:
     hostname: zookeeper2.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -47,7 +47,7 @@ platforms:
     hostname: zookeeper3.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -59,7 +59,7 @@ platforms:
     hostname: kafka-broker1.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -71,7 +71,7 @@ platforms:
     hostname: kafka-broker2.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -83,7 +83,7 @@ platforms:
     hostname: kafka-broker3.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -95,7 +95,7 @@ platforms:
     hostname: schema-registry1.confluent
     groups:
       - schema_registry
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -107,7 +107,7 @@ platforms:
     hostname: kafka-rest1.confluent
     groups:
       - kafka_rest
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -119,7 +119,7 @@ platforms:
     hostname: kafka-connect1.confluent
     groups:
       - kafka_connect
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -131,7 +131,7 @@ platforms:
     hostname: ksql1.confluent
     groups:
       - ksql
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -143,7 +143,7 @@ platforms:
     hostname: control-center1.confluent
     groups:
       - control_center
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:

--- a/molecule/cp-kafka-plain-rhel/molecule.yml
+++ b/molecule/cp-kafka-plain-rhel/molecule.yml
@@ -10,7 +10,7 @@ platforms:
     groups:
       - kafka_broker
       - zookeeper
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -22,7 +22,7 @@ platforms:
     groups:
       - kafka_broker
       - zookeeper
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -34,7 +34,7 @@ platforms:
     groups:
       - kafka_broker
       - zookeeper
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -45,7 +45,7 @@ platforms:
     hostname: schema-registry1.confluent
     groups:
       - schema_registry
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -56,7 +56,7 @@ platforms:
     hostname: kafka-rest1.confluent
     groups:
       - kafka_rest
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -67,7 +67,7 @@ platforms:
     hostname: kafka-connect1.confluent
     groups:
       - kafka_connect
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -78,7 +78,7 @@ platforms:
     hostname: ksql1.confluent
     groups:
       - ksql
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -89,7 +89,7 @@ platforms:
     hostname: control-center1.confluent
     groups:
       - control_center
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/molecule/custom-user-plaintext-rhel/molecule.yml
+++ b/molecule/custom-user-plaintext-rhel/molecule.yml
@@ -12,7 +12,7 @@ platforms:
     groups:
       - zookeeper
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -24,7 +24,7 @@ platforms:
     hostname: schema-registry1${JOB_BASE_NAME}${BUILD_NUMBER}.confluent${JOB_BASE_NAME}${BUILD_NUMBER}
     groups:
       - schema_registry
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -36,7 +36,7 @@ platforms:
     hostname: kafka-rest1${JOB_BASE_NAME}${BUILD_NUMBER}.confluent${JOB_BASE_NAME}${BUILD_NUMBER}
     groups:
       - kafka_rest
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -48,7 +48,7 @@ platforms:
     hostname: kafka-connect1${JOB_BASE_NAME}${BUILD_NUMBER}.confluent${JOB_BASE_NAME}${BUILD_NUMBER}
     groups:
       - kafka_connect
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -60,7 +60,7 @@ platforms:
     hostname: ksql1${JOB_BASE_NAME}${BUILD_NUMBER}.confluent${JOB_BASE_NAME}${BUILD_NUMBER}
     groups:
       - ksql
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -72,7 +72,7 @@ platforms:
     hostname: control-center1${JOB_BASE_NAME}${BUILD_NUMBER}.confluent${JOB_BASE_NAME}${BUILD_NUMBER}
     groups:
       - control_center
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:

--- a/molecule/kafka-connect-replicator-mtls-scram-rhel/molecule.yml
+++ b/molecule/kafka-connect-replicator-mtls-scram-rhel/molecule.yml
@@ -14,7 +14,7 @@ platforms:
     hostname: mds-kerberos1.confluent
     groups:
       - kerberos_server
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -27,7 +27,7 @@ platforms:
     groups:
       - zookeeper
       - mds
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -40,7 +40,7 @@ platforms:
     groups:
       - kafka_broker
       - mds
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -53,7 +53,7 @@ platforms:
     groups:
       - kafka_broker
       - mds
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -66,7 +66,7 @@ platforms:
     groups:
       - kafka_broker
       - mds
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -80,7 +80,7 @@ platforms:
     groups:
       - zookeeper2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -93,7 +93,7 @@ platforms:
     groups:
       - kafka_broker2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -106,7 +106,7 @@ platforms:
     groups:
       - kafka_broker2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -119,7 +119,7 @@ platforms:
     groups:
       - kafka_broker2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -132,7 +132,7 @@ platforms:
     groups:
       - kafka_connect_replicator2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:

--- a/molecule/kafka-connect-replicator-plain-kerberos-rhel/molecule.yml
+++ b/molecule/kafka-connect-replicator-plain-kerberos-rhel/molecule.yml
@@ -14,7 +14,7 @@ platforms:
     hostname: mds-kerberos1.confluent
     groups:
       - kerberos_server
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -27,7 +27,7 @@ platforms:
     groups:
       - zookeeper
       - mds
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -40,7 +40,7 @@ platforms:
     groups:
       - kafka_broker
       - mds
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -53,7 +53,7 @@ platforms:
     groups:
       - kafka_broker
       - mds
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -66,7 +66,7 @@ platforms:
     groups:
       - kafka_broker
       - mds
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -80,7 +80,7 @@ platforms:
     groups:
       - zookeeper2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -93,7 +93,7 @@ platforms:
     groups:
       - kafka_broker2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -106,7 +106,7 @@ platforms:
     groups:
       - kafka_broker2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -119,7 +119,7 @@ platforms:
     groups:
       - kafka_broker2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -132,7 +132,7 @@ platforms:
     groups:
       - kafka_connect_replicator2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:

--- a/molecule/kerberos-customcerts-rhel/molecule.yml
+++ b/molecule/kerberos-customcerts-rhel/molecule.yml
@@ -10,7 +10,7 @@ platforms:
     hostname: kerberos1.confluent
     groups:
       - kerberos_server
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -22,7 +22,7 @@ platforms:
     hostname: zookeeper1.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -34,7 +34,7 @@ platforms:
     hostname: kafka-broker1.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -46,7 +46,7 @@ platforms:
     hostname: kafka-broker2.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -58,7 +58,7 @@ platforms:
     hostname: kafka-broker3.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -70,7 +70,7 @@ platforms:
     hostname: schema-registry1.confluent
     groups:
       - schema_registry
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -82,7 +82,7 @@ platforms:
     hostname: kafka-rest1.confluent
     groups:
       - kafka_rest
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -94,7 +94,7 @@ platforms:
     hostname: kafka-connect1.confluent
     groups:
       - kafka_connect
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -106,7 +106,7 @@ platforms:
     hostname: ksql1.confluent
     groups:
       - ksql
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -118,7 +118,7 @@ platforms:
     hostname: control-center1.confluent
     groups:
       - control_center
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:

--- a/molecule/kerberos-rhel/molecule.yml
+++ b/molecule/kerberos-rhel/molecule.yml
@@ -9,7 +9,7 @@ platforms:
     hostname: kerberos1.confluent
     groups:
       - kerberos_server
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -21,7 +21,7 @@ platforms:
     hostname: zookeeper1.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -33,7 +33,7 @@ platforms:
     hostname: kafka-broker1.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -45,7 +45,7 @@ platforms:
     hostname: kafka-broker2.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -57,7 +57,7 @@ platforms:
     hostname: kafka-broker3.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -69,7 +69,7 @@ platforms:
     hostname: schema-registry1.confluent
     groups:
       - schema_registry
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -81,7 +81,7 @@ platforms:
     hostname: kafka-rest1.confluent
     groups:
       - kafka_rest
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -93,7 +93,7 @@ platforms:
     hostname: kafka-connect1.confluent
     groups:
       - kafka_connect
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -105,7 +105,7 @@ platforms:
     hostname: ksql1.confluent
     groups:
       - ksql
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -117,7 +117,7 @@ platforms:
     hostname: control-center1.confluent
     groups:
       - control_center
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:

--- a/molecule/mtls-custombundle-rhel/molecule.yml
+++ b/molecule/mtls-custombundle-rhel/molecule.yml
@@ -12,7 +12,7 @@ platforms:
     hostname: zookeeper1.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile-rhel-java8.j2
     command: ""
     volumes:
@@ -24,7 +24,7 @@ platforms:
     hostname: kafka-broker1.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile-rhel-java8.j2
     command: ""
     volumes:
@@ -36,7 +36,7 @@ platforms:
     hostname: kafka-broker2.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile-rhel-java8.j2
     command: ""
     volumes:
@@ -48,7 +48,7 @@ platforms:
     hostname: kafka-broker3.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile-rhel-java8.j2
     command: ""
     volumes:
@@ -60,7 +60,7 @@ platforms:
     hostname: schema-registry1.confluent
     groups:
       - schema_registry
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile-rhel-java8.j2
     command: ""
     volumes:
@@ -72,7 +72,7 @@ platforms:
     hostname: kafka-rest1.confluent
     groups:
       - kafka_rest
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile-rhel-java8.j2
     command: ""
     volumes:
@@ -84,7 +84,7 @@ platforms:
     hostname: kafka-connect1.confluent
     groups:
       - kafka_connect
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile-rhel-java8.j2
     command: ""
     volumes:
@@ -96,7 +96,7 @@ platforms:
     hostname: ksql1.confluent
     groups:
       - ksql
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile-rhel-java8.j2
     command: ""
     volumes:
@@ -110,7 +110,7 @@ platforms:
     groups:
       - control_center
       - schema_registry
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile-rhel-java8.j2
     command: ""
     volumes:

--- a/molecule/mtls-customcerts-rhel/molecule.yml
+++ b/molecule/mtls-customcerts-rhel/molecule.yml
@@ -9,7 +9,7 @@ platforms:
     hostname: zookeeper1.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -20,7 +20,7 @@ platforms:
     hostname: kafka-broker1.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -31,7 +31,7 @@ platforms:
     hostname: kafka-broker2.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -42,7 +42,7 @@ platforms:
     hostname: kafka-broker3.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -53,7 +53,7 @@ platforms:
     hostname: schema-registry1.confluent
     groups:
       - schema_registry
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -64,7 +64,7 @@ platforms:
     hostname: kafka-rest1.confluent
     groups:
       - kafka_rest
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -75,7 +75,7 @@ platforms:
     hostname: kafka-connect1.confluent
     groups:
       - kafka_connect
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -86,7 +86,7 @@ platforms:
     hostname: ksql1.confluent
     groups:
       - ksql
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -97,7 +97,7 @@ platforms:
     hostname: control-center1.confluent
     groups:
       - control_center
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/molecule/mtls-debian/molecule.yml
+++ b/molecule/mtls-debian/molecule.yml
@@ -15,7 +15,7 @@ platforms:
     hostname: zookeeper1.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
@@ -27,7 +27,7 @@ platforms:
     hostname: kafka-broker1.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
@@ -39,7 +39,7 @@ platforms:
     hostname: kafka-broker2.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
@@ -51,7 +51,7 @@ platforms:
     hostname: kafka-broker3.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
@@ -63,7 +63,7 @@ platforms:
     hostname: kafka-broker4.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
@@ -75,7 +75,7 @@ platforms:
     hostname: schema-registry1.confluent
     groups:
       - schema_registry
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
@@ -87,7 +87,7 @@ platforms:
     hostname: kafka-rest1.confluent
     groups:
       - kafka_rest
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
@@ -99,7 +99,7 @@ platforms:
     hostname: kafka-connect1.confluent
     groups:
       - kafka_connect
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
@@ -111,7 +111,7 @@ platforms:
     hostname: ksql1.confluent
     groups:
       - ksql
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
@@ -123,7 +123,7 @@ platforms:
     hostname: control-center1.confluent
     groups:
       - control_center
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:

--- a/molecule/mtls-java8-debian/molecule.yml
+++ b/molecule/mtls-java8-debian/molecule.yml
@@ -10,7 +10,7 @@ platforms:
     hostname: zookeeper1.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian-java8.j2
     command: ""
     volumes:
@@ -22,7 +22,7 @@ platforms:
     hostname: kafka-broker1.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian-java8.j2
     command: ""
     volumes:
@@ -34,7 +34,7 @@ platforms:
     hostname: kafka-broker2.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian-java8.j2
     command: ""
     volumes:
@@ -46,7 +46,7 @@ platforms:
     hostname: kafka-broker3.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian-java8.j2
     command: ""
     volumes:
@@ -58,7 +58,7 @@ platforms:
     hostname: schema-registry1.confluent
     groups:
       - schema_registry
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian-java8.j2
     command: ""
     volumes:
@@ -70,7 +70,7 @@ platforms:
     hostname: kafka-rest1.confluent
     groups:
       - kafka_rest
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian-java8.j2
     command: ""
     volumes:
@@ -82,7 +82,7 @@ platforms:
     hostname: kafka-connect1.confluent
     groups:
       - kafka_connect
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian-java8.j2
     command: ""
     volumes:
@@ -94,7 +94,7 @@ platforms:
     hostname: ksql1.confluent
     groups:
       - ksql
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian-java8.j2
     command: ""
     volumes:
@@ -106,7 +106,7 @@ platforms:
     hostname: control-center1.confluent
     groups:
       - control_center
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian-java8.j2
     command: ""
     volumes:

--- a/molecule/mtls-java8-rhel/molecule.yml
+++ b/molecule/mtls-java8-rhel/molecule.yml
@@ -10,7 +10,7 @@ platforms:
     hostname: zookeeper1.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile-rhel-java8.j2
     command: ""
     volumes:
@@ -22,7 +22,7 @@ platforms:
     hostname: kafka-broker1.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile-rhel-java8.j2
     command: ""
     volumes:
@@ -34,7 +34,7 @@ platforms:
     hostname: schema-registry1.confluent
     groups:
       - schema_registry
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile-rhel-java8.j2
     command: ""
     volumes:
@@ -46,7 +46,7 @@ platforms:
     hostname: kafka-rest1.confluent
     groups:
       - kafka_rest
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile-rhel-java8.j2
     command: ""
     volumes:
@@ -58,7 +58,7 @@ platforms:
     hostname: kafka-connect1.confluent
     groups:
       - kafka_connect
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile-rhel-java8.j2
     command: ""
     volumes:
@@ -70,7 +70,7 @@ platforms:
     hostname: ksql1.confluent
     groups:
       - ksql
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile-rhel-java8.j2
     command: ""
     volumes:
@@ -82,7 +82,7 @@ platforms:
     hostname: control-center1.confluent
     groups:
       - control_center
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile-rhel-java8.j2
     command: ""
     volumes:

--- a/molecule/mtls-java8-ubuntu/molecule.yml
+++ b/molecule/mtls-java8-ubuntu/molecule.yml
@@ -10,7 +10,7 @@ platforms:
     hostname: zookeeper1.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-ubuntu2004-ansible
+    image: utkarsh5474/docker-ubuntu2004-ansible
     dockerfile: ../Dockerfile-ubuntu-java8.j2
     command: ""
     volumes:
@@ -22,7 +22,7 @@ platforms:
     hostname: kafka-broker1.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-ubuntu2004-ansible
+    image: utkarsh5474/docker-ubuntu2004-ansible
     dockerfile: ../Dockerfile-ubuntu-java8.j2
     command: ""
     volumes:
@@ -34,7 +34,7 @@ platforms:
     hostname: kafka-broker2.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-ubuntu2004-ansible
+    image: utkarsh5474/docker-ubuntu2004-ansible
     dockerfile: ../Dockerfile-ubuntu-java8.j2
     command: ""
     volumes:
@@ -46,7 +46,7 @@ platforms:
     hostname: kafka-broker3.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-ubuntu2004-ansible
+    image: utkarsh5474/docker-ubuntu2004-ansible
     dockerfile: ../Dockerfile-ubuntu-java8.j2
     command: ""
     volumes:
@@ -58,7 +58,7 @@ platforms:
     hostname: schema-registry1.confluent
     groups:
       - schema_registry
-    image: geerlingguy/docker-ubuntu2004-ansible
+    image: utkarsh5474/docker-ubuntu2004-ansible
     dockerfile: ../Dockerfile-ubuntu-java8.j2
     command: ""
     volumes:
@@ -70,7 +70,7 @@ platforms:
     hostname: kafka-rest1.confluent
     groups:
       - kafka_rest
-    image: geerlingguy/docker-ubuntu2004-ansible
+    image: utkarsh5474/docker-ubuntu2004-ansible
     dockerfile: ../Dockerfile-ubuntu-java8.j2
     command: ""
     volumes:
@@ -82,7 +82,7 @@ platforms:
     hostname: kafka-connect1.confluent
     groups:
       - kafka_connect
-    image: geerlingguy/docker-ubuntu2004-ansible
+    image: utkarsh5474/docker-ubuntu2004-ansible
     dockerfile: ../Dockerfile-ubuntu-java8.j2
     command: ""
     volumes:
@@ -94,7 +94,7 @@ platforms:
     hostname: ksql1.confluent
     groups:
       - ksql
-    image: geerlingguy/docker-ubuntu2004-ansible
+    image: utkarsh5474/docker-ubuntu2004-ansible
     dockerfile: ../Dockerfile-ubuntu-java8.j2
     command: ""
     volumes:
@@ -106,7 +106,7 @@ platforms:
     hostname: control-center1.confluent
     groups:
       - control_center
-    image: geerlingguy/docker-ubuntu2004-ansible
+    image: utkarsh5474/docker-ubuntu2004-ansible
     dockerfile: ../Dockerfile-ubuntu-java8.j2
     command: ""
     volumes:

--- a/molecule/mtls-ubuntu-acl/molecule.yml
+++ b/molecule/mtls-ubuntu-acl/molecule.yml
@@ -10,7 +10,7 @@ platforms:
     hostname: zookeeper1.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-ubuntu1804-ansible
+    image: utkarsh5474/docker-ubuntu1804-ansible
     dockerfile: ../Dockerfile-ubuntu.j2
     command: ""
     volumes:
@@ -22,7 +22,7 @@ platforms:
     hostname: kafka-broker1.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-ubuntu1804-ansible
+    image: utkarsh5474/docker-ubuntu1804-ansible
     dockerfile: ../Dockerfile-ubuntu.j2
     command: ""
     volumes:
@@ -34,7 +34,7 @@ platforms:
     hostname: schema-registry1.confluent
     groups:
       - schema_registry
-    image: geerlingguy/docker-ubuntu1804-ansible
+    image: utkarsh5474/docker-ubuntu1804-ansible
     dockerfile: ../Dockerfile-ubuntu.j2
     command: ""
     volumes:
@@ -46,7 +46,7 @@ platforms:
     hostname: kafka-connect1.confluent
     groups:
       - kafka_connect
-    image: geerlingguy/docker-ubuntu1804-ansible
+    image: utkarsh5474/docker-ubuntu1804-ansible
     dockerfile: ../Dockerfile-ubuntu.j2
     command: ""
     volumes:
@@ -58,7 +58,7 @@ platforms:
     hostname: ksql1.confluent
     groups:
       - ksql
-    image: geerlingguy/docker-ubuntu1804-ansible
+    image: utkarsh5474/docker-ubuntu1804-ansible
     dockerfile: ../Dockerfile-ubuntu.j2
     command: ""
     volumes:
@@ -70,7 +70,7 @@ platforms:
     hostname: control-center1.confluent
     groups:
       - control_center
-    image: geerlingguy/docker-ubuntu1804-ansible
+    image: utkarsh5474/docker-ubuntu1804-ansible
     dockerfile: ../Dockerfile-ubuntu.j2
     command: ""
     volumes:

--- a/molecule/mtls-ubuntu/molecule.yml
+++ b/molecule/mtls-ubuntu/molecule.yml
@@ -9,7 +9,7 @@ platforms:
     hostname: zookeeper1.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-ubuntu1804-ansible
+    image: utkarsh5474/docker-ubuntu1804-ansible
     dockerfile: ../Dockerfile-ubuntu.j2
     command: ""
     volumes:
@@ -21,7 +21,7 @@ platforms:
     hostname: kafka-broker1.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-ubuntu1804-ansible
+    image: utkarsh5474/docker-ubuntu1804-ansible
     dockerfile: ../Dockerfile-ubuntu.j2
     command: ""
     volumes:
@@ -33,7 +33,7 @@ platforms:
     hostname: kafka-broker2.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-ubuntu1804-ansible
+    image: utkarsh5474/docker-ubuntu1804-ansible
     dockerfile: ../Dockerfile-ubuntu.j2
     command: ""
     volumes:
@@ -45,7 +45,7 @@ platforms:
     hostname: kafka-broker3.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-ubuntu1804-ansible
+    image: utkarsh5474/docker-ubuntu1804-ansible
     dockerfile: ../Dockerfile-ubuntu.j2
     command: ""
     volumes:
@@ -57,7 +57,7 @@ platforms:
     hostname: schema-registry1.confluent
     groups:
       - schema_registry
-    image: geerlingguy/docker-ubuntu1804-ansible
+    image: utkarsh5474/docker-ubuntu1804-ansible
     dockerfile: ../Dockerfile-ubuntu.j2
     command: ""
     volumes:
@@ -69,7 +69,7 @@ platforms:
     hostname: kafka-rest1.confluent
     groups:
       - kafka_rest
-    image: geerlingguy/docker-ubuntu1804-ansible
+    image: utkarsh5474/docker-ubuntu1804-ansible
     dockerfile: ../Dockerfile-ubuntu.j2
     command: ""
     volumes:
@@ -81,7 +81,7 @@ platforms:
     hostname: kafka-connect1.confluent
     groups:
       - kafka_connect
-    image: geerlingguy/docker-ubuntu1804-ansible
+    image: utkarsh5474/docker-ubuntu1804-ansible
     dockerfile: ../Dockerfile-ubuntu.j2
     command: ""
     volumes:
@@ -93,7 +93,7 @@ platforms:
     hostname: ksql1.confluent
     groups:
       - ksql
-    image: geerlingguy/docker-ubuntu1804-ansible
+    image: utkarsh5474/docker-ubuntu1804-ansible
     dockerfile: ../Dockerfile-ubuntu.j2
     command: ""
     volumes:
@@ -105,7 +105,7 @@ platforms:
     hostname: control-center1.confluent
     groups:
       - control_center
-    image: geerlingguy/docker-ubuntu1804-ansible
+    image: utkarsh5474/docker-ubuntu1804-ansible
     dockerfile: ../Dockerfile-ubuntu.j2
     command: ""
     volumes:

--- a/molecule/multi-ksql-connect-rhel/molecule.yml
+++ b/molecule/multi-ksql-connect-rhel/molecule.yml
@@ -11,7 +11,7 @@ platforms:
     hostname: zookeeper1.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -23,7 +23,7 @@ platforms:
     hostname: kafka-broker1.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -35,7 +35,7 @@ platforms:
     hostname: kafka-broker2.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -47,7 +47,7 @@ platforms:
     hostname: kafka-broker3.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -60,7 +60,7 @@ platforms:
     groups:
       - kafka_connect
       - syslog
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -73,7 +73,7 @@ platforms:
     groups:
       - kafka_connect
       - elastic
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -86,7 +86,7 @@ platforms:
     groups:
       - kafka_connect
       - ssl
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -99,7 +99,7 @@ platforms:
     groups:
       - ksql
       - ks1
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -112,7 +112,7 @@ platforms:
     groups:
       - ksql
       - ks2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -125,7 +125,7 @@ platforms:
     groups:
       - ksql
       - ks2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -137,7 +137,7 @@ platforms:
     hostname: control-center1.confluent
     groups:
       - control_center
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:

--- a/molecule/plain-customcerts-rhel/molecule.yml
+++ b/molecule/plain-customcerts-rhel/molecule.yml
@@ -10,7 +10,7 @@ platforms:
     hostname: zookeeper1.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -22,7 +22,7 @@ platforms:
     hostname: kafka-broker1.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -34,7 +34,7 @@ platforms:
     hostname: kafka-broker2.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -46,7 +46,7 @@ platforms:
     hostname: kafka-broker3.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -58,7 +58,7 @@ platforms:
     hostname: schema-registry1.confluent
     groups:
       - schema_registry
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -70,7 +70,7 @@ platforms:
     hostname: kafka-rest1.confluent
     groups:
       - kafka_rest
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -82,7 +82,7 @@ platforms:
     hostname: kafka-connect1.confluent
     groups:
       - kafka_connect
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -94,7 +94,7 @@ platforms:
     hostname: ksql1.confluent
     groups:
       - ksql
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -106,7 +106,7 @@ platforms:
     hostname: control-center1.confluent
     groups:
       - control_center
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:

--- a/molecule/plain-erp-tls-rhel/molecule.yml
+++ b/molecule/plain-erp-tls-rhel/molecule.yml
@@ -10,7 +10,7 @@ platforms:
     hostname: zookeeper1.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -22,7 +22,7 @@ platforms:
     hostname: kafka-broker1.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -34,7 +34,7 @@ platforms:
     hostname: control-center1.confluent
     groups:
       - control_center
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:

--- a/molecule/plain-rhel/molecule.yml
+++ b/molecule/plain-rhel/molecule.yml
@@ -13,7 +13,7 @@ platforms:
     hostname: zookeeper1.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -25,7 +25,7 @@ platforms:
     hostname: kafka-broker1.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -37,7 +37,7 @@ platforms:
     hostname: schema-registry1.confluent
     groups:
       - schema_registry
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -49,7 +49,7 @@ platforms:
     hostname: kafka-rest1.confluent
     groups:
       - kafka_rest
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -61,7 +61,7 @@ platforms:
     hostname: kafka-connect1.confluent
     groups:
       - kafka_connect
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -73,7 +73,7 @@ platforms:
     hostname: ksql1.confluent
     groups:
       - ksql
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -85,7 +85,7 @@ platforms:
     hostname: control-center1.confluent
     groups:
       - control_center
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:

--- a/molecule/plaintext-basic-rhel/molecule.yml
+++ b/molecule/plaintext-basic-rhel/molecule.yml
@@ -10,7 +10,7 @@ platforms:
     hostname: zookeeper1${JOB_BASE_NAME}${BUILD_NUMBER}.confluent${JOB_BASE_NAME}${BUILD_NUMBER}
     groups:
       - zookeeper
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -22,7 +22,7 @@ platforms:
     hostname: kafka-broker1${JOB_BASE_NAME}${BUILD_NUMBER}.confluent${JOB_BASE_NAME}${BUILD_NUMBER}
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -34,7 +34,7 @@ platforms:
     hostname: schema-registry1${JOB_BASE_NAME}${BUILD_NUMBER}.confluent${JOB_BASE_NAME}${BUILD_NUMBER}
     groups:
       - schema_registry
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -46,7 +46,7 @@ platforms:
     hostname: kafka-rest1${JOB_BASE_NAME}${BUILD_NUMBER}.confluent${JOB_BASE_NAME}${BUILD_NUMBER}
     groups:
       - kafka_rest
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -58,7 +58,7 @@ platforms:
     hostname: kafka-connect1${JOB_BASE_NAME}${BUILD_NUMBER}.confluent${JOB_BASE_NAME}${BUILD_NUMBER}
     groups:
       - kafka_connect
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -70,7 +70,7 @@ platforms:
     hostname: ksql1${JOB_BASE_NAME}${BUILD_NUMBER}.confluent${JOB_BASE_NAME}${BUILD_NUMBER}
     groups:
       - ksql
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -82,7 +82,7 @@ platforms:
     hostname: control-center1${JOB_BASE_NAME}${BUILD_NUMBER}.confluent${JOB_BASE_NAME}${BUILD_NUMBER}
     groups:
       - control_center
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:

--- a/molecule/plaintext-rhel/molecule.yml
+++ b/molecule/plaintext-rhel/molecule.yml
@@ -11,7 +11,7 @@ platforms:
     hostname: zookeeper1${JOB_BASE_NAME}${BUILD_NUMBER}.confluent${JOB_BASE_NAME}${BUILD_NUMBER}
     groups:
       - zookeeper
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -23,7 +23,7 @@ platforms:
     hostname: zookeeper2${JOB_BASE_NAME}${BUILD_NUMBER}.confluent${JOB_BASE_NAME}${BUILD_NUMBER}
     groups:
       - zookeeper
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -34,7 +34,7 @@ platforms:
     hostname: zookeeper3${JOB_BASE_NAME}${BUILD_NUMBER}.confluent${JOB_BASE_NAME}${BUILD_NUMBER}
     groups:
       - zookeeper
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -45,7 +45,7 @@ platforms:
     hostname: kafka-broker1${JOB_BASE_NAME}${BUILD_NUMBER}.confluent${JOB_BASE_NAME}${BUILD_NUMBER}
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -57,7 +57,7 @@ platforms:
     hostname: kafka-broker2${JOB_BASE_NAME}${BUILD_NUMBER}.confluent${JOB_BASE_NAME}${BUILD_NUMBER}
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -69,7 +69,7 @@ platforms:
     hostname: schema-registry1${JOB_BASE_NAME}${BUILD_NUMBER}.confluent${JOB_BASE_NAME}${BUILD_NUMBER}
     groups:
       - schema_registry
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -81,7 +81,7 @@ platforms:
     hostname: kafka-rest1${JOB_BASE_NAME}${BUILD_NUMBER}.confluent${JOB_BASE_NAME}${BUILD_NUMBER}
     groups:
       - kafka_rest
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -93,7 +93,7 @@ platforms:
     hostname: kafka-connect1${JOB_BASE_NAME}${BUILD_NUMBER}.confluent${JOB_BASE_NAME}${BUILD_NUMBER}
     groups:
       - kafka_connect
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -105,7 +105,7 @@ platforms:
     hostname: ksql1${JOB_BASE_NAME}${BUILD_NUMBER}.confluent${JOB_BASE_NAME}${BUILD_NUMBER}
     groups:
       - ksql
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -117,7 +117,7 @@ platforms:
     hostname: control-center1${JOB_BASE_NAME}${BUILD_NUMBER}.confluent${JOB_BASE_NAME}${BUILD_NUMBER}
     groups:
       - control_center
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:

--- a/molecule/provided-rhel/molecule.yml
+++ b/molecule/provided-rhel/molecule.yml
@@ -10,7 +10,7 @@ platforms:
     hostname: zookeeper1.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -22,7 +22,7 @@ platforms:
     hostname: zookeeper2.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -34,7 +34,7 @@ platforms:
     hostname: kafka-broker1.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -46,7 +46,7 @@ platforms:
     hostname: kafka-broker2.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -58,7 +58,7 @@ platforms:
     hostname: kafka-broker3.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -70,7 +70,7 @@ platforms:
     hostname: schema-registry1.confluent
     groups:
       - schema_registry
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -82,7 +82,7 @@ platforms:
     hostname: kafka-rest1.confluent
     groups:
       - kafka_rest
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -94,7 +94,7 @@ platforms:
     hostname: kafka-connect1.confluent
     groups:
       - kafka_connect
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -106,7 +106,7 @@ platforms:
     hostname: ksql1.confluent
     groups:
       - ksql
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -118,7 +118,7 @@ platforms:
     hostname: control-center1.confluent
     groups:
       - control_center
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:

--- a/molecule/rbac-kafka-connect-replicator-kerberos-mtls-custom-debian10/molecule.yml
+++ b/molecule/rbac-kafka-connect-replicator-kerberos-mtls-custom-debian10/molecule.yml
@@ -39,7 +39,7 @@ platforms:
     groups:
       - zookeeper
       - mds
-    image: geerlingguy/docker-debian10-ansible
+    image: utkarsh5474/docker-debian10-ansible
     dockerfile: ../Dockerfile-debian10.j2
     command: ""
     volumes:
@@ -52,7 +52,7 @@ platforms:
     groups:
       - kafka_broker
       - mds
-    image: geerlingguy/docker-debian10-ansible
+    image: utkarsh5474/docker-debian10-ansible
     dockerfile: ../Dockerfile-debian10.j2
     command: ""
     volumes:
@@ -65,7 +65,7 @@ platforms:
     groups:
       - kafka_broker
       - mds
-    image: geerlingguy/docker-debian10-ansible
+    image: utkarsh5474/docker-debian10-ansible
     dockerfile: ../Dockerfile-debian10.j2
     command: ""
     volumes:
@@ -78,7 +78,7 @@ platforms:
     groups:
       - kafka_broker
       - mds
-    image: geerlingguy/docker-debian10-ansible
+    image: utkarsh5474/docker-debian10-ansible
     dockerfile: ../Dockerfile-debian10.j2
     command: ""
     volumes:
@@ -92,7 +92,7 @@ platforms:
     groups:
       - zookeeper2
       - cluster2
-    image: geerlingguy/docker-debian10-ansible
+    image: utkarsh5474/docker-debian10-ansible
     dockerfile: ../Dockerfile-debian10.j2
     command: ""
     volumes:
@@ -105,7 +105,7 @@ platforms:
     groups:
       - kafka_broker2
       - cluster2
-    image: geerlingguy/docker-debian10-ansible
+    image: utkarsh5474/docker-debian10-ansible
     dockerfile: ../Dockerfile-debian10.j2
     command: ""
     volumes:
@@ -118,7 +118,7 @@ platforms:
     groups:
       - kafka_broker2
       - cluster2
-    image: geerlingguy/docker-debian10-ansible
+    image: utkarsh5474/docker-debian10-ansible
     dockerfile: ../Dockerfile-debian10.j2
     command: ""
     volumes:
@@ -131,7 +131,7 @@ platforms:
     groups:
       - kafka_broker2
       - cluster2
-    image: geerlingguy/docker-debian10-ansible
+    image: utkarsh5474/docker-debian10-ansible
     dockerfile: ../Dockerfile-debian10.j2
     command: ""
     volumes:
@@ -144,7 +144,7 @@ platforms:
     groups:
       - kafka_connect_replicator2
       - cluster2
-    image: geerlingguy/docker-debian10-ansible
+    image: utkarsh5474/docker-debian10-ansible
     dockerfile: ../Dockerfile-debian10.j2
     command: ""
     volumes:

--- a/molecule/rbac-kafka-connect-replicator-kerberos-mtls-custom-debian10/molecule.yml
+++ b/molecule/rbac-kafka-connect-replicator-kerberos-mtls-custom-debian10/molecule.yml
@@ -13,7 +13,7 @@ platforms:
     hostname: mds-ldap1.confluent
     groups:
       - ldap_server
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -25,7 +25,7 @@ platforms:
     hostname: mds-kerberos1.confluent
     groups:
       - kerberos_server
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:

--- a/molecule/rbac-kafka-connect-replicator-kerberos-mtls-custom-rhel/molecule.yml
+++ b/molecule/rbac-kafka-connect-replicator-kerberos-mtls-custom-rhel/molecule.yml
@@ -20,7 +20,7 @@ platforms:
     hostname: mds-ldap1.confluent
     groups:
       - ldap_server
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -32,7 +32,7 @@ platforms:
     hostname: mds-kerberos1.confluent
     groups:
       - kerberos_server
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -46,7 +46,7 @@ platforms:
     groups:
       - zookeeper
       - mds
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -59,7 +59,7 @@ platforms:
     groups:
       - kafka_broker
       - mds
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -72,7 +72,7 @@ platforms:
     groups:
       - kafka_broker
       - mds
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -85,7 +85,7 @@ platforms:
     groups:
       - kafka_broker
       - mds
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -99,7 +99,7 @@ platforms:
     groups:
       - zookeeper2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -112,7 +112,7 @@ platforms:
     groups:
       - kafka_broker2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -125,7 +125,7 @@ platforms:
     groups:
       - kafka_broker2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -138,7 +138,7 @@ platforms:
     groups:
       - kafka_broker2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -151,7 +151,7 @@ platforms:
     groups:
       - kafka_connect_replicator2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:

--- a/molecule/rbac-kafka-connect-replicator-kerberos-mtls-custom-ubuntu2004/molecule.yml
+++ b/molecule/rbac-kafka-connect-replicator-kerberos-mtls-custom-ubuntu2004/molecule.yml
@@ -39,7 +39,7 @@ platforms:
     groups:
       - zookeeper
       - mds
-    image: geerlingguy/docker-ubuntu2004-ansible
+    image: utkarsh5474/docker-ubuntu2004-ansible
     dockerfile: ../Dockerfile-ubuntu2004.j2
     command: ""
     volumes:
@@ -52,7 +52,7 @@ platforms:
     groups:
       - kafka_broker
       - mds
-    image: geerlingguy/docker-ubuntu2004-ansible
+    image: utkarsh5474/docker-ubuntu2004-ansible
     dockerfile: ../Dockerfile-ubuntu2004.j2
     command: ""
     volumes:
@@ -65,7 +65,7 @@ platforms:
     groups:
       - kafka_broker
       - mds
-    image: geerlingguy/docker-ubuntu2004-ansible
+    image: utkarsh5474/docker-ubuntu2004-ansible
     dockerfile: ../Dockerfile-ubuntu2004.j2
     command: ""
     volumes:
@@ -78,7 +78,7 @@ platforms:
     groups:
       - kafka_broker
       - mds
-    image: geerlingguy/docker-ubuntu2004-ansible
+    image: utkarsh5474/docker-ubuntu2004-ansible
     dockerfile: ../Dockerfile-ubuntu2004.j2
     command: ""
     volumes:
@@ -92,7 +92,7 @@ platforms:
     groups:
       - zookeeper2
       - cluster2
-    image: geerlingguy/docker-ubuntu2004-ansible
+    image: utkarsh5474/docker-ubuntu2004-ansible
     dockerfile: ../Dockerfile-ubuntu2004.j2
     command: ""
     volumes:
@@ -105,7 +105,7 @@ platforms:
     groups:
       - kafka_broker2
       - cluster2
-    image: geerlingguy/docker-ubuntu2004-ansible
+    image: utkarsh5474/docker-ubuntu2004-ansible
     dockerfile: ../Dockerfile-ubuntu2004.j2
     command: ""
     volumes:
@@ -118,7 +118,7 @@ platforms:
     groups:
       - kafka_broker2
       - cluster2
-    image: geerlingguy/docker-ubuntu2004-ansible
+    image: utkarsh5474/docker-ubuntu2004-ansible
     dockerfile: ../Dockerfile-ubuntu2004.j2
     command: ""
     volumes:
@@ -131,7 +131,7 @@ platforms:
     groups:
       - kafka_broker2
       - cluster2
-    image: geerlingguy/docker-ubuntu2004-ansible
+    image: utkarsh5474/docker-ubuntu2004-ansible
     dockerfile: ../Dockerfile-ubuntu2004.j2
     command: ""
     volumes:
@@ -144,7 +144,7 @@ platforms:
     groups:
       - kafka_connect_replicator2
       - cluster2
-    image: geerlingguy/docker-ubuntu2004-ansible
+    image: utkarsh5474/docker-ubuntu2004-ansible
     dockerfile: ../Dockerfile-ubuntu2004.j2
     command: ""
     volumes:

--- a/molecule/rbac-kafka-connect-replicator-kerberos-mtls-custom-ubuntu2004/molecule.yml
+++ b/molecule/rbac-kafka-connect-replicator-kerberos-mtls-custom-ubuntu2004/molecule.yml
@@ -13,7 +13,7 @@ platforms:
     hostname: mds-ldap1.confluent
     groups:
       - ldap_server
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -25,7 +25,7 @@ platforms:
     hostname: mds-kerberos1.confluent
     groups:
       - kerberos_server
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:

--- a/molecule/rbac-kerberos-debian/molecule.yml
+++ b/molecule/rbac-kerberos-debian/molecule.yml
@@ -13,7 +13,7 @@ platforms:
     hostname: ldap1.confluent
     groups:
       - ldap_server
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -25,7 +25,7 @@ platforms:
     hostname: kerberos1.confluent
     groups:
       - kerberos_server
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:

--- a/molecule/rbac-kerberos-debian/molecule.yml
+++ b/molecule/rbac-kerberos-debian/molecule.yml
@@ -37,7 +37,7 @@ platforms:
     hostname: zookeeper1.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
@@ -49,7 +49,7 @@ platforms:
     hostname: kafka-broker1.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
@@ -61,7 +61,7 @@ platforms:
     hostname: kafka-broker2.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
@@ -73,7 +73,7 @@ platforms:
     hostname: kafka-broker3.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
@@ -85,7 +85,7 @@ platforms:
     hostname: schema-registry1.confluent
     groups:
       - schema_registry
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
@@ -97,7 +97,7 @@ platforms:
     hostname: kafka-rest1.confluent
     groups:
       - kafka_rest
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
@@ -109,7 +109,7 @@ platforms:
     hostname: kafka-connect1.confluent
     groups:
       - kafka_connect
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
@@ -121,7 +121,7 @@ platforms:
     hostname: ksql1.confluent
     groups:
       - ksql
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
@@ -133,7 +133,7 @@ platforms:
     hostname: control-center1.confluent
     groups:
       - control_center
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:

--- a/molecule/rbac-mds-kerberos-debian/molecule.yml
+++ b/molecule/rbac-mds-kerberos-debian/molecule.yml
@@ -14,7 +14,7 @@ platforms:
     hostname: mds-ldap1.confluent
     groups:
       - ldap_server
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -26,7 +26,7 @@ platforms:
     hostname: mds-kerberos1.confluent
     groups:
       - kerberos_server
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:

--- a/molecule/rbac-mds-kerberos-debian/molecule.yml
+++ b/molecule/rbac-mds-kerberos-debian/molecule.yml
@@ -40,7 +40,7 @@ platforms:
     groups:
       - zookeeper
       - mds
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
@@ -53,7 +53,7 @@ platforms:
     groups:
       - kafka_broker
       - mds
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
@@ -66,7 +66,7 @@ platforms:
     groups:
       - kafka_broker
       - mds
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
@@ -80,7 +80,7 @@ platforms:
     groups:
       - zookeeper2
       - cluster2
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
@@ -93,7 +93,7 @@ platforms:
     groups:
       - kafka_broker2
       - cluster2
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
@@ -106,7 +106,7 @@ platforms:
     groups:
       - kafka_broker2
       - cluster2
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
@@ -119,7 +119,7 @@ platforms:
     groups:
       - kafka_broker2
       - cluster2
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
@@ -132,7 +132,7 @@ platforms:
     groups:
       - schema_registry2
       - cluster2
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
@@ -145,7 +145,7 @@ platforms:
     groups:
       - kafka_rest2
       - cluster2
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
@@ -158,7 +158,7 @@ platforms:
     groups:
       - kafka_connect2
       - cluster2
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
@@ -171,7 +171,7 @@ platforms:
     groups:
       - ksql2
       - cluster2
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
@@ -184,7 +184,7 @@ platforms:
     groups:
       - control_center2
       - cluster2
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:

--- a/molecule/rbac-mds-kerberos-mtls-custom-rhel/molecule.yml
+++ b/molecule/rbac-mds-kerberos-mtls-custom-rhel/molecule.yml
@@ -16,7 +16,7 @@ platforms:
     hostname: mds-ldap1.confluent
     groups:
       - ldap_server
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -28,7 +28,7 @@ platforms:
     hostname: mds-kerberos1.confluent
     groups:
       - kerberos_server
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -42,7 +42,7 @@ platforms:
     groups:
       - zookeeper
       - mds
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -55,7 +55,7 @@ platforms:
     groups:
       - kafka_broker
       - mds
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -68,7 +68,7 @@ platforms:
     groups:
       - kafka_broker
       - mds
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -82,7 +82,7 @@ platforms:
     groups:
       - zookeeper2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -95,7 +95,7 @@ platforms:
     groups:
       - kafka_broker2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -108,7 +108,7 @@ platforms:
     groups:
       - kafka_broker2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -121,7 +121,7 @@ platforms:
     groups:
       - kafka_broker2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -134,7 +134,7 @@ platforms:
     groups:
       - schema_registry2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -147,7 +147,7 @@ platforms:
     groups:
       - kafka_rest2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -160,7 +160,7 @@ platforms:
     groups:
       - kafka_connect2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -173,7 +173,7 @@ platforms:
     groups:
       - ksql2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -186,7 +186,7 @@ platforms:
     groups:
       - control_center2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:

--- a/molecule/rbac-mds-mtls-custom-kerberos-rhel/molecule.yml
+++ b/molecule/rbac-mds-mtls-custom-kerberos-rhel/molecule.yml
@@ -15,7 +15,7 @@ platforms:
     hostname: mds-ldap1.confluent
     groups:
       - ldap_server
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -27,7 +27,7 @@ platforms:
     hostname: mds-kerberos1.confluent
     groups:
       - kerberos_server
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -41,7 +41,7 @@ platforms:
     groups:
       - zookeeper
       - mds
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -54,7 +54,7 @@ platforms:
     groups:
       - kafka_broker
       - mds
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -67,7 +67,7 @@ platforms:
     groups:
       - kafka_broker
       - mds
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -81,7 +81,7 @@ platforms:
     groups:
       - zookeeper2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -94,7 +94,7 @@ platforms:
     groups:
       - kafka_broker2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -107,7 +107,7 @@ platforms:
     groups:
       - kafka_broker2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -120,7 +120,7 @@ platforms:
     groups:
       - kafka_broker2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -133,7 +133,7 @@ platforms:
     groups:
       - schema_registry2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -146,7 +146,7 @@ platforms:
     groups:
       - kafka_rest2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -159,7 +159,7 @@ platforms:
     groups:
       - kafka_connect2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -172,7 +172,7 @@ platforms:
     groups:
       - ksql2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -185,7 +185,7 @@ platforms:
     groups:
       - control_center2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:

--- a/molecule/rbac-mds-mtls-custom-rhel/molecule.yml
+++ b/molecule/rbac-mds-mtls-custom-rhel/molecule.yml
@@ -14,7 +14,7 @@ platforms:
     hostname: mds-ldap1.confluent
     groups:
       - ldap_server
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -28,7 +28,7 @@ platforms:
     groups:
       - zookeeper
       - mds
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -41,7 +41,7 @@ platforms:
     groups:
       - kafka_broker
       - mds
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -54,7 +54,7 @@ platforms:
     groups:
       - kafka_broker
       - mds
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -68,7 +68,7 @@ platforms:
     groups:
       - zookeeper2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -81,7 +81,7 @@ platforms:
     groups:
       - kafka_broker2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -94,7 +94,7 @@ platforms:
     groups:
       - kafka_broker2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -107,7 +107,7 @@ platforms:
     groups:
       - kafka_broker2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -120,7 +120,7 @@ platforms:
     groups:
       - schema_registry2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -133,7 +133,7 @@ platforms:
     groups:
       - kafka_rest2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -146,7 +146,7 @@ platforms:
     groups:
       - kafka_connect2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -159,7 +159,7 @@ platforms:
     groups:
       - ksql2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -172,7 +172,7 @@ platforms:
     groups:
       - control_center2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:

--- a/molecule/rbac-mds-plain-custom-rhel/molecule.yml
+++ b/molecule/rbac-mds-plain-custom-rhel/molecule.yml
@@ -14,7 +14,7 @@ platforms:
     hostname: mds-ldap1.confluent
     groups:
       - ldap_server
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -28,7 +28,7 @@ platforms:
     groups:
       - zookeeper
       - mds
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -41,7 +41,7 @@ platforms:
     groups:
       - kafka_broker
       - mds
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -54,7 +54,7 @@ platforms:
     groups:
       - kafka_broker
       - mds
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -68,7 +68,7 @@ platforms:
     groups:
       - zookeeper2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -81,7 +81,7 @@ platforms:
     groups:
       - kafka_broker2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -94,7 +94,7 @@ platforms:
     groups:
       - kafka_broker2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -107,7 +107,7 @@ platforms:
     groups:
       - kafka_broker2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -120,7 +120,7 @@ platforms:
     groups:
       - schema_registry2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -133,7 +133,7 @@ platforms:
     groups:
       - kafka_rest2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -146,7 +146,7 @@ platforms:
     groups:
       - kafka_connect2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -159,7 +159,7 @@ platforms:
     groups:
       - ksql2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -172,7 +172,7 @@ platforms:
     groups:
       - control_center2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:

--- a/molecule/rbac-mds-scram-custom-rhel/molecule.yml
+++ b/molecule/rbac-mds-scram-custom-rhel/molecule.yml
@@ -14,7 +14,7 @@ platforms:
     hostname: mds-ldap1.confluent
     groups:
       - ldap_server
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -28,7 +28,7 @@ platforms:
     groups:
       - zookeeper
       - mds
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -41,7 +41,7 @@ platforms:
     groups:
       - kafka_broker
       - mds
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -54,7 +54,7 @@ platforms:
     groups:
       - kafka_broker
       - mds
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -68,7 +68,7 @@ platforms:
     groups:
       - zookeeper2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -81,7 +81,7 @@ platforms:
     groups:
       - kafka_broker2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -94,7 +94,7 @@ platforms:
     groups:
       - kafka_broker2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -107,7 +107,7 @@ platforms:
     groups:
       - kafka_broker2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -120,7 +120,7 @@ platforms:
     groups:
       - schema_registry2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -133,7 +133,7 @@ platforms:
     groups:
       - kafka_rest2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -146,7 +146,7 @@ platforms:
     groups:
       - kafka_connect2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -159,7 +159,7 @@ platforms:
     groups:
       - ksql2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -172,7 +172,7 @@ platforms:
     groups:
       - control_center2
       - cluster2
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:

--- a/molecule/rbac-mtls-provided-ubuntu/molecule.yml
+++ b/molecule/rbac-mtls-provided-ubuntu/molecule.yml
@@ -13,7 +13,7 @@ platforms:
     hostname: ldap1.confluent
     groups:
       - ldap_server
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:

--- a/molecule/rbac-mtls-provided-ubuntu/molecule.yml
+++ b/molecule/rbac-mtls-provided-ubuntu/molecule.yml
@@ -25,7 +25,7 @@ platforms:
     hostname: zookeeper1.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-ubuntu1804-ansible
+    image: utkarsh5474/docker-ubuntu1804-ansible
     dockerfile: ../Dockerfile-ubuntu.j2
     command: ""
     volumes:
@@ -37,7 +37,7 @@ platforms:
     hostname: kafka-broker1.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-ubuntu1804-ansible
+    image: utkarsh5474/docker-ubuntu1804-ansible
     dockerfile: ../Dockerfile-ubuntu.j2
     command: ""
     volumes:
@@ -49,7 +49,7 @@ platforms:
     hostname: kafka-broker2.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-ubuntu1804-ansible
+    image: utkarsh5474/docker-ubuntu1804-ansible
     dockerfile: ../Dockerfile-ubuntu.j2
     command: ""
     volumes:
@@ -61,7 +61,7 @@ platforms:
     hostname: kafka-broker3.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-ubuntu1804-ansible
+    image: utkarsh5474/docker-ubuntu1804-ansible
     dockerfile: ../Dockerfile-ubuntu.j2
     command: ""
     volumes:
@@ -73,7 +73,7 @@ platforms:
     hostname: schema-registry1.confluent
     groups:
       - schema_registry
-    image: geerlingguy/docker-ubuntu1804-ansible
+    image: utkarsh5474/docker-ubuntu1804-ansible
     dockerfile: ../Dockerfile-ubuntu.j2
     command: ""
     volumes:
@@ -85,7 +85,7 @@ platforms:
     hostname: kafka-rest1.confluent
     groups:
       - kafka_rest
-    image: geerlingguy/docker-ubuntu1804-ansible
+    image: utkarsh5474/docker-ubuntu1804-ansible
     dockerfile: ../Dockerfile-ubuntu.j2
     command: ""
     volumes:
@@ -97,7 +97,7 @@ platforms:
     hostname: kafka-connect1.confluent
     groups:
       - kafka_connect
-    image: geerlingguy/docker-ubuntu1804-ansible
+    image: utkarsh5474/docker-ubuntu1804-ansible
     dockerfile: ../Dockerfile-ubuntu.j2
     command: ""
     volumes:
@@ -109,7 +109,7 @@ platforms:
     hostname: ksql1.confluent
     groups:
       - ksql
-    image: geerlingguy/docker-ubuntu1804-ansible
+    image: utkarsh5474/docker-ubuntu1804-ansible
     dockerfile: ../Dockerfile-ubuntu.j2
     command: ""
     volumes:
@@ -121,7 +121,7 @@ platforms:
     hostname: control-center1.confluent
     groups:
       - control_center
-    image: geerlingguy/docker-ubuntu1804-ansible
+    image: utkarsh5474/docker-ubuntu1804-ansible
     dockerfile: ../Dockerfile-ubuntu.j2
     command: ""
     volumes:

--- a/molecule/rbac-mtls-rhel/molecule.yml
+++ b/molecule/rbac-mtls-rhel/molecule.yml
@@ -13,7 +13,7 @@ platforms:
     hostname: ldap1.confluent
     groups:
       - ldap_server
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -25,7 +25,7 @@ platforms:
     hostname: zookeeper1.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -37,7 +37,7 @@ platforms:
     hostname: kafka-broker1.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -49,7 +49,7 @@ platforms:
     hostname: kafka-broker2.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -61,7 +61,7 @@ platforms:
     hostname: kafka-broker3.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -73,7 +73,7 @@ platforms:
     hostname: schema-registry1.confluent
     groups:
       - schema_registry
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -85,7 +85,7 @@ platforms:
     hostname: kafka-rest1.confluent
     groups:
       - kafka_rest
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -97,7 +97,7 @@ platforms:
     hostname: kafka-connect1.confluent
     groups:
       - kafka_connect
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -109,7 +109,7 @@ platforms:
     hostname: ksql1.confluent
     groups:
       - ksql
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -121,7 +121,7 @@ platforms:
     hostname: control-center1.confluent
     groups:
       - control_center
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:

--- a/molecule/rbac-mtls-rhel8/molecule.yml
+++ b/molecule/rbac-mtls-rhel8/molecule.yml
@@ -11,7 +11,7 @@ platforms:
     hostname: ldap1.confluent
     groups:
       - ldap_server
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile-rhel-base.j2
     command: ""
     volumes:
@@ -23,7 +23,7 @@ platforms:
     hostname: zookeeper1.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-centos8-ansible
+    image: utkarsh5474/docker-centos8-ansible
     dockerfile: ../Dockerfile-rhel-base.j2
     command: ""
     volumes:
@@ -35,7 +35,7 @@ platforms:
     hostname: kafka-broker1.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos8-ansible
+    image: utkarsh5474/docker-centos8-ansible
     dockerfile: ../Dockerfile-rhel-base.j2
     command: ""
     volumes:
@@ -47,7 +47,7 @@ platforms:
     hostname: kafka-broker2.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos8-ansible
+    image: utkarsh5474/docker-centos8-ansible
     dockerfile: ../Dockerfile-rhel-base.j2
     command: ""
     volumes:
@@ -59,7 +59,7 @@ platforms:
     hostname: kafka-broker3.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos8-ansible
+    image: utkarsh5474/docker-centos8-ansible
     dockerfile: ../Dockerfile-rhel-base.j2
     command: ""
     volumes:
@@ -71,7 +71,7 @@ platforms:
     hostname: schema-registry1.confluent
     groups:
       - schema_registry
-    image: geerlingguy/docker-centos8-ansible
+    image: utkarsh5474/docker-centos8-ansible
     dockerfile: ../Dockerfile-rhel-base.j2
     command: ""
     volumes:
@@ -83,7 +83,7 @@ platforms:
     hostname: kafka-rest1.confluent
     groups:
       - kafka_rest
-    image: geerlingguy/docker-centos8-ansible
+    image: utkarsh5474/docker-centos8-ansible
     dockerfile: ../Dockerfile-rhel-base.j2
     command: ""
     volumes:
@@ -95,7 +95,7 @@ platforms:
     hostname: kafka-connect1.confluent
     groups:
       - kafka_connect
-    image: geerlingguy/docker-centos8-ansible
+    image: utkarsh5474/docker-centos8-ansible
     dockerfile: ../Dockerfile-rhel-base.j2
     command: ""
     volumes:
@@ -107,7 +107,7 @@ platforms:
     hostname: ksql1.confluent
     groups:
       - ksql
-    image: geerlingguy/docker-centos8-ansible
+    image: utkarsh5474/docker-centos8-ansible
     dockerfile: ../Dockerfile-rhel-base.j2
     command: ""
     volumes:
@@ -119,7 +119,7 @@ platforms:
     hostname: control-center1.confluent
     groups:
       - control_center
-    image: geerlingguy/docker-centos8-ansible
+    image: utkarsh5474/docker-centos8-ansible
     dockerfile: ../Dockerfile-rhel-base.j2
     command: ""
     volumes:

--- a/molecule/rbac-plain-provided-debian/molecule.yml
+++ b/molecule/rbac-plain-provided-debian/molecule.yml
@@ -26,7 +26,7 @@ platforms:
     hostname: zookeeper1.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
@@ -38,7 +38,7 @@ platforms:
     hostname: zookeeper2.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
@@ -50,7 +50,7 @@ platforms:
     hostname: zookeeper3.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
@@ -62,7 +62,7 @@ platforms:
     hostname: kafka-broker1.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
@@ -74,7 +74,7 @@ platforms:
     hostname: kafka-broker2.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
@@ -86,7 +86,7 @@ platforms:
     hostname: kafka-broker3.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
@@ -98,7 +98,7 @@ platforms:
     hostname: schema-registry1.confluent
     groups:
       - schema_registry
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
@@ -110,7 +110,7 @@ platforms:
     hostname: kafka-rest1.confluent
     groups:
       - kafka_rest
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
@@ -122,7 +122,7 @@ platforms:
     hostname: kafka-connect1.confluent
     groups:
       - kafka_connect
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
@@ -134,7 +134,7 @@ platforms:
     hostname: ksql1.confluent
     groups:
       - ksql
-    image: geerlingguy/docker-debian9-ansible
+    image: utkarsh5474/docker-debian9-ansible
     dockerfile: ../Dockerfile-debian.j2
     command: ""
     volumes:
@@ -147,7 +147,7 @@ platforms:
   #   hostname: control-center1.confluent
   #   groups:
   #     - control_center
-  #   image: geerlingguy/docker-debian9-ansible
+  #   image: utkarsh5474/docker-debian9-ansible
   #   dockerfile: ../Dockerfile-debian.j2
   #   command: ""
   #   volumes:

--- a/molecule/rbac-plain-provided-debian/molecule.yml
+++ b/molecule/rbac-plain-provided-debian/molecule.yml
@@ -14,7 +14,7 @@ platforms:
     hostname: ldap1.confluent
     groups:
       - ldap_server
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:

--- a/molecule/rbac-scram-custom-rhel/molecule.yml
+++ b/molecule/rbac-scram-custom-rhel/molecule.yml
@@ -14,7 +14,7 @@ platforms:
     hostname: ldap1${BUILD_NUMBER}.confluent${BUILD_NUMBER}
     groups:
       - ldap_server
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -26,7 +26,7 @@ platforms:
     hostname: zookeeper1${BUILD_NUMBER}.confluent${BUILD_NUMBER}
     groups:
       - zookeeper
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -38,7 +38,7 @@ platforms:
     hostname: zookeeper2${BUILD_NUMBER}.confluent${BUILD_NUMBER}
     groups:
       - zookeeper
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -50,7 +50,7 @@ platforms:
     hostname: zookeeper3${BUILD_NUMBER}.confluent${BUILD_NUMBER}
     groups:
       - zookeeper
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -62,7 +62,7 @@ platforms:
     hostname: kafka-broker1${BUILD_NUMBER}.confluent${BUILD_NUMBER}
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -74,7 +74,7 @@ platforms:
     hostname: kafka-broker2${BUILD_NUMBER}.confluent${BUILD_NUMBER}
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -86,7 +86,7 @@ platforms:
     hostname: kafka-broker3${BUILD_NUMBER}.confluent${BUILD_NUMBER}
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -98,7 +98,7 @@ platforms:
     hostname: schema-registry1${BUILD_NUMBER}.confluent${BUILD_NUMBER}
     groups:
       - schema_registry
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -110,7 +110,7 @@ platforms:
     hostname: kafka-rest1${BUILD_NUMBER}.confluent${BUILD_NUMBER}
     groups:
       - kafka_rest
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -122,7 +122,7 @@ platforms:
     hostname: kafka-connect1${BUILD_NUMBER}.confluent${BUILD_NUMBER}
     groups:
       - kafka_connect
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -134,7 +134,7 @@ platforms:
     hostname: ksql1${BUILD_NUMBER}.confluent${BUILD_NUMBER}
     groups:
       - ksql
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -146,7 +146,7 @@ platforms:
     hostname: control-center1${BUILD_NUMBER}.confluent${BUILD_NUMBER}
     groups:
       - control_center
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:

--- a/molecule/scram-rhel/molecule.yml
+++ b/molecule/scram-rhel/molecule.yml
@@ -9,7 +9,7 @@ platforms:
     hostname: zookeeper1.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -21,7 +21,7 @@ platforms:
     hostname: kafka-broker1.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -33,7 +33,7 @@ platforms:
     hostname: schema-registry1.confluent
     groups:
       - schema_registry
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -45,7 +45,7 @@ platforms:
     hostname: kafka-rest1.confluent
     groups:
       - kafka_rest
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -57,7 +57,7 @@ platforms:
     hostname: kafka-connect1.confluent
     groups:
       - kafka_connect
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -69,7 +69,7 @@ platforms:
     hostname: ksql1.confluent
     groups:
       - ksql
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -81,7 +81,7 @@ platforms:
     hostname: control-center1.confluent
     groups:
       - control_center
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:

--- a/molecule/zookeeper-digest-rhel/molecule.yml
+++ b/molecule/zookeeper-digest-rhel/molecule.yml
@@ -11,7 +11,7 @@ platforms:
     hostname: zookeeper1.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -23,7 +23,7 @@ platforms:
     hostname: zookeeper2.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -35,7 +35,7 @@ platforms:
     hostname: zookeeper3.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -47,7 +47,7 @@ platforms:
     hostname: kafka-broker1.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -59,7 +59,7 @@ platforms:
     hostname: kafka-broker2.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -71,7 +71,7 @@ platforms:
     hostname: kafka-broker3.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -83,7 +83,7 @@ platforms:
     hostname: schema-registry1.confluent
     groups:
       - schema_registry
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:

--- a/molecule/zookeeper-kerberos-rhel/molecule.yml
+++ b/molecule/zookeeper-kerberos-rhel/molecule.yml
@@ -10,7 +10,7 @@ platforms:
     hostname: kerberos1.confluent
     groups:
       - kerberos_server
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -22,7 +22,7 @@ platforms:
     hostname: zookeeper1.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -34,7 +34,7 @@ platforms:
     hostname: zookeeper2.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -46,7 +46,7 @@ platforms:
     hostname: zookeeper3.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -58,7 +58,7 @@ platforms:
     hostname: kafka-broker1.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -70,7 +70,7 @@ platforms:
     hostname: kafka-broker2.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -82,7 +82,7 @@ platforms:
     hostname: kafka-broker3.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -94,7 +94,7 @@ platforms:
     hostname: schema-registry1.confluent
     groups:
       - schema_registry
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:

--- a/molecule/zookeeper-mtls-rhel/molecule.yml
+++ b/molecule/zookeeper-mtls-rhel/molecule.yml
@@ -12,7 +12,7 @@ platforms:
     hostname: zookeeper1.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -24,7 +24,7 @@ platforms:
     hostname: zookeeper2.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -36,7 +36,7 @@ platforms:
     hostname: zookeeper3.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -48,7 +48,7 @@ platforms:
     hostname: kafka-broker1.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -60,7 +60,7 @@ platforms:
     hostname: kafka-broker2.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -72,7 +72,7 @@ platforms:
     hostname: kafka-broker3.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -84,7 +84,7 @@ platforms:
     hostname: schema-registry1.confluent
     groups:
       - schema_registry
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -96,7 +96,7 @@ platforms:
     hostname: kafka-connect1.confluent
     groups:
       - kafka_connect
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -108,7 +108,7 @@ platforms:
     hostname: kafka-rest1.confluent
     groups:
       - kafka_rest
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -120,7 +120,7 @@ platforms:
     hostname: ksql1.confluent
     groups:
       - ksql
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -132,7 +132,7 @@ platforms:
     hostname: control-center1.confluent
     groups:
       - control_center
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:

--- a/molecule/zookeeper-mtls-secrets-rhel/molecule.yml
+++ b/molecule/zookeeper-mtls-secrets-rhel/molecule.yml
@@ -13,7 +13,7 @@ platforms:
     hostname: zookeeper1.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -25,7 +25,7 @@ platforms:
     hostname: zookeeper2.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -37,7 +37,7 @@ platforms:
     hostname: zookeeper3.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -49,7 +49,7 @@ platforms:
     hostname: kafka-broker1.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -61,7 +61,7 @@ platforms:
     hostname: kafka-broker2.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -73,7 +73,7 @@ platforms:
     hostname: kafka-broker3.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -85,7 +85,7 @@ platforms:
     hostname: schema-registry1.confluent
     groups:
       - schema_registry
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -97,7 +97,7 @@ platforms:
     hostname: kafka-connect1.confluent
     groups:
       - kafka_connect
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -109,7 +109,7 @@ platforms:
     hostname: kafka-rest1.confluent
     groups:
       - kafka_rest
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -121,7 +121,7 @@ platforms:
     hostname: ksql1.confluent
     groups:
       - ksql
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -133,7 +133,7 @@ platforms:
     hostname: control-center1.confluent
     groups:
       - control_center
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:

--- a/molecule/zookeeper-tls-rhel/molecule.yml
+++ b/molecule/zookeeper-tls-rhel/molecule.yml
@@ -13,7 +13,7 @@ platforms:
     hostname: zookeeper1.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -25,7 +25,7 @@ platforms:
     hostname: zookeeper2.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -37,7 +37,7 @@ platforms:
     hostname: zookeeper3.confluent
     groups:
       - zookeeper
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -49,7 +49,7 @@ platforms:
     hostname: kafka-broker1.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -61,7 +61,7 @@ platforms:
     hostname: kafka-broker2.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -73,7 +73,7 @@ platforms:
     hostname: kafka-broker3.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -85,7 +85,7 @@ platforms:
     hostname: schema-registry1.confluent
     groups:
       - schema_registry
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -97,7 +97,7 @@ platforms:
     hostname: kafka-connect1.confluent
     groups:
       - kafka_connect
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -109,7 +109,7 @@ platforms:
     hostname: kafka-rest1.confluent
     groups:
       - kafka_rest
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -121,7 +121,7 @@ platforms:
     hostname: ksql1.confluent
     groups:
       - ksql
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
@@ -133,7 +133,7 @@ platforms:
     hostname: control-center1.confluent
     groups:
       - control_center
-    image: geerlingguy/docker-centos7-ansible
+    image: utkarsh5474/docker-centos7-ansible
     dockerfile: ../Dockerfile.j2
     command: ""
     volumes:


### PR DESCRIPTION
# Description

Blocked by https://confluentinc.atlassian.net/browse/DP-9709
Currently, these images have been pushed to utkarsh5474 dockerhub account. We're waiting on devprod to allow pushing these to confluentinc dockerhub public repo
This [repo](https://github.com/confluentinc/cp-ansible-internal/tree/test-images) hosts all the image dockerfiles.

Fixes # (ANSIENG-1926)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

All tests on 7.0.x are green. After pint merge, we might have to fix on downstream branches
We might also have to introduce ansible_python_interpretor var to ensure it's picking the correct python version (7.3 onwards mostly)


**Test Configuration**:


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible