### PR TITLE
Don't require RBAC for confluent secret v3

### DIFF
--- a/roles/control_center/tasks/main.yml
+++ b/roles/control_center/tasks/main.yml
@@ -208,7 +208,7 @@
     - configuration
   when:
     - control_center_secrets_protection_enabled|bool
-    - rbac_enabled|bool
+    - rbac_enabled|bool or confluent_cli_version is version('3.0.0', '>=')
 
 - name: Create Logs Directory
   file:

--- a/roles/kafka_broker/tasks/health_check.yml
+++ b/roles/kafka_broker/tasks/health_check.yml
@@ -13,7 +13,7 @@
   ignore_errors: true
   changed_when: false
   check_mode: false
-  when: not rbac_enabled|bool
+  when: not kafka_broker_client_secrets_protection_enabled or not (rbac_enabled|bool or confluent_cli_version is version('3.0.0', '>='))
 
 - name: Get Topics with UnderReplicatedPartitions with Secrets Protection enabled
   shell: |
@@ -32,7 +32,7 @@
   check_mode: false
   when:
     - kafka_broker_client_secrets_protection_enabled|bool
-    - rbac_enabled|bool
+    - rbac_enabled|bool or confluent_cli_version is version('3.0.0', '>=')
 
 - name: Wait for Metadata Service to start
   uri:

--- a/roles/kafka_broker/tasks/health_check.yml
+++ b/roles/kafka_broker/tasks/health_check.yml
@@ -13,7 +13,7 @@
   ignore_errors: true
   changed_when: false
   check_mode: false
-  when: not kafka_broker_client_secrets_protection_enabled or not (rbac_enabled|bool or confluent_cli_version is version('3.0.0', '>='))
+  when: not ( rbac_enabled|bool or kafka_broker_client_secrets_protection_enabled|bool )
 
 - name: Get Topics with UnderReplicatedPartitions with Secrets Protection enabled
   shell: |

--- a/roles/kafka_broker/tasks/main.yml
+++ b/roles/kafka_broker/tasks/main.yml
@@ -434,7 +434,7 @@
   include_tasks: secrets_protection.yml
   when:
     - kafka_broker_secrets_protection_enabled|bool or kafka_broker_client_secrets_protection_enabled|bool
-    - rbac_enabled|bool
+    - rbac_enabled|bool or confluent_cli_version is version('3.0.0', '>=')
 
 - meta: flush_handlers
 

--- a/roles/kafka_connect/tasks/main.yml
+++ b/roles/kafka_connect/tasks/main.yml
@@ -196,7 +196,7 @@
     - configuration
   when:
     - kafka_connect_secrets_protection_enabled|bool
-    - rbac_enabled|bool
+    - rbac_enabled|bool or confluent_cli_version is version('3.0.0', '>=')
 
 - name: Install Connect Plugins
   include_tasks: connect_plugins.yml

--- a/roles/kafka_rest/tasks/main.yml
+++ b/roles/kafka_rest/tasks/main.yml
@@ -224,7 +224,7 @@
     - configuration
   when:
     - kafka_rest_secrets_protection_enabled|bool
-    - rbac_enabled|bool
+    - rbac_enabled|bool or confluent_cli_version is version('3.0.0', '>=')
 
 - name: Create Logs Directory
   file:

--- a/roles/ksql/tasks/main.yml
+++ b/roles/ksql/tasks/main.yml
@@ -205,7 +205,7 @@
     - configuration
   when:
     - ksql_secrets_protection_enabled|bool
-    - rbac_enabled|bool
+    - rbac_enabled|bool or confluent_cli_version is version('3.0.0', '>=')
 
 - name: Create Logs Directory
   file:

--- a/roles/schema_registry/tasks/main.yml
+++ b/roles/schema_registry/tasks/main.yml
@@ -186,7 +186,7 @@
     - configuration
   when:
     - schema_registry_secrets_protection_enabled|bool
-    - rbac_enabled|bool
+    - rbac_enabled|bool or confluent_cli_version is version('3.0.0', '>=')
 
 
 - name: Create Logs Directory


### PR DESCRIPTION
# Description

With version 3 of the CLI confluent secrets command, the RBAC login requirement was removed. The playbooks have not been updated to reflect this change and secrets management is getting disabled.

Fixes issues https://confluent.slack.com/archives/CM80GTNUQ/p1656981267820799

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

These changes have been tested against EC2 instances running in AWS on a n mTLS non RBAC cluster with secret management and health checks enabled.



**Test Configuration**:


# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible