### PR TITLE
ANSIENG-2023 Fix export certificate logic

### DIFF
--- a/roles/confluent.ssl/tasks/export_certs_from_keystore_and_truststore.yml
+++ b/roles/confluent.ssl/tasks/export_certs_from_keystore_and_truststore.yml
@@ -54,6 +54,6 @@
           -nodes -nocerts -out {{key_path}} \
           -passin pass:{{keystore_storepass}}
 
-- name: Unset export certs var
+- name: Set certs already exported
   set_fact:
-    export_certs: false
+    certs_already_exported: true

--- a/roles/confluent.ssl/tasks/main.yml
+++ b/roles/confluent.ssl/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+- set_fact:
+    certs_already_exported: false
+
 - name: Register if Keystore Exists
   stat:
     path: "{{keystore_path}}"
@@ -17,6 +20,7 @@
   include_tasks: export_certs_from_keystore_and_truststore.yml
   when:
     - export_certs|bool
+    - not certs_already_exported|bool
     - ssl_provided_keystore_and_truststore|bool
 
 - name: Set Truststore and Keystore File Permissions

--- a/roles/confluent.test/molecule/rbac-mtls-provided-ubuntu/molecule.yml
+++ b/roles/confluent.test/molecule/rbac-mtls-provided-ubuntu/molecule.yml
@@ -179,6 +179,9 @@ provisioner:
         rbac_component_additional_system_admins:
           - user1
 
+      zookeeper:
+        zookeeper_export_certs: true
+
       kafka_broker:
         ldap_config: |
           ldap.java.naming.factory.initial=com.sun.jndi.ldap.LdapCtxFactory


### PR DESCRIPTION
# Description

`Export Certs from Keystore and Truststore` happening twice in some cases and second one fails with error - 
“Can’t open /var/ssl/private/generation/zookeeper.p12 for reading, No such file or directory”
PR aims to rectify above issue.

Fixes # (issue)
https://confluentinc.atlassian.net/browse/ANSIENG-2023

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Modified one of the molecule scenarios to test this, as you can see in the screenshot, first `Export Certs from Keystore and Truststore` task passed through and second one got skipped.

<img width="1219" alt="Screenshot 2023-01-20 at 4 33 07 PM" src="https://user-images.githubusercontent.com/62242771/213680854-a24943ef-f88a-4fa2-9cdb-0a18f9e9fc6d.png">

https://jenkins.confluent.io/job/cp-ansible-on-demand/991/
https://jenkins.confluent.io/job/cp-ansible-on-demand/990/

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible