### PR TITLE
Enable allow_weak_crypto as a kerberos setting

### DIFF
--- a/docs/VARIABLES.md
+++ b/docs/VARIABLES.md
@@ -190,7 +190,7 @@ Default:  0
 
 ### kerberos_configure
 
-Boolean to configure Kerberos krb5.conf file, must also set kerberos.realm, keberos.kdc_hostname, kerberos.admin_hostname, where kerberos is a dictionary
+Boolean to configure Kerberos krb5.conf file, must also set kerberos.realm, kerberos.kdc_hostname, kerberos.admin_hostname, where kerberos is a dictionary
 
 Default:  true
 

--- a/molecule/rbac-kerberos-debian/molecule.yml
+++ b/molecule/rbac-kerberos-debian/molecule.yml
@@ -10,7 +10,7 @@
 driver:
   name: docker
 platforms:
-  # LDAP and Keberos on centos, rest on debian
+  # LDAP and kerberos on centos, rest on debian
   - name: ldap1
     hostname: ldap1.confluent
     groups:

--- a/molecule/rbac-mds-kerberos-debian/molecule.yml
+++ b/molecule/rbac-mds-kerberos-debian/molecule.yml
@@ -9,7 +9,7 @@
 driver:
   name: docker
 platforms:
-  # LDAP and Keberos on centos, rest on debian
+  # LDAP and kerberos on centos, rest on debian
   - name: mds-ldap1
     hostname: mds-ldap1.confluent
     groups:

--- a/roles/kerberos/defaults/main.yml
+++ b/roles/kerberos/defaults/main.yml
@@ -9,3 +9,4 @@ kerberos:
   default_tgs_enctypes: aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 arc-four-hmac rc4-hmac
   permitted_enctypes: aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96 arc-four-hmac rc4-hmac
   canonicalize: true
+  allow_weak_crypto: false

--- a/roles/kerberos/templates/krb5.conf.j2
+++ b/roles/kerberos/templates/krb5.conf.j2
@@ -9,6 +9,7 @@
  default_tgs_enctypes = {{ kerberos.default_tgs_enctypes }}
  permitted_enctypes = {{ kerberos.permitted_enctypes }}
  canonicalize = {{ kerberos.canonicalize }}
+ allow_weak_crypto = {{ kerberos.allow_weak_crypto }}
 
 [realms]
  {{ kerberos.realm| upper() }} = {

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -79,7 +79,7 @@ logredactor_rule_url: ""
 ### If present, it's used to specify a time in ms for how often the file system or URL of the policy rules will be checked for changes. Default is 0 and it means that the policy rules will be checked only at startup. Can be specified as logredactor_policy_refresh_interval: 7000
 logredactor_policy_refresh_interval: 0
 
-### Boolean to configure Kerberos krb5.conf file, must also set kerberos.realm, keberos.kdc_hostname, kerberos.admin_hostname, where kerberos is a dictionary
+### Boolean to configure Kerberos krb5.conf file, must also set kerberos.realm, kerberos.kdc_hostname, kerberos.admin_hostname, where kerberos is a dictionary
 kerberos_configure: true
 
 ### Custom path for the location of kerberos client configuration file, works with any value of kerberos_configure


### PR DESCRIPTION
# Description

https://confluentinc.atlassian.net/browse/ANSIENG-2056
Context on what the variable does - https://web.mit.edu/kerberos/krb5-1.12/doc/admin/conf_files/krb5_conf.html#libdefaults
Default value is set to false
Context on why we need to expose this var - https://confluentinc.atlassian.net/browse/FF-9024
Target branch is kept to 7.3.x since we started supporting java17 from 7.3

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

https://jenkins.confluent.io/job/cp-ansible-on-demand/1097/
https://jenkins.confluent.io/job/cp-ansible-on-demand/1096/


**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible