### PR TITLE
Fix service environment issue

### DIFF
--- a/discovery/README.md
+++ b/discovery/README.md
@@ -12,15 +12,14 @@ Though this script tries to come up with inventory which is the closed represent
 
 These are dependencies for this script and should be installed on the machine where we are executing it from. This is not a requirement for managed nodes of the cluster.
 #### Hosts
-The discovery script needs list of hosts which is part of the existing cluster on which services has to be discovered. Apart from the list of hosts, the script also need the Confluent Service names. If these service names has been updated, the same should be provided under `service_override` section.
+The discovery script needs list of hosts which is part of the existing cluster on which services have to be discovered. Apart from the list of hosts, the script also need the Confluent Service names. If these service names has been updated, the same should be provided under `service_override` section.
 
 ```yaml
-all:
-  vars:
-    ansible_connection: docker
-    ansible_user: null
-    service_override:
-      zookeeper_service_name: myservice.zookeeper
+vars:
+  ansible_connection: docker
+  ansible_user: null
+  service_override:
+    zookeeper_service_name: myservice.zookeeper
 ```
 
 ### How
@@ -112,16 +111,22 @@ hosts:
 ```
 
 #### Command Line options
-##### verbose
+##### verbosity
 To get the verbose output from script and Ansible you can set the verbosity level between 0 to 4. Where 4 means more verbose.
+```shell
+python discovery/main.py --input discovery/hosts.yml --verbosity 4
+```
 ##### limit
 Use limit flag to limit the discovery for specified list of hosts
+```shell
+python discovery/main.py --input discovery/hosts.yml --limit host1,host2
+```
 ##### output_file
 Use this flag to specify output inventory file name. Default value is inventory.yml
-
 ```shell
-python discovery/main.py --input discovery/hosts.yml --verbose 4 --limit host1,host2
+python discovery/main.py --input discovery/hosts.yml --output inventory.yml
 ```
+
 ### FQA
 * **Can I use it for older CP versions**  
 Ideally we should be using the discovery from the branch which maps to the CP cluster. However, to onboard existing cluster, one can use the latest disvoery code and use **--from_version** parameter to specify the CP cluster version

--- a/discovery/service/kafka_broker.py
+++ b/discovery/service/kafka_broker.py
@@ -138,8 +138,10 @@ class KafkaServicePropertyBaseBuilder(AbstractPropertyBuilder):
 
     def _build_inter_broker_listener_name(self, service_prop: dict) -> tuple:
         key = "inter.broker.listener.name"
-        self.mapped_service_properties.add(key)
-        return self.group, {"kafka_broker_inter_broker_listener_name": service_prop.get(key).lower()}
+        if key in service_prop:
+            self.mapped_service_properties.add(key)
+            return self.group, {"kafka_broker_inter_broker_listener_name": service_prop.get(key).lower()}
+        return self.group, {}
 
     def _build_http_server_listener(self, service_prop: dict) -> tuple:
 


### PR DESCRIPTION
# Description

Ansible Runner APIs truncates larger string of service environment variable. As a result we have been seeing [unprintable] while trying to discover jolokia and jmx properties. This change now directly reads from the service and override files and creates environment variable map. 

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested on molecule scenarios with Jolokia and Prometheus enabled. 



**Test Configuration**:


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible