### PR TITLE
ANSIENG-1990 Improve error handling deploying connectors

### DIFF
--- a/HOW_TO_TEST.md
+++ b/HOW_TO_TEST.md
@@ -26,11 +26,7 @@ cd ansible_collections/confluent/platform
 
 ## Using Molecule
 
-<<<<<<< HEAD
-We have an extensive set of integration test in the form of Molecule Scenarios within the `molecule/` directory at the base of this repo. To list these scenarios, simply run:
-=======
 The following is a list of the most common commands used with Molecule.  For a complete list of scenarios and test functionality please review [MOLECULE_SCENARIOS.md](MOLECULE_SCENARIOS.md).
->>>>>>> 6.2.x
 
 ```
 ls molecule

--- a/molecule/archive-plain-rhel/verify.yml
+++ b/molecule/archive-plain-rhel/verify.yml
@@ -67,6 +67,113 @@
         property: security.protocol
         expected_value: SASL_SSL
 
+    - import_role:
+        name: variables
+
+    - name: Test data
+      set_fact:
+        kafka_connect_url: "{{kafka_connect_http_protocol}}://{{ hostvars[inventory_hostname]|confluent.platform.resolve_hostname }}:{{kafka_connect_rest_port}}/connectors"
+        reset_all_connectors: []
+
+        add_new_connector:
+          - name: test-connector-1
+            config:
+              connector.class: "org.apache.kafka.connect.tools.VerifiableSinkConnector"
+              tasks.max: "1"
+              file: "/etc/kafka/connect-distributed.properties"
+              topics: "test_topic"
+
+        update_existing_connector:
+          - name: test-connector-1
+            config:
+              connector.class: "org.apache.kafka.connect.tools.VerifiableSinkConnector"
+              tasks.max: "5"
+              file: "/etc/kafka/connect-distributed.properties"
+              topics: "test_topic"
+
+        add_bad_request_connector:
+          - name: test-connector-1
+            config:
+              connector.class: "org.apache.kafka.connect.tools.VerifiableSinkConnector"
+              tasks.max: "5"
+              file: "/etc/kafka/connect-distributed.properties"
+              topics: "test_topic"
+          - name: test-connector-2
+            config:
+              connector.class: "org.apache.kafka.connect.mirror.MirrorHeartbeatConnector"
+              tasks.max: "1"
+              file: "/etc/kafka/connect-distributed.properties"
+              topics: "foo"
+
+        add_non_existent_connector:
+          - name: test-connector-1
+            config:
+              connector.class: "org.apache.kafka.connect.tools.VerifiableSinkConnector"
+              tasks.max: "5"
+              file: "/etc/kafka/connect-distributed.properties"
+              topics: "test_topic"
+          - name: test-connector-2
+            config:
+              connector.class: "io.confluent.connect.s3.S3SinkConnector"
+              tasks.max: "1"
+              topics: "foo"
+
+        delete_connector:
+          - name: test-connector-2
+            config:
+              connector.class: "org.apache.kafka.connect.tools.VerifiableSinkConnector"
+              tasks.max: "1"
+              topics: "bar"
+
+    - import_role:
+        name: confluent.test
+        tasks_from: check_connector.yml
+      vars:
+        connect_url_input: "{{ kafka_connect_url }}"
+        active_connectors_input: "{{ reset_all_connectors }}"
+        expected_message: ""
+
+    - import_role:
+        name: confluent.test
+        tasks_from: check_connector.yml
+      vars:
+        connect_url_input: "{{ kafka_connect_url }}"
+        active_connectors_input: "{{ add_new_connector }}"
+        expected_message: "Connectors added or updated: test-connector-1: new connector added."
+
+    - import_role:
+        name: confluent.test
+        tasks_from: check_connector.yml
+      vars:
+        connect_url_input: "{{ kafka_connect_url }}"
+        active_connectors_input: "{{ update_existing_connector }}"
+        expected_message: "Connectors added or updated: test-connector-1: connector configuration updated."
+
+    - import_role:
+        name: confluent.test
+        tasks_from: check_connector.yml
+      vars:
+        connect_url_input: "{{ kafka_connect_url }}"
+        active_connectors_input: "{{ add_bad_request_connector }}"
+        expected_message: "Connectors added or updated: test-connector-1: no configuration change, test-connector-2: ERROR error while updating configuration (HTTP Error 400: Bad Request)."
+
+    - import_role:
+        name: confluent.test
+        tasks_from: check_connector.yml
+      vars:
+        connect_url_input: "{{ kafka_connect_url }}"
+        active_connectors_input: "{{ add_non_existent_connector }}"
+        expected_message: "Connectors added or updated: test-connector-1: no configuration change, test-connector-2: ERROR error while updating configuration (HTTP Error 500: Internal Server Error)."
+
+    - import_role:
+        name: confluent.test
+        tasks_from: check_connector.yml
+      vars:
+        connect_url_input: "{{ kafka_connect_url }}"
+        active_connectors_input: "{{ delete_connector }}"
+        expected_message: "Connectors removed: test-connector-1. Connectors added or updated: test-connector-2: new connector added."
+
+
 - name: Verify - ksql
   hosts: ksql
   gather_facts: false

--- a/molecule/archive-plain-rhel/verify.yml
+++ b/molecule/archive-plain-rhel/verify.yml
@@ -155,7 +155,7 @@
       vars:
         connect_url_input: "{{ kafka_connect_url }}"
         active_connectors_input: "{{ add_bad_request_connector }}"
-        expected_message: "Connectors added or updated: test-connector-1: no configuration change, test-connector-2: ERROR error while updating configuration (HTTP Error 400: Bad Request)."
+        expected_message: "Connectors added or updated: test-connector-1: no configuration change, test-connector-2: ERROR error while adding new connector configuration (HTTP Error 400: Bad Request)."
 
     - import_role:
         name: confluent.test
@@ -163,7 +163,7 @@
       vars:
         connect_url_input: "{{ kafka_connect_url }}"
         active_connectors_input: "{{ add_non_existent_connector }}"
-        expected_message: "Connectors added or updated: test-connector-1: no configuration change, test-connector-2: ERROR error while updating configuration (HTTP Error 500: Internal Server Error)."
+        expected_message: "Connectors added or updated: test-connector-1: no configuration change, test-connector-2: ERROR error while adding new connector configuration (HTTP Error 500: Internal Server Error)."
 
     - import_role:
         name: confluent.test

--- a/molecule/multi-ksql-connect-rhel/molecule.yml
+++ b/molecule/multi-ksql-connect-rhel/molecule.yml
@@ -176,6 +176,8 @@ provisioner:
               tasks.max: "1"
               file: "/etc/kafka/connect-distributed.properties"
               topics: "test_topic"
+              key.converter: "org.apache.kafka.connect.json.JsonConverter"
+              value.converter: "org.apache.kafka.connect.json.JsonConverter"
       elastic:
         kafka_connect_group_id: connect-elastic
         # Create Connectors not working w ssl
@@ -188,6 +190,8 @@ provisioner:
               tasks.max: "1"
               file: "/etc/kafka/connect-distributed.properties"
               topics: "test_topic"
+              key.converter: "org.apache.kafka.connect.json.JsonConverter"
+              value.converter: "org.apache.kafka.connect.json.JsonConverter"
 
       # ksql clusters
       ks1:

--- a/molecule/plain-rhel/verify.yml
+++ b/molecule/plain-rhel/verify.yml
@@ -183,12 +183,16 @@
         fail_msg: "Connector not created"
         quiet: true
 
+    - import_role:
+        name: variables
+
     - name: Test data
       set_fact:
-        reset_all_connectors: [ ]
+        kafka_connect_url: "{{kafka_connect_http_protocol}}://{{ hostvars[inventory_hostname]|confluent.platform.resolve_hostname }}:{{kafka_connect_rest_port}}/connectors"
+        reset_all_connectors: []
 
         add_new_connector:
-          - name: sample-connector-1
+          - name: test-connector-1
             config:
               connector.class: "org.apache.kafka.connect.tools.VerifiableSinkConnector"
               tasks.max: "1"
@@ -196,7 +200,7 @@
               topics: "test_topic"
 
         update_existing_connector:
-          - name: sample-connector-1
+          - name: test-connector-1
             config:
               connector.class: "org.apache.kafka.connect.tools.VerifiableSinkConnector"
               tasks.max: "5"
@@ -204,13 +208,13 @@
               topics: "test_topic"
 
         add_bad_request_connector:
-          - name: sample-connector-1
+          - name: test-connector-1
             config:
               connector.class: "org.apache.kafka.connect.tools.VerifiableSinkConnector"
               tasks.max: "5"
               file: "/etc/kafka/connect-distributed.properties"
               topics: "test_topic"
-          - name: sample-connector-2
+          - name: test-connector-2
             config:
               connector.class: "org.apache.kafka.connect.mirror.MirrorHeartbeatConnector"
               tasks.max: "1"
@@ -218,22 +222,30 @@
               topics: "foo"
 
         add_non_existent_connector:
-          - name: sample-connector-1
+          - name: test-connector-1
             config:
               connector.class: "org.apache.kafka.connect.tools.VerifiableSinkConnector"
               tasks.max: "5"
               file: "/etc/kafka/connect-distributed.properties"
               topics: "test_topic"
-          - name: sample-connector-2
+          - name: test-connector-2
             config:
               connector.class: "io.confluent.connect.s3.S3SinkConnector"
               tasks.max: "1"
               topics: "foo"
 
+        delete_connector:
+          - name: test-connector-2
+            config:
+              connector.class: "org.apache.kafka.connect.tools.VerifiableSinkConnector"
+              tasks.max: "1"
+              topics: "bar"
+
     - import_role:
         name: confluent.test
         tasks_from: check_connector.yml
       vars:
+        connect_url_input: "{{ kafka_connect_url }}"
         active_connectors_input: "{{ reset_all_connectors }}"
         expected_message: ""
 
@@ -241,29 +253,41 @@
         name: confluent.test
         tasks_from: check_connector.yml
       vars:
+        connect_url_input: "{{ kafka_connect_url }}"
         active_connectors_input: "{{ add_new_connector }}"
-        expected_message: "Connectors added or updated: sample-connector-1: new connector added."
+        expected_message: "Connectors added or updated: test-connector-1: new connector added."
 
     - import_role:
         name: confluent.test
         tasks_from: check_connector.yml
       vars:
+        connect_url_input: "{{ kafka_connect_url }}"
         active_connectors_input: "{{ update_existing_connector }}"
-        expected_message: "Connectors added or updated: sample-connector-1: connector configuration updated."
+        expected_message: "Connectors added or updated: test-connector-1: connector configuration updated."
 
     - import_role:
         name: confluent.test
         tasks_from: check_connector.yml
       vars:
+        connect_url_input: "{{ kafka_connect_url }}"
         active_connectors_input: "{{ add_bad_request_connector }}"
-        expected_message: "Connectors added or updated: sample-connector-1: no configuration change, sample-connector-2: ERROR error while updating configuration (HTTP Error 400: Bad Request)."
+        expected_message: "Connectors added or updated: test-connector-1: no configuration change, test-connector-2: ERROR error while updating configuration (HTTP Error 400: Bad Request)."
 
     - import_role:
         name: confluent.test
         tasks_from: check_connector.yml
       vars:
+        connect_url_input: "{{ kafka_connect_url }}"
         active_connectors_input: "{{ add_non_existent_connector }}"
-        expected_message: "Connectors added or updated: sample-connector-1: no configuration change, sample-connector-2: ERROR error while updating configuration (HTTP Error 500: Internal Server Error)."
+        expected_message: "Connectors added or updated: test-connector-1: no configuration change, test-connector-2: ERROR error while updating configuration (HTTP Error 500: Internal Server Error)."
+
+    - import_role:
+        name: confluent.test
+        tasks_from: check_connector.yml
+      vars:
+        connect_url_input: "{{ kafka_connect_url }}"
+        active_connectors_input: "{{ delete_connector }}"
+        expected_message: "Connectors removed: test-connector-1. Connectors added or updated: test-connector-2: new connector added."
 
     - import_role:
         name: confluent.test

--- a/molecule/plain-rhel/verify.yml
+++ b/molecule/plain-rhel/verify.yml
@@ -271,7 +271,7 @@
       vars:
         connect_url_input: "{{ kafka_connect_url }}"
         active_connectors_input: "{{ add_bad_request_connector }}"
-        expected_message: "Connectors added or updated: test-connector-1: no configuration change, test-connector-2: ERROR error while updating configuration (HTTP Error 400: Bad Request)."
+        expected_message: "Connectors added or updated: test-connector-1: no configuration change, test-connector-2: ERROR error while adding new connector configuration (HTTP Error 400: Bad Request)."
 
     - import_role:
         name: confluent.test
@@ -279,7 +279,7 @@
       vars:
         connect_url_input: "{{ kafka_connect_url }}"
         active_connectors_input: "{{ add_non_existent_connector }}"
-        expected_message: "Connectors added or updated: test-connector-1: no configuration change, test-connector-2: ERROR error while updating configuration (HTTP Error 500: Internal Server Error)."
+        expected_message: "Connectors added or updated: test-connector-1: no configuration change, test-connector-2: ERROR error while adding new connector configuration (HTTP Error 500: Internal Server Error)."
 
     - import_role:
         name: confluent.test
@@ -288,14 +288,6 @@
         connect_url_input: "{{ kafka_connect_url }}"
         active_connectors_input: "{{ delete_connector }}"
         expected_message: "Connectors removed: test-connector-1. Connectors added or updated: test-connector-2: new connector added."
-
-    - import_role:
-        name: confluent.test
-        tasks_from: check_property.yml
-      vars:
-        file_path: /etc/kafka/connect-log4j.properties
-        property: log4j.rootLogger
-        expected_value: "INFO, connectAppender"
 
     - import_role:
         name: confluent.test

--- a/molecule/plain-rhel/verify.yml
+++ b/molecule/plain-rhel/verify.yml
@@ -183,6 +183,96 @@
         fail_msg: "Connector not created"
         quiet: true
 
+    - name: Test data
+      set_fact:
+        reset_all_connectors: [ ]
+
+        add_new_connector:
+          - name: sample-connector-1
+            config:
+              connector.class: "org.apache.kafka.connect.tools.VerifiableSinkConnector"
+              tasks.max: "1"
+              file: "/etc/kafka/connect-distributed.properties"
+              topics: "test_topic"
+
+        update_existing_connector:
+          - name: sample-connector-1
+            config:
+              connector.class: "org.apache.kafka.connect.tools.VerifiableSinkConnector"
+              tasks.max: "5"
+              file: "/etc/kafka/connect-distributed.properties"
+              topics: "test_topic"
+
+        add_bad_request_connector:
+          - name: sample-connector-1
+            config:
+              connector.class: "org.apache.kafka.connect.tools.VerifiableSinkConnector"
+              tasks.max: "5"
+              file: "/etc/kafka/connect-distributed.properties"
+              topics: "test_topic"
+          - name: sample-connector-2
+            config:
+              connector.class: "org.apache.kafka.connect.mirror.MirrorHeartbeatConnector"
+              tasks.max: "1"
+              file: "/etc/kafka/connect-distributed.properties"
+              topics: "foo"
+
+        add_non_existent_connector:
+          - name: sample-connector-1
+            config:
+              connector.class: "org.apache.kafka.connect.tools.VerifiableSinkConnector"
+              tasks.max: "5"
+              file: "/etc/kafka/connect-distributed.properties"
+              topics: "test_topic"
+          - name: sample-connector-2
+            config:
+              connector.class: "io.confluent.connect.s3.S3SinkConnector"
+              tasks.max: "1"
+              topics: "foo"
+
+    - import_role:
+        name: confluent.test
+        tasks_from: check_connector.yml
+      vars:
+        active_connectors_input: "{{ reset_all_connectors }}"
+        expected_message: ""
+
+    - import_role:
+        name: confluent.test
+        tasks_from: check_connector.yml
+      vars:
+        active_connectors_input: "{{ add_new_connector }}"
+        expected_message: "Connectors added or updated: sample-connector-1: new connector added."
+
+    - import_role:
+        name: confluent.test
+        tasks_from: check_connector.yml
+      vars:
+        active_connectors_input: "{{ update_existing_connector }}"
+        expected_message: "Connectors added or updated: sample-connector-1: connector configuration updated."
+
+    - import_role:
+        name: confluent.test
+        tasks_from: check_connector.yml
+      vars:
+        active_connectors_input: "{{ add_bad_request_connector }}"
+        expected_message: "Connectors added or updated: sample-connector-1: no configuration change, sample-connector-2: ERROR error while updating configuration (HTTP Error 400: Bad Request)."
+
+    - import_role:
+        name: confluent.test
+        tasks_from: check_connector.yml
+      vars:
+        active_connectors_input: "{{ add_non_existent_connector }}"
+        expected_message: "Connectors added or updated: sample-connector-1: no configuration change, sample-connector-2: ERROR error while updating configuration (HTTP Error 500: Internal Server Error)."
+
+    - import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: /etc/kafka/connect-log4j.properties
+        property: log4j.rootLogger
+        expected_value: "INFO, connectAppender"
+
     - import_role:
         name: confluent.test
         tasks_from: check_property.yml

--- a/plugins/modules/kafka_connectors.py
+++ b/plugins/modules/kafka_connectors.py
@@ -67,7 +67,7 @@ TIMEOUT_WAITING_FOR_TASK_STATUS = 30  # seconds
 
 def get_current_connectors(connect_url):
     try:
-        res = open_url(connect_url)
+        res = open_url(connect_url, validate_certs=False)
         return json.loads(res.read())
     except urllib_error.HTTPError as e:
         if e.code != 404:
@@ -77,7 +77,7 @@ def get_current_connectors(connect_url):
 
 def remove_connector(connect_url, name):
     url = "{}/{}".format(connect_url, name)
-    r = open_url(method='DELETE', url=url)
+    r = open_url(method='DELETE', url=url, validate_certs=False)
     return r.getcode() == 200
 
 
@@ -86,7 +86,7 @@ def create_new_connector(connect_url, name, config):
     data = json.dumps({'name': name, 'config': config})
     headers = {'Content-Type': 'application/json'}
     try:
-        r = open_url(method='POST', url=connect_url, data=data, headers=headers)
+        r = open_url(method='POST', url=connect_url, data=data, headers=headers, validate_certs=False)
     except urllib_error.HTTPError as e:
         message = "error while updating configuration ({})".format(e)
         return False, False, message
@@ -117,7 +117,7 @@ def get_connector_status(connect_url, connector_name):
     time.sleep(WAIT_TIME_BEFORE_GET_STATUS)
     status_url = "{}/{}/status".format(connect_url, connector_name)
 
-    res = open_url(status_url)
+    res = open_url(status_url, validate_certs=False)
     current_status = json.loads(res.read())
 
     connector_status = current_status['connector']['state']
@@ -134,7 +134,7 @@ def get_connector_status(connect_url, connector_name):
         if time_waited > TIMEOUT_WAITING_FOR_TASK_STATUS:
             return False, "timeout getting task status"
 
-        res = open_url(status_url)
+        res = open_url(status_url, validate_certs=False)
         current_status = json.loads(res.read())
         nb_tasks = len(current_status['tasks'])
 
@@ -153,7 +153,7 @@ def update_existing_connector(connect_url, name, config):
     url = "{}/{}/config".format(connect_url, name)
     restart_url = "{}/{}/restart".format(connect_url, name)
 
-    res = open_url(url)
+    res = open_url(url, validate_certs=False)
     current_config = json.loads(res.read())
 
     existing_config = config.copy()
@@ -171,7 +171,7 @@ def update_existing_connector(connect_url, name, config):
     headers = {'Content-Type': 'application/json'}
     r = None
     try:
-        r = open_url(method='PUT', url=url, data=data, headers=headers)
+        r = open_url(method='PUT', url=url, data=data, headers=headers, validate_certs=False)
     except urllib_error.HTTPError as e:
         message = "error while updating configuration ({})".format(e)
         success = False
@@ -186,7 +186,7 @@ def update_existing_connector(connect_url, name, config):
     message = "connector configuration updated"
     success = True
     try:
-        r = open_url(method='POST', url=restart_url)
+        r = open_url(method='POST', url=restart_url, validate_certs=False)
     except urllib_error.HTTPError:
         pass
     finally:

--- a/plugins/modules/kafka_connectors.py
+++ b/plugins/modules/kafka_connectors.py
@@ -88,7 +88,7 @@ def create_new_connector(connect_url, name, config):
     try:
         r = open_url(method='POST', url=connect_url, data=data, headers=headers, validate_certs=False)
     except urllib_error.HTTPError as e:
-        message = "error while updating configuration ({})".format(e)
+        message = "error while adding new connector configuration ({})".format(e)
         return False, False, message
 
     success = r.getcode() in (200, 201, 409)

--- a/plugins/modules/kafka_connectors.py
+++ b/plugins/modules/kafka_connectors.py
@@ -5,7 +5,7 @@
 from __future__ import (absolute_import, division, print_function)
 
 ANSIBLE_METADATA = {
-    'metadata_version': '0.9',
+    'metadata_version': '0.91',
     'status': ['preview'],
     'supported_by': 'community'
 }
@@ -53,11 +53,16 @@ message:
 '''
 
 import json
+import time
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import open_url
 import ansible.module_utils.six.moves.urllib.error as urllib_error
 __metaclass__ = type
+
+RUNNING_STATE = "RUNNING"
+WAIT_TIME_BEFORE_GET_STATUS = 1  # seconds
+TIMEOUT_WAITING_FOR_TASK_STATUS = 30  # seconds
 
 
 def get_current_connectors(connect_url):
@@ -76,13 +81,74 @@ def remove_connector(connect_url, name):
     return r.getcode() == 200
 
 
+# return value: success (bool), changed (bool), message (str)
 def create_new_connector(connect_url, name, config):
     data = json.dumps({'name': name, 'config': config})
     headers = {'Content-Type': 'application/json'}
-    r = open_url(method='POST', url=connect_url, data=data, headers=headers)
-    return r.getcode() in (200, 201, 409)
+    try:
+        r = open_url(method='POST', url=connect_url, data=data, headers=headers)
+    except urllib_error.HTTPError as e:
+        message = "error while updating configuration ({})".format(e)
+        return False, False, message
+
+    success = r.getcode() in (200, 201, 409)
+    changed = True
+    message = "new connector added"
+
+    is_running, failures_msg = get_connector_status(connect_url, name)
+    if not is_running:
+        success = False
+        message = failures_msg
+
+    return success, changed, message
 
 
+# truncates to 200 chars or the first line feed
+def truncate_error_message(message):
+    lines = message.splitlines()
+    if lines:
+        return lines[0][0:200]
+    return message[0:200]
+
+
+# to be successful, the connector and all its tasks must be running
+# if anything fails, we fail and return the associated error messages
+def get_connector_status(connect_url, connector_name):
+    time.sleep(WAIT_TIME_BEFORE_GET_STATUS)
+    status_url = "{}/{}/status".format(connect_url, connector_name)
+
+    res = open_url(status_url)
+    current_status = json.loads(res.read())
+
+    connector_status = current_status['connector']['state']
+
+    failures = []
+    if connector_status != RUNNING_STATE:
+        failures.append("connector state paused or failed")
+
+    nb_tasks = len(current_status['tasks'])
+    time_waited = 0
+    while not nb_tasks:
+        time_waited += 1
+        time.sleep(1)
+        if time_waited > TIMEOUT_WAITING_FOR_TASK_STATUS:
+            return False, "timeout getting task status"
+
+        res = open_url(status_url)
+        current_status = json.loads(res.read())
+        nb_tasks = len(current_status['tasks'])
+
+    for task in current_status['tasks']:
+        if task['state'] != RUNNING_STATE:
+            failures.append("task {}: {}".format(task['id'], truncate_error_message(task.get('trace'))))
+
+    if failures:
+        return False, ", ".join(failures)
+
+    return True, None
+
+
+# return value: success (bool), changed (bool), message (str)
 def update_existing_connector(connect_url, name, config):
     url = "{}/{}/config".format(connect_url, name)
     restart_url = "{}/{}/restart".format(connect_url, name)
@@ -94,19 +160,57 @@ def update_existing_connector(connect_url, name, config):
     existing_config.update({'name': name})
 
     if current_config == existing_config:
-        return False
+        return True, False, "no configuration change"
+
+    success = True
+    message = ""
+
+    # configuration has changed, let's update it
 
     data = json.dumps(config)
     headers = {'Content-Type': 'application/json'}
-    r = open_url(method='PUT', url=url, data=data, headers=headers)
+    r = None
+    try:
+        r = open_url(method='PUT', url=url, data=data, headers=headers)
+    except urllib_error.HTTPError as e:
+        message = "error while updating configuration ({})".format(e)
+        success = False
+    finally:
+        changed = r is not None and r.getcode() in (200, 201)
 
-    changed = r.getcode() in (200, 201, 409)
+    if not success:
+        return success, changed, message
 
-    r = open_url(method='POST', url=restart_url)
-    if r.getcode() not in (200, 204, 409):
-        raise Exception("Connector {} failed to restart after a configuration update. {}".format(name, r.msg))
+    # configuration was updated, let's restart the connector
 
-    return changed
+    message = "connector configuration updated"
+    success = True
+    try:
+        r = open_url(method='POST', url=restart_url)
+    except urllib_error.HTTPError:
+        pass
+    finally:
+        if r.getcode() not in (200, 204, 409):
+            success = False
+            message = "connector configuration updated but failed to restart " \
+                      "after a configuration update. {}".format(r.msg)
+
+    # get the connector's status
+    # if failed, return it
+    # if there's a rebalance, wait for it to finish? how?
+    is_running, failures_msg = get_connector_status(connect_url, name)
+    if not is_running:
+        success = False
+        message = failures_msg
+
+    return success, changed, message
+
+
+def format_output(connector_name, success, message):
+    if not success:
+        return "{}: ERROR {}".format(connector_name, message)
+    else:
+        return "{}: {}".format(connector_name, message)
 
 
 def run_module():
@@ -131,7 +235,9 @@ def run_module():
     # when the connector doesn't exist
     #
     result['changed'] = False
+    connector_failure = False
     output_messages = []
+    added_updated_messages = []
     try:
         current_connector_names = get_current_connectors(connect_url=module.params['connect_url'])
         active_connector_names = (c['name'] for c in module.params['active_connectors'])
@@ -149,27 +255,35 @@ def run_module():
             try:
                 _unused = current_connector_names.index(connector['name'])
 
-                changed = update_existing_connector(
+                success, changed, message = update_existing_connector(
                     connect_url=module.params['connect_url'],
                     name=connector['name'],
                     config=connector['config']
                 )
-                if changed:
-                    output_messages.append("Connector {} updated.".format(connector['name']))
-
-                result['changed'] = changed
-
             except ValueError:
-                result['changed'] = create_new_connector(
+                success, changed, message = create_new_connector(
                     connect_url=module.params['connect_url'],
                     name=connector['name'],
-                    config=connector['config'])
-                output_messages.append("New connector {} created.".format(connector['name']))
+                    config=connector['config']
+                )
 
+            if changed:  # one connector changed is enough
+                result['changed'] = True
+
+            if not success:
+                connector_failure = True
+
+            added_updated_messages.append(format_output(connector['name'], success, message))
+
+        output_messages.append("Connectors added or updated: {}.".format(', '.join(added_updated_messages)))
         result['message'] = " ".join(output_messages)
+
+        if connector_failure:
+            module.fail_json(msg='An error occurred while running the module', **result)
 
     except Exception as e:
         result['message'] = str(e)
+
         module.fail_json(msg='An error occurred while running the module', **result)
 
     module.exit_json(**result)

--- a/test_roles/confluent.test/tasks/check_connector.yml
+++ b/test_roles/confluent.test/tasks/check_connector.yml
@@ -1,7 +1,7 @@
 ---
 - name: Deploy connectors
   confluent.platform.kafka_connectors:
-    connect_url: "http://kafka-connect1:8083/connectors"
+    connect_url: "{{ connect_url_input }}"
     active_connectors: "{{ active_connectors_input }}"
   ignore_errors: true
   register: json_output

--- a/test_roles/confluent.test/tasks/check_connector.yml
+++ b/test_roles/confluent.test/tasks/check_connector.yml
@@ -1,0 +1,16 @@
+---
+- name: Deploy connectors
+  confluent.platform.kafka_connectors:
+    connect_url: "http://kafka-connect1:8083/connectors"
+    active_connectors: "{{ active_connectors_input }}"
+  ignore_errors: true
+  register: json_output
+
+- debug:
+    msg: "{{json_output.message}}"
+
+- name: Assert response
+  assert:
+    that:
+      - active_connectors_input == [] or json_output.message == "{{expected_message}}"
+    fail_msg: "Incorrect error handling while deploying connectors {{ active_connectors_input }}"


### PR DESCRIPTION
# Description

- Improve error handling while deploying connectors (Based on previous PR - https://github.com/confluentinc/cp-ansible/pull/490 + added error handling in create_new_connector)
- Fix kafka_connectors module to support ssl_enabled=true
- Updated molecule scenarios to test above - error handling of module + deploying connectors with ssl_enabled=true

Fixes # (issue)
GH #401  


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
https://jenkins.confluent.io/job/cp-ansible-on-demand/996/


**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible