### PR TITLE
Revert "Disable metrics reporter on Controller (#1378)"

### DIFF
--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -522,6 +522,9 @@ kafka_controller_copy_files: []
 ### Replication Factor for internal topics. Defaults to the minimum of the number of controllers and can be overridden via default replication factor (see default_internal_replication_factor).
 kafka_controller_default_internal_replication_factor: "{{ [ groups['kafka_controller'] | default(['localhost']) | length, default_internal_replication_factor ] | min }}"
 
+### Boolean to enable the kafka's metrics reporter. Defaults to true if Control Center in inventory. Enable if you wish to have metrics reported to a centralized monitoring cluster.
+kafka_controller_metrics_reporter_enabled: "{{ confluent_server_enabled and 'control_center' in groups }}"
+
 ### Use to set custom kafka properties. This variable is a dictionary. Put values true/false in quotation marks to perserve case.
 kafka_controller_custom_properties: {}
 

--- a/roles/variables/vars/main.yml
+++ b/roles/variables/vars/main.yml
@@ -234,13 +234,13 @@ kafka_controller_properties:
                     plain_jaas_config, kafka_controller_keytab_path, kafka_controller_kerberos_principal|default('kafka'), kerberos_kafka_controller_primary,
                     sasl_scram_users_final.admin.principal, sasl_scram_users_final.admin.password, sasl_scram256_users_final.admin.principal, sasl_scram256_users_final.admin.password, rbac_enabled_public_pem_path ) }}"
   metrics_reporter:
-    enabled: false #Disabled since metrics reporter is not enabled on controller yet, will need to enable when the support is available
+    enabled: "{{ kafka_controller_metrics_reporter_enabled|bool }}"
     properties:
       metric.reporters: io.confluent.metrics.reporter.ConfluentMetricsReporter
       confluent.metrics.reporter.bootstrap.servers: "{{ groups['kafka_broker'] | default(['localhost']) | confluent.platform.resolve_hostnames(hostvars) | join(':' + kafka_broker_listeners[kafka_broker_inter_broker_listener_name]['port']|string + ',') }}:{{kafka_broker_listeners[kafka_broker_inter_broker_listener_name]['port']}}"
       confluent.metrics.reporter.topic.replicas: "{{kafka_broker_default_internal_replication_factor}}"
   metrics_reporter_client:
-    enabled: false
+    enabled: "{{ kafka_controller_metrics_reporter_enabled|bool }}"
     properties: "{{ kafka_broker_listeners[kafka_broker_inter_broker_listener_name] | confluent.platform.client_properties(ssl_enabled, fips_enabled, ssl_mutual_auth_enabled, sasl_protocol,
                     'confluent.metrics.reporter.', kafka_controller_truststore_path, kafka_controller_truststore_storepass, False, kafka_controller_keystore_path, kafka_controller_keystore_storepass, kafka_controller_keystore_keypass,
                     false, sasl_plain_users_final.admin.principal, sasl_plain_users_final.admin.password, '', '', '','',


### PR DESCRIPTION
# Description

This reverts commit 0018652b64be571bcd6f00bf117cb214ca2f50ed.
The commit was added as a fix for [ANSIENG-2218](https://confluentinc.atlassian.net/jira/software/c/projects/ANSIENG/issues/ANSIENG-2218), However it has other implications — like the offline partition count metric no longer being reported.  The metric reporters need to be re-enabled, and a different solution needs to be found for the “extra brokers being reported” issue.

Fixes # [ANSIENG-2218](https://confluentinc.atlassian.net/jira/software/c/projects/ANSIENG/issues/ANSIENG-2218) [MMA-13091](https://confluentinc.atlassian.net/browse/MMA-13091)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?




**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Any variable changes have been validated to be backwards compatible

[ANSIENG-2218]: https://confluentinc.atlassian.net/browse/ANSIENG-2218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ANSIENG-2218]: https://confluentinc.atlassian.net/browse/ANSIENG-2218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MMA-13091]: https://confluentinc.atlassian.net/browse/MMA-13091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ