### PR TITLE
kafka_connect_replicator_consumer_timestamps_topic is not configurable

### DIFF
--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -2756,14 +2756,6 @@ Default:  connect-configs
 
 ***
 
-### kafka_connect_replicator_consumer_timestamps_topic
-
-Set this variable to customize the topic where Kafka Connect Replicator consumer stores it's timestamps.
-
-Default:   __consumer_timestamps
-
-***
-
 ### kafka_connect_replicator_white_list
 
 Set this variable with a comma seperated list of Topics for Kafka Connect Replicator to replicate from.  This is a mandatory variable.

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -1578,7 +1578,7 @@ kafka_connect_replicator_status_topic: connect-status
 ### Set this variable to customize the topic where Kafka Connect Replicator stores it's configuration.
 kafka_connect_replicator_storage_topic: connect-configs
 
-### Set this variable to customize the topic where Kafka Connect Replicator consumer stores it's timestamps.
+## Timestamps topic used by Kafka Connect Replicator to grant DeveloperRead, DeveloperManage bindings (non configurable variable)
 kafka_connect_replicator_consumer_timestamps_topic:  __consumer_timestamps
 
 ### Set this variable with a comma seperated list of Topics for Kafka Connect Replicator to replicate from.  This is a mandatory variable.


### PR DESCRIPTION
# Description

As requested in [on-call issue](https://confluent.slack.com/archives/CMTBL483Y/p1677186314680819), one of the customers was looking to customize the timestamps topic used by replicator (__consumer_timestamps). However, Kafka (base feature) itself doesn't support this. To avoid confusion, we are removing it from VARIABLES.md

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration



**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible