### PR TITLE
Add sample kraft inventory and failure task when both zookeeper and controller present

### DIFF
--- a/docs/hosts_example.yml
+++ b/docs/hosts_example.yml
@@ -29,6 +29,11 @@ all:
     ## When a mechanism is selected, zookeeper.set.acl=true is added to kafka's server.properties. Note: property not added when using mTLS, set manually with Custom Properties
     # zookeeper_sasl_protocol: <none/kerberos/digest>
 
+    #### Kafka Controller SASL Authentication ####
+    ## Controller can have Kerberos, Plain or Oauth Authentication
+    ## By default when sasl_protocol = kerberos, kafka_controller will also use sasl kerberos. It can  be configured with:
+    # kafka_controller_sasl_protocol: <none/kerberos/plain/oauth>
+
     #### Kerberos Configuration ####
     ## Applicable when sasl_protocol is kerberos
     ## REQUIRED: Under each host set keytab file path and principal name, see below
@@ -78,6 +83,13 @@ all:
     ## If you have ssl_enabled, but want zookeeper without TLS, uncomment these lines
     # zookeeper_ssl_enabled: false
     # zookeeper_ssl_mutual_auth_enabled: false
+
+    #### Kafka Controller TLS Configuration ####
+    ## Controller can also have TLS Encryption and mTLS Authentication
+    ## Controller's TLS settings are inherited from the ssl_enabled settings.
+    ## If you have ssl_enabled, but want controller without TLS, uncomment these lines
+    # kafka_controller_ssl_enabled: false
+    # kafka_controller_ssl_mutual_auth_enabled: false
 
     #### Certificate Regeneration ####
     ## When using self signed certificates, each playbook run will regenerate the CA, to turn this off, uncomment this line:
@@ -226,6 +238,8 @@ all:
     #   ssl_mutual_auth_enabled: true <set to false if remote MDS doe not use MTLS>
     #   sasl_protocol: none <set protocol for remote MDS, options are: kerberos, sasl_plain, sasl_scram>
     ##
+    # kafka_controller_ldap_user: <Your Kafka Controller username in LDAP, works only when kafka_controller_rbac_enabled is true>
+    # kafka_controller_ldap_password: <Your Kafka Controller user's LDAP password>
     ## By default the Confluent CLI will be installed on each host *when rbac is enabled*, to stop this download set:
     # confluent_cli_download_enabled: false
     ## CLI will be downloaded from Confluent's webservers, to customize the location of the binary set:
@@ -280,6 +294,35 @@ zookeeper:
       # zookeeper_id: 3
     ip-172-31-34-231.us-east-2.compute.internal:
       # zookeeper_id: 1
+
+kafka_controller:
+  ## To set variables on all kafka_controller hosts, use the vars block here
+  # vars:
+  #   ## To configure Kafka to run as a custom user, uncomment below
+  #   kafka_controller_user: custom-user
+  #   kafka_controller_group: custom-group
+  #
+  #   # To update data log location use custom properties:
+  #   # By default the log directory is /var/lib/controller/data
+  #
+  #
+  #   ## To configure LDAP for RBAC enablement, you will need to provide the appropiate properties to connect to your LDAP server
+  #   ## RBAC enablement in Controller is supported when LDAP is handled by the remote MDS.
+  #   ## To configure RBAC for Controller to Broker communication, uncomment below. It is set to false by default   
+  #   kafka_controller_rbac_enabled: true
+  hosts:
+    ip-172-31-34-246.us-east-2.compute.internal:
+      ## By default the first host will get controller id=9991, second gets id=9992. Set node_id to customize
+      ## Please note that when customizing node_id, you will need to update kafka_controller_quorum_voters accordingly
+      # node_id: 9993
+
+      ## For kerberos sasl protocol, EACH host will need these two variables:
+      # kafka_controller_kerberos_keytab_path: <The path on ansible host to keytab file, eg. /tmp/keytabs/ip-172-31-34-246.us-east-2.compute.internal>
+      # kafka_controller_kerberos_principal: <The principal configured in kdc server, eg. kafka/ip-172-31-34-246.us-east-2.compute.internal@REALM.EXAMPLE.COM>
+    ip-172-31-37-15.us-east-2.compute.internal:
+      # kafka_controller_custom_properties:
+    ip-172-31-34-231.us-east-2.compute.internal:
+      # kafka_controller_custom_properties:
 
 kafka_broker:
   ## To set variables on all kafka_broker hosts, use the vars block here

--- a/docs/hosts_example.yml
+++ b/docs/hosts_example.yml
@@ -308,7 +308,7 @@ kafka_controller:
   #
   #   ## To configure LDAP for RBAC enablement, you will need to provide the appropiate properties to connect to your LDAP server
   #   ## RBAC enablement in Controller is supported when LDAP is handled by the remote MDS.
-  #   ## To configure RBAC for Controller to Broker communication, uncomment below. It is set to false by default   
+  #   ## To configure RBAC for Controller to Broker communication, uncomment below. It is set to false by default.
   #   kafka_controller_rbac_enabled: true
   hosts:
     ip-172-31-34-246.us-east-2.compute.internal:

--- a/docs/sample_inventories/kraft_controller.yml
+++ b/docs/sample_inventories/kraft_controller.yml
@@ -1,0 +1,47 @@
+---
+##
+## The following is an example inventory file of the configuration required for setting up Confluent Platform with Kraft Controller
+
+all:
+  vars:
+    ansible_connection: ssh
+    ansible_user: ec2-user
+    ansible_become: true
+    ansible_ssh_private_key_file: /home/ec2-user/guest.pem
+    ansible_python_interpreter: /usr/bin/python3
+
+    ssl_enabled: true
+    ssl_mutual_auth_enabled: true
+
+
+kafka_controller:
+  hosts:
+    ec2-35-160-193-90.us-west-2.compute.amazonaws.com:
+    ec2-35-85-219-150.us-west-2.compute.amazonaws.com:
+    ec2-34-219-169-190.us-west-2.compute.amazonaws.com:
+
+kafka_broker:
+  hosts:
+    ec2-35-91-214-11.us-west-2.compute.amazonaws.com:
+    ec2-54-71-228-219.us-west-2.compute.amazonaws.com:
+    ec2-54-218-9-145.us-west-2.compute.amazonaws.com:
+
+schema_registry:
+  hosts:
+    ec2-35-160-193-90.us-west-2.compute.amazonaws.com:
+
+kafka_connect:
+  hosts:
+    ec2-35-85-219-150.us-west-2.compute.amazonaws.com:
+
+kafka_rest:
+  hosts:
+    ec2-34-219-169-190.us-west-2.compute.amazonaws.com:
+
+ksql:
+  hosts:
+    ec2-35-91-214-11.us-west-2.compute.amazonaws.com:
+
+control_center:
+  hosts:
+    ec2-35-85-219-150.us-west-2.compute.amazonaws.com:

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -17,6 +17,13 @@
     - validate
     - validate_ansi_version
 
+- name: Check the presence of Controller and Zookeeper
+  fail:
+    msg:  "Providing Zookeeper and Controller both are not supported at this time. Please remove one of these from your inventory"
+  when:
+    - ('kafka_controller' in groups.keys() and groups['kafka_controller'] | length > 0) | bool
+    - ('zookeeper' in groups.keys() and groups['zookeeper'] | length > 0) | bool
+
 - name: Gather OS Facts
   setup:
     gather_subset:


### PR DESCRIPTION
# Description

This PR aims to Add sample kraft inventory and failure task when both zookeeper and controller present

Fixes # [ANSIENG-1999](https://confluentinc.atlassian.net/browse/ANSIENG-1999)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Tested locally



**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Any variable changes have been validated to be backwards compatible

[ANSIENG-1999]: https://confluentinc.atlassian.net/browse/ANSIENG-1999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ