### PR TITLE
Fix upgrades for archive installation

### DIFF
--- a/roles/confluent.variables/vars/main.yml
+++ b/roles/confluent.variables/vars/main.yml
@@ -9,9 +9,9 @@ confluent_repo_version: "{{ confluent_package_version | regex_replace('^([0-9])\
 ssl_file_dir_final: "{{ ssl_file_dir |regex_replace('\\/$', '') }}"
 
 ### The base path for the binary files. When in Archive File deployment mode this results in binary files being based in, for example `/opt/confluent/confluent-5.5.1/bin`, otherwise they are based in `/usr/bin`.
-base_path: "{{ ((config_base_path,('confluent-',confluent_package_version) | join) | community.general.path_join) if installation_method == 'archive' else '/' }}"
+base_path: "{{ ((config_base_path,('confluent-',archive_version) | join) | community.general.path_join) if installation_method == 'archive' else '/' }}"
 
-binary_base_path: "{{ ((config_base_path,('confluent-',confluent_package_version) | join) | community.general.path_join) if installation_method == 'archive' else '/usr' }}"
+binary_base_path: "{{ ((config_base_path,('confluent-',archive_version) | join) | community.general.path_join) if installation_method == 'archive' else '/usr' }}"
 
 #### Zookeeper Variables ####
 zookeeper_service_name: confluent-zookeeper


### PR DESCRIPTION
# Description

https://github.com/confluentinc/cp-ansible/issues/1243
For upgrades with archive installation, zookeeper_health_check was failing when being called in dynamic_groups.yml
In our code, zookeeper_health_check var was resolving with the incorrect/target version, while it should be resolving with starting version (because the tasks in dynamic_groups.yml file are pre-upgrade)
Similar issue for kafka_broker

Fixing base_path and binary_base_path utilises the var archive_version which is set here - https://github.com/confluentinc/cp-ansible/blob/6.2.7-post/roles/confluent.zookeeper/tasks/dynamic_groups.yml#L31 by slurping the properties file

Fixes # ([issue](https://confluentinc.atlassian.net/browse/ANSIENG-1943))

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested archive-plain-rhel locally.
Tested manual upgrade of both zookeeper and kafka broker.



**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible