### PR TITLE
Fix bug in nuke.yml

### DIFF
--- a/playbooks/nuke.yml
+++ b/playbooks/nuke.yml
@@ -76,11 +76,11 @@
 
     - set_fact:
         data_dirs: "{{ data_dirs + [ control_center_rocksdb_path|default('') ] }}"
-      when: inventory_hostname in groups.control_center
+      when: "'control_center' in groups.keys() and inventory_hostname in groups.control_center"
 
     - set_fact:
         data_dirs: "{{ data_dirs + [ ksql_rocksdb_path| default('/tmp/ksqldb'), ksql_final_properties['ksql.streams.state.dir'] ] }}"
-      when: inventory_hostname in groups.ksql
+      when: "'ksql' in groups.keys() and inventory_hostname in groups.ksql"
 
     - name: List Package names to be deleted
       debug:


### PR DESCRIPTION
# Description

Fixes minor bug in nuke.yml, the playbook can now run without control center and ksql in cluster

Fixes # [2215](https://confluentinc.atlassian.net/browse/ANSIENG-2215)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

tested locally

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible