### PR TITLE
Fix errors downloading confluent CLI v3

### DIFF
--- a/molecule/archive-plain-debian/molecule.yml
+++ b/molecule/archive-plain-debian/molecule.yml
@@ -99,6 +99,7 @@ provisioner:
     group_vars:
       all:
         confluent_cli_download_enabled: true
+        confluent_cli_version: 3.2.1
         sasl_protocol: plain
         ssl_enabled: true
         installation_method: "archive"

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -75,7 +75,7 @@ confluent_archive_file_remote: true
 confluent_cli_repository_baseurl: "https://s3-us-west-2.amazonaws.com/confluent.cloud"
 
 ### A path reference to a local archive file or URL. By default this is the URL from Confluent CLI repository.
-confluent_cli_archive_file_source: "{{confluent_cli_repository_baseurl}}/confluent-cli/archives/{{confluent_cli_version}}/{{confluent_cli_binary}}_{{(confluent_cli_version == 'latest') | ternary('', 'v')}}{{confluent_cli_version}}_{{ansible_system|lower}}_{{confluent_cli_goarch[ansible_architecture]}}.tar.gz"
+confluent_cli_archive_file_source: "{{confluent_cli_repository_baseurl}}/confluent-cli/archives/{{confluent_cli_version}}/{{confluent_cli_binary}}_{{(confluent_cli_version is version('3.0.0', '>=')) | ternary('', 'v')}}{{confluent_cli_version}}_{{ansible_system|lower}}_{{confluent_cli_goarch[ansible_architecture]}}.tar.gz"
 
 ### Set to true to indicate the CLI archive file is remote (i.e. already on the target node) or a URL. Set to false if the archive file is on the control node.
 confluent_cli_archive_file_remote: true


### PR DESCRIPTION
# Description

Users experiencing issues with downloading confluent CLI v3 because - 

for CLI v3 and above, archive name is somewhat different - confluent_v3.2.1_linux_amd64.tar.gz should become confluent_3.2.1_linux_amd64.tar.gz (remove leading ‘v’)

PR is to fix above problem.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Before - https://jenkins.confluent.io/job/cp-ansible-on-demand/1216/ 🔴 failed, Failure downloading https://s3-us-west-2.amazonaws.com/confluent.cloud/confluent-cli/archives/3.2.1/confluent_v3.2.1_linux_amd64.tar.gz, HTTP Error 404: Not Found

After fix - https://jenkins.confluent.io/job/cp-ansible-on-demand/1217/ 🟢 passed



**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible