### PR TITLE
Fixing mTLS healthcheck extracting wrong certificate when providing a full chain bundle

### DIFF
--- a/roles/kafka_connect/tasks/health_check.yml
+++ b/roles/kafka_connect/tasks/health_check.yml
@@ -22,7 +22,7 @@
     url: "{{kafka_connect_http_protocol}}://{{ hostvars[inventory_hostname]|confluent.platform.resolve_hostname }}:{{kafka_connect_rest_port}}/connectors"
     status_code: 200
     validate_certs: false
-    client_cert: "{{kafka_connect_cert_path}}"
+    client_cert: "{{ssl_file_dir_final}}/{{service_name}}.chain"
     client_key: "{{kafka_connect_key_path}}"
     # Basic auth header is redundant for non rbac install
     url_username: "{{kafka_connect_health_check_user}}"

--- a/roles/kafka_connect_replicator/tasks/health_check.yml
+++ b/roles/kafka_connect_replicator/tasks/health_check.yml
@@ -22,7 +22,7 @@
     url: "{{kafka_connect_replicator_http_protocol}}://{{ hostvars[inventory_hostname]|confluent.platform.resolve_hostname }}:{{kafka_connect_replicator_port}}/connectors"
     status_code: 200
     validate_certs: false
-    client_cert: "{{kafka_connect_replicator_cert_path}}"
+    client_cert: "{{ssl_file_dir_final}}/{{service_name}}.chain"
     client_key: "{{kafka_connect_replicator_key_path}}"
     # Basic auth header is redundant for non rbac install
     url_username: "{{kafka_connect_replicator_health_check_user}}"

--- a/roles/kafka_rest/tasks/health_check.yml
+++ b/roles/kafka_rest/tasks/health_check.yml
@@ -22,7 +22,7 @@
     url: "{{kafka_rest_http_protocol}}://{{hostvars[inventory_hostname]|confluent.platform.resolve_hostname}}:{{kafka_rest_port}}/topics"
     status_code: 200
     validate_certs: false
-    client_cert: "{{kafka_rest_cert_path}}"
+    client_cert: "{{ssl_file_dir_final}}/{{service_name}}.chain"
     client_key: "{{kafka_rest_key_path}}"
     # Basic auth header is redundant for non rbac install
     url_username: "{{kafka_rest_health_check_user}}"

--- a/roles/ksql/tasks/health_check.yml
+++ b/roles/ksql/tasks/health_check.yml
@@ -22,7 +22,7 @@
     url: "{{ksql_http_protocol}}://{{ hostvars[inventory_hostname]|confluent.platform.resolve_hostname }}:{{ksql_listener_port}}/info"
     status_code: 200
     validate_certs: false
-    client_cert: "{{ksql_cert_path}}"
+    client_cert: "{{ssl_file_dir_final}}/{{service_name}}.chain"
     client_key: "{{ksql_key_path}}"
     # Basic auth header is redundant for non rbac install
     url_username: "{{ksql_health_check_user}}"

--- a/roles/schema_registry/tasks/health_check.yml
+++ b/roles/schema_registry/tasks/health_check.yml
@@ -22,7 +22,7 @@
     url: "{{schema_registry_http_protocol}}://{{ hostvars[inventory_hostname]|confluent.platform.resolve_hostname }}:{{schema_registry_listener_port}}/subjects"
     status_code: 200
     validate_certs: false
-    client_cert: "{{schema_registry_cert_path}}"
+    client_cert: "{{ssl_file_dir_final}}/{{service_name}}.chain"
     client_key: "{{schema_registry_key_path}}"
     # Basic auth header is redundant for non rbac install
     url_username: "{{schema_registry_health_check_user}}"


### PR DESCRIPTION
# Description
In some cases deploying cp with mTLS, `Wait for API to return 200 - mTLS` tasks fail if you provide providing a full chain in the inventory (custom certs) due to incorrect extracted server certificate. 

```yml
- name: Extract Final Cert from Signed Cert Chain
  shell: |
    tac {{ ssl_file_dir_final }}/{{service_name}}.chain | awk '!flag; /-----BEGIN CERTIFICATE-----/{flag = 1};' | tac > {{cert_path}}
  diff: "{{ not mask_sensitive_diff|bool }}"
```

The  `Extract Final Cert from Signed Cert Chain` task above can extract the CA (or the intermediate) instead of the server certificate since the extraction depends on the order of the certificates in the bundle, **the server certificate is always expected to be the last**, which is not always the case. If that happens the health check fails.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This was tested (and currently running) on a production server I've been working with during an installation using mTLS with custom certs and RBAC. The bundle used contains `Root CA -> Intermediate CA -> Server cert` where the server cert is not the last certificate in the bundle.

If the proposed change is not a valid solution, we can think about a different way of extracting or providing the certificates to avoid the issue. If there is anything I can do please let me know, we can also add this nuance on the docs

This was also tested on 7.2.x

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation 
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Any variable changes have been validated to be backwards compatible