### PR TITLE
Add variable to customize the number of days from Certificate Authority creation to expiration

### DIFF
--- a/docs/VARIABLES.md
+++ b/docs/VARIABLES.md
@@ -532,6 +532,14 @@ Default:  "{{ssl_provided_keystore_and_truststore}}"
 
 ***
 
+### keystore_expiration_days
+
+Number of days from keystore creation to expiration. Set for all components of Confluent Platform.
+
+Default:  365
+
+***
+
 ### ssl_keystore_filepath
 
 Full path to host specific keystore on ansible control node. Used with ssl_provided_keystore_and_truststore: true. May set per host, or use inventory_hostname variable eg "/tmp/certs/{{inventory_hostname}}-keystore.jks"

--- a/docs/VARIABLES.md
+++ b/docs/VARIABLES.md
@@ -468,6 +468,14 @@ Default:  false
 
 ***
 
+### certificate_authority_expiration_days
+
+Number of days from certificate authority creation to expiration. Set for all components of Confluent Platform.
+
+Default:  365
+
+***
+
 ### ssl_mutual_auth_enabled
 
 Boolean to enable mTLS Authentication on all components. Configures all components to use mTLS for authentication into Kafka

--- a/docs/VARIABLES.md
+++ b/docs/VARIABLES.md
@@ -470,7 +470,7 @@ Default:  false
 
 ### certificate_authority_expiration_days
 
-Number of days from certificate authority creation to expiration. Set for all components of Confluent Platform.
+Set this variable to customize expiration days for certificate authority. Applies for all components of Confluent Platform.
 
 Default:  365
 
@@ -537,14 +537,6 @@ Default:  false
 Boolean to provide custom password for keystores and truststore. Enabled with ssl_provided_keystore_and_truststore, but can be enabled independently to set the custom password for generated keystores and truststores when using custom or self-signed certificates
 
 Default:  "{{ssl_provided_keystore_and_truststore}}"
-
-***
-
-### keystore_expiration_days
-
-Number of days from keystore creation to expiration. Set for all components of Confluent Platform.
-
-Default:  365
 
 ***
 
@@ -5117,6 +5109,14 @@ Default:  30
 # ssl
 
 Below are the supported variables for the role ssl
+
+***
+
+### keystore_expiration_days
+
+Set this variable to customize expiration days for keystore. Applies for all components of Confluent Platform.
+
+Default:  365
 
 ***
 

--- a/playbooks/tasks/certificate_authority.yml
+++ b/playbooks/tasks/certificate_authority.yml
@@ -100,7 +100,7 @@
         openssl req -new -x509 \
           -keyout {{ ssl_file_dir_final }}/generation/{{ssl_self_signed_ca_key_filepath|basename}} \
           -out {{ ssl_file_dir_final }}/generation/{{ssl_self_signed_ca_cert_filepath|basename}} \
-          -days 365 \
+          -days {{ certificate_authority_expiration_days }} \
           -subj '/CN=ca1.test.confluent.io/OU=TEST/O=CONFLUENT/L=MountainView/S=Ca/C=US' \
           -passin pass:{{ssl_self_signed_ca_password}} -passout pass:{{ssl_self_signed_ca_password}}
       when: >

--- a/roles/ssl/defaults/main.yml
+++ b/roles/ssl/defaults/main.yml
@@ -1,5 +1,7 @@
 ---
+### Set this variable to customize expiration days for keystore. Applies for all components of Confluent Platform.
 keystore_expiration_days: 365
+
 delete_generation_dir: true
 
 ca_key_path: "{{ ssl_file_dir_final }}/generation/ca.key"

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -202,7 +202,7 @@ sasl_protocol: none
 ### Boolean to configure components with TLS Encryption. Also manages Java Keystore creation
 ssl_enabled: false
 
-### Variable to define number of days from certificate authority creation to expiration. Set for all components of Confluent Platform.
+### Set this variable to customize expiration days for certificate authority. Applies for all components of Confluent Platform.
 certificate_authority_expiration_days: 365
 
 ### Boolean to enable mTLS Authentication on all components. Configures all components to use mTLS for authentication into Kafka

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -202,6 +202,9 @@ sasl_protocol: none
 ### Boolean to configure components with TLS Encryption. Also manages Java Keystore creation
 ssl_enabled: false
 
+### Variable to define number of days from certificate authority creation to expiration. Set for all components of Confluent Platform.
+certificate_authority_expiration_days: 365
+
 ### Boolean to enable mTLS Authentication on all components. Configures all components to use mTLS for authentication into Kafka
 ssl_mutual_auth_enabled: false
 


### PR DESCRIPTION
# Description
1. Currently, hard code with [the number of days from Certificate Authority creation to expiration](https://github.com/confluentinc/cp-ansible/blob/7.3.4-post/playbooks/tasks/certificate_authority.yml#L103)
2. No keystore_expiration_days variable in docs VARIABLES.md for guideline.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
1. Run ansible playbook to generate the certificate authority (CA)
2. Check expiration days of certificate authority (CA) with `openssl x509 -enddate -noout -in ca.crt`

**Test Configuration**:

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Any dependent changes have been merged and published in downstream modules
- [X] Any variable changes have been validated to be backwards compatible