### PR TITLE
Add Confluent Kafka Principal Builder when OIDC is enabled

### DIFF
--- a/docs/sample_inventories/rbac_sso_c3.yml
+++ b/docs/sample_inventories/rbac_sso_c3.yml
@@ -104,6 +104,5 @@ ksql:
     demo-ksql-0:
 
 control_center:
-  
   hosts:
     demo-c3-0:

--- a/plugins/filter/filters.py
+++ b/plugins/filter/filters.py
@@ -213,7 +213,8 @@ class FilterModule(object):
                 final_dict['listener.name.' + listener_name + '.oauthbearer.sasl.login.callback.handler.class'] =\
                     'io.confluent.kafka.server.plugins.auth.token.TokenBearerServerLoginCallbackHandler'
                 final_dict['listener.name.' + listener_name + '.oauthbearer.sasl.jaas.config'] =\
-                    'org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required publicKeyPath=\"' + oauth_pem_path + '\";'
+                    'org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required publicKeyPath=\"' + oauth_pem_path + '\";'    
+                final_dict['listener.name.' + listener_name + '.principal.builder.class'] = 'io.confluent.kafka.security.authenticator.OAuthKafkaPrincipalBuilder'
 
         return final_dict
 


### PR DESCRIPTION
# Description

This PR adds principal builder for Kafka when OIDC is enabled

Fixes # [ANSIENG-2500](https://confluentinc.atlassian.net/browse/ANSIENG-2500)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?



# Checklist:

- [x] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[ANSIENG-2500]: https://confluentinc.atlassian.net/browse/ANSIENG-2500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ