### PR TITLE
Switch to archive repo for debian9

### DIFF
--- a/molecule/Dockerfile-debian-archive.j2
+++ b/molecule/Dockerfile-debian-archive.j2
@@ -1,6 +1,12 @@
 FROM {{ item.image }}
 
-RUN echo 'deb [check-valid-until=no] http://ftp.debian.org/debian stretch-backports main' | sudo tee /etc/apt/sources.list.d/stretch-backports.list
+RUN echo 'deb [check-valid-until=no] http://archive.debian.org/debian stretch-backports main' | sudo tee /etc/apt/sources.list.d/stretch-backports.list
+
+RUN sed -i s/ftp.debian.org/archive.debian.org/g /etc/apt/sources.list
+RUN sed -i s/deb.debian.org/archive.debian.org/g /etc/apt/sources.list
+RUN sed -i s/security.debian.org/archive.debian.org/g /etc/apt/sources.list
+RUN sed -i '/stretch-updates/d' /etc/apt/sources.list
+RUN sed -i s/ftp.debian.org/archive.debian.org/g /etc/apt/sources.list.d/stretch-backports.list
 
 RUN apt-get update && \
     apt-get install --no-install-recommends --yes \

--- a/molecule/Dockerfile-debian-java8.j2
+++ b/molecule/Dockerfile-debian-java8.j2
@@ -1,6 +1,12 @@
 FROM {{ item.image }}
 
-RUN echo 'deb [check-valid-until=no] http://ftp.debian.org/debian stretch-backports main' | sudo tee /etc/apt/sources.list.d/stretch-backports.list
+RUN echo 'deb [check-valid-until=no] http://archive.debian.org/debian stretch-backports main' | sudo tee /etc/apt/sources.list.d/stretch-backports.list
+
+RUN sed -i s/ftp.debian.org/archive.debian.org/g /etc/apt/sources.list
+RUN sed -i s/deb.debian.org/archive.debian.org/g /etc/apt/sources.list
+RUN sed -i s/security.debian.org/archive.debian.org/g /etc/apt/sources.list
+RUN sed -i '/stretch-updates/d' /etc/apt/sources.list
+RUN sed -i s/ftp.debian.org/archive.debian.org/g /etc/apt/sources.list.d/stretch-backports.list
 
 RUN apt-get update && \
     apt-get install --no-install-recommends --yes \

--- a/molecule/Dockerfile-debian.j2
+++ b/molecule/Dockerfile-debian.j2
@@ -1,6 +1,12 @@
 FROM {{ item.image }}
 
-RUN echo 'deb [check-valid-until=no] http://ftp.debian.org/debian stretch-backports main' | sudo tee /etc/apt/sources.list.d/stretch-backports.list
+RUN echo 'deb [check-valid-until=no] http://archive.debian.org/debian stretch-backports main' | sudo tee /etc/apt/sources.list.d/stretch-backports.list
+
+RUN sed -i s/ftp.debian.org/archive.debian.org/g /etc/apt/sources.list
+RUN sed -i s/deb.debian.org/archive.debian.org/g /etc/apt/sources.list
+RUN sed -i s/security.debian.org/archive.debian.org/g /etc/apt/sources.list
+RUN sed -i '/stretch-updates/d' /etc/apt/sources.list
+RUN sed -i s/ftp.debian.org/archive.debian.org/g /etc/apt/sources.list.d/stretch-backports.list
 
 RUN apt-get update && \
     apt-get install --no-install-recommends --yes \

--- a/roles/common/tasks/debian.yml
+++ b/roles/common/tasks/debian.yml
@@ -109,7 +109,7 @@
 - name: Add stretch-backports Repo
   lineinfile:
     path: /etc/apt/sources.list
-    line: deb [check-valid-until=no] http://ftp.debian.org/debian stretch-backports main
+    line: deb [check-valid-until=no] http://archive.debian.org/debian stretch-backports main
     regexp: '.*stretch-backports.*'
   notify:
     - debian apt-get update


### PR DESCRIPTION
# Description

- debian9 has been moved to archived status because of which few of our molecule tests started failing across 7.0.x to master branches
- Updated dockerfiles to point to archive repo url


Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Failing weekly tests - https://jenkins.confluent.io/job/cp-ansible-weekly/job/7.0.x/131/testReport/
Re-ran failing tests https://jenkins.confluent.io/job/cp-ansible-on-demand/1275/, they are all passing now

**Test Configuration**:


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible