### PR TITLE
get connect config file from var

### DIFF
--- a/roles/confluent.variables/vars/main.yml
+++ b/roles/confluent.variables/vars/main.yml
@@ -528,7 +528,7 @@ kafka_connect_default_log_dir: /var/log/kafka
 kafka_connect:
   server_start_file: "{{ binary_base_path }}/bin/connect-distributed"
   systemd_file: "{{systemd_base_dir}}/{{kafka_connect_service_name}}.service"
-  config_file: "{{ (config_base_path,'etc/kafka/connect-distributed.properties') | community.general.path_join }}"
+  config_file: "{{ (config_base_path,'etc/kafka',kafka_connect_config_filename) | community.general.path_join }}"
   systemd_override: /etc/systemd/system/{{kafka_connect_service_name}}.service.d/override.conf
   log4j_file: "{{ (base_path, 'etc/kafka/connect-log4j.properties') | community.general.path_join }}"
 


### PR DESCRIPTION
# Description

Addresses - https://github.com/confluentinc/cp-ansible/issues/1298
If multiple connect clusters want different config file, we need a variable to define it separately.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

PR CI tests - just need to test if connect starts up successfully


**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible