### PR TITLE
Make pip install and upgrade tasks skippable

### DIFF
--- a/roles/common/tasks/debian.yml
+++ b/roles/common/tasks/debian.yml
@@ -219,12 +219,15 @@
       - python3-pip
     state: present
   become: true
+  tags: package
 
 - name: Upgrade pip
   ansible.builtin.pip:
     name: pip
     extra_args: --upgrade
+  tags: package
 
 - name: Install pip packages
   ansible.builtin.pip:
     name: "{{pip_packages}}"
+  tags: package

--- a/roles/common/tasks/redhat.yml
+++ b/roles/common/tasks/redhat.yml
@@ -60,12 +60,15 @@
       - python3-pip
     state: present
   become: true
+  tags: package
 
 - name: Upgrade pip
   ansible.builtin.pip:
     name: pip
     extra_args: --upgrade
+  tags: package
 
 - name: Install pip packages
   ansible.builtin.pip:
     name: "{{pip_packages}}"
+  tags: package

--- a/roles/common/tasks/ubuntu.yml
+++ b/roles/common/tasks/ubuntu.yml
@@ -116,12 +116,15 @@
       - python3-pip
     state: present
   become: true
+  tags: package
 
 - name: Upgrade pip
   ansible.builtin.pip:
     name: pip
     extra_args: --upgrade
+  tags: package
 
 - name: Install pip packages
   ansible.builtin.pip:
     name: "{{pip_packages}}"
+  tags: package


### PR DESCRIPTION
# Description

Make pip install and upgrade pip tasks skippable with `tags: package` 

Fixes # (issue)
[ANSIENG-1953](https://confluentinc.atlassian.net/browse/ANSIENG-1953)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration



**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible