### PR TITLE
Remove timeout configs from client properties

### DIFF
--- a/roles/confluent.kafka_broker/templates/client.properties.j2
+++ b/roles/confluent.kafka_broker/templates/client.properties.j2
@@ -4,5 +4,3 @@
 {% for key, value in kafka_broker_client_properties|dictsort%}
 {{key}}={{value}}
 {% endfor %}
-default.api.timeout.ms=20000
-request.timeout.ms=20000


### PR DESCRIPTION
# Description

the configs `default.api.timeout.ms`  and `request.timeout.ms` are hard coded in client properties template, whereas they already have their default values defined in [CP](https://docs.confluent.io/platform/current/installation/configuration/consumer-configs.html#default-api-timeout-ms). Removing them from client properties template, gives customers the option to customize these configs via `kafka_broker_custom_client_properties` variable

Fixes # [ANSIENG-2459](https://confluentinc.atlassian.net/browse/ANSIENG-2459)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

[jenkins test](https://jenkins.confluent.io/job/cp-ansible-on-demand/1526/testReport/)

# Checklist:

- [x] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[ANSIENG-2459]: https://confluentinc.atlassian.net/browse/ANSIENG-2459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ