### PR TITLE
Add each broker's principal in Controller's super user list

### DIFF
--- a/roles/kafka_broker/tasks/set_controller_principal.yml
+++ b/roles/kafka_broker/tasks/set_controller_principal.yml
@@ -1,9 +1,24 @@
 ---
+- name: Initialize Broker principals list in Controller
+  set_fact:
+    broker_principals: []
+
+- name: Add Each Broker's Principal to Controller's List
+  set_fact:
+    broker_principals: "{{ broker_principals + [ hostvars[broker_item]['kafka_broker_principal'] ] }}"
+  loop: "{{ groups['kafka_broker'] }}"
+  loop_control:
+    loop_var: broker_item
+
+- name: Remove Duplicates and Convert to String
+  set_fact:
+    broker_principals: "{{ broker_principals | unique | join(';') }}"
+
 - name: Add Super Users list to Kafka Controller Properties
   set_fact:
     kafka_controller_final_properties: "{{ hostvars[controller_host]['kafka_controller_final_properties'] | combine(
       {
-          'super.users': hostvars[controller_host]['super_users'] + ';' + hostvars[groups.kafka_broker[0]]['kafka_broker_principal']
+          'super.users': hostvars[controller_host]['super_users'] + ';' + broker_principals
       }
     ) }}"
 


### PR DESCRIPTION
# Description

This PR aims to add each broker's principal to Controller's super users list on RBAC cluster with mTLS

Fixes # [ANSIENG-2385](https://confluentinc.atlassian.net/browse/ANSIENG-2385)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

tested locally

# Checklist:

- [x] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[ANSIENG-2385]: https://confluentinc.atlassian.net/browse/ANSIENG-2385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ