### PR TITLE
Added ports for kerberos template with defaults

### DIFF
--- a/docs/VARIABLES.md
+++ b/docs/VARIABLES.md
@@ -190,7 +190,8 @@ Default:  0
 
 ### kerberos_configure
 
-Boolean to configure Kerberos krb5.conf file, must also set kerberos.realm, kerberos.kdc_hostname, kerberos.admin_hostname, where kerberos is a dictionary
+Boolean to configure Kerberos krb5.conf file, must also set kerberos.realm, kerberos.kdc_hostname, kerberos.admin_hostname, where kerberos is a dictionary.
+Optional variables: kerberos.kdc_port (default: 88), kerberos.admin_port (default: 749)
 
 Default:  true
 

--- a/roles/kerberos/templates/krb5.conf.j2
+++ b/roles/kerberos/templates/krb5.conf.j2
@@ -13,8 +13,8 @@
 
 [realms]
  {{ kerberos.realm| upper() }} = {
-  kdc = {{ kerberos.kdc_hostname }}:88
-  admin_server = {{ kerberos.admin_hostname }}:749
+  kdc = {{ kerberos.kdc_hostname }}:{{ kerberos.kdc_port|default('88') }}
+  admin_server = {{ kerberos.admin_hostname }}:{{ kerberos.admin_port|default('749') }}
   default_domain = {{ kerberos.realm|lower() }}
  }
 


### PR DESCRIPTION
# Description

As described in https://github.com/confluentinc/cp-ansible/issues/1371
Added variables for kerberos port(s) with defaults for the currently hard-coded values in krb5.conf.j2 to allow installation e.g. in cloud-hosted MS AD setups.

Fixes #1371 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

* Local testing of template in ansible
* Integration - full deployment in target system with modified template


**Test Configuration**:
- fallback / defaults: 
```bash
ansible all -i "localhost," -c local -m template -a "src=./roles/kerberos/templates/krb5.conf.j2 dest=./test.txt" --extra-vars='{kerberos: {realm: TEST.REALM, dns_lookup_realm: test.realm, dns_lookup_kdc: test.kdc, ticket_lifetime: 42, forwardable: false, udp_preference_limit: 4242, default_tkt_enctypes: aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96, default_tgs_enctypes: default, permitted_enctypes: none, canonicalize: false, allow_weak_crypto: false, kdc_hostname: kdc.local, admin_hostname: krb.local } }'
```

- new variables: 
```bash
ansible all -i "localhost," -c local -m template -a "src=./roles/kerberos/templates/krb5.conf.j2 dest=./test.txt" --extra-vars='{kerberos: {realm: TEST.REALM, dns_lookup_realm: test.realm, dns_lookup_kdc: test.kdc, ticket_lifetime: 42, forwardable: false, udp_preference_limit: 4242, default_tkt_enctypes: aes256-cts-hmac-sha1-96 aes128-cts-hmac-sha1-96, default_tgs_enctypes: default, permitted_enctypes: none, canonicalize: false, allow_weak_crypto: false, kdc_hostname: kdc.local, admin_hostname: krb.local, kdc_port: 666, admin_port: 777 } }'
```

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Any variable changes have been validated to be backwards compatible