### PR TITLE
Support custom kerberos client config file and custom path

### DIFF
--- a/hosts_example.yml
+++ b/hosts_example.yml
@@ -32,7 +32,8 @@ all:
     #### Kerberos Configuration ####
     ## Applicable when sasl_protocol is kerberos
     ## REQUIRED: Under each host set keytab file path and principal name, see below
-    # kerberos_configure: <Boolean for ansible to install kerberos packages and configure this file: /etc/krb5.conf, defaults to true>
+    # kerberos_configure: <Boolean for ansible to install kerberos packages and configure client config file: kerberos_client_config_file_dest, defaults to true>
+    # kerberos_client_config_file_dest: /krb/krb5.conf <use only if you want to change the location of client config file, default - /etc/krb5.conf>
     # kerberos:
     #   realm: <KDC server realm eg. confluent.example.com>
     #   kdc_hostname: <hostname of machine with KDC running eg. ip-172-31-45-82.us-east-2.compute.internal>

--- a/molecule/kerberos-rhel/molecule.yml
+++ b/molecule/kerberos-rhel/molecule.yml
@@ -1,6 +1,6 @@
 ---
 ### Installation of Confluent Platform on CentOS7.
-### Kerberos enabled.
+### Kerberos enabled with custom client config path
 
 driver:
   name: docker
@@ -141,6 +141,8 @@ provisioner:
           realm: realm.example.com
           kdc_hostname: kerberos1
           admin_hostname: kerberos1
+
+        kerberos_client_config_file_dest: /krb/krb5.conf
 
       zookeeper:
         zookeeper_kerberos_principal: "zk/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"

--- a/molecule/rbac-kerberos-debian/molecule.yml
+++ b/molecule/rbac-kerberos-debian/molecule.yml
@@ -2,6 +2,7 @@
 ### Installation of Confluent Platform on Debian9.
 ### RBAC enabled.
 ### Kerberos enabled.
+### Provided kerberos client config (kerberos_configure:false) file with custom location
 ### Kafka broker custom listener.
 ### RBAC additional system admin user.
 
@@ -185,10 +186,8 @@ provisioner:
         control_center_ldap_password: password
 
         kerberos_kafka_broker_primary: kafka
-        kerberos:
-          realm: realm.example.com
-          kdc_hostname: kerberos1
-          admin_hostname: kerberos1
+        kerberos_configure: false
+        kerberos_client_config_file_dest: /krb/krb5.conf
 
         kafka_broker_custom_properties:
           ldap.java.naming.factory.initial: com.sun.jndi.ldap.LdapCtxFactory
@@ -206,16 +205,16 @@ provisioner:
           ldap.user.object.class: account
 
       zookeeper:
-        zookeeper_kerberos_principal: "zookeeper/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
+        zookeeper_kerberos_principal: "zookeeper/{{inventory_hostname}}.confluent@REALM.EXAMPLE.COM"
         zookeeper_kerberos_keytab_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs/zookeeper-{{inventory_hostname}}.keytab"
 
       kafka_broker:
-        kafka_broker_kerberos_principal: "{{kerberos_kafka_broker_primary}}/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
+        kafka_broker_kerberos_principal: "{{kerberos_kafka_broker_primary}}/{{inventory_hostname}}.confluent@REALM.EXAMPLE.COM"
         kafka_broker_kerberos_keytab_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs/kafka_broker-{{inventory_hostname}}.keytab"
 
       ksql:
         ksql_log_streaming_enabled: true
-        ksql_kerberos_principal: "ksql/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
+        ksql_kerberos_principal: "ksql/{{inventory_hostname}}.confluent@REALM.EXAMPLE.COM"
         ksql_kerberos_keytab_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs/ksql-{{inventory_hostname}}.keytab"
 
       kerberos_server:
@@ -224,15 +223,15 @@ provisioner:
         keytab_output_directory: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs"
 
         kerberos_principals:
-          - principal: "zookeeper/zookeeper1.confluent@{{kerberos.realm | upper}}"
+          - principal: "zookeeper/zookeeper1.confluent@REALM.EXAMPLE.COM"
             keytab_path: "keytabs/zookeeper-zookeeper1.keytab"
-          - principal: "{{kerberos_kafka_broker_primary}}/kafka-broker1.confluent@{{kerberos.realm | upper}}"
+          - principal: "{{kerberos_kafka_broker_primary}}/kafka-broker1.confluent@REALM.EXAMPLE.COM"
             keytab_path: "keytabs/kafka_broker-kafka-broker1.keytab"
-          - principal: "{{kerberos_kafka_broker_primary}}/kafka-broker2.confluent@{{kerberos.realm | upper}}"
+          - principal: "{{kerberos_kafka_broker_primary}}/kafka-broker2.confluent@REALM.EXAMPLE.COM"
             keytab_path: "keytabs/kafka_broker-kafka-broker2.keytab"
-          - principal: "{{kerberos_kafka_broker_primary}}/kafka-broker3.confluent@{{kerberos.realm | upper}}"
+          - principal: "{{kerberos_kafka_broker_primary}}/kafka-broker3.confluent@REALM.EXAMPLE.COM"
             keytab_path: "keytabs/kafka_broker-kafka-broker3.keytab"
-          - principal: "ksql/ksql1.confluent@{{kerberos.realm | upper}}"
+          - principal: "ksql/ksql1.confluent@REALM.EXAMPLE.COM"
             keytab_path: "keytabs/ksql-ksql1.keytab"
 
       ldap_server:

--- a/molecule/rbac-kerberos-debian/prepare.yml
+++ b/molecule/rbac-kerberos-debian/prepare.yml
@@ -4,3 +4,26 @@
 
 - name: Provision Kerberos Server
   import_playbook: ../kerberos.yml
+
+- name: Copy kerberos client configuration file
+  hosts: zookeeper:kafka_broker:schema_registry:kafka_rest:kafka_connect:ksql:control_center:kafka_connect_replicator
+  tasks:
+    - name: Create a directory if it does not exist
+      ansible.builtin.file:
+        path: "{{ kerberos_client_config_file_dest | dirname }}"
+        state: directory
+        mode: '0755'
+
+    - name: Include vars from test role kerberos
+      ansible.builtin.include_vars:
+        file: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/../../test_roles/confluent.test.kerberos/defaults/main.yml"
+
+    - name: Include vars from role kerberos
+      ansible.builtin.include_vars:
+        file: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/../../roles/kerberos/defaults/main.yml"
+
+    - name: Copy kerberos client config file
+      template:
+        src: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/../../roles/kerberos/templates/krb5.conf.j2"
+        dest: "{{ kerberos_client_config_file_dest }}"
+        mode: 0755

--- a/molecule_doc.py
+++ b/molecule_doc.py
@@ -74,6 +74,7 @@ for item in directory_contents:
     if os.path.isdir(full_path):
         scenario_name.append(item)
 
+scenario_name.sort()
 # Call function to write content to docs file
 parse_molecule_scenario(scenario_name, docs_file)
 

--- a/molecule_scenarios.md
+++ b/molecule_scenarios.md
@@ -1,338 +1,30 @@
-### molecule/plain-customcerts-rhel
+### molecule/archive-community-plaintext-rhel
 
-#### Scenario plain-customcerts-rhel test's the following:
+#### Scenario archive-community-plaintext-rhel test's the following:
 
-Installation of Confluent Platform on CentOS7.
+Archive Installation of Confluent Community Edition on CentOS7
 
-TLS enabled.
+JAVA 11.
 
-SASL Plain enabled.
+Custom Package Repository for Confluent Platform.
 
-#### Scenario plain-customcerts-rhel verify test's the following:
+Custom Package Repository for Confluent CLI.
 
-Validates that keystores are present on all components.
+Control Center is not included in the Confluent Community Edition.
 
-Validates that SASL mechanism is set to PLAIN on all components.
+#### Scenario archive-community-plaintext-rhel verify test's the following:
 
-***
-
-### molecule/confluent-kafka-kerberos-customcerts-rhel
-
-#### Scenario confluent-kafka-kerberos-customcerts-rhel test's the following:
-
-Installation of Confluent Community Edition on CentOS7.
-
-Kerberos protocol.
-
-TLS Enabled.
-
-Custom TLS certificates.
-
-#### Scenario confluent-kafka-kerberos-customcerts-rhel verify test's the following:
-
-Validates GSSAPI Protocol for Kerberos is set.
-
-Validates that SASL_SSL is Protocol is set.
-
-Validates that Confluent Community Packages are used.
+Validates that Confluent CLI is installed.
 
 ***
 
-### molecule/scram-rhel
+### molecule/archive-plain-debian
 
-#### Scenario scram-rhel test's the following:
+#### Scenario archive-plain-debian test's the following:
 
-Installs Confluent Platform Cluster on CentOS7.
+Archive installation of Confluent Platform on Debian 9.
 
-SCRAM enabled.
-
-#### Scenario scram-rhel verify test's the following:
-
-Validates that SCRAM is enabled on all components.
-
-***
-
-### molecule/kerberos-customcerts-rhel
-
-#### Scenario kerberos-customcerts-rhel test's the following:
-
-Installation of Confluent Platform on CentOS7.
-
-TLS Enabled with custom certs.
-
-Kerberos enabled.
-
-#### Scenario kerberos-customcerts-rhel verify test's the following:
-
-Validates that Kerberos is enabled across all components.
-
-Validates that SASL SSL Protocol is enabled across all components.
-
-***
-
-### molecule/rbac-plain-provided-debian
-
-#### Scenario rbac-plain-provided-debian test's the following:
-
-Installs Confluent Platform Cluster on Debian9.
-
-RBAC enabled.
-
-SASL PLAIN enabled.
-
-TLS with custom certs enabled.
-
-Kafka Broker Customer Listener.
-
-Secrets protection enabled.
-
-Control Center disabled, metrics reporters enabled.
-
-#### Scenario rbac-plain-provided-debian verify test's the following:
-
-Validates Metrics reporter without C3.
-
-Validates that secrets protection is enabled on correct properties.
-
-Validates truststore is present across components.
-
-***
-
-### molecule/rbac-mds-mtls-custom-rhel
-
-#### Scenario rbac-mds-mtls-custom-rhel test's the following:
-
-Installs two Confluent Platform Clusters on CentOS7.
-
-RBAC enabled.
-
-Remote MDS from Cluster2 to Cluster1 (MDS).
-
-Custom TLS certificates.
-
-MTLS enabled on both clusters.
-
-Kafka Broker Customer Listener.
-
-RBAC Additional System Admin.
-
-#### Scenario rbac-mds-mtls-custom-rhel verify test's the following:
-
-Validates that Audit logs are working on topic creation.
-
-Validates that keystores are in place.
-
-Validates that MDS is HTTP on Cluster1 (MDS).
-
-Validates that all components on Cluster2 are pointing to the MDS on Cluster1.
-
-***
-
-### molecule/zookeeper-digest-rhel
-
-#### Scenario zookeeper-digest-rhel test's the following:
-
-Installs Zookeeper, Kafka Broker, Schema Registry on CentOS7
-
-Digest authentication enabled.
-
-SASL SCRAM enabled.
-
-Customer Zookeeper Root.
-
-#### Scenario zookeeper-digest-rhel verify test's the following:
-
-Validates authorization mechanism as SASL.
-
-Validates that SCRAM is enabled on the Kafka Broker and Schema Registry.
-
-***
-
-### molecule/mtls-java8-ubuntu
-
-#### Scenario mtls-java8-ubuntu test's the following:
-
-Installation of Confluent Platform on Ubuntu1804.
-
-MTLS enabled.
-
-Java 8.
-
-#### Scenario mtls-java8-ubuntu verify test's the following:
-
-Validates that Java 8 is in use.
-
-***
-
-### molecule/rbac-mds-mtls-custom-kerberos-rhel
-
-#### Scenario rbac-mds-mtls-custom-kerberos-rhel test's the following:
-
-Installs two Confluent Platform Clusters on CentOS7.
-
-RBAC enabled.
-
-Remote MDS from Cluster2 to Cluster1 (MDS).
-
-Custom TLS certificates.
-
-Kafka Broker Customer Listener.
-
-RBAC Additional System Admin.
-
-Kerberos enabled on Cluster2.
-
-MTLS enabled on Cluster2.
-
-#### Scenario rbac-mds-mtls-custom-kerberos-rhel verify test's the following:
-
-Validates that TLS is setup correctly.
-
-Validates that regular user cannot access topics, while super user can.
-
-Validates that MDS is HTTP on Cluster1 (MDS).
-
-Validates that all components on Cluster2 are pointing to the MDS on Cluster1.
-
-***
-
-### molecule/plaintext-basic-rhel
-
-#### Scenario plaintext-basic-rhel test's the following:
-
-Installation of Confluent Platform on CentOS7.
-
-Kafka Rest API Basic Auth.
-
-#### Scenario plaintext-basic-rhel verify test's the following:
-
-Validates that each component has a unique auth user.
-
-Validates that Rest Proxy has correct auth property.
-
-***
-
-### molecule/rbac-mds-kerberos-mtls-custom-rhel
-
-#### Scenario rbac-mds-kerberos-mtls-custom-rhel test's the following:
-
-Installs two Confluent Platform Clusters on CentOS7.
-
-RBAC enabled.
-
-Remote MDS from Cluster2 to Cluster1 (MDS).
-
-Custom TLS certificates.
-
-Kafka Broker Customer Listener.
-
-RBAC Additional System Admin.
-
-Kerberos enabled on Cluster1.
-
-MTLS enabled on Cluster2.
-
-Audit logs enabled on Cluster2, to ship to Cluster1 (MDS).
-
-#### Scenario rbac-mds-kerberos-mtls-custom-rhel verify test's the following:
-
-Validates that Audit logs are working on topic creation.
-
-Validates that keystores are in place.
-
-Validates that regular user cannot access topics, while super user can.
-
-Validates that MDS is HTTP on Cluster1 (MDS).
-
-Validates that all components on Cluster2 are pointing to the MDS on Cluster1.
-
-***
-
-### molecule/plain-erp-tls-rhel
-
-#### Scenario plain-erp-tls-rhel test's the following:
-
-Installation of Confluent Platform on CentOS7.
-
-SASL Plain enabled.
-
-TLS enabled on ERP only.
-
-#### Scenario plain-erp-tls-rhel verify test's the following:
-
-Validates that SASL protocol is PLAIN on all components.
-
-Validates that ERP is accessible over HTTPS.
-
-Validates that Control Center is avaiable over HTTP.
-
-Validates that Control Center has truststore in place.
-
-***
-
-### molecule/mtls-ubuntu
-
-#### Scenario mtls-ubuntu test's the following:
-
-Installation of Confluent Platform on CentOS7.
-
-MTLS enabled.
-
-#### Scenario mtls-ubuntu verify test's the following:
-
-Validates that protocol is set to SSl across all components.
-
-***
-
-### molecule/zookeeper-kerberos-rhel
-
-#### Scenario zookeeper-kerberos-rhel test's the following:
-
-Installs Confluent Platform on CentOS7
-
-Enables Kerberos on Zookeeper.
-
-SASL SCRAM enabled on all components except Zookeeper.
-
-#### Scenario zookeeper-kerberos-rhel verify test's the following:
-
-Validates Zookeeper sasl mechanism.
-
-Validates Kafka Broker and Schema Registry is set to SCRAM.
-
-***
-
-### molecule/custom-user-plaintext-rhel
-
-#### Scenario custom-user-plaintext-rhel test's the following:
-
-Installation of Confluent Platform on CentOS7.
-
-Custom user set on each component.
-
-Custom log appender path on each component.
-
-#### Scenario custom-user-plaintext-rhel verify test's the following:
-
-Creates custom user for Zookeeper.
-
-Creates custom log directory for zookeeper.
-
-Restarts Zookeeper and runs health check to validate changes.
-
-Validates that each component is running with the correct custom user.
-
-Validates that each component is running with the correct custom logging path.
-
-***
-
-### molecule/archive-plain-ubuntu
-
-#### Scenario archive-plain-ubuntu test's the following:
-
-Archive Installation of Confluent Platform on Ubuntu1804.
-
-SASL Plain protocol.
+SASL Protocol Plain.
 
 SSL Enabled.
 
@@ -340,57 +32,33 @@ Kafka Connect Confluent Hub Plugins logic (Installs jcustenborder/kafka-connect-
 
 Custom log dirs for all components.
 
-#### Scenario archive-plain-ubuntu verify test's the following:
+#### Scenario archive-plain-debian verify test's the following:
 
-Validates that protocol is set to sasl plain.
+Validates that SASL SSL protocol is set across all components
 
-Validates that protocol is set to SASL SSL.
-
-Validates log4j config.
+Validates that custom log4j configuration is in place.
 
 ***
 
-### molecule/rbac-mds-scram-custom-rhel
+### molecule/archive-plain-debian10
 
-#### Scenario rbac-mds-scram-custom-rhel test's the following:
+#### Scenario archive-plain-debian10 test's the following:
 
-Installs two Confluent Platform Clusters on CentOS7.
+Archive installation of Confluent Platform on Debian 9.
 
-RBAC enabled.
+SASL Protocol Plain.
 
-Remote MDS from Cluster2 to Cluster1 (MDS).
+SSL Enabled.
 
-Custom TLS certificates.
+Kafka Connect Confluent Hub Plugins logic (Installs jcustenborder/kafka-connect-spooldir:2.0.43).
 
-SASL SCRAM enabled on both clusters.
+Custom log dirs for all components.
 
-Kafka Broker Customer Listener.
+#### Scenario archive-plain-debian10 verify test's the following:
 
-RBAC Additional System Admin.
+Validates that SASL SSL protocol is set across all components.
 
-#### Scenario rbac-mds-scram-custom-rhel verify test's the following:
-
-Validates that protocol is sasl scram.
-
-Validates that MDS is HTTPs on Cluster1 (MDS).
-
-Validates that all components on Cluster2 are pointing to the MDS on Cluster1.
-
-***
-
-### molecule/mtls-customcerts-rhel
-
-#### Scenario mtls-customcerts-rhel test's the following:
-
-Installation of Confluent Platform on CentOS7.
-
-MTLS enabled with custom certificates.
-
-#### Scenario mtls-customcerts-rhel verify test's the following:
-
-Verifies that keystore is present on all components.
-
-Validates the ERP returns values over MTLS.
+Validates that custom log4j configuration is in place.
 
 ***
 
@@ -422,89 +90,13 @@ Validates that FIPS security is enabled on the Brokers.
 
 ***
 
-### molecule/rbac-mds-kerberos-debian
+### molecule/archive-plain-ubuntu
 
-#### Scenario rbac-mds-kerberos-debian test's the following:
+#### Scenario archive-plain-ubuntu test's the following:
 
-Installs two Confluent Platform Clusters on Debian9.
+Archive Installation of Confluent Platform on Ubuntu1804.
 
-RBAC enabled.
-
-Remote MDS from Cluster2 to Cluster1 (MDS).
-
-Custom TLS certificates.
-
-Kafka Broker Customer Listener
-
-RBAC Additional System Admin.
-
-#### Scenario rbac-mds-kerberos-debian verify test's the following:
-
-Validates that GSSAPI protocol is set on Cluster2.
-
-Validates that MDS is HTTP on Cluster1 (MDS).
-
-Validates that all components on Cluster2 are pointing to the MDS on Cluster1.
-
-***
-
-### molecule/rbac-kafka-connect-replicator-kerberos-mtls-custom-ubuntu2004
-
-#### Scenario rbac-kafka-connect-replicator-kerberos-mtls-custom-ubuntu2004 test's the following:
-
-Installation of Confluent Platform on Ubuntu2004.
-
-RBAC Enabled.
-
-Customer RBAC system admins.
-
-Kerberos enabled on Cluster1(mds).
-
-MTLS Customer certs enabled on cluster2.
-
-Replicator Configured with Kerberos and MTLS.
-
-#### Scenario rbac-kafka-connect-replicator-kerberos-mtls-custom-ubuntu2004 verify test's the following:
-
-Validates that the Console Consumer can consume data from cluster2, proving that data has been replicated from cluster1 (MDS).
-
-Validates that Replicator is using MTLS with RBAC to Produce data to Cluster2.
-
-Validates that Replicator is using Kerberos with RBAC to Consume from Cluster1 (MDS).
-
-Validates that client ID's are set correctly on Replicator.
-
-Validates that Replicator logging path is valid.
-
-Validates client packages.
-
-***
-
-### molecule/rbac-mtls-rhel8
-
-#### Scenario rbac-mtls-rhel8 test's the following:
-
-Installs Confluent Platform Cluster on CentOS8.
-
-RBAC enabled.
-
-MTLS enabled.
-
-Kafka Broker Customer Listener.
-
-#### Scenario rbac-mtls-rhel8 verify test's the following:
-
-Validates TLS keysizes across all components.
-
-***
-
-### molecule/archive-plain-debian10
-
-#### Scenario archive-plain-debian10 test's the following:
-
-Archive installation of Confluent Platform on Debian 9.
-
-SASL Protocol Plain.
+SASL Plain protocol.
 
 SSL Enabled.
 
@@ -512,11 +104,393 @@ Kafka Connect Confluent Hub Plugins logic (Installs jcustenborder/kafka-connect-
 
 Custom log dirs for all components.
 
-#### Scenario archive-plain-debian10 verify test's the following:
+#### Scenario archive-plain-ubuntu verify test's the following:
 
-Validates that SASL SSL protocol is set across all components.
+Validates that protocol is set to sasl plain.
 
-Validates that custom log4j configuration is in place.
+Validates that protocol is set to SASL SSL.
+
+Validates log4j config.
+
+***
+
+### molecule/archive-plain-ubuntu2004
+
+#### Scenario archive-plain-ubuntu2004 test's the following:
+
+Archive Installation of Confluent Platform on Ubuntu2004.
+
+SASL Plain protocol.
+
+SSL Enabled.
+
+Kafka Connect Confluent Hub Plugins logic (Installs jcustenborder/kafka-connect-spooldir:2.0.43).
+
+Custom log dirs for all components.
+
+#### Scenario archive-plain-ubuntu2004 verify test's the following:
+
+Validates that protocol is set to sasl plain.
+
+Validates that protocol is set to SASL SSL.
+
+Validates log4j config.
+
+***
+
+### molecule/archive-scram-rhel
+
+#### Scenario archive-scram-rhel test's the following:
+
+Archive Installation of Confluent Platform on CentOS7.
+
+SASL SCRAM protocol.
+
+TLS Enabled.
+
+Secrets Protection.
+
+Custom Archive owner.
+
+#### Scenario archive-scram-rhel verify test's the following:
+
+Validates that customer user and group on archive are set.
+
+Validates that SASL SCRAM is Protocol is set.
+
+Validates that TLS is configured properly.
+
+***
+
+### molecule/ccloud
+
+#### Scenario ccloud test's the following:
+
+Simulates linking an on prem cluster to Confluent Cloud on CentOS7.
+
+TLS Enabled.
+
+SASL Plain Enabled.
+
+Schema Registry uses Basic Auth.
+
+#### Scenario ccloud verify test's the following:
+
+Validates that Schema Registry SASL Plain configs are correct.
+
+Validates that Replication Factor is 3.
+
+Validates that all components connect to Confluent Cloud.
+
+***
+
+### molecule/confluent-kafka-kerberos-customcerts-rhel
+
+#### Scenario confluent-kafka-kerberos-customcerts-rhel test's the following:
+
+Installation of Confluent Community Edition on CentOS7.
+
+Kerberos protocol.
+
+TLS Enabled.
+
+Custom TLS certificates.
+
+#### Scenario confluent-kafka-kerberos-customcerts-rhel verify test's the following:
+
+Validates GSSAPI Protocol for Kerberos is set.
+
+Validates that SASL_SSL is Protocol is set.
+
+Validates that Confluent Community Packages are used.
+
+***
+
+### molecule/cp-kafka-plain-rhel
+
+#### Scenario cp-kafka-plain-rhel test's the following:
+
+Installation of Confluent Community Edition on CentOS7.
+
+SASL Plain Auth.
+
+#### Scenario cp-kafka-plain-rhel verify test's the following:
+
+Validates that SASL Plaintext protocol is set.
+
+***
+
+### molecule/custom-user-plaintext-rhel
+
+#### Scenario custom-user-plaintext-rhel test's the following:
+
+Installation of Confluent Platform on CentOS7.
+
+Custom user set on each component.
+
+Custom log appender path on each component.
+
+#### Scenario custom-user-plaintext-rhel verify test's the following:
+
+Creates custom user for Zookeeper.
+
+Creates custom log directory for zookeeper.
+
+Restarts Zookeeper and runs health check to validate changes.
+
+Validates that each component is running with the correct custom user.
+
+Validates that each component is running with the correct custom logging path.
+
+***
+
+### molecule/kafka-connect-replicator-mtls-scram-rhel
+
+#### Scenario kafka-connect-replicator-mtls-scram-rhel test's the following:
+
+Installation of Confluent Platform on CentOS7 with two distinct clusters.
+
+Installation of Confluent Replicator.
+
+Cluster1 (MDS) is running MTLS with Custom Certs.
+
+Cluster2 is running SCRAM with TLS enabled.
+
+Replicator consumes from Cluster1 (MDS) using MTLS with Custom Certs for TLS.
+
+Replicator Produces to Cluster2 using SCRAM with Custom Certs for TLS.
+
+Tests default values for replicator configuration works.
+
+#### Scenario kafka-connect-replicator-mtls-scram-rhel verify test's the following:
+
+Validates that the Console Consumer can consume data from cluster2, proving that data has been replicated from cluster1 (MDS).
+
+Validates that Replicator is using SCRAM and TLS to Produce to cluster2.
+
+Validates that Replicator is using MTLS to Consume from Cluster1 (MDS).
+
+Validates that client ID's are set correctly on Replicator.
+
+***
+
+### molecule/kafka-connect-replicator-plain-kerberos-rhel
+
+#### Scenario kafka-connect-replicator-plain-kerberos-rhel test's the following:
+
+Installation of Confluent Platform on CentOS7 with two distinct clusters.
+
+Installation of Confluent Replicator.
+
+Cluster1 (MDS) is running SASL Plain with Custom Certs.
+
+Cluster2 is running Kerberos with TLS enabled.
+
+Replicator consumes from Cluster1 (MDS) using SASL Plain with Custom Certs for TLS.
+
+Replicator Produces to Cluster2 using Kerberos with Custom Certs for TLS.
+
+Tests custom client IDs for Replicator.
+
+#### Scenario kafka-connect-replicator-plain-kerberos-rhel verify test's the following:
+
+Validates that the Console Consumer can consume data from cluster2, proving that data has been replicated from cluster1 (MDS).
+
+Validates that Replicator is using Kerberos and TLS to Produce data to Cluster2.
+
+Validates that Replicator is using SASL PLAIN with TLS to Consume from Cluster1 (MDS).
+
+Validates that client ID's are set correctly on Replicator.
+
+***
+
+### molecule/kerberos-customcerts-rhel
+
+#### Scenario kerberos-customcerts-rhel test's the following:
+
+Installation of Confluent Platform on CentOS7.
+
+TLS Enabled with custom certs.
+
+Kerberos enabled.
+
+#### Scenario kerberos-customcerts-rhel verify test's the following:
+
+Validates that Kerberos is enabled across all components.
+
+Validates that SASL SSL Protocol is enabled across all components.
+
+***
+
+### molecule/kerberos-rhel
+
+#### Scenario kerberos-rhel test's the following:
+
+Installation of Confluent Platform on CentOS7.
+
+Kerberos enabled with custom client config path
+
+#### Scenario kerberos-rhel verify test's the following:
+
+Validates that Kerberos is enabled across all components.
+
+Validates that SASL SSL Plaintext is enabled across all components.
+
+***
+
+### molecule/mtls-custombundle-rhel
+
+#### Scenario mtls-custombundle-rhel test's the following:
+
+Installation of Confluent Platform Edition on CentOS7.
+
+MTLS Enabled with custom certificates.
+
+Secrets Protection Enabled.
+
+Tests custom filtering properties for Secrets Protection.
+
+TLS is disabled for Zookeeper.
+
+#### Scenario mtls-custombundle-rhel verify test's the following:
+
+Validates that Keystore is present.
+
+Validates that secrets protection has masked correct properties.
+
+Validates that back slashes are not lost with secrets protection.
+
+***
+
+### molecule/mtls-customcerts-rhel
+
+#### Scenario mtls-customcerts-rhel test's the following:
+
+Installation of Confluent Platform on CentOS7.
+
+MTLS enabled with custom certificates.
+
+#### Scenario mtls-customcerts-rhel verify test's the following:
+
+Verifies that keystore is present on all components.
+
+Validates the ERP returns values over MTLS.
+
+***
+
+### molecule/mtls-debian
+
+#### Scenario mtls-debian test's the following:
+
+Installation of Confluent Platform on Debian9.
+
+MTLS Enabled.
+
+ERP Disabled.
+
+Kafka Connect Confluent Hub Plugins logic (Installs jcustenborder/kafka-connect-spooldir:2.0.43).
+
+Default replication factor set to 4.
+
+Jolokia Enabled.
+
+Confluent CLI Download enabled.
+
+Schema Validation is enabled.
+
+#### Scenario mtls-debian verify test's the following:
+
+Validates that SSL Protocol is set.
+
+Validates that replication factor is 4.
+
+Validates that Jolokia end point is reachable.
+
+Validates that Schema Validation is working.
+
+Validates that CLI is present.
+
+***
+
+### molecule/mtls-java8-debian
+
+#### Scenario mtls-java8-debian test's the following:
+
+Installation of Confluent Platform on Debian9.
+
+MTLS enabled.
+
+Java 8.
+
+#### Scenario mtls-java8-debian verify test's the following:
+
+Validates that Java 8 is in use.
+
+***
+
+### molecule/mtls-java8-rhel
+
+#### Scenario mtls-java8-rhel test's the following:
+
+Installation of Confluent Platform on CentOS7.
+
+MTLS enabled.
+
+Java 8.
+
+#### Scenario mtls-java8-rhel verify test's the following:
+
+Validates that Java 8 is in use.
+
+***
+
+### molecule/mtls-java8-ubuntu
+
+#### Scenario mtls-java8-ubuntu test's the following:
+
+Installation of Confluent Platform on Ubuntu1804.
+
+MTLS enabled.
+
+Java 8.
+
+#### Scenario mtls-java8-ubuntu verify test's the following:
+
+Validates that Java 8 is in use.
+
+***
+
+### molecule/mtls-ubuntu
+
+#### Scenario mtls-ubuntu test's the following:
+
+Installation of Confluent Platform on CentOS7.
+
+MTLS enabled.
+
+#### Scenario mtls-ubuntu verify test's the following:
+
+Validates that protocol is set to SSl across all components.
+
+***
+
+### molecule/mtls-ubuntu-acl
+
+#### Scenario mtls-ubuntu-acl test's the following:
+
+Installation of Confluent Platform on Ubuntu1804.
+
+MTLS enabled.
+
+ACL authorization.
+
+#### Scenario mtls-ubuntu-acl verify test's the following:
+
+Validates that MTLS is enabled.
+
+Validates mapping rules for ACLs.
+
+Validates ACL users.
 
 ***
 
@@ -545,6 +519,130 @@ Validates that two KSQL clusters are running.
 Validates that Control Center can connect to each Kafka Connect Cluster.
 
 Validates that Control Center Can connect to each KSQL cluster.
+
+***
+
+### molecule/plain-customcerts-rhel
+
+#### Scenario plain-customcerts-rhel test's the following:
+
+Installation of Confluent Platform on CentOS7.
+
+TLS enabled.
+
+SASL Plain enabled.
+
+#### Scenario plain-customcerts-rhel verify test's the following:
+
+Validates that keystores are present on all components.
+
+Validates that SASL mechanism is set to PLAIN on all components.
+
+***
+
+### molecule/plain-erp-tls-rhel
+
+#### Scenario plain-erp-tls-rhel test's the following:
+
+Installation of Confluent Platform on CentOS7.
+
+SASL Plain enabled.
+
+TLS enabled on ERP only.
+
+#### Scenario plain-erp-tls-rhel verify test's the following:
+
+Validates that SASL protocol is PLAIN on all components.
+
+Validates that ERP is accessible over HTTPS.
+
+Validates that Control Center is avaiable over HTTP.
+
+Validates that Control Center has truststore in place.
+
+***
+
+### molecule/plain-rhel
+
+#### Scenario plain-rhel test's the following:
+
+Installation of Confluent Platform on CentOS7.
+
+SASL Plain enabled.
+
+Control Plane listener enabled.
+
+Kafka Connect Confluent Hub Plugins logic (Installs jcustenborder/kafka-connect-spooldir:2.0.43).
+
+Custom Service Unit overrides.
+
+Custom log4j appender names.
+
+#### Scenario plain-rhel verify test's the following:
+
+Validates that custom log4j appenders are present on each component.
+
+Validates that Service Description has been overridden.
+
+Validates that SASL Plaintext protocol is set across components.
+
+Validates that Connectors are present on Kafka Connect.
+
+***
+
+### molecule/plaintext-basic-rhel
+
+#### Scenario plaintext-basic-rhel test's the following:
+
+Installation of Confluent Platform on CentOS7.
+
+Kafka Rest API Basic Auth.
+
+#### Scenario plaintext-basic-rhel verify test's the following:
+
+Validates that each component has a unique auth user.
+
+Validates that Rest Proxy has correct auth property.
+
+***
+
+### molecule/plaintext-rhel
+
+#### Scenario plaintext-rhel test's the following:
+
+Installation of Confluent Platform on CentOS7.
+
+Copying local JMX agent.
+
+Copying local files.
+
+#### Scenario plaintext-rhel verify test's the following:
+
+Validates Package version installed.
+
+Validates log4j configuration.
+
+Validates all components are running with plaintext.
+
+Validates that copied files are present.
+
+Validates that JMX exporter was copied and is running.
+
+***
+
+### molecule/provided-rhel
+
+#### Scenario provided-rhel test's the following:
+
+Installation of Confluent Platform on CentOS7.
+
+TLS enabled.
+
+Customer keystore alias.
+
+#### Scenario provided-rhel verify test's the following:
+
+Validates that keystores are in place across all components.
 
 ***
 
@@ -577,114 +675,6 @@ Validates that client ID's are set correctly on Replicator.
 Validates that Replicator logging path is valid.
 
 Validates client packages.
-
-***
-
-### molecule/rbac-mtls-rhel
-
-#### Scenario rbac-mtls-rhel test's the following:
-
-Installs Confluent Platform Cluster on CentOS7.
-
-RBAC enabled.
-
-MTLS enabled.
-
-Secrets protection disabled
-
-Kafka Broker Customer Listener.
-
-RBAC Additional System Admin.
-
-#### Scenario rbac-mtls-rhel verify test's the following:
-
-Validates TLS version across all components.
-
-Validates super users are present.
-
-Validates that secrets protection is masking the correct properties.
-
-Validates Kafka Connect secrets registry.
-
-Validates Cluster Registry.
-
-***
-
-### molecule/zookeeper-mtls-rhel
-
-#### Scenario zookeeper-mtls-rhel test's the following:
-
-Installs Confluent Platform on CentOS7
-
-Enables MTLS Auth on Zookeeper.
-
-SASL SCRAM enabled on all components except Zookeeper.
-
-Customer zookeeper root.
-
-Secrets Protection enabled.
-
-#### Scenario zookeeper-mtls-rhel verify test's the following:
-
-Validates that Confluent CLI is installed.
-
-Validates that Zookeeper is using MTLS for auth.
-
-Validates that other components are using SCRAM for auth.
-
-Validates that Secrets protection is applied to the correct properties.
-
-***
-
-### molecule/ccloud
-
-#### Scenario ccloud test's the following:
-
-Simulates linking an on prem cluster to Confluent Cloud on CentOS7.
-
-TLS Enabled.
-
-SASL Plain Enabled.
-
-Schema Registry uses Basic Auth.
-
-#### Scenario ccloud verify test's the following:
-
-Validates that Schema Registry SASL Plain configs are correct.
-
-Validates that Replication Factor is 3.
-
-Validates that all components connect to Confluent Cloud.
-
-***
-
-### molecule/kafka-connect-replicator-mtls-scram-rhel
-
-#### Scenario kafka-connect-replicator-mtls-scram-rhel test's the following:
-
-Installation of Confluent Platform on CentOS7 with two distinct clusters.
-
-Installation of Confluent Replicator.
-
-Cluster1 (MDS) is running MTLS with Custom Certs.
-
-Cluster2 is running SCRAM with TLS enabled.
-
-Replicator consumes from Cluster1 (MDS) using MTLS with Custom Certs for TLS.
-
-Replicator Produces to Cluster2 using SCRAM with Custom Certs for TLS.
-
-Tests default values for replicator configuration works.
-
-#### Scenario kafka-connect-replicator-mtls-scram-rhel verify test's the following:
-
-Validates that the Console Consumer can consume data from cluster2, proving that data has been replicated from cluster1 (MDS).
-
-Validates that Replicator is using SCRAM and TLS to Produce to cluster2.
-
-Validates that Replicator is using MTLS to Consume from Cluster1 (MDS).
-
-Validates that client ID's are set correctly on Replicator.
 
 ***
 
@@ -732,185 +722,345 @@ Validates that Replicator logging path is valid.
 
 ***
 
-### molecule/kafka-connect-replicator-plain-kerberos-rhel
+### molecule/rbac-kafka-connect-replicator-kerberos-mtls-custom-ubuntu2004
 
-#### Scenario kafka-connect-replicator-plain-kerberos-rhel test's the following:
+#### Scenario rbac-kafka-connect-replicator-kerberos-mtls-custom-ubuntu2004 test's the following:
 
-Installation of Confluent Platform on CentOS7 with two distinct clusters.
+Installation of Confluent Platform on Ubuntu2004.
 
-Installation of Confluent Replicator.
+RBAC Enabled.
 
-Cluster1 (MDS) is running SASL Plain with Custom Certs.
+Customer RBAC system admins.
 
-Cluster2 is running Kerberos with TLS enabled.
+Kerberos enabled on Cluster1(mds).
 
-Replicator consumes from Cluster1 (MDS) using SASL Plain with Custom Certs for TLS.
+MTLS Customer certs enabled on cluster2.
 
-Replicator Produces to Cluster2 using Kerberos with Custom Certs for TLS.
+Replicator Configured with Kerberos and MTLS.
 
-Tests custom client IDs for Replicator.
-
-#### Scenario kafka-connect-replicator-plain-kerberos-rhel verify test's the following:
+#### Scenario rbac-kafka-connect-replicator-kerberos-mtls-custom-ubuntu2004 verify test's the following:
 
 Validates that the Console Consumer can consume data from cluster2, proving that data has been replicated from cluster1 (MDS).
 
-Validates that Replicator is using Kerberos and TLS to Produce data to Cluster2.
+Validates that Replicator is using MTLS with RBAC to Produce data to Cluster2.
 
-Validates that Replicator is using SASL PLAIN with TLS to Consume from Cluster1 (MDS).
+Validates that Replicator is using Kerberos with RBAC to Consume from Cluster1 (MDS).
 
 Validates that client ID's are set correctly on Replicator.
 
-***
+Validates that Replicator logging path is valid.
 
-### molecule/plaintext-rhel
-
-#### Scenario plaintext-rhel test's the following:
-
-Installation of Confluent Platform on CentOS7.
-
-Copying local JMX agent.
-
-Copying local files.
-
-#### Scenario plaintext-rhel verify test's the following:
-
-Validates Package version installed.
-
-Validates log4j configuration.
-
-Validates all components are running with plaintext.
-
-Validates that copied files are present.
-
-Validates that JMX exporter was copied and is running.
+Validates client packages.
 
 ***
 
-### molecule/archive-scram-rhel
+### molecule/rbac-kerberos-debian
 
-#### Scenario archive-scram-rhel test's the following:
-
-Archive Installation of Confluent Platform on CentOS7.
-
-SASL SCRAM protocol.
-
-TLS Enabled.
-
-Secrets Protection.
-
-Custom Archive owner.
-
-#### Scenario archive-scram-rhel verify test's the following:
-
-Validates that customer user and group on archive are set.
-
-Validates that SASL SCRAM is Protocol is set.
-
-Validates that TLS is configured properly.
-
-***
-
-### molecule/archive-plain-ubuntu2004
-
-#### Scenario archive-plain-ubuntu2004 test's the following:
-
-Archive Installation of Confluent Platform on Ubuntu2004.
-
-SASL Plain protocol.
-
-SSL Enabled.
-
-Kafka Connect Confluent Hub Plugins logic (Installs jcustenborder/kafka-connect-spooldir:2.0.43).
-
-Custom log dirs for all components.
-
-#### Scenario archive-plain-ubuntu2004 verify test's the following:
-
-Validates that protocol is set to sasl plain.
-
-Validates that protocol is set to SASL SSL.
-
-Validates log4j config.
-
-***
-
-### molecule/zookeeper-tls-rhel
-
-#### Scenario zookeeper-tls-rhel test's the following:
-
-Installs Confluent Platform on CentOS7
-
-Enables SASL SCRAM Auth on Zookeeper.
-
-TLS enabled.
-
-Customer zookeeper root.
-
-Secrets Protection enabled.
-
-Jolokia has TLS disabled.
-
-#### Scenario zookeeper-tls-rhel verify test's the following:
-
-Validates that Zookeeper is using TLS.
-
-Validates that other components are using SCRAM for auth.
-
-***
-
-### molecule/kerberos-rhel
-
-#### Scenario kerberos-rhel test's the following:
-
-Installation of Confluent Platform on CentOS7.
-
-Kerberos enabled.
-
-#### Scenario kerberos-rhel verify test's the following:
-
-Validates that Kerberos is enabled across all components.
-
-Validates that SASL SSL Plaintext is enabled across all components.
-
-***
-
-### molecule/mtls-custombundle-rhel
-
-#### Scenario mtls-custombundle-rhel test's the following:
-
-Installation of Confluent Platform Edition on CentOS7.
-
-MTLS Enabled with custom certificates.
-
-Secrets Protection Enabled.
-
-Tests custom filtering properties for Secrets Protection.
-
-TLS is disabled for Zookeeper.
-
-#### Scenario mtls-custombundle-rhel verify test's the following:
-
-Validates that Keystore is present.
-
-Validates that secrets protection has masked correct properties.
-
-Validates that back slashes are not lost with secrets protection.
-
-***
-
-### molecule/mtls-java8-debian
-
-#### Scenario mtls-java8-debian test's the following:
+#### Scenario rbac-kerberos-debian test's the following:
 
 Installation of Confluent Platform on Debian9.
 
+RBAC enabled.
+
+Kerberos enabled.
+
+Provided kerberos client config (kerberos_configure:false) file with custom location
+
+Kafka broker custom listener.
+
+RBAC additional system admin user.
+
+#### Scenario rbac-kerberos-debian verify test's the following:
+
+Validates that protocol set to GSSAPI.
+
+Validates that a regular user cannot access topics.
+
+Validates that a super user can access topics.
+
+Validates that all components are pointing to the MDS for authorization.
+
+***
+
+### molecule/rbac-mds-kerberos-debian
+
+#### Scenario rbac-mds-kerberos-debian test's the following:
+
+Installs two Confluent Platform Clusters on Debian9.
+
+RBAC enabled.
+
+Remote MDS from Cluster2 to Cluster1 (MDS).
+
+Custom TLS certificates.
+
+Kafka Broker Customer Listener
+
+RBAC Additional System Admin.
+
+#### Scenario rbac-mds-kerberos-debian verify test's the following:
+
+Validates that GSSAPI protocol is set on Cluster2.
+
+Validates that MDS is HTTP on Cluster1 (MDS).
+
+Validates that all components on Cluster2 are pointing to the MDS on Cluster1.
+
+***
+
+### molecule/rbac-mds-kerberos-mtls-custom-rhel
+
+#### Scenario rbac-mds-kerberos-mtls-custom-rhel test's the following:
+
+Installs two Confluent Platform Clusters on CentOS7.
+
+RBAC enabled.
+
+Remote MDS from Cluster2 to Cluster1 (MDS).
+
+Custom TLS certificates.
+
+Kafka Broker Customer Listener.
+
+RBAC Additional System Admin.
+
+Kerberos enabled on Cluster1.
+
+MTLS enabled on Cluster2.
+
+Audit logs enabled on Cluster2, to ship to Cluster1 (MDS).
+
+#### Scenario rbac-mds-kerberos-mtls-custom-rhel verify test's the following:
+
+Validates that Audit logs are working on topic creation.
+
+Validates that keystores are in place.
+
+Validates that regular user cannot access topics, while super user can.
+
+Validates that MDS is HTTP on Cluster1 (MDS).
+
+Validates that all components on Cluster2 are pointing to the MDS on Cluster1.
+
+***
+
+### molecule/rbac-mds-mtls-custom-kerberos-rhel
+
+#### Scenario rbac-mds-mtls-custom-kerberos-rhel test's the following:
+
+Installs two Confluent Platform Clusters on CentOS7.
+
+RBAC enabled.
+
+Remote MDS from Cluster2 to Cluster1 (MDS).
+
+Custom TLS certificates.
+
+Kafka Broker Customer Listener.
+
+RBAC Additional System Admin.
+
+Kerberos enabled on Cluster2.
+
+MTLS enabled on Cluster2.
+
+#### Scenario rbac-mds-mtls-custom-kerberos-rhel verify test's the following:
+
+Validates that TLS is setup correctly.
+
+Validates that regular user cannot access topics, while super user can.
+
+Validates that MDS is HTTP on Cluster1 (MDS).
+
+Validates that all components on Cluster2 are pointing to the MDS on Cluster1.
+
+***
+
+### molecule/rbac-mds-mtls-custom-rhel
+
+#### Scenario rbac-mds-mtls-custom-rhel test's the following:
+
+Installs two Confluent Platform Clusters on CentOS7.
+
+RBAC enabled.
+
+Remote MDS from Cluster2 to Cluster1 (MDS).
+
+Custom TLS certificates.
+
+MTLS enabled on both clusters.
+
+Kafka Broker Customer Listener.
+
+RBAC Additional System Admin.
+
+#### Scenario rbac-mds-mtls-custom-rhel verify test's the following:
+
+Validates that Audit logs are working on topic creation.
+
+Validates that keystores are in place.
+
+Validates that MDS is HTTP on Cluster1 (MDS).
+
+Validates that all components on Cluster2 are pointing to the MDS on Cluster1.
+
+***
+
+### molecule/rbac-mds-plain-custom-rhel
+
+#### Scenario rbac-mds-plain-custom-rhel test's the following:
+
+Installs two Confluent Platform Clusters on CentOS7.
+
+RBAC enabled.
+
+Remote MDS from Cluster2 to Cluster1 (MDS).
+
+Custom TLS certificates.
+
+SASL PLAIN enabled on both clusters.
+
+Kafka Broker Customer Listener.
+
+RBAC Additional System Admin.
+
+#### Scenario rbac-mds-plain-custom-rhel verify test's the following:
+
+Validates that protocol is sasl plain.
+
+Validates that MDS is HTTPs on Cluster1 (MDS).
+
+Validates that all components on Cluster2 are pointing to the MDS on Cluster1.
+
+***
+
+### molecule/rbac-mds-scram-custom-rhel
+
+#### Scenario rbac-mds-scram-custom-rhel test's the following:
+
+Installs two Confluent Platform Clusters on CentOS7.
+
+RBAC enabled.
+
+Remote MDS from Cluster2 to Cluster1 (MDS).
+
+Custom TLS certificates.
+
+SASL SCRAM enabled on both clusters.
+
+Kafka Broker Customer Listener.
+
+RBAC Additional System Admin.
+
+#### Scenario rbac-mds-scram-custom-rhel verify test's the following:
+
+Validates that protocol is sasl scram.
+
+Validates that MDS is HTTPs on Cluster1 (MDS).
+
+Validates that all components on Cluster2 are pointing to the MDS on Cluster1.
+
+***
+
+### molecule/rbac-mtls-provided-ubuntu
+
+#### Scenario rbac-mtls-provided-ubuntu test's the following:
+
+Installs Confluent Platform Cluster on CentOS7.
+
+RBAC enabled.
+
+Provided Custom Keystore and Truststore for TLS..
+
 MTLS enabled.
 
-Java 8.
+Kafka Broker Customer Listener.
 
-#### Scenario mtls-java8-debian verify test's the following:
+RBAC Additional System Admin.
 
-Validates that Java 8 is in use.
+#### Scenario rbac-mtls-provided-ubuntu verify test's the following:
+
+Validates that keystores are present on all components.
+
+Validates that LDAPS is working.
+
+Validates that TLS CN is being registered as super user.
+
+***
+
+### molecule/rbac-mtls-rhel
+
+#### Scenario rbac-mtls-rhel test's the following:
+
+Installs Confluent Platform Cluster on CentOS7.
+
+RBAC enabled.
+
+MTLS enabled.
+
+Secrets protection disabled
+
+Kafka Broker Customer Listener.
+
+RBAC Additional System Admin.
+
+#### Scenario rbac-mtls-rhel verify test's the following:
+
+Validates TLS version across all components.
+
+Validates super users are present.
+
+Validates that secrets protection is masking the correct properties.
+
+Validates Kafka Connect secrets registry.
+
+Validates Cluster Registry.
+
+***
+
+### molecule/rbac-mtls-rhel8
+
+#### Scenario rbac-mtls-rhel8 test's the following:
+
+Installs Confluent Platform Cluster on CentOS8.
+
+RBAC enabled.
+
+MTLS enabled.
+
+Kafka Broker Customer Listener.
+
+#### Scenario rbac-mtls-rhel8 verify test's the following:
+
+Validates TLS keysizes across all components.
+
+***
+
+### molecule/rbac-plain-provided-debian
+
+#### Scenario rbac-plain-provided-debian test's the following:
+
+Installs Confluent Platform Cluster on Debian9.
+
+RBAC enabled.
+
+SASL PLAIN enabled.
+
+TLS with custom certs enabled.
+
+Kafka Broker Customer Listener.
+
+Secrets protection enabled.
+
+Control Center disabled, metrics reporters enabled.
+
+#### Scenario rbac-plain-provided-debian verify test's the following:
+
+Validates Metrics reporter without C3.
+
+Validates that secrets protection is enabled on correct properties.
+
+Validates truststore is present across components.
 
 ***
 
@@ -946,63 +1096,81 @@ Validates truststore across all components.
 
 ***
 
-### molecule/mtls-java8-rhel
+### molecule/scram-rhel
 
-#### Scenario mtls-java8-rhel test's the following:
+#### Scenario scram-rhel test's the following:
 
-Installation of Confluent Platform on CentOS7.
+Installs Confluent Platform Cluster on CentOS7.
 
-MTLS enabled.
+SCRAM enabled.
 
-Java 8.
+#### Scenario scram-rhel verify test's the following:
 
-#### Scenario mtls-java8-rhel verify test's the following:
-
-Validates that Java 8 is in use.
+Validates that SCRAM is enabled on all components.
 
 ***
 
-### molecule/provided-rhel
+### molecule/zookeeper-digest-rhel
 
-#### Scenario provided-rhel test's the following:
+#### Scenario zookeeper-digest-rhel test's the following:
 
-Installation of Confluent Platform on CentOS7.
+Installs Zookeeper, Kafka Broker, Schema Registry on CentOS7
 
-TLS enabled.
+Digest authentication enabled.
 
-Customer keystore alias.
+SASL SCRAM enabled.
 
-#### Scenario provided-rhel verify test's the following:
+Customer Zookeeper Root.
 
-Validates that keystores are in place across all components.
+#### Scenario zookeeper-digest-rhel verify test's the following:
+
+Validates authorization mechanism as SASL.
+
+Validates that SCRAM is enabled on the Kafka Broker and Schema Registry.
 
 ***
 
-### molecule/rbac-mds-plain-custom-rhel
+### molecule/zookeeper-kerberos-rhel
 
-#### Scenario rbac-mds-plain-custom-rhel test's the following:
+#### Scenario zookeeper-kerberos-rhel test's the following:
 
-Installs two Confluent Platform Clusters on CentOS7.
+Installs Confluent Platform on CentOS7
 
-RBAC enabled.
+Enables Kerberos on Zookeeper.
 
-Remote MDS from Cluster2 to Cluster1 (MDS).
+SASL SCRAM enabled on all components except Zookeeper.
 
-Custom TLS certificates.
+#### Scenario zookeeper-kerberos-rhel verify test's the following:
 
-SASL PLAIN enabled on both clusters.
+Validates Zookeeper sasl mechanism.
 
-Kafka Broker Customer Listener.
+Validates Kafka Broker and Schema Registry is set to SCRAM.
 
-RBAC Additional System Admin.
+***
 
-#### Scenario rbac-mds-plain-custom-rhel verify test's the following:
+### molecule/zookeeper-mtls-rhel
 
-Validates that protocol is sasl plain.
+#### Scenario zookeeper-mtls-rhel test's the following:
 
-Validates that MDS is HTTPs on Cluster1 (MDS).
+Installs Confluent Platform on CentOS7
 
-Validates that all components on Cluster2 are pointing to the MDS on Cluster1.
+Enables MTLS Auth on Zookeeper.
+
+SASL SCRAM enabled on all components except Zookeeper.
+
+Customer zookeeper root.
+
+Secrets Protection enabled.
+
+#### Scenario zookeeper-mtls-rhel verify test's the following:
+
+Validates that Confluent CLI is installed.
+
+Validates that Zookeeper is using MTLS for auth.
+
+Validates that other components are using SCRAM for auth.
+
+Validates that Secrets protection is applied to the correct properties.
 
 ***
 
@@ -1034,193 +1202,27 @@ Validates that Secrets protection is applied to the correct properties.
 
 ***
 
-### molecule/mtls-ubuntu-acl
+### molecule/zookeeper-tls-rhel
 
-#### Scenario mtls-ubuntu-acl test's the following:
+#### Scenario zookeeper-tls-rhel test's the following:
 
-Installation of Confluent Platform on Ubuntu1804.
+Installs Confluent Platform on CentOS7
 
-MTLS enabled.
+Enables SASL SCRAM Auth on Zookeeper.
 
-ACL authorization.
+TLS enabled.
 
-#### Scenario mtls-ubuntu-acl verify test's the following:
+Customer zookeeper root.
 
-Validates that MTLS is enabled.
+Secrets Protection enabled.
 
-Validates mapping rules for ACLs.
+Jolokia has TLS disabled.
 
-Validates ACL users.
+#### Scenario zookeeper-tls-rhel verify test's the following:
 
-***
+Validates that Zookeeper is using TLS.
 
-### molecule/cp-kafka-plain-rhel
-
-#### Scenario cp-kafka-plain-rhel test's the following:
-
-Installation of Confluent Community Edition on CentOS7.
-
-SASL Plain Auth.
-
-#### Scenario cp-kafka-plain-rhel verify test's the following:
-
-Validates that SASL Plaintext protocol is set.
-
-***
-
-### molecule/rbac-mtls-provided-ubuntu
-
-#### Scenario rbac-mtls-provided-ubuntu test's the following:
-
-Installs Confluent Platform Cluster on CentOS7.
-
-RBAC enabled.
-
-Provided Custom Keystore and Truststore for TLS..
-
-MTLS enabled.
-
-Kafka Broker Customer Listener.
-
-RBAC Additional System Admin.
-
-#### Scenario rbac-mtls-provided-ubuntu verify test's the following:
-
-Validates that keystores are present on all components.
-
-Validates that LDAPS is working.
-
-Validates that TLS CN is being registered as super user.
-
-***
-
-### molecule/mtls-debian
-
-#### Scenario mtls-debian test's the following:
-
-Installation of Confluent Platform on Debian9.
-
-MTLS Enabled.
-
-ERP Disabled.
-
-Kafka Connect Confluent Hub Plugins logic (Installs jcustenborder/kafka-connect-spooldir:2.0.43).
-
-Default replication factor set to 4.
-
-Jolokia Enabled.
-
-Confluent CLI Download enabled.
-
-Schema Validation is enabled.
-
-#### Scenario mtls-debian verify test's the following:
-
-Validates that SSL Protocol is set.
-
-Validates that replication factor is 4.
-
-Validates that Jolokia end point is reachable.
-
-Validates that Schema Validation is working.
-
-Validates that CLI is present.
-
-***
-
-### molecule/archive-community-plaintext-rhel
-
-#### Scenario archive-community-plaintext-rhel test's the following:
-
-Archive Installation of Confluent Community Edition on CentOS7
-
-JAVA 11.
-
-Custom Package Repository for Confluent Platform.
-
-Custom Package Repository for Confluent CLI.
-
-Control Center is not included in the Confluent Community Edition.
-
-#### Scenario archive-community-plaintext-rhel verify test's the following:
-
-Validates that Confluent CLI is installed.
-
-***
-
-### molecule/archive-plain-debian
-
-#### Scenario archive-plain-debian test's the following:
-
-Archive installation of Confluent Platform on Debian 9.
-
-SASL Protocol Plain.
-
-SSL Enabled.
-
-Kafka Connect Confluent Hub Plugins logic (Installs jcustenborder/kafka-connect-spooldir:2.0.43).
-
-Custom log dirs for all components.
-
-#### Scenario archive-plain-debian verify test's the following:
-
-Validates that SASL SSL protocol is set across all components
-
-Validates that custom log4j configuration is in place.
-
-***
-
-### molecule/rbac-kerberos-debian
-
-#### Scenario rbac-kerberos-debian test's the following:
-
-Installation of Confluent Platform on Debian9.
-
-RBAC enabled.
-
-Kerberos enabled.
-
-Kafka broker custom listener.
-
-RBAC additional system admin user.
-
-#### Scenario rbac-kerberos-debian verify test's the following:
-
-Validates that protocol set to GSSAPI.
-
-Validates that a regular user cannot access topics.
-
-Validates that a super user can access topics.
-
-Validates that all components are pointing to the MDS for authorization.
-
-***
-
-### molecule/plain-rhel
-
-#### Scenario plain-rhel test's the following:
-
-Installation of Confluent Platform on CentOS7.
-
-SASL Plain enabled.
-
-Control Plane listener enabled.
-
-Kafka Connect Confluent Hub Plugins logic (Installs jcustenborder/kafka-connect-spooldir:2.0.43).
-
-Custom Service Unit overrides.
-
-Custom log4j appender names.
-
-#### Scenario plain-rhel verify test's the following:
-
-Validates that custom log4j appenders are present on each component.
-
-Validates that Service Description has been overridden.
-
-Validates that SASL Plaintext protocol is set across components.
-
-Validates that Connectors are present on Kafka Connect.
+Validates that other components are using SCRAM for auth.
 
 ***
 

--- a/playbooks/fetch_logs.yml
+++ b/playbooks/fetch_logs.yml
@@ -51,7 +51,7 @@
         user: "{{schema_registry_user}}"
         group: "{{schema_registry_group}}"
 
-- name: Kafta Connect Provisioning
+- name: Kafka Connect Provisioning
   hosts: kafka_connect
   gather_facts: false
   tags: kafka_connect
@@ -66,7 +66,7 @@
         user: "{{kafka_connect_user}}"
         group: "{{kafka_connect_group}}"
 
-- name: Kafta Connect Provisioning
+- name: Kafka Connect Provisioning
   hosts: kafka_connect_replicator
   gather_facts: false
   tags: kafka_connect_replicator

--- a/playbooks/health_check.yml
+++ b/playbooks/health_check.yml
@@ -23,7 +23,7 @@
         name: schema_registry
         tasks_from: health_check.yml
 
-- name: Kafta Connect Provisioning
+- name: Kafka Connect Provisioning
   hosts: kafka_connect
   tags: kafka_connect
   tasks:
@@ -31,7 +31,7 @@
         name: kafka_connect
         tasks_from: health_check.yml
 
-- name: Kafta Connect Provisioning
+- name: Kafka Connect Provisioning
   hosts: kafka_connect_replicator
   tags: kafka_connect_replicator
   tasks:

--- a/roles/control_center/defaults/main.yml
+++ b/roles/control_center/defaults/main.yml
@@ -16,6 +16,7 @@ control_center_log_file_size: 100MB
 control_center_java_args:
   - "{% if control_center_ssl_enabled|bool %}-Djdk.tls.ephemeralDHKeySize=2048{% endif %}"
   - "{% if control_center_authentication_type == 'basic' %}-Djava.security.auth.login.config={{control_center.jaas_file}}{% endif %}"
+  - "{% if kerberos_client_config_file_dest != '/etc/krb5.conf' %}-Djava.security.krb5.conf={{kerberos_client_config_file_dest}}{% endif %}"
 
 ### Custom Java Args to add to the Control Center Process
 control_center_custom_java_args: ""

--- a/roles/kafka_broker/defaults/main.yml
+++ b/roles/kafka_broker/defaults/main.yml
@@ -20,6 +20,7 @@ kafka_broker_java_args:
   - "{% if kafka_broker_jolokia_enabled|bool %}-javaagent:{{jolokia_jar_path}}=config={{kafka_broker_jolokia_config}}{% endif %}"
   - "{% if kafka_broker_jmxexporter_enabled|bool %}-javaagent:{{jmxexporter_jar_path}}={{kafka_broker_jmxexporter_port}}:{{kafka_broker_jmxexporter_config_path}}{% endif %}"
   - "{% if zookeeper_client_authentication_type == 'kerberos' and zookeeper_kerberos_primary != 'zookeeper' %}-Dzookeeper.sasl.client.username={{zookeeper_kerberos_primary}}{% endif %}"
+  - "{% if kerberos_client_config_file_dest != '/etc/krb5.conf' %}-Djava.security.krb5.conf={{kerberos_client_config_file_dest}}{% endif %}"
 
 # Strip primary from the zookeeper principal on first zk host. Adds defaults for if there is not even a zookeeper group
 zookeeper_kerberos_primary: "{{ (hostvars[ groups['zookeeper'][0] | default('zookeeper') ] | default({})) ['zookeeper_kerberos_principal'] | default('zookeeper/host@EXAMPLE>COM') | regex_replace('/.*') }}"

--- a/roles/kafka_broker/tasks/health_check.yml
+++ b/roles/kafka_broker/tasks/health_check.yml
@@ -4,7 +4,7 @@
     {{ binary_base_path }}/bin/kafka-topics --bootstrap-server {{ hostvars[inventory_hostname]|confluent.platform.resolve_hostname }}:{{kafka_broker_listeners[kafka_broker_inter_broker_listener_name]['port']}} \
       --describe --under-replicated-partitions --command-config {{kafka_broker.client_config_file}}
   environment:
-    KAFKA_OPTS: "-Xlog:all=error -XX:+IgnoreUnrecognizedVMOptions"
+    KAFKA_OPTS: "-Xlog:all=error -XX:+IgnoreUnrecognizedVMOptions {% if not kerberos_configure and kerberos_client_config_file_dest != '/etc/krb5.conf' %}-Djava.security.krb5.conf={{kerberos_client_config_file_dest}}{% endif %}"
   register: urp_topics
   # stdout_lines will have topics with URPs and stderr has WARN and ERROR level logs
   until: urp_topics.stdout_lines|length == 0 and 'ERROR' not in urp_topics.stderr
@@ -21,7 +21,7 @@
       --describe --under-replicated-partitions --command-config {{kafka_broker.client_config_file}}
   environment:
     CONFLUENT_SECURITY_MASTER_KEY: "{{ secrets_protection_masterkey }}"
-    KAFKA_OPTS: "-Xlog:all=error -XX:+IgnoreUnrecognizedVMOptions"
+    KAFKA_OPTS: "-Xlog:all=error -XX:+IgnoreUnrecognizedVMOptions {% if not kerberos_configure and kerberos_client_config_file_dest != '/etc/krb5.conf' %}-Djava.security.krb5.conf={{kerberos_client_config_file_dest}}{% endif %}"
   register: urp_topics_secrets_protection
   # stdout_lines will have topics with URPs and stderr has WARN and ERROR level logs
   until: urp_topics_secrets_protection.stdout_lines|length == 0 and 'ERROR' not in urp_topics_secrets_protection.stderr

--- a/roles/kafka_broker/tasks/health_check.yml
+++ b/roles/kafka_broker/tasks/health_check.yml
@@ -4,7 +4,7 @@
     {{ binary_base_path }}/bin/kafka-topics --bootstrap-server {{ hostvars[inventory_hostname]|confluent.platform.resolve_hostname }}:{{kafka_broker_listeners[kafka_broker_inter_broker_listener_name]['port']}} \
       --describe --under-replicated-partitions --command-config {{kafka_broker.client_config_file}}
   environment:
-    KAFKA_OPTS: "-Xlog:all=error -XX:+IgnoreUnrecognizedVMOptions {% if not kerberos_configure and kerberos_client_config_file_dest != '/etc/krb5.conf' %}-Djava.security.krb5.conf={{kerberos_client_config_file_dest}}{% endif %}"
+    KAFKA_OPTS: "-Xlog:all=error -XX:+IgnoreUnrecognizedVMOptions {% if kerberos_client_config_file_dest != '/etc/krb5.conf' %}-Djava.security.krb5.conf={{kerberos_client_config_file_dest}}{% endif %}"
   register: urp_topics
   # stdout_lines will have topics with URPs and stderr has WARN and ERROR level logs
   until: urp_topics.stdout_lines|length == 0 and 'ERROR' not in urp_topics.stderr
@@ -21,7 +21,7 @@
       --describe --under-replicated-partitions --command-config {{kafka_broker.client_config_file}}
   environment:
     CONFLUENT_SECURITY_MASTER_KEY: "{{ secrets_protection_masterkey }}"
-    KAFKA_OPTS: "-Xlog:all=error -XX:+IgnoreUnrecognizedVMOptions {% if not kerberos_configure and kerberos_client_config_file_dest != '/etc/krb5.conf' %}-Djava.security.krb5.conf={{kerberos_client_config_file_dest}}{% endif %}"
+    KAFKA_OPTS: "-Xlog:all=error -XX:+IgnoreUnrecognizedVMOptions {% if kerberos_client_config_file_dest != '/etc/krb5.conf' %}-Djava.security.krb5.conf={{kerberos_client_config_file_dest}}{% endif %}"
   register: urp_topics_secrets_protection
   # stdout_lines will have topics with URPs and stderr has WARN and ERROR level logs
   until: urp_topics_secrets_protection.stdout_lines|length == 0 and 'ERROR' not in urp_topics_secrets_protection.stderr

--- a/roles/kafka_connect/defaults/main.yml
+++ b/roles/kafka_connect/defaults/main.yml
@@ -18,6 +18,7 @@ kafka_connect_java_args:
   - "{% if kafka_connect_jolokia_enabled|bool %}-javaagent:{{jolokia_jar_path}}=config={{kafka_connect_jolokia_config}}{% endif %}"
   - "{% if kafka_connect_jmxexporter_enabled|bool %}-javaagent:{{jmxexporter_jar_path}}={{kafka_connect_jmxexporter_port}}:{{kafka_connect_jmxexporter_config_path}}{% endif %}"
   - "{% if kafka_connect_authentication_type == 'basic' %}-Djava.security.auth.login.config={{kafka_connect.jaas_file}}{% endif %}"
+  - "{% if kerberos_client_config_file_dest != '/etc/krb5.conf' %}-Djava.security.krb5.conf={{kerberos_client_config_file_dest}}{% endif %}"
 
 ### Custom Java Args to add to the Connect Process
 kafka_connect_custom_java_args: ""

--- a/roles/kafka_connect_replicator/defaults/main.yml
+++ b/roles/kafka_connect_replicator/defaults/main.yml
@@ -10,6 +10,7 @@ kafka_connect_replicator_log4j_root_logger: "INFO, replicatorAppender, stdout"
 kafka_connect_replicator_java_args:
   - "{% if kafka_connect_replicator_ssl_mutual_auth_enabled| bool %}-Djdk.tls.ephemeralDHKeySize=2048{% endif %}"
   - "{% if kafka_connect_replicator_jolokia_enabled|bool %}-javaagent:{{kafka_connect_replicator_jolokia_jar_path}}=config={{kafka_connect_replicator_jolokia_config}}{% endif %}"
+  - "{% if kerberos_client_config_file_dest != '/etc/krb5.conf' %}-Djava.security.krb5.conf={{kerberos_client_config_file_dest}}{% endif %}"
 
 ### Custom Java Args to add to the Kafka Connect Replicator Process
 kafka_connect_replicator_custom_java_args: ""

--- a/roles/kafka_rest/defaults/main.yml
+++ b/roles/kafka_rest/defaults/main.yml
@@ -18,6 +18,7 @@ kafka_rest_java_args:
   - "{% if kafka_rest_jolokia_enabled|bool %}-javaagent:{{jolokia_jar_path}}=config={{kafka_rest_jolokia_config}}{% endif %}"
   - "{% if kafka_rest_jmxexporter_enabled|bool %}-javaagent:{{jmxexporter_jar_path}}={{kafka_rest_jmxexporter_port}}:{{kafka_rest_jmxexporter_config_path}}{% endif %}"
   - "{% if kafka_rest_authentication_type == 'basic' %}-Djava.security.auth.login.config={{kafka_rest.jaas_file}}{% endif %}"
+  - "{% if kerberos_client_config_file_dest != '/etc/krb5.conf' %}-Djava.security.krb5.conf={{kerberos_client_config_file_dest}}{% endif %}"
 
 ### Custom Java Args to add to the Rest Proxy Process
 kafka_rest_custom_java_args: ""

--- a/roles/kerberos/tasks/main.yml
+++ b/roles/kerberos/tasks/main.yml
@@ -1,4 +1,10 @@
 ---
+- name: Create directory for client config file if it does not exist
+  ansible.builtin.file:
+    path: "{{ kerberos_client_config_file_dest | dirname }}"
+    state: directory
+    mode: '0755'
+
 - name: Copy the client configuration file
   template:
     src: krb5.conf.j2

--- a/roles/kerberos/tasks/main.yml
+++ b/roles/kerberos/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Copy the client configuration file
   template:
     src: krb5.conf.j2
-    dest: /etc/krb5.conf
+    dest: "{{ kerberos_client_config_file_dest }}"
     mode: 0755
   when: kerberos_configure|bool
 

--- a/roles/ksql/defaults/main.yml
+++ b/roles/ksql/defaults/main.yml
@@ -19,6 +19,7 @@ ksql_java_args:
   - "{% if ksql_jolokia_enabled|bool %}-javaagent:{{jolokia_jar_path}}=config={{ksql_jolokia_config}}{% endif %}"
   - "{% if ksql_jmxexporter_enabled|bool %}-javaagent:{{jmxexporter_jar_path}}={{ksql_jmxexporter_port}}:{{ksql_jmxexporter_config_path}}{% endif %}"
   - "{% if ksql_authentication_type == 'basic' %}-Djava.security.auth.login.config={{ksql.jaas_file}}{% endif %}"
+  - "{% if kerberos_client_config_file_dest != '/etc/krb5.conf' %}-Djava.security.krb5.conf={{kerberos_client_config_file_dest}}{% endif %}"
 
 ### Custom Java Args to add to the ksqlDB Process
 ksql_custom_java_args: ""

--- a/roles/schema_registry/defaults/main.yml
+++ b/roles/schema_registry/defaults/main.yml
@@ -18,6 +18,7 @@ schema_registry_java_args:
   - "{% if schema_registry_jolokia_enabled|bool %}-javaagent:{{jolokia_jar_path}}=config={{schema_registry_jolokia_config}}{% endif %}"
   - "{% if schema_registry_jmxexporter_enabled|bool %}-javaagent:{{jmxexporter_jar_path}}={{schema_registry_jmxexporter_port}}:{{schema_registry_jmxexporter_config_path}}{% endif %}"
   - "{% if schema_registry_authentication_type == 'basic' %}-Djava.security.auth.login.config={{schema_registry.jaas_file}}{% endif %}"
+  - "{% if kerberos_client_config_file_dest != '/etc/krb5.conf' %}-Djava.security.krb5.conf={{kerberos_client_config_file_dest}}{% endif %}"
 
 ### Custom Java Args to add to the Schema Registry Process
 schema_registry_custom_java_args: ""

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -64,6 +64,9 @@ custom_log4j: true
 ### Boolean to configure Kerberos krb5.conf file, must also set kerberos.realm, keberos.kdc_hostname, kerberos.admin_hostname, where kerberos is a dictionary
 kerberos_configure: true
 
+### Custom path for the location of kerberos client configuration file, works with any value of kerberos_configure
+kerberos_client_config_file_dest: /etc/krb5.conf
+
 # Deprecated variable now that primary can be pulled from kafka_broker_kerberos_principal
 kerberos_kafka_broker_primary: "{{ (hostvars[ groups['kafka_broker'][0] | default('kafka') ] | default({})) ['kafka_broker_kerberos_principal'] | default('kafka/host@EXAMPLE>COM') | regex_replace('/.*') }}"
 

--- a/roles/zookeeper/defaults/main.yml
+++ b/roles/zookeeper/defaults/main.yml
@@ -18,6 +18,7 @@ zookeeper_java_args:
   - "{% if zookeeper_client_authentication_type in ['kerberos', 'digest'] or zookeeper_quorum_authentication_type in ['kerberos', 'digest', 'digest_over_tls'] %}-Djava.security.auth.login.config={{zookeeper.jaas_file}}{% endif %}"
   - "{% if zookeeper_jolokia_enabled|bool %}-javaagent:{{jolokia_jar_path}}=config={{zookeeper_jolokia_config}}{% endif %}"
   - "{% if zookeeper_jmxexporter_enabled|bool %}-javaagent:{{jmxexporter_jar_path}}={{zookeeper_jmxexporter_port}}:{{zookeeper_jmxexporter_config_path}}{% endif %}"
+  - "{% if kerberos_client_config_file_dest != '/etc/krb5.conf' %}-Djava.security.krb5.conf={{kerberos_client_config_file_dest}}{% endif %}"
 
 ### Custom Java Args to add to the Zookeeper Process
 zookeeper_custom_java_args: ""

--- a/test_roles/confluent.test.kerberos/defaults/main.yml
+++ b/test_roles/confluent.test.kerberos/defaults/main.yml
@@ -6,3 +6,8 @@ kadmin_pass: foobar
 kadmin_user: benz
 
 keytab_output_directory: keytabs
+
+kerberos:
+  realm: realm.example.com
+  kdc_hostname: kerberos1
+  admin_hostname: kerberos1


### PR DESCRIPTION
# Description

This PR enhances our security configurations.
It allows customer to specify custom location of their kerberos client configuration file for both cases (where they want cp-ansible to configure the file and where they want to configure the file themselves) 
We use a variable kerberos_client_config_file_dest for the same. This custom path needs to be specified as java arg for each of our services.
Tests have been added for both cases:
custom location with cp-ansible confguring the file
custom location with customer configuring and providing the file

The change requires public facing doc change - will open a ticket after approval

Fixes # (ANSIENG-1964)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

https://jenkins.confluent.io/job/cp-ansible-on-demand/966/
One failing fixed in - https://jenkins.confluent.io/job/cp-ansible-on-demand/967/

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible