### PR TITLE
Adding cluster linking metrics

### DIFF
--- a/roles/kafka_broker/templates/kafka.yml.j2
+++ b/roles/kafka_broker/templates/kafka.yml.j2
@@ -19,6 +19,18 @@ blacklistObjectNames:
   - "kafka.server:type=*,cipher=*,protocol=*,listener=*,networkProcessor=*"
   - "kafka.server:type=*"
 rules:
+  # Needed for Cluster Linking metrics
+  # This rule is more specific than the next rule; it has to come before it otherwise it will never be hit
+  # "kafka.server:type=*, name=*, client-id=*, topic=*, partition=*, link-name=*"
+  - pattern: kafka.server<type=(.+), name=(.+), clientId=(.+), topic=(.+), partition=(.*), link-name=(.+)><>Value
+    name: kafka_server_$1_$2
+    type: GAUGE
+    cache: {{ kafka_broker_jmxexporter_bean_name_expressions_cache | lower }}
+    labels:
+      clientId: "$3"
+      topic: "$4"
+      partition: "$5"
+      linkName: "$6" # The other Cluster Linking metrics are using the "link-name" syntax
   # This rule is more specific than the next rule; it has to come before it otherwise it will never be hit
   # "kafka.server:type=*, name=*, client-id=*, topic=*, partition=*"
   - pattern: kafka.server<type=(.+), name=(.+), clientId=(.+), topic=(.+), partition=(.*)><>Value
@@ -187,6 +199,77 @@ rules:
     cache: {{ kafka_broker_jmxexporter_bean_name_expressions_cache | lower }}
     labels:
       quantile: "0.$4"
+  # Needed for Cluster Linking metrics
+  # kafka.server.link:type=ClusterLinkFetcherManager,name=*,clientId=&,link-name=*
+  - pattern : kafka.server.link<type=ClusterLinkFetcherManager, name=(.+), (.+)=(.+), (.+)=(.+)><>Value
+    name: kafka_server_link_clusterlinkfetchermanager_$1
+    type: GAUGE
+    cache: {{ kafka_broker_jmxexporter_bean_name_expressions_cache | lower }}
+    labels:
+      "$2": "$3"
+      "$4": "$5"
+  # kafka.server:type=cluster-link,link-name=*
+  - pattern : kafka.server<type=cluster-link, (.+)=(.+)><>(fetch-throttle-time-avg|fetch-throttle-time-max)
+    name: kafka_server_cluster_link_$3
+    type: GAUGE
+    labels:
+      "$1": "$2"
+  # kafka.server:type=cluster-link-metadata-metrics,link-name=*, mechanism=*
+  - pattern : 'kafka.server<type=cluster-link-metadata-metrics, (.+)=(.+), (.+)=(.+)><>(.+):'
+    name: kafka_server_cluster_link_metadata_metrics_$5
+    type: GAUGE
+    cache: {{ kafka_broker_jmxexporter_bean_name_expressions_cache | lower }}
+    labels:
+      "$1": "$2"
+      "$3": "$4"
+  # kafka.server:type=cluster-link-fetcher-metrics,link-name=*,broker-id=*,fetcher-id=*, mechanism=*
+  - pattern : 'kafka.server<type=cluster-link-fetcher-metrics, (.+)=(.+), (.+)=(.+), (.+)=(.+), (.+)=(.+)><>(.+):'
+    name: kafka_server_cluster_link_fetcher_metrics_$9
+    type: GAUGE
+    labels:
+      "$1": "$2"
+      "$3": "$4"
+      "$5": "$6"
+      "$7": "$8"
+  # kafka.server:type=cluster-link-fetcher-metrics,link-name=*,broker-id=*,fetcher-id=*
+  - pattern : 'kafka.server<type=cluster-link-fetcher-metrics, (.+)=(.+), (.+)=(.+), (.+)=(.+)><>(.+):'
+    name: kafka_server_cluster_link_fetcher_metrics_$7
+    type: GAUGE
+    cache: {{ kafka_broker_jmxexporter_bean_name_expressions_cache | lower }}
+    labels:
+      "$1": "$2"
+      "$3": "$4"
+      "$5": "$6"
+  # kafka.server:type=cluster-link-metrics, mode=*, state=*, link-name=*, name=*
+  - pattern : 'kafka.server<type=cluster-link-metrics, (.+)=(.+), (.+)=(.+), (.+)=(.+)><>(.+):'
+    name: kafka_server_cluster_link_metrics_$7
+    type: GAUGE
+    labels:
+      "$1": "$2"
+      "$3": "$4"
+      "$5": "$6"
+  # kafka.server:type=cluster-link-metrics,state=*,link-name=*,name=*
+  - pattern : 'kafka.server<type=cluster-link-metrics, (.+)=(.+), (.+)=(.+)><>(.+):'
+    name: kafka_server_cluster_link_metrics_$5
+    type: GAUGE
+    cache: {{ kafka_broker_jmxexporter_bean_name_expressions_cache | lower }}
+    labels:
+      "$1": "$2"
+      "$3": "$4"
+  # kafka.server:type=cluster-link-metrics,name=*,link-name=*
+  - pattern : 'kafka.server<type=cluster-link-metrics, (.+)=(.+)><>(.+):'
+    name: kafka_server_cluster_link_metrics_$3
+    type: GAUGE
+    labels:
+      "$1": "$2"
+  # kafka.server:type=cluster-link-source-metrics,request=*,link-id=*
+  - pattern : kafka.server<type=cluster-link-source-metrics, (.+)=(.+), (.+)=(.+)><>Value
+    name: kafka_server_cluster_link_source_metrics
+    type: GAUGE
+    cache: {{ kafka_broker_jmxexporter_bean_name_expressions_cache | lower }}
+    labels:
+      "$1: "$2"
+      "$3": "$4"
   # Additional Rules for Confluent Server Metrics
   # 'confluent.metadata:type=*, name=*, topic=*, partition=*'
   - pattern: confluent.(\w+)<type=(.+), (.+)=(.+), (.+)=(.+), (.+)=(.+)><>Value


### PR DESCRIPTION
# Description

Updating the JMX exporter rules to include cluster linking metrics as defined in https://docs.confluent.io/platform/current/multi-dc-deployments/cluster-linking/metrics.html#monitoring-cluster-metrics-and-optimizing-links

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This config is supporting the following demo
https://github.com/vdesabou/kafka-docker-playground/tree/master/other/monitoring-cluster-linking

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
