### PR TITLE
Fix bugs in discovery 

### DIFF
--- a/discovery/manager/manager.py
+++ b/discovery/manager/manager.py
@@ -362,7 +362,7 @@ class ServicePropertyManager:
 
         tokens = ['KAFKA_HEAP_OPTS', 'KAFKA_OPTS', 'KAFKA_LOG4J_OPTS', 'LOG_DIR', 'CONFLUENT_SECURITY_MASTER_KEY']
         for token in tokens:
-            pattern = f"{token}=(.*?) ([A-Z]{{3}}|$)"
+            pattern = f"{token}=(.*?)( [A-Z]{{3}}|$)"
             match = re.search(pattern, env_command)
             if match:
                 env_details[token] = match.group(1).rstrip()

--- a/discovery/utils/utils.py
+++ b/discovery/utils/utils.py
@@ -2,6 +2,8 @@ import argparse
 import logging
 import sys
 from os.path import exists
+from os.path import dirname
+from os.path import realpath
 
 import yaml
 from jproperties import Properties
@@ -260,7 +262,8 @@ class FileUtils:
     def __read_service_configuration_file(file_name):
 
         # Check if config file exists. We return an empty dictionary if there isn't any config
-        file_path = f"service/config/{file_name}"
+        parent_dir = dirname(dirname(realpath(__file__)))
+        file_path = f"{parent_dir}/service/config/{file_name}"
         if not exists(file_path):
             logger.error(f"Cannot find config file {file_name}. Returning an empty config.")
             return dict()


### PR DESCRIPTION
# Description

Fixes minor bugs in discovery. 

1. the regex pattern to get environment variables was giving wrong output for the last variable in the variables list
2. the path to get config files was absolute and hence, the code was throwing utils - ERROR - Cannot find config file zookeeper.yml. Returning an empty config.   and adding unnecessary properties in the inventory file

Fixes # [ANSIENG-2280](https://confluentinc.atlassian.net/browse/ANSIENG-2280)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

tested locally 


**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Any variable changes have been validated to be backwards compatible

[ANSIENG-2280]: https://confluentinc.atlassian.net/browse/ANSIENG-2280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ