### PR TITLE
Revert "Remove unused confluent.ssl.* prop"

### DIFF
--- a/roles/confluent.variables/vars/main.yml
+++ b/roles/confluent.variables/vars/main.yml
@@ -195,6 +195,14 @@ kafka_broker_properties:
     enabled: "{{ kafka_broker_schema_validation_enabled and 'schema_registry' in groups }}"
     properties:
       confluent.schema.registry.url: "{{schema_registry_url}}"
+  sr_ssl:
+    enabled: "{{ kafka_broker_schema_validation_enabled and 'schema_registry' in groups and schema_registry_ssl_enabled }}"
+    properties:
+      confluent.ssl.truststore.location: "{{kafka_broker_truststore_path}}"
+      confluent.ssl.truststore.password: "{{kafka_broker_truststore_storepass}}"
+      confluent.ssl.keystore.location: "{{kafka_broker_keystore_path}}"
+      confluent.ssl.keystore.password: "{{kafka_broker_keystore_storepass}}"
+      confluent.ssl.key.password: "{{kafka_broker_keystore_keypass}}"
   sr_ssl_fips:
     enabled: "{{ kafka_broker_schema_validation_enabled and 'schema_registry' in groups and schema_registry_ssl_enabled and fips_enabled }}"
     properties:


### PR DESCRIPTION
Reverts confluentinc/cp-ansible#1208

It's a miss. Recently found in oncall that these props are required. 
Our existing tests didn't catch this even though being very similar to the customer's env. So, can't add any other tests.
Customer can be unblocked by mentioning these props in kafka_broker_custom_properties for now. 