### PR TITLE
Add TLSv1.3 support for FIPS

### DIFF
--- a/molecule/Dockerfile-rhel9-java11.j2
+++ b/molecule/Dockerfile-rhel9-java11.j2
@@ -27,8 +27,6 @@ VOLUME ["/sys/fs/cgroup"]
 CMD ["/usr/lib/systemd/systemd"]
 
 RUN yum -y install java-11-openjdk \
-      # workaround for openjdk11.0.20, reference https://access.redhat.com/solutions/7025428
-      tzdata-java \
       rsync \
       openssl \
       rsyslog \

--- a/plugins/filter/filters.py
+++ b/plugins/filter/filters.py
@@ -178,7 +178,7 @@ class FilterModule(object):
                 final_dict['listener.name.' + listener_name + '.ssl.trustmanager.algorithm'] = 'PKIX'
                 final_dict['listener.name.' + listener_name + '.ssl.keystore.type'] = 'BCFKS'
                 final_dict['listener.name.' + listener_name + '.ssl.truststore.type'] = 'BCFKS'
-                final_dict['listener.name.' + listener_name + '.ssl.enabled.protocols'] = 'TLSv1.2'
+                final_dict['listener.name.' + listener_name + '.ssl.enabled.protocols'] = 'TLSv1.2,TLSv1.3'
 
             if listeners_dict[listener].get('ssl_mutual_auth_enabled', default_ssl_mutual_auth_enabled):
                 final_dict['listener.name.' + listener_name + '.ssl.client.auth'] = 'required'

--- a/roles/variables/vars/main.yml
+++ b/roles/variables/vars/main.yml
@@ -188,7 +188,7 @@ kafka_controller_properties:
       ssl.keystore.location: "{{kafka_controller_keystore_path}}"
       ssl.keystore.password: "{{kafka_controller_keystore_storepass}}"
       ssl.key.password: "{{kafka_controller_keystore_storepass}}"
-      ssl.enabled.protocols: TLSv1.2
+      ssl.enabled.protocols: TLSv1.2,TLSv1.3
   sasl_enabled:
     enabled: "{{ kafka_controller_sasl_enabled_mechanisms|length > 0 }}"
     properties:
@@ -410,7 +410,7 @@ kafka_broker_properties:
       ssl.keystore.location: "{{kafka_broker_keystore_path}}"
       ssl.keystore.password: "{{kafka_broker_keystore_storepass}}"
       ssl.key.password: "{{kafka_broker_keystore_storepass}}"
-      ssl.enabled.protocols: TLSv1.2
+      ssl.enabled.protocols: TLSv1.2,TLSv1.3
   inter_broker_sasl:
     enabled: "{{ kafka_broker_listeners[kafka_broker_inter_broker_listener_name]['sasl_protocol'] | default(sasl_protocol) | confluent.platform.normalize_sasl_protocol != 'none' }}"
     properties:


### PR DESCRIPTION
# Description

this PR aims to add TLSv1.3 in FIPS Enabled clusters. Both TLSv1.2 and TLSv1.3 are now supported.

Fixes # [ANSIENG-2524](https://confluentinc.atlassian.net/browse/ANSIENG-2524)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

[jenkins job](https://jenkins.confluent.io/job/cp-ansible-on-demand/1681/)

# Checklist:

- [x] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[ANSIENG-2524]: https://confluentinc.atlassian.net/browse/ANSIENG-2524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ