### PR TITLE
Copy only MQ jars to ext folder to be loaded by the extension classloader

### DIFF
--- a/roles/kafka_connect/tasks/zos_connect_plugins.yml
+++ b/roles/kafka_connect/tasks/zos_connect_plugins.yml
@@ -56,10 +56,8 @@
       - "confluentinc-kafka-connect-ibmmq*"
   register: kafka_connect_ibm_mq_plugins
 
-- name: Copy MQ libs under MQ plugin folders
-  shell: "cp {{ kafka_connect_ibm_mqm_lib_path }}/*.jar {{item}}/lib"
-  loop: "{{ kafka_connect_ibm_mq_plugins.files | map(attribute='path') | list }}"
-
+- name: Copy MQ libs under JDK ext
+  shell: "cp {{ kafka_connect_ibm_mqm_lib_path }}/*.jar {{ jdk_ext_path }}"
 
 - debug:
     msg: Confluent hub plugins are not supported on z/OS

--- a/roles/kafka_connect/tasks/zos_connect_plugins.yml
+++ b/roles/kafka_connect/tasks/zos_connect_plugins.yml
@@ -48,14 +48,6 @@
 
 # Special processing for IBM MQ connectors
 # they need MQ libraries to be present
-- name: Gather all IBM MQ plugin folders
-  find:
-    paths: "{{ kafka_connect_plugins_dest }}"
-    file_type: directory
-    patterns:
-      - "confluentinc-kafka-connect-ibmmq*"
-  register: kafka_connect_ibm_mq_plugins
-
 - name: Copy MQ libs under JDK ext
   shell: "cp {{ kafka_connect_ibm_mqm_lib_path }}/*.jar {{ jdk_ext_path }}"
 


### PR DESCRIPTION
# Description
Modify the step to copy over .jars to each connector's lib directory.
Instead we copy these jars just once to the java ext directory.
The LIBPATH environment variable points to the native libraries.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration



**Test Configuration**:


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible