### PR TITLE
SSL principal mapping rule fixes

### DIFF
--- a/molecule/rbac-mtls-rhel/verify.yml
+++ b/molecule/rbac-mtls-rhel/verify.yml
@@ -346,7 +346,7 @@
         that:
           - dname == "{{ common_names|confluent.platform.resolve_principal(rules) }}"
       vars:
-        rules: "^CN=(.*?), OU=(.*?)$/$1/U"
+        rules: "^CN=(.*?), OU=(.*?)$/$1/U,DEFAULT"
         common_names: "CN=kafka-server1, OU=KAFKA"
         dname: KAFKA-SERVER1
 
@@ -373,6 +373,15 @@
         that:
           - dname == "{{ common_names|confluent.platform.resolve_principal(rules) }}"
       vars:
-        rules: "RULE:^cn=(.*?),ou=(.*?),dc=(.*?),dc=(.*?)$/$1/LRULE:^CN=(.*?), OU=(.*?), O=(.*?), L=(.*?), ST=(.*?), C=(.*?)$/$1@$2/"
+        rules: "RULE:^cn=(.*?),ou=(.*?),dc=(.*?),dc=(.*?)$/$1/L,RULE:^CN=(.*?), OU=(.*?), O=(.*?), L=(.*?), ST=(.*?), C=(.*?)$/$1@$2/"
+        common_names: "cn=kafka1,ou=SME,dc=mycp,dc=com"
+        dname: kafka1
+
+    - name: Validate multiple mapping rule with default
+      assert:
+        that:
+          - dname == "{{ common_names|confluent.platform.resolve_principal(rules) }}"
+      vars:
+        rules: "RULE:^cn=(.*?),du=(.*?),dc=(.*?),dc=(.*?)$/$1/L,RULE:^CN=(.*?), OU=(.*?), O=(.*?), L=(.*?), ST=(.*?), C=(.*?)$/$1@$2/,DEFAULT"
         common_names: "cn=kafka1,ou=SME,dc=mycp,dc=com"
         dname: kafka1

--- a/molecule/rbac-mtls-rhel/verify.yml
+++ b/molecule/rbac-mtls-rhel/verify.yml
@@ -377,6 +377,15 @@
         common_names: "cn=kafka1,ou=SME,dc=mycp,dc=com"
         dname: KAFKA1
 
+    - name: Validate first rule gets applied in case of multiple rule matches
+      assert:
+        that:
+          - dname == "{{ common_names|confluent.platform.resolve_principal(rules) }}"
+      vars:
+        rules: "RULE:^cn=(.*?),ou=(.*?),dc=(.*?),dc=(.*?)$/$1/U,RULE:^cn=(.*?),ou=(.*?),dc=(.*?),dc=(.*?)$/$1/L"
+        common_names: "cn=kafka1,ou=SME,dc=mycp,dc=com"
+        dname: KAFKA1
+
     - name: Validate multiple mapping rule with default
       assert:
         that:

--- a/molecule/rbac-mtls-rhel/verify.yml
+++ b/molecule/rbac-mtls-rhel/verify.yml
@@ -373,15 +373,15 @@
         that:
           - dname == "{{ common_names|confluent.platform.resolve_principal(rules) }}"
       vars:
-        rules: "RULE:^cn=(.*?),ou=(.*?),dc=(.*?),dc=(.*?)$/$1/L,RULE:^CN=(.*?), OU=(.*?), O=(.*?), L=(.*?), ST=(.*?), C=(.*?)$/$1@$2/"
+        rules: "RULE:^cn=(.*?),ou=(.*?),dc=(.*?),dc=(.*?)$/$1/U,RULE:^CN=(.*?), OU=(.*?), O=(.*?), L=(.*?), ST=(.*?), C=(.*?)$/$1@$2/"
         common_names: "cn=kafka1,ou=SME,dc=mycp,dc=com"
-        dname: kafka1
+        dname: KAFKA1
 
     - name: Validate multiple mapping rule with default
       assert:
         that:
           - dname == "{{ common_names|confluent.platform.resolve_principal(rules) }}"
       vars:
-        rules: "RULE:^cn=(.*?),du=(.*?),dc=(.*?),dc=(.*?)$/$1/L,RULE:^CN=(.*?), OU=(.*?), O=(.*?), L=(.*?), ST=(.*?), C=(.*?)$/$1@$2/,DEFAULT"
-        common_names: "cn=kafka1,ou=SME,dc=mycp,dc=com"
-        dname: kafka1
+        rules: "RULE:^cn=(.*?),ou=(.*?),dc=(.*?),dc=(.*?)$/$1/L,RULE:^CN=(.*?), OU=(.*?), O=(.*?), L=(.*?), ST=(.*?), C=(.*?)$/$1@$2/,DEFAULT"
+        common_names: "cn=kafka1,ou=SME,dc=mycp"
+        dname: "cn=kafka1,ou=SME,dc=mycp"

--- a/plugins/filter/filters.py
+++ b/plugins/filter/filters.py
@@ -384,5 +384,7 @@ class FilterModule(object):
                     elif case[0].startswith('U'):
                         principal_mapping_value = mapping_value.upper()
                     break
-
+            if bool(matched):
+                # Remaining rules in the list are ignored when match is found
+                break
         return principal_mapping_value

--- a/plugins/filter/filters.py
+++ b/plugins/filter/filters.py
@@ -366,7 +366,7 @@ class FilterModule(object):
         list_of_rules = [i for i in list_of_rules if i]
 
         for rule_str in list_of_rules:
-            mapping_pattern, mapping_value, *case = rule_str.split('/')
+            mapping_pattern, mapping_value, *options = rule_str.split('/')
             for common_name in common_names:
                 matched = re.match(mapping_pattern, common_name)
                 if bool(matched):
@@ -378,10 +378,10 @@ class FilterModule(object):
                     # Remove leading and trailing whitespaces
                     mapping_value = mapping_value.strip()
                     principal_mapping_value = mapping_value
-
-                    if case[0].startswith('L'):
+                    case = [option for option in options[0].split(',') if option]
+                    if case and case[0] == 'L':
                         principal_mapping_value = mapping_value.lower()
-                    elif case[0].startswith('U'):
+                    elif case and case[0] == 'U':
                         principal_mapping_value = mapping_value.upper()
                     break
             if bool(matched):

--- a/plugins/filter/filters.py
+++ b/plugins/filter/filters.py
@@ -379,9 +379,9 @@ class FilterModule(object):
                     mapping_value = mapping_value.strip()
                     principal_mapping_value = mapping_value
 
-                    if case[0] == 'L':
+                    if case[0].startswith('L'):
                         principal_mapping_value = mapping_value.lower()
-                    elif case[0] == 'U':
+                    elif case[0].startswith('U'):
                         principal_mapping_value = mapping_value.upper()
                     break
 


### PR DESCRIPTION
# Description

Fixed below issues
- `RULE:pattern/replacement/[LU],DEFAULT` - was resulting into error
- Fixed - Support for comma separated mapping rules RULE:pattern1/replacement/[LU],RULE:pattern2/replacement/[LU]
- Fixed - First matching rule should get applied, and rest of the list should be ignored

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Added few assertions to test above fixes in molecule verify
https://jenkins.confluent.io/job/cp-ansible-on-demand/1251/

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible