### PR TITLE
update 'logdirs' failure message for clarity

### DIFF
--- a/roles/kafka_broker/tasks/main.yml
+++ b/roles/kafka_broker/tasks/main.yml
@@ -15,7 +15,7 @@
     - ansible_fqdn
     - ansible_distribution
 
-# datadir is not supported way to provide data directories for kafka brokers
+# datadir is no longer supported method to provide data directories for kafka brokers
 - name: Assert that datadir is not present in the inventory
   assert:
     that: >
@@ -23,7 +23,7 @@
       hostvars[item].kafka_broker == None or
       'datadir' not in hostvars[item].kafka_broker
     fail_msg: |
-      "Providing 'datadir' in inventory file is no more supported way to configure data directories for kafka brokers."
+      "The 'datadir' configuration property is now obsolete for configuration of kafka broker data directories."
       "Please use 'log.dirs' under kafka_broker_custom_properties with comma separated directories."
   loop: "{{ groups['kafka_broker'] }}"
 


### PR DESCRIPTION
# Description

While updating my own cp-ansible hosts file to upgrade from 6 to 7, I came across this message in during execution:

```
Providing 'datadir' in inventory file is no more supported way to configure data directories for kafka brokers.
```

I am suggesting improving the language to be more clear:

```
The 'datadir' configuration property is now obsolete for configuration of kafka broker data directories.
```
Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# How Has This Been Tested?

N/A - this is a simple update to a string


**Test Configuration**: N/A


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible