### PR TITLE
Only install/update appropriate connect plugins

### DIFF
--- a/roles/kafka_connect/tasks/confluent_hub.yml
+++ b/roles/kafka_connect/tasks/confluent_hub.yml
@@ -23,7 +23,7 @@
     - kafka_connect_confluent_hub_plugins|length > 0
     - plugin_versions.results | selectattr('item', 'eq', item) | selectattr('matched', 'eq', 0) | length > 0
   notify: restart connect distributed
-  
+
 - name: Set Permissions on Plugin Folder(s)
   file:
     path: "{{ kafka_connect_confluent_hub_plugins_dest }}/{{ item.split(':')[0] | replace('/', '-') }}"

--- a/roles/kafka_connect/tasks/confluent_hub.yml
+++ b/roles/kafka_connect/tasks/confluent_hub.yml
@@ -1,4 +1,13 @@
 ---
+- name: "Identify installed plugin versions"
+  find:
+    paths: "{{ kafka_connect_confluent_hub_plugins_dest }}/{{ item.split(':')[0] | replace('/', '-') }}"
+    patterns: "manifest.json"
+    contains: ".*\"version\" : \"{{ item.split(':')[1] }}\",$"
+  register: plugin_versions
+  with_items: "{{kafka_connect_confluent_hub_plugins}}"
+  when: kafka_connect_confluent_hub_plugins|length > 0
+
 - name: "Installing Kafka Connect Connector(s) from Confluent Hub"
   shell: |
     {{ (installation_method == 'archive') | ternary(archive_destination_path + '/confluent-' + confluent_package_version, '/usr') }}/bin/confluent-hub install \
@@ -6,13 +15,15 @@
       {{ (installation_method == 'archive') | ternary('--worker-configs ' + kafka_connect.config_file, '') }} \
       {{ item }}
   register: install_connect_connector_result
-  until: install_connect_connector_result is success  or ansible_check_mode
+  until: install_connect_connector_result is success or ansible_check_mode
   retries: 5
   delay: 90
   with_items: "{{kafka_connect_confluent_hub_plugins}}"
-  when: kafka_connect_confluent_hub_plugins|length > 0
+  when:
+    - kafka_connect_confluent_hub_plugins|length > 0
+    - plugin_versions.results | selectattr('item', 'eq', item) | selectattr('matched', 'eq', 0) | length > 0
   notify: restart connect distributed
-
+  
 - name: Set Permissions on Plugin Folder(s)
   file:
     path: "{{ kafka_connect_confluent_hub_plugins_dest }}/{{ item.split(':')[0] | replace('/', '-') }}"


### PR DESCRIPTION
# Description

This PR allows the playbook to only install the connect plugins that are either absent, or do not match the requested version.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This code change has been tested against my sandbox environment, and functions as expected with both new plugins, and installed plugin versions that do not match the required version.

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Any variable changes have been validated to be backwards compatible