### PR TITLE
Fix for missing schema registry URL in rest, c3 and ksql (see issue 1425)

### DIFF
--- a/roles/variables/vars/main.yml
+++ b/roles/variables/vars/main.yml
@@ -1064,7 +1064,7 @@ ksql_properties:
       sasl.jaas.config: |-
         org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required username="{{ksql_ldap_user | default('ksql')}}" password="{{ksql_ldap_password | default('pass')}}" metadataServerUrls="{{mds_bootstrap_server_urls}}";
   sr:
-    enabled: "{{ 'schema_registry' in groups }}"
+    enabled: "{{ 'schema_registry' in groups or ccloud_schema_registry_enabled|bool }}"
     properties:
       ksql.schema.registry.url: "{{schema_registry_url}}"
   sr_ssl:
@@ -1218,7 +1218,7 @@ kafka_rest_properties:
       client.config.providers: securepass
       client.config.providers.securepass.class: io.confluent.kafka.security.config.provider.SecurePassConfigProvider
   sr:
-    enabled: "{{ 'schema_registry' in groups }}"
+    enabled: "{{ 'schema_registry' in groups or ccloud_schema_registry_enabled|bool }}"
     properties:
       schema.registry.url: "{{schema_registry_url}}"
   sr_ssl:
@@ -1362,7 +1362,7 @@ control_center_properties:
                     kerberos_kafka_broker_primary, control_center_keytab_path, control_center_kerberos_principal|default('c3'),
                     false, control_center_ldap_user, control_center_ldap_password, mds_bootstrap_server_urls) }}"
   sr:
-    enabled: "{{ 'schema_registry' in groups }}"
+    enabled: "{{ 'schema_registry' in groups or ccloud_schema_registry_enabled|bool }}"
     properties:
       confluent.controlcenter.schema.registry.url: "{{schema_registry_url}}"
   sr_ssl:


### PR DESCRIPTION
# Description

When deploying self-managed components, schema.registry.url is missing for rest, ksql and c3 properties even if ccloud_schema_registry_url is congihured and ccloud_schema_registry_enabled: true while for connect it does work.

This is a fix for this issue.

Fixes # 1425

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Example deployment in hybrid CCloud setup with a customer.

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
