### PR TITLE
Add secrets protection without RBAC with cli v3

### DIFF
--- a/molecule/mtls-ubuntu/molecule.yml
+++ b/molecule/mtls-ubuntu/molecule.yml
@@ -121,3 +121,5 @@ provisioner:
       all:
         ssl_enabled: true
         ssl_mutual_auth_enabled: true
+        secrets_protection_enabled: true # To test secrets protection on cli v3 without rbac
+        confluent_cli_version: 3.2.1

--- a/roles/common/tasks/secrets_protection.yml
+++ b/roles/common/tasks/secrets_protection.yml
@@ -11,7 +11,7 @@
   until: mds_login_result.rc == 0
   retries: 30
   delay: 5
-  when: confluent_cli_version is version('2.3', '>=')
+  when: confluent_cli_version is version('2.3', '>=') and confluent_cli_version is version('3.0', '<')
 
 - name: Set Up Secrets Protection
   include_tasks: masterkey.yml

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -163,8 +163,8 @@ config_base_path: "{{ (archive_config_base_path | regex_replace('\\/$','')) if i
 ### The configuration prefix to use, by default /etc. Note - Only valid to customize when installation_method: archive
 config_prefix: "/etc"
 
-### Boolean to have cp-ansible download the Confluent CLI
-confluent_cli_download_enabled: "{{rbac_enabled}}"
+### Boolean to have cp-ansible download the Confluent CLI, required to be enabled in case of secrets protection
+confluent_cli_download_enabled: "{{ secrets_protection_enabled }}"
 
 ### The path the Confluent CLI archive is expanded into.
 confluent_cli_base_path: /opt/confluent-cli


### PR DESCRIPTION
# Description

This PR aims to Add secrets protection without RBAC using confluent cli v3

Fixes # [ANSIENG-2151](https://confluentinc.atlassian.net/browse/ANSIENG-2151)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

tested locally


**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Any variable changes have been validated to be backwards compatible

[ANSIENG-2151]: https://confluentinc.atlassian.net/browse/ANSIENG-2151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ