### PR TITLE
zookeeper_quorum_authenticaion_type will not take the value kerberos as server-server to authentication doesn't support kerberos

### DIFF
--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -567,8 +567,7 @@ Default:  "{{sasl_protocol if sasl_protocol == 'kerberos' else 'none'}}"
 ### zookeeper_quorum_authentication_type
 
 Authentication to put on ZK Server to Server connections. Available options: [mtls, digest, digest_over_tls].
-
-Default:  "{{ 'mtls' if zookeeper_ssl_enabled and zookeeper_ssl_mutual_auth_enabled else zookeeper_sasl_protocol }}"
+Default:  "{% if zookeeper_ssl_enabled and zookeeper_ssl_mutual_auth_enabled %}mtls{% elif zookeeper_sasl_protocol in ['mtls', 'digest_over_tls'] %}{{zookeeper_sasl_protocol}}{% else %}none{% endif %}"
 
 ***
 

--- a/hosts_example.yml
+++ b/hosts_example.yml
@@ -23,11 +23,14 @@ all:
     ## For SASL/GSSAPI uncomment this line and see Kerberos Configuration properties below
     # sasl_protocol: kerberos
 
-    #### Zookeeper SASL Authentication ####
-    ## Zookeeper can have Kerberos (GSSAPI) or Digest-MD5 SASL Authentication
-    ## By default when sasl_protocol = kerberos, zookeeper will also use sasl kerberos. It can  be configured with:
-    ## When a mechanism is selected, zookeeper.set.acl=true is added to kafka's server.properties. Note: property not added when using mTLS, set manually with Custom Properties
-    # zookeeper_sasl_protocol: <none/kerberos/digest>
+    #### Zookeeper Server - Server Authentication ####
+    ## Note: kerberos is not a supported option for Server to Server Authentication
+    # zookeeper_quorum_authentication_type: <none/mtls/digest/digest_over_tls>
+
+    #### Zookeeper Client - Server Authentication ####
+    ## When a Client Authentication method is either digest or kerberos, zookeeper.set.acl=true is added to kafka's server.properties. Note: property not added when using mTLS, set manually with Custom Properties
+    ## By default when sasl_protocol = kerberos, zookeeper Client to Server Authentication will also use kerberos. It can  be configured with:
+    # zookeeper_client_authentication_type: <none/mtls/digest/kerberos>
 
     #### Kerberos Configuration ####
     ## Applicable when sasl_protocol is kerberos

--- a/roles/confluent.kafka_broker/tasks/main.yml
+++ b/roles/confluent.kafka_broker/tasks/main.yml
@@ -286,7 +286,7 @@
     owner: "{{kafka_broker_user}}"
     group: "{{kafka_broker_group}}"
   when: "'GSSAPI' in kafka_broker_sasl_enabled_mechanisms or
-          zookeeper_quorum_authentication_type == 'digest' or
+          zookeeper_sasl_protocol in ['kerberos', 'digest'] or
           zookeeper_client_authentication_type in ['kerberos', 'digest'] or
           (kafka_broker_rest_proxy_enabled and (not rbac_enabled or (rbac_enabled and external_mds_enabled)) and kafka_broker_rest_proxy_authentication_type == 'basic')"
   notify: restart kafka

--- a/roles/confluent.kafka_broker/tasks/main.yml
+++ b/roles/confluent.kafka_broker/tasks/main.yml
@@ -286,7 +286,7 @@
     owner: "{{kafka_broker_user}}"
     group: "{{kafka_broker_group}}"
   when: "'GSSAPI' in kafka_broker_sasl_enabled_mechanisms or
-          zookeeper_sasl_protocol in ['kerberos', 'digest'] or
+          zookeeper_quorum_authentication_type == 'digest' or
           zookeeper_client_authentication_type in ['kerberos', 'digest'] or
           (kafka_broker_rest_proxy_enabled and (not rbac_enabled or (rbac_enabled and external_mds_enabled)) and kafka_broker_rest_proxy_authentication_type == 'basic')"
   notify: restart kafka

--- a/roles/confluent.test/molecule/zookeeper-digest-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/zookeeper-digest-rhel/molecule.yml
@@ -103,7 +103,8 @@ provisioner:
       all:
         scenario_name: zookeeper-digest-rhel
 
-        zookeeper_sasl_protocol: digest
+        zookeeper_quorum_authentication_type: digest
+        zookeeper_client_authentication_type: digest
         sasl_protocol: scram
 
         zookeeper_chroot: "/kafka"

--- a/roles/confluent.test/molecule/zookeeper-kerberos-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/zookeeper-kerberos-rhel/molecule.yml
@@ -115,7 +115,8 @@ provisioner:
       all:
         scenario_name: zookeeper-kerberos-rhel
 
-        zookeeper_sasl_protocol: kerberos
+        zookeeper_quorum_authentication_type: none # kerberos not supported in Server - Server authentication
+        zookeeper_client_authentication_type: kerberos
         sasl_protocol: scram
 
         kerberos_kafka_broker_primary: kafka

--- a/roles/confluent.variables/defaults/main.yml
+++ b/roles/confluent.variables/defaults/main.yml
@@ -245,7 +245,7 @@ zookeeper_ssl_mutual_auth_enabled: "{{ssl_mutual_auth_enabled}}"
 zookeeper_sasl_protocol: "{{sasl_protocol if sasl_protocol == 'kerberos' else 'none'}}"
 
 ### Authentication to put on ZK Server to Server connections. Available options: [mtls, digest, digest_over_tls].
-zookeeper_quorum_authentication_type: "{{ 'mtls' if zookeeper_ssl_enabled and zookeeper_ssl_mutual_auth_enabled else zookeeper_sasl_protocol }}"
+zookeeper_quorum_authentication_type: "{% if zookeeper_ssl_enabled and zookeeper_ssl_mutual_auth_enabled %}mtls{% elif zookeeper_sasl_protocol in ['mtls', 'digest_over_tls'] %}{{zookeeper_sasl_protocol}}{% else %}none{% endif %}"
 
 ### Authentication to put on ZK Client to Server connections. This is Kafka's connection to ZK. Available options: [mtls, digest, kerberos].
 zookeeper_client_authentication_type: "{{ 'mtls' if zookeeper_ssl_enabled and zookeeper_ssl_mutual_auth_enabled else zookeeper_sasl_protocol }}"

--- a/roles/confluent.zookeeper/defaults/main.yml
+++ b/roles/confluent.zookeeper/defaults/main.yml
@@ -15,7 +15,7 @@ zookeeper_log_file_size: 100MB
 
 zookeeper_java_args:
   - "{% if zookeeper_ssl_enabled|bool %}-Djdk.tls.ephemeralDHKeySize=2048{% endif %}"
-  - "{% if zookeeper_client_authentication_type in ['kerberos', 'digest'] or zookeeper_quorum_authentication_type in ['kerberos', 'digest', 'digest_over_tls'] %}-Djava.security.auth.login.config={{zookeeper.jaas_file}}{% endif %}"
+  - "{% if zookeeper_client_authentication_type in ['kerberos', 'digest'] or zookeeper_quorum_authentication_type in ['digest', 'digest_over_tls'] %}-Djava.security.auth.login.config={{zookeeper.jaas_file}}{% endif %}"
   - "{% if zookeeper_jolokia_enabled|bool %}-javaagent:{{jolokia_jar_path}}=config={{zookeeper_jolokia_config}}{% endif %}"
   - "{% if zookeeper_jmxexporter_enabled|bool %}-javaagent:{{jmxexporter_jar_path}}={{zookeeper_jmxexporter_port}}:{{zookeeper_jmxexporter_config_path}}{% endif %}"
 

--- a/roles/confluent.zookeeper/tasks/main.yml
+++ b/roles/confluent.zookeeper/tasks/main.yml
@@ -232,7 +232,7 @@
     mode: 0640
     owner: "{{zookeeper_user}}"
     group: "{{zookeeper_group}}"
-  when: zookeeper_client_authentication_type in ['kerberos', 'digest'] or zookeeper_quorum_authentication_type in ['kerberos', 'digest', 'digest_over_tls']
+  when: zookeeper_client_authentication_type in ['kerberos', 'digest'] or zookeeper_quorum_authentication_type in ['digest', 'digest_over_tls']
   notify: restart zookeeper
   diff: "{{ not mask_sensitive_diff|bool }}"
 


### PR DESCRIPTION
# Description

Server - Server authentication via kerberos is not supported in cp. Hence the value of variable for server to server authentication should also not be 'kerberos' as it might be misleading.

Fixes # [ANSIENG-2480](https://confluentinc.atlassian.net/browse/ANSIENG-2480)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

jenkins  #1623, #1624, #1625 in cp-ansible-on-demand

# Checklist:

- [x] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[ANSIENG-2480]: https://confluentinc.atlassian.net/browse/ANSIENG-2480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ