### PR TITLE
Fix logic related to input file/cli args, fix logging

### DIFF
--- a/discovery/manager/manager.py
+++ b/discovery/manager/manager.py
@@ -74,6 +74,7 @@ class SystemPropertyManager:
         runner_utils = AnsibleRunnerUtils('ansible_facts')
         hosts, host_pattern = AnsibleRunnerUtils.get_host_and_pattern_from_input_context(input_context)
         ansible_runner.run(
+            quiet=True,
             host_pattern=host_pattern,
             inventory=AnsibleRunnerUtils.get_inventory_dict(input_context),
             module='service_facts',
@@ -114,6 +115,7 @@ class SystemPropertyManager:
         runner_utils = AnsibleRunnerUtils()
         ansible_hosts, host_pattern = AnsibleRunnerUtils.get_host_and_pattern_from_host_list(hosts)
         ansible_runner.run(
+            quiet=True,
             host_pattern=host_pattern,
             inventory=AnsibleRunnerUtils.get_inventory_dict(input_context, hosts),
             module='ansible.builtin.systemd',
@@ -134,6 +136,7 @@ class SystemPropertyManager:
         runner_utils = AnsibleRunnerUtils('ansible_facts')
         hosts, host_pattern = AnsibleRunnerUtils.get_host_and_pattern_from_input_context(input_context)
         ansible_runner.run(
+            quiet=True,
             host_pattern=host_pattern,
             inventory=AnsibleRunnerUtils.get_inventory_dict(input_context),
             module='ansible_facts',
@@ -152,6 +155,7 @@ class SystemPropertyManager:
         runner_utils = AnsibleRunnerUtils('ansible_facts')
         hosts, host_pattern = AnsibleRunnerUtils.get_host_and_pattern_from_input_context(input_context)
         ansible_runner.run(
+            quiet=True,
             host_pattern=host_pattern,
             inventory=AnsibleRunnerUtils.get_inventory_dict(input_context),
             module='package_facts',
@@ -174,6 +178,7 @@ class SystemPropertyManager:
         runner_utils = AnsibleRunnerUtils('ansible_facts')
         hosts, host_pattern = AnsibleRunnerUtils.get_host_and_pattern_from_input_context(input_context)
         ansible_runner.run(
+            quiet=True,
             host_pattern=host_pattern,
             inventory=AnsibleRunnerUtils.get_inventory_dict(input_context),
             module="shell",
@@ -230,6 +235,7 @@ class ServicePropertyManager:
             runner_utils = AnsibleRunnerUtils()
             hosts, host_pattern = AnsibleRunnerUtils.get_host_and_pattern_from_host_list(hosts)
             ansible_runner.run(
+                quiet=True,
                 host_pattern=host_pattern,
                 inventory=AnsibleRunnerUtils.get_inventory_dict(input_context, hosts),
                 module="slurp",
@@ -256,6 +262,7 @@ class ServicePropertyManager:
         runner_utils = AnsibleRunnerUtils()
         ansilble_hosts, host_pattern = AnsibleRunnerUtils.get_host_and_pattern_from_host_list(hosts)
         ansible_runner.run(
+            quiet=True,
             host_pattern=host_pattern,
             inventory=AnsibleRunnerUtils.get_inventory_dict(input_context, hosts),
             module="shell",
@@ -297,6 +304,7 @@ class ServicePropertyManager:
         runner_utils = AnsibleRunnerUtils()
         ansible_hosts, host_pattern = AnsibleRunnerUtils.get_host_and_pattern_from_host_list(hosts)
         ansible_runner.run(
+            quiet=True,
             host_pattern=host_pattern,
             inventory=AnsibleRunnerUtils.get_inventory_dict(input_context, hosts),
             module="shell",
@@ -342,6 +350,7 @@ class ServicePropertyManager:
         runner_utils = AnsibleRunnerUtils()
         ansible_hosts, host_pattern = AnsibleRunnerUtils.get_host_and_pattern_from_host_list(hosts)
         ansible_runner.run(
+            quiet=True,
             host_pattern=host_pattern,
             inventory=AnsibleRunnerUtils.get_inventory_dict(input_context, hosts),
             module="shell",
@@ -356,6 +365,7 @@ class ServicePropertyManager:
         runner_utils = AnsibleRunnerUtils()
         ansible_hosts, host_pattern = AnsibleRunnerUtils.get_host_and_pattern_from_host_list(hosts)
         ansible_runner.run(
+            quiet=True,
             host_pattern=host_pattern,
             inventory=AnsibleRunnerUtils.get_inventory_dict(input_context, hosts),
             module="shell",
@@ -370,6 +380,7 @@ class ServicePropertyManager:
         runner_utils = AnsibleRunnerUtils()
         ansible_hosts, host_pattern = AnsibleRunnerUtils.get_host_and_pattern_from_host_list(hosts)
         ansible_runner.run(
+            quiet=True,
             host_pattern=host_pattern,
             inventory=AnsibleRunnerUtils.get_inventory_dict(input_context, hosts),
             module="shell",
@@ -390,6 +401,7 @@ class ServicePropertyManager:
         runner_utils = AnsibleRunnerUtils()
         ansible_hosts, host_pattern = AnsibleRunnerUtils.get_host_and_pattern_from_host_list(hosts)
         ansible_runner.run(
+            quiet=True,
             host_pattern=host_pattern,
             inventory=AnsibleRunnerUtils.get_inventory_dict(input_context, hosts),
             module="shell",
@@ -405,6 +417,7 @@ class ServicePropertyManager:
         runner_utils = AnsibleRunnerUtils()
         ansible_hosts, host_pattern = AnsibleRunnerUtils.get_host_and_pattern_from_host_list(hosts)
         ansible_runner.run(
+            quiet=True,
             host_pattern=host_pattern,
             inventory=AnsibleRunnerUtils.get_inventory_dict(input_context, hosts),
             module="shell",
@@ -429,6 +442,7 @@ class ServicePropertyManager:
             runner_utils = AnsibleRunnerUtils()
             ansible_hosts, host_pattern = AnsibleRunnerUtils.get_host_and_pattern_from_host_list(hosts)
             ansible_runner.run(
+                quiet=True,
                 host_pattern=host_pattern,
                 inventory=AnsibleRunnerUtils.get_inventory_dict(input_context, hosts),
                 module="shell",
@@ -454,6 +468,7 @@ class ServicePropertyManager:
         runner_utils = AnsibleRunnerUtils()
         ansible_hosts, host_pattern = AnsibleRunnerUtils.get_host_and_pattern_from_host_list(hosts)
         ansible_runner.run(
+            quiet=True,
             host_pattern=host_pattern,
             inventory=AnsibleRunnerUtils.get_inventory_dict(input_context, hosts),
             module="shell",
@@ -484,6 +499,7 @@ class ServicePropertyManager:
             runner_utils = AnsibleRunnerUtils()
             ansible_hosts, host_pattern = AnsibleRunnerUtils.get_host_and_pattern_from_host_list(hosts)
             ansible_runner.run(
+                quiet=True,
                 host_pattern=host_pattern,
                 inventory=AnsibleRunnerUtils.get_inventory_dict(input_context, hosts),
                 module="shell",

--- a/discovery/utils/utils.py
+++ b/discovery/utils/utils.py
@@ -132,7 +132,7 @@ class Arguments:
         parser.add_argument("--input", type=str, help="Input Inventory file")
         parser.add_argument("--hosts", type=str, action="extend", nargs="*", help="List of hosts")
         parser.add_argument("--from_version", type=str, help="Target cp cluster version")
-        parser.add_argument("--verbosity", type=int, default=0, help="Log level")
+        parser.add_argument("--verbosity", type=int, help="Log level")
         parser.add_argument("--ansible_connection", type=str, default=None,
                             help="The connection plugin actually used for the task on the target host.")
 
@@ -153,7 +153,7 @@ class Arguments:
     def validate_args(cls, args):
 
         # Set the default verbosity to INFO level
-        verbosity = args.verbosity if args.verbosity >= 0 and args.verbosity <= 4 else 4
+        verbosity = args.verbosity if args.verbosity and args.verbosity >= 0 and args.verbosity <= 4 else 3
         logger.setLevel((5 - verbosity) * 10)
 
         cls.__validate_hosts(cls.get_hosts(args))

--- a/discovery/utils/utils.py
+++ b/discovery/utils/utils.py
@@ -136,11 +136,11 @@ class Arguments:
         parser.add_argument("--ansible_connection", type=str, default=None,
                             help="The connection plugin actually used for the task on the target host.")
 
-        parser.add_argument("--ansible_user", type=str, default=None, help="The user Ansible ‘logs in’ as.")
+        parser.add_argument("--ansible_user", type=str, default=None, help="The user Ansible 'logs in' as.")
         parser.add_argument("--ansible_become", type=bool, default=False, help="Boolean to use privileged ")
         parser.add_argument("--ansible_become_method", type=str, default='sudo', help="Method to become privileged")
         parser.add_argument("--ansible_become_user", type=str, default=None,
-                            help="The user Ansible ‘becomes’ after using privilege escalation.")
+                            help="The user Ansible 'becomes' after using privilege escalation.")
         parser.add_argument("--ansible_ssh_private_key_file", type=str, default=None, help="Private key for ssh login")
         parser.add_argument("--ansible_ssh_extra_args", type=str, default=None, help="Extra arguments for ssh")
         parser.add_argument("--ansible_python_interpreter", type=str, default='auto', help="Python interpreter path")
@@ -172,7 +172,6 @@ class Arguments:
                             ansible_user=vars.get("ansible_user"),
                             ansible_ssh_extra_args=vars.get("ansible_ssh_extra_args"),
                             ansible_python_interpretor=vars.get("ansible_python_interpretor"),
-                            verbosity=args.verbosity,
                             output_file=args.output_file,
                             from_version=vars.get("from_version"))
 
@@ -260,6 +259,9 @@ class Arguments:
 
         if args.from_version:
             vars['from_version'] = args.from_version
+
+        if args.ansible_python_interpreter:
+            vars['ansible_python_interpreter'] = args.ansible_python_interpreter
 
         return vars
 

--- a/discovery/utils/utils.py
+++ b/discovery/utils/utils.py
@@ -103,7 +103,7 @@ class InputContext:
                  ansible_ssh_private_key_file,
                  verbosity,
                  ansible_ssh_extra_args,
-                 ansible_python_interpretor=None,
+                 ansible_python_interpreter=None,
                  from_version=None,
                  output_file=None):
         self.ansible_hosts = ansible_hosts
@@ -115,7 +115,7 @@ class InputContext:
         self.ansible_ssh_private_key_file = ansible_ssh_private_key_file
         self.from_version = from_version
         self.ansible_ssh_extra_args = ansible_ssh_extra_args
-        self.ansible_python_interpreter = ansible_python_interpretor
+        self.ansible_python_interpreter = ansible_python_interpreter
         self.verbosity = verbosity
         self.output_file = output_file
 
@@ -129,7 +129,7 @@ class Arguments:
         parser = argparse.ArgumentParser()
 
         # Adding optional argument
-        parser.add_argument("--input", type=str, help="Input Inventory file")
+        parser.add_argument("--input", type=str, required=True, help="Input Inventory file")
         parser.add_argument("--hosts", type=str, action="extend", nargs="*", help="List of hosts")
         parser.add_argument("--from_version", type=str, help="Target cp cluster version")
         parser.add_argument("--verbosity", type=int, help="Log level")
@@ -137,14 +137,14 @@ class Arguments:
                             help="The connection plugin actually used for the task on the target host.")
 
         parser.add_argument("--ansible_user", type=str, default=None, help="The user Ansible 'logs in' as.")
-        parser.add_argument("--ansible_become", type=bool, default=False, help="Boolean to use privileged ")
-        parser.add_argument("--ansible_become_method", type=str, default='sudo', help="Method to become privileged")
+        parser.add_argument("--ansible_become", type=lambda x: (str(x).lower() == 'true'), help="Boolean to use privileged")
+        parser.add_argument("--ansible_become_method", type=str, help="Method to become privileged")
         parser.add_argument("--ansible_become_user", type=str, default=None,
                             help="The user Ansible 'becomes' after using privilege escalation.")
         parser.add_argument("--ansible_ssh_private_key_file", type=str, default=None, help="Private key for ssh login")
         parser.add_argument("--ansible_ssh_extra_args", type=str, default=None, help="Extra arguments for ssh")
-        parser.add_argument("--ansible_python_interpreter", type=str, default='auto', help="Python interpreter path")
-        parser.add_argument("--output_file", type=str, default='inventory.yml', help="Generated output inventory file")
+        parser.add_argument("--ansible_python_interpreter", type=str, help="Python interpreter path")
+        parser.add_argument("--output_file", type=str, help="Generated output inventory file")
 
         # Read arguments from command line
         return parser.parse_args()
@@ -152,12 +152,14 @@ class Arguments:
     @classmethod
     def validate_args(cls, args):
 
-        # Set the default verbosity to INFO level
-        verbosity = args.verbosity if args.verbosity and args.verbosity >= 0 and args.verbosity <= 4 else 3
-        logger.setLevel((5 - verbosity) * 10)
-
         cls.__validate_hosts(cls.get_hosts(args))
-        cls.__validate_variables(cls.get_vars(args))
+        vars = cls.get_vars(args)
+        cls.__validate_variables(vars)
+
+        # Set the default verbosity to INFO level
+        log_level = vars.get("verbosity")
+        verbosity = log_level if log_level and log_level >= 0 and log_level <= 4 else 3
+        logger.setLevel((5 - verbosity) * 10)
 
     @classmethod
     def get_input_context(cls, args) -> InputContext:
@@ -171,8 +173,9 @@ class Arguments:
                             ansible_ssh_private_key_file=vars.get("ansible_ssh_private_key_file"),
                             ansible_user=vars.get("ansible_user"),
                             ansible_ssh_extra_args=vars.get("ansible_ssh_extra_args"),
-                            ansible_python_interpretor=vars.get("ansible_python_interpretor"),
-                            output_file=args.output_file,
+                            ansible_python_interpreter=vars.get("ansible_python_interpreter"),
+                            output_file=vars.get("output_file"),
+                            verbosity=vars.get("verbosity"),
                             from_version=vars.get("from_version"))
 
     @classmethod
@@ -236,7 +239,7 @@ class Arguments:
             vars = inventory.get('all').get('vars')
 
         # Override the inventory vars with command line variables.
-        if args.ansible_become:
+        if args.ansible_become is not None:
             vars['ansible_become'] = args.ansible_become
 
         if args.ansible_user:
@@ -260,8 +263,22 @@ class Arguments:
         if args.from_version:
             vars['from_version'] = args.from_version
 
+        if args.verbosity:
+            vars['verbosity'] = args.verbosity
+
+        if args.output_file:
+            vars['output_file'] = args.output_file
+
         if args.ansible_python_interpreter:
             vars['ansible_python_interpreter'] = args.ansible_python_interpreter
+
+        # set default values of some variables explicitly
+        if vars.get('ansible_python_interpreter') is None:
+            vars['ansible_python_interpreter'] = 'auto'
+        if vars.get('ansible_become_method') is None:
+            vars['ansible_become_method'] = 'sudo'
+        if vars.get('ansible_become') is None:
+            vars['ansible_become'] = False
 
         return vars
 


### PR DESCRIPTION
# Description

Multiple changes:
- Ansible runner by default dumps the entire output of the ansible task onto stdout, which is very overwhelming. Preventing that.
- Default logging level was bugged. It defaulted to CRITICAL, which has been fixed to INFO.
- Fix the logic to have all variables supported both as part of input file as well as command line arguments. Variables can be passed from either of these two places (cl arguments having higher priority)
- The CLI args which were given any default value (other than None) always override no matter what was supplied in the input file. For ex, ansible_python_intepretor even if supplied in input file was always overriden by the default value of CLI arg, which was 'auto'. Now, we want to assign default value to var if it's not present in both input file and cli arg.
- Fixed a bug where any non empty value of ansible_become passed through cli was being considered as True.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Locally


**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible