### PR TITLE
Remove command warnings to support latest ansible

### DIFF
--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -1,10 +1,6 @@
 ---
 - name: debian apt-get update
   shell: apt-get -o Acquire::Check-Valid-Until=false update
-  args:
-    warn: false
 
 - name: apt-get update
   shell: apt-get update
-  args:
-    warn: false

--- a/roles/common/tasks/debian.yml
+++ b/roles/common/tasks/debian.yml
@@ -18,8 +18,6 @@
 
 - name: Install apt-transport-https
   shell: apt-get install apt-transport-https -y --force-yes
-  args:
-    warn: false
   register: install_apt_transport_result
   until: install_apt_transport_result is success  or ansible_check_mode
   retries: 5

--- a/roles/common/tasks/redhat.yml
+++ b/roles/common/tasks/redhat.yml
@@ -41,8 +41,6 @@
 # Not using handler because of https://github.com/ansible/ansible/issues/41313
 - name: yum-clean-all
   command: yum clean all
-  args:
-    warn: false
   register: yum_clean_result
   until: yum_clean_result is success
   retries: 5


### PR DESCRIPTION
# Description
Command warnings feature has been deprecated, setting warn=false is resulting into an error in latest ansible-core 2.14.
reference - https://github.com/ansible/ansible/pull/70504


Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
https://jenkins.confluent.io/job/cp-ansible-on-demand/1019/testReport/junit/molecule.plain-rhel.molecule/yml/test/
Initially, running playbook against ansi-core 2.14 resulted into error ☝️ 

After fixing, ran few scenarios against both ansi versions - 2.13 and 2.14
https://jenkins.confluent.io/job/cp-ansible-on-demand/1022/ ✅ 
https://jenkins.confluent.io/job/cp-ansible-on-demand/1028/ ✅ 


**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible