### PR TITLE
fix an issue where newly released RC are only available in internal o…

### DIFF
--- a/molecule/plaintext-rhel-customrepo/prepare.yml
+++ b/molecule/plaintext-rhel-customrepo/prepare.yml
@@ -9,27 +9,23 @@
         ansible_distribution_major_version: 7
     - import_role:
         name: variables
-    - debug:
-        msg:
-          - "Confluent Client Repo Version -> {{ confluent_common_repository_redhat_release_version }}"
-          - "OS Family -> {{ ansible_os_family }}"
     - name: Create custom repo file
       copy:
         dest: "{{ custom_yum_repofile_filepath }}"
         content: |
           [Confluent.custom]
           async = 1
-          baseurl = "https://packages.confluent.io/rpm/{{confluent_repo_version}}"
+          baseurl = {{confluent_common_repository_baseurl}}/rpm/{{confluent_repo_version}}
           enabled = 1
           gpgcheck = 1
-          gpgkey = "https://packages.confluent.io/rpm/{{confluent_repo_version}}/archive.key"
+          gpgkey = {{confluent_common_repository_baseurl}}/rpm/{{confluent_repo_version}}/archive.key
           name = Custom Confluent repository
           [Confluent.clients.custom]
           async = 1
-          baseurl = "https://packages.confluent.io/clients/rpm/centos/{{confluent_common_repository_redhat_release_version}}/x86_64"
+          baseurl = https://packages.confluent.io/clients/rpm/centos/{{confluent_common_repository_redhat_release_version}}/x86_64
           enabled = 1
           gpgcheck = 1
-          gpgkey = "https://packages.confluent.io/clients/rpm/archive.key"
+          gpgkey = https://packages.confluent.io/clients/rpm/archive.key
           name = Custom Confluent repository (clients)
     - name: Download Jolokia Jar
       get_url:


### PR DESCRIPTION
# Description

Newly released RC's are hosted internally, and those are not available on https://packages.confluent.io . So tests fails with error that the new release (for eg 7.3.1) is not available on repo.
Taking repo ad a variable in custom packages file solves the problem.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

https://jenkins.confluent.io/job/cp-ansible-on-demand/901/

PLAY [Kafka Connect Replicator Serial Provisioning] ****************************
skipping: no hosts matched

PLAY RECAP *********************************************************************
control-center1            : ok=61   changed=19   unreachable=0    failed=0    skipped=56   rescued=0    ignored=0
kafka-broker1              : ok=69   changed=26   unreachable=0    failed=0    skipped=64   rescued=0    ignored=0
kafka-broker2              : ok=69   changed=26   unreachable=0    failed=0    skipped=61   rescued=0    ignored=0
kafka-connect1             : ok=67   changed=23   unreachable=0    failed=0    skipped=72   rescued=0    ignored=0
kafka-rest1                : ok=63   changed=21   unreachable=0    failed=0    skipped=57   rescued=0    ignored=0
ksql1                      : ok=63   changed=22   unreachable=0    failed=0    skipped=66   rescued=0    ignored=0
schema-registry1           : ok=58   changed=21   unreachable=0    failed=0    skipped=57   rescued=0    ignored=0
zookeeper1                 : ok=61   changed=21   unreachable=0    failed=0    skipped=54   rescued=0    ignored=0
zookeeper2                 : ok=61   changed=21   unreachable=0    failed=0    skipped=53   rescued=0    ignored=0
zookeeper3                 : ok=61   changed=21   unreachable=0    failed=0    skipped=53   rescued=0    ignored=0



**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible