### PR TITLE
changed mode from octal to string

### DIFF
--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -574,7 +574,7 @@ Default:  3888
 
 ### zookeeper_copy_files
 
-Use to copy files from control node to zookeeper hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode (default: '0640') to set directory and file permissions.
+Use to copy files from control node to zookeeper hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '750') and file_mode (default: '640') to set directory and file permissions.
 
 Default:  []
 
@@ -694,7 +694,7 @@ Default:  8080
 
 ### kafka_broker_copy_files
 
-Use to copy files from control node to kafka hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode (default: '0640') to set directory and file permissions.
+Use to copy files from control node to kafka hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '750') and file_mode (default: '640') to set directory and file permissions.
 
 Default:  []
 
@@ -846,7 +846,7 @@ Default:  8078
 
 ### schema_registry_copy_files
 
-Use to copy files from control node to schema registry hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode (default: '0640') to set directory and file permissions.
+Use to copy files from control node to schema registry hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '750') and file_mode (default: '640') to set directory and file permissions.
 
 Default:  []
 
@@ -974,7 +974,7 @@ Default:  8075
 
 ### kafka_rest_copy_files
 
-Use to copy files from control node to schema registry hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode (default: '0640') to set directory and file permissions.
+Use to copy files from control node to schema registry hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '750') and file_mode (default: '640') to set directory and file permissions.
 
 Default:  []
 
@@ -1118,7 +1118,7 @@ Default:  8077
 
 ### kafka_connect_copy_files
 
-Use to copy files from control node to connect hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode (default: '0640') to set directory and file permissions.
+Use to copy files from control node to connect hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '750') and file_mode (default: '640') to set directory and file permissions.
 
 Default:  []
 
@@ -1286,7 +1286,7 @@ Default:  8076
 
 ### ksql_copy_files
 
-Use to copy files from control node to ksqlDB hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode (default: '0640') to set directory and file permissions.
+Use to copy files from control node to ksqlDB hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '750') and file_mode (default: '640') to set directory and file permissions.
 
 Default:  []
 
@@ -1374,7 +1374,7 @@ Default:  "{{ssl_enabled}}"
 
 ### control_center_copy_files
 
-Use to copy files from control node to Control Center hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode (default: '0640') to set directory and file permissions.
+Use to copy files from control node to Control Center hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '750') and file_mode (default: '640') to set directory and file permissions.
 
 Default:  []
 

--- a/roles/confluent.common/tasks/confluent_cli.yml
+++ b/roles/confluent.common/tasks/confluent_cli.yml
@@ -15,7 +15,7 @@
   file:
     path: "{{item}}"
     state: directory
-    mode: '0755'
+    mode: '755'
   loop:
     - "{{confluent_cli_base_path}}"
     - "{{confluent_cli_base_path}}/{{confluent_cli_binary}}"
@@ -27,7 +27,7 @@
     dest: "{{confluent_cli_base_path}}"
     group: "{{ omit if archive_group == '' else archive_group }}"
     owner: "{{ omit if archive_owner == '' else archive_owner }}"
-    mode: 0755
+    mode: '755'
     creates: "{{confluent_cli_base_path}}/{{confluent_cli_binary}}/{{confluent_cli_binary}}"
   when: confluent_cli_custom_download_url is not defined
 
@@ -35,7 +35,7 @@
   get_url:
     url: "{{ confluent_cli_custom_download_url }}"
     dest: "{{confluent_cli_base_path}}/{{confluent_cli_binary}}/{{confluent_cli_binary}}"
-    mode: 0755
+    mode: '755'
   register: cli_download_result
   until: cli_download_result is success
   retries: 5

--- a/roles/confluent.common/tasks/main.yml
+++ b/roles/confluent.common/tasks/main.yml
@@ -34,7 +34,7 @@
     group: "{{ omit if archive_group == '' else archive_group }}"
     owner: "{{ omit if archive_owner == '' else archive_owner }}"
     state: directory
-    mode: 0755
+    mode: '755'
   when: installation_method == "archive"
 
 # If the target directory (i.e. creates) doesn't exist then download and expand the remote archive into target
@@ -45,7 +45,7 @@
     dest: "{{archive_destination_path}}"
     group: "{{ omit if archive_group == '' else archive_group }}"
     owner: "{{ omit if archive_owner == '' else archive_owner }}"
-    mode: 0755
+    mode: '755'
     creates: "{{binary_base_path}}"
   when: installation_method == "archive"
 
@@ -53,14 +53,14 @@
   file:
     path: "{{ jolokia_jar_path | dirname }}"
     state: directory
-    mode: 0755
+    mode: '755'
   when: jolokia_enabled|bool
 
 - name: Copy Jolokia Jar
   copy:
     src: "{{ jolokia_jar_url }}"
     dest: "{{ jolokia_jar_path }}"
-    mode: 0755
+    mode: '755'
   when:
     - jolokia_enabled|bool
     - not jolokia_url_remote|bool
@@ -70,7 +70,7 @@
   get_url:
     url: "{{ jolokia_jar_url }}"
     dest: "{{ jolokia_jar_path }}"
-    mode: 0755
+    mode: '755'
   register: joklokia_download_result
   until: joklokia_download_result is success
   retries: 5
@@ -84,14 +84,14 @@
   file:
     path: "{{ jmxexporter_jar_path | dirname }}"
     state: directory
-    mode: 0755
+    mode: '755'
   when: jmxexporter_enabled|bool
 
 - name: Copy Prometheus Jar
   copy:
     src: "{{ jmxexporter_jar_url }}"
     dest: "{{ jmxexporter_jar_path }}"
-    mode: 0755
+    mode: '755'
   when:
     - jmxexporter_enabled|bool
     - not jmxexporter_url_remote|bool
@@ -101,7 +101,7 @@
   get_url:
     url: "{{ jmxexporter_jar_url }}"
     dest: "{{ jmxexporter_jar_path }}"
-    mode: 0755
+    mode: '755'
   register: prometheus_download_result
   until: prometheus_download_result is success
   retries: 5

--- a/roles/confluent.control_center/tasks/main.yml
+++ b/roles/confluent.control_center/tasks/main.yml
@@ -64,7 +64,7 @@
     owner: "{{control_center_user}}"
     group: "{{control_center_group}}"
     state: directory
-    mode: 0750
+    mode: '750'
 
 - name: Set Control Center Data Dir file permissions
   file:
@@ -80,7 +80,7 @@
     src: "{{binary_base_path}}/lib/systemd/system/{{control_center.systemd_file|basename}}"
     remote_src: true
     dest: "{{control_center.systemd_file}}"
-    mode: 0644
+    mode: '644'
     force: true
   when: installation_method == "archive"
 
@@ -133,7 +133,7 @@
   file:
     path: "{{ control_center.config_file | dirname }}"
     state: directory
-    mode: 0750
+    mode: '750'
     owner: "{{control_center_user}}"
     group: "{{control_center_group}}"
 
@@ -154,7 +154,7 @@
   template:
     src: control-center.properties.j2
     dest: "{{control_center.config_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{control_center_user}}"
     group: "{{control_center_group}}"
   notify: restart control center
@@ -174,14 +174,14 @@
     state: directory
     group: "{{control_center_group}}"
     owner: "{{control_center_user}}"
-    mode: 0770
+    mode: '770'
 
 - name: Create RocksDB Directory
   file:
     path: "{{control_center_rocksdb_path}}"
     group: "{{control_center_group}}"
     owner: "{{control_center_user}}"
-    mode: 0750
+    mode: '750'
     state: directory
   when: control_center_rocksdb_path != ""
 
@@ -199,13 +199,13 @@
     owner: "{{control_center_user}}"
     group: "{{control_center_group}}"
     state: directory
-    mode: 0750
+    mode: '750'
 
 - name: Create Control Center log4j Config
   template:
     src: control-center_log4j.properties.j2
     dest: "{{control_center.log4j_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{control_center_user}}"
     group: "{{control_center_group}}"
   notify: restart control center
@@ -216,13 +216,13 @@
     state: directory
     owner: "{{control_center_user}}"
     group: "{{control_center_group}}"
-    mode: 0640
+    mode: '640'
 
 - name: Write Service Overrides
   template:
     src: override.conf.j2
     dest: "{{control_center.systemd_override}}"
-    mode: 0640
+    mode: '640'
     owner: root
     group: root
   notify: restart control center

--- a/roles/confluent.kafka_broker/tasks/main.yml
+++ b/roles/confluent.kafka_broker/tasks/main.yml
@@ -63,7 +63,7 @@
     src: "{{binary_base_path}}/lib/systemd/system/{{kafka_broker.systemd_file|basename}}"
     remote_src: true
     dest: "{{kafka_broker.systemd_file}}"
-    mode: 0644
+    mode: '644'
     force: true
   when: installation_method == "archive"
 
@@ -123,7 +123,7 @@
     owner: "{{kafka_broker_user}}"
     group: "{{kafka_broker_group}}"
     state: directory
-    mode: 0750
+    mode: '750'
 
 # To avoid a catastrophic user error where root directory permissions get recursively changed
 - name: Assert log.dirs Property not Misconfigured
@@ -139,7 +139,7 @@
     owner: "{{kafka_broker_user}}"
     group: "{{kafka_broker_group}}"
     state: directory
-    mode: 0750
+    mode: '750'
   with_items: "{{ kafka_broker_final_properties['log.dirs'].split(',') }}"
 
 - name: Set Permissions on Data Dir files
@@ -154,7 +154,7 @@
   file:
     path: "{{ kafka_broker.config_file | dirname }}"
     state: directory
-    mode: 0750
+    mode: '750'
     owner: "{{kafka_broker_user}}"
     group: "{{kafka_broker_group}}"
 
@@ -175,7 +175,7 @@
   template:
     src: server.properties.j2
     dest: "{{kafka_broker.config_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_broker_user}}"
     group: "{{kafka_broker_group}}"
   notify: restart kafka
@@ -188,7 +188,7 @@
     state: directory
     group: "{{kafka_broker_group}}"
     owner: "{{kafka_broker_user}}"
-    mode: 0770
+    mode: '770'
 
 - name: Create log4j Directory
   file:
@@ -196,13 +196,13 @@
     owner: "{{kafka_broker_user}}"
     group: "{{kafka_broker_group}}"
     state: directory
-    mode: 0750
+    mode: '750'
 
 - name: Create Kafka Broker log4j Config
   template:
     src: kafka_server_log4j.properties.j2
     dest: "{{kafka_broker.log4j_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_broker_user}}"
     group: "{{kafka_broker_group}}"
   when: kafka_broker_custom_log4j|bool
@@ -212,7 +212,7 @@
   template:
     src: kafka_jolokia.properties.j2
     dest: "{{kafka_broker_jolokia_config}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_broker_user}}"
     group: "{{kafka_broker_group}}"
   when: kafka_broker_jolokia_enabled|bool
@@ -223,7 +223,7 @@
   template:
     src: kafka_server_jaas.conf.j2
     dest: "{{kafka_broker.jaas_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_broker_user}}"
     group: "{{kafka_broker_group}}"
   when: "'GSSAPI' in kafka_broker_sasl_enabled_mechanisms or zookeeper_sasl_protocol in ['kerberos', 'digest']"
@@ -245,7 +245,7 @@
   copy:
     src: "kafka.yml"
     dest: "{{kafka_broker_jmxexporter_config_path}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_broker_user}}"
     group: "{{kafka_broker_group}}"
   when: kafka_broker_jmxexporter_enabled|bool
@@ -256,13 +256,13 @@
     owner: "{{kafka_broker_user}}"
     group: "{{kafka_broker_group}}"
     state: directory
-    mode: 0640
+    mode: '640'
 
 - name: Write Service Overrides
   template:
     src: override.conf.j2
     dest: "{{ kafka_broker.systemd_override }}"
-    mode: 0640
+    mode: '640'
     owner: root
     group: root
   notify: restart kafka

--- a/roles/confluent.kafka_broker/tasks/rbac.yml
+++ b/roles/confluent.kafka_broker/tasks/rbac.yml
@@ -29,7 +29,7 @@
   file:
     path: /var/ssl/private
     state: directory
-    mode: 0755
+    mode: '755'
 
 - name: Check if MDS public pem file exists on Ansible Controller
   stat:
@@ -49,7 +49,7 @@
   copy:
     src: "{{token_services_public_pem_file}}"
     dest: "{{rbac_enabled_public_pem_path}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_broker_user}}"
     group: "{{kafka_broker_group}}"
   when: broker_public_pem_file.stat.exists|bool
@@ -73,7 +73,7 @@
   copy:
     src: "{{token_services_private_pem_file}}"
     dest: "{{rbac_enabled_private_pem_path}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_broker_user}}"
     group: "{{kafka_broker_group}}"
   when: broker_private_pem_file.stat.exists|bool

--- a/roles/confluent.kafka_connect/tasks/confluent_hub.yml
+++ b/roles/confluent.kafka_connect/tasks/confluent_hub.yml
@@ -19,7 +19,7 @@
     owner: "{{kafka_connect_user}}"
     group: "{{kafka_connect_group}}"
     state: directory
-    mode: 0750
+    mode: '750'
   loop: "{{ kafka_connect_confluent_hub_plugins }}"
   when: kafka_connect_confluent_hub_plugins|length > 0
 

--- a/roles/confluent.kafka_connect/tasks/connect_plugins.yml
+++ b/roles/confluent.kafka_connect/tasks/connect_plugins.yml
@@ -5,7 +5,7 @@
     state: directory
     group: "{{kafka_connect_group}}"
     owner: "{{kafka_connect_user}}"
-    mode: 0755
+    mode: '755'
   when: item != '/usr/share/java'
   with_items: "{{ kafka_connect_final_properties['plugin.path'].split(',') }}"
 
@@ -15,7 +15,7 @@
     dest: "{{kafka_connect_plugins_dest}}"
     group: "{{kafka_connect_group}}"
     owner: "{{kafka_connect_user}}"
-    mode: 0755
+    mode: '755'
     remote_src: false
   register: install_local_plugin_result
   until: install_local_plugin_result is success  or ansible_check_mode
@@ -31,7 +31,7 @@
     dest: "{{kafka_connect_plugins_dest}}"
     group: "{{kafka_connect_group}}"
     owner: "{{kafka_connect_user}}"
-    mode: 0755
+    mode: '755'
     remote_src: true
   register: install_remote_plugin_result
   until: install_remote_plugin_result is success  or ansible_check_mode

--- a/roles/confluent.kafka_connect/tasks/main.yml
+++ b/roles/confluent.kafka_connect/tasks/main.yml
@@ -65,7 +65,7 @@
     src: "{{binary_base_path}}/lib/systemd/system/{{kafka_connect.systemd_file|basename}}"
     remote_src: true
     dest: "{{kafka_connect.systemd_file}}"
-    mode: 0644
+    mode: '644'
     force: true
   when: installation_method == "archive"
 
@@ -118,7 +118,7 @@
   file:
     path: "{{ kafka_connect.config_file | dirname }}"
     state: directory
-    mode: 0750
+    mode: '750'
     owner: "{{kafka_connect_user}}"
     group: "{{kafka_connect_group}}"
 
@@ -139,7 +139,7 @@
   template:
     src: connect-distributed.properties.j2
     dest: "{{kafka_connect.config_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_connect_user}}"
     group: "{{kafka_connect_group}}"
   notify: restart connect distributed
@@ -155,7 +155,7 @@
     state: directory
     group: "{{kafka_connect_group}}"
     owner: "{{kafka_connect_user}}"
-    mode: 0770
+    mode: '770'
 
 - name: Create log4j Directory
   file:
@@ -163,13 +163,13 @@
     owner: "{{kafka_connect_user}}"
     group: "{{kafka_connect_group}}"
     state: directory
-    mode: 0750
+    mode: '750'
 
 - name: Create Connect Distributed log4j Config
   template:
     src: connect_distributed_log4j.properties.j2
     dest: "{{kafka_connect.log4j_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_connect_user}}"
     group: "{{kafka_connect_group}}"
   when: kafka_connect_custom_log4j|bool
@@ -179,7 +179,7 @@
   template:
     src: kafka_connect_jolokia.properties.j2
     dest: "{{kafka_connect_jolokia_config}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_connect_user}}"
     group: "{{kafka_connect_group}}"
   when: kafka_connect_jolokia_enabled|bool
@@ -190,7 +190,7 @@
   copy:
     src: "kafka_connect.yml"
     dest: "{{kafka_connect_jmxexporter_config_path}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_connect_user}}"
     group: "{{kafka_connect_group}}"
   when: kafka_connect_jmxexporter_enabled|bool
@@ -201,13 +201,13 @@
     owner: "{{kafka_connect_user}}"
     group: "{{kafka_connect_group}}"
     state: directory
-    mode: 0640
+    mode: '640'
 
 - name: Write Service Overrides
   template:
     src: override.conf.j2
     dest: "{{ kafka_connect.systemd_override }}"
-    mode: 0640
+    mode: '640'
     owner: root
     group: root
   notify: restart connect distributed

--- a/roles/confluent.kafka_rest/tasks/main.yml
+++ b/roles/confluent.kafka_rest/tasks/main.yml
@@ -65,7 +65,7 @@
     src: "{{binary_base_path}}/lib/systemd/system/{{kafka_rest.systemd_file|basename}}"
     remote_src: true
     dest: "{{kafka_rest.systemd_file}}"
-    mode: 0644
+    mode: '644'
     force: true
   when: installation_method == "archive"
 
@@ -118,7 +118,7 @@
   file:
     path: /var/ssl/private
     state: directory
-    mode: 0755
+    mode: '755'
   when: rbac_enabled|bool
 
 - name: Check if MDS public pem file exists on Ansible Controller
@@ -151,7 +151,7 @@
   file:
     path: "{{ kafka_rest.config_file | dirname }}"
     state: directory
-    mode: 0750
+    mode: '750'
     owner: "{{kafka_rest_user}}"
     group: "{{kafka_rest_group}}"
 
@@ -172,7 +172,7 @@
   template:
     src: kafka-rest.properties.j2
     dest: "{{kafka_rest.config_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_rest_user}}"
     group: "{{kafka_rest_group}}"
   notify: restart kafka-rest
@@ -185,7 +185,7 @@
     state: directory
     owner: "{{kafka_rest_user}}"
     group: "{{kafka_rest_group}}"
-    mode: 0770
+    mode: '770'
 
 - name: Create log4j Directory
   file:
@@ -193,13 +193,13 @@
     owner: "{{kafka_rest_user}}"
     group: "{{kafka_rest_group}}"
     state: directory
-    mode: 0750
+    mode: '750'
 
 - name: Create Kafka Rest log4j Config
   template:
     src: kafka-rest_log4j.properties.j2
     dest: "{{kafka_rest.log4j_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_rest_user}}"
     group: "{{kafka_rest_group}}"
   when: kafka_rest_custom_log4j|bool
@@ -209,7 +209,7 @@
   template:
     src: kafka_rest_jolokia.properties.j2
     dest: "{{kafka_rest_jolokia_config}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_rest_user}}"
     group: "{{kafka_rest_group}}"
   when: kafka_rest_jolokia_enabled|bool
@@ -220,7 +220,7 @@
   copy:
     src: "kafka_rest.yml"
     dest: "{{kafka_rest_jmxexporter_config_path}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_rest_user}}"
     group: "{{kafka_rest_group}}"
   when: kafka_rest_jmxexporter_enabled|bool
@@ -231,13 +231,13 @@
     owner: "{{kafka_rest_user}}"
     group: "{{kafka_rest_group}}"
     state: directory
-    mode: 0640
+    mode: '640'
 
 - name: Write Service Overrides
   template:
     src: override.conf.j2
     dest: "{{kafka_rest.systemd_override}}"
-    mode: 0640
+    mode: '640'
     owner: root
     group: root
   notify: restart kafka-rest

--- a/roles/confluent.kerberos/tasks/main.yml
+++ b/roles/confluent.kerberos/tasks/main.yml
@@ -10,7 +10,7 @@
     path: "{{ kerberos_keytab_destination_path | dirname }}"
     state: directory
     group: "{{kerberos_group}}"
-    mode: 0750
+    mode: '750'
 
 - name: Copy in Keytab File
   copy:
@@ -18,5 +18,5 @@
     dest: "{{kerberos_keytab_destination_path}}"
     owner: "{{kerberos_user}}"
     group: "{{kerberos_group}}"
-    mode: 0640
+    mode: '640'
   notify: "{{kerberos_handler}}"

--- a/roles/confluent.ksql/tasks/main.yml
+++ b/roles/confluent.ksql/tasks/main.yml
@@ -64,7 +64,7 @@
     owner: "{{ksql_user}}"
     group: "{{ksql_group}}"
     state: directory
-    mode: 0750
+    mode: '750'
 
 # Archive File deployments need to create SystemD service units
 # Copy the tarball's systemd service to the system
@@ -73,7 +73,7 @@
     src: "{{binary_base_path}}/lib/systemd/system/{{ksql.systemd_file|basename}}"
     remote_src: true
     dest: "{{ksql.systemd_file}}"
-    mode: 0644
+    mode: '644'
     force: true
   when: installation_method == "archive"
 
@@ -126,7 +126,7 @@
   file:
     path: "{{ ksql.config_file | dirname }}"
     state: directory
-    mode: 0750
+    mode: '750'
     owner: "{{ksql_user}}"
     group: "{{ksql_group}}"
 
@@ -147,7 +147,7 @@
   template:
     src: ksql-server.properties.j2
     dest: "{{ksql.config_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{ksql_user}}"
     group: "{{ksql_group}}"
   notify: restart ksql
@@ -160,7 +160,7 @@
     state: directory
     group: "{{ksql_group}}"
     owner: "{{ksql_user}}"
-    mode: 0770
+    mode: '770'
 
 - name: Create log4j Directory
   file:
@@ -168,13 +168,13 @@
     owner: "{{ksql_user}}"
     group: "{{ksql_group}}"
     state: directory
-    mode: 0750
+    mode: '750'
 
 - name: Create Ksql log4j Config
   template:
     src: ksql-server_log4j.properties.j2
     dest: "{{ksql.log4j_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{ksql_user}}"
     group: "{{ksql_group}}"
   when: ksql_custom_log4j|bool
@@ -184,7 +184,7 @@
   template:
     src: ksql_jolokia.properties.j2
     dest: "{{ksql_jolokia_config}}"
-    mode: 0640
+    mode: '640'
     owner: "{{ksql_user}}"
     group: "{{ksql_group}}"
   when: ksql_jolokia_enabled|bool
@@ -196,7 +196,7 @@
     path: "{{ksql_rocksdb_path}}"
     group: "{{ksql_group}}"
     owner: "{{ksql_user}}"
-    mode: 0750
+    mode: '750'
     state: directory
   when: ksql_rocksdb_path != ""
 
@@ -212,7 +212,7 @@
   copy:
     src: "ksql.yml"
     dest: "{{ksql_jmxexporter_config_path}}"
-    mode: 0640
+    mode: '640'
     owner: "{{ksql_user}}"
     group: "{{ksql_group}}"
   when: ksql_jmxexporter_enabled|bool
@@ -223,13 +223,13 @@
     owner: "{{ksql_user}}"
     group: "{{ksql_group}}"
     state: directory
-    mode: 0640
+    mode: '640'
 
 - name: Write Service Overrides
   template:
     src: override.conf.j2
     dest: "{{ksql.systemd_override}}"
-    mode: 0640
+    mode: '640'
     owner: root
     group: root
   notify: restart ksql

--- a/roles/confluent.schema_registry/tasks/main.yml
+++ b/roles/confluent.schema_registry/tasks/main.yml
@@ -65,7 +65,7 @@
     src: "{{binary_base_path}}/lib/systemd/system/{{schema_registry.systemd_file|basename}}"
     remote_src: true
     dest: "{{schema_registry.systemd_file}}"
-    mode: 0644
+    mode: '644'
     force: true
   when: installation_method == "archive"
 
@@ -118,7 +118,7 @@
   file:
     path: "{{ schema_registry.config_file | dirname }}"
     state: directory
-    mode: 0750
+    mode: '750'
     owner: "{{schema_registry_user}}"
     group: "{{schema_registry_group}}"
 
@@ -139,7 +139,7 @@
   template:
     src: schema-registry.properties.j2
     dest: "{{schema_registry.config_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{schema_registry_user}}"
     group: "{{schema_registry_group}}"
   notify: restart schema-registry
@@ -152,7 +152,7 @@
     state: directory
     group: "{{schema_registry_group}}"
     owner: "{{schema_registry_user}}"
-    mode: 0770
+    mode: '770'
 
 - name: Create log4j Directory
   file:
@@ -160,13 +160,13 @@
     owner: "{{schema_registry_user}}"
     group: "{{schema_registry_group}}"
     state: directory
-    mode: 0750
+    mode: '750'
 
 - name: Create Schema Registry log4j Config
   template:
     src: schema_registry_log4j.properties.j2
     dest: "{{schema_registry.log4j_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{schema_registry_user}}"
     group: "{{schema_registry_group}}"
   when: schema_registry_custom_log4j|bool
@@ -176,7 +176,7 @@
   template:
     src: schema_registry_jolokia.properties.j2
     dest: "{{schema_registry_jolokia_config}}"
-    mode: 0640
+    mode: '640'
     owner: "{{schema_registry_user}}"
     group: "{{schema_registry_group}}"
   when: schema_registry_jolokia_enabled|bool
@@ -187,7 +187,7 @@
   copy:
     src: "schema_registry.yml"
     dest: "{{schema_registry_jmxexporter_config_path}}"
-    mode: 0640
+    mode: '640'
     owner: "{{schema_registry_user}}"
     group: "{{schema_registry_group}}"
   when: schema_registry_jmxexporter_enabled|bool
@@ -198,13 +198,13 @@
     owner: "{{schema_registry_user}}"
     group: "{{schema_registry_group}}"
     state: directory
-    mode: 0640
+    mode: '640'
 
 - name: Write Service Overrides
   template:
     src: override.conf.j2
     dest: "{{schema_registry.systemd_override}}"
-    mode: 0640
+    mode: '640'
     owner: root
     group: root
   notify: restart schema-registry

--- a/roles/confluent.ssl/tasks/create_keystore_and_truststore.yml
+++ b/roles/confluent.ssl/tasks/create_keystore_and_truststore.yml
@@ -21,7 +21,7 @@
   file:
     path: /var/ssl/private/generation
     state: directory
-    mode: 0755
+    mode: '755'
 
 - name: Create Keystore and Truststore with Self Signed Certs
   include_tasks: self_signed_certs.yml

--- a/roles/confluent.ssl/tasks/import_ca_chain.yml
+++ b/roles/confluent.ssl/tasks/import_ca_chain.yml
@@ -3,7 +3,7 @@
   file:
     path: /var/ssl/private/generation/trustCAs
     state: directory
-    mode: 0755
+    mode: '755'
 
 - name: Split CA Certificate Bundle into Cert Files
   shell: |

--- a/roles/confluent.ssl/tasks/main.yml
+++ b/roles/confluent.ssl/tasks/main.yml
@@ -28,7 +28,7 @@
     path: "{{item}}"
     owner: "{{user}}"
     group: "{{group}}"
-    mode: 0640
+    mode: '640'
   loop:
     - "{{keystore_path}}"
     - "{{truststore_path}}"
@@ -38,7 +38,7 @@
     path: "{{item}}"
     owner: "{{user}}"
     group: "{{group}}"
-    mode: 0640
+    mode: '640'
   loop:
     - "{{ca_cert_path}}"
     - "{{cert_path}}"
@@ -50,7 +50,7 @@
     path: "{{item}}"
     owner: "{{user}}"
     group: "{{group}}"
-    mode: 0640
+    mode: '640'
   loop:
     - "{{bcfks_keystore_path}}"
     - "{{bcfks_truststore_path}}"

--- a/roles/confluent.test.kerberos/tasks/main.yml
+++ b/roles/confluent.test.kerberos/tasks/main.yml
@@ -9,7 +9,7 @@
   file:
     path: /tmp/keytabs/
     state: directory
-    mode: 0755
+    mode: '755'
 
 - name: "Add Principal: {{item.principal}}"
   shell: "kadmin.local -q 'addprinc -randkey {{item.principal}}'"

--- a/roles/confluent.test.ldap/tasks/tls.yml
+++ b/roles/confluent.test.ldap/tasks/tls.yml
@@ -3,7 +3,7 @@
   file:
     path: /var/ssl/private/ldaps/
     state: directory
-    mode: 0755
+    mode: '755'
   when:
 
 - name: Generate Self Signed Certificates

--- a/roles/confluent.test.ldap/tasks/tls_custom_certs.yml
+++ b/roles/confluent.test.ldap/tasks/tls_custom_certs.yml
@@ -3,16 +3,16 @@
   copy:
     src: "{{ssl_ca_cert_filepath}}"
     dest: "/var/ssl/private/ldaps/{{ssl_ca_cert_filepath|basename}}"
-    mode: 0666
+    mode: '666'
 
 - name: Copy Signed Cert to Host
   copy:
     src: "{{ssl_signed_cert_filepath}}"
     dest: "/var/ssl/private/ldaps/{{ssl_signed_cert_filepath|basename}}"
-    mode: 0666
+    mode: '666'
 
 - name: Copy Key to Host
   copy:
     src: "{{ssl_key_filepath}}"
     dest: "/var/ssl/private/ldaps/{{ssl_key_filepath|basename}}"
-    mode: 0666
+    mode: '666'

--- a/roles/confluent.test/molecule/certificates.yml
+++ b/roles/confluent.test/molecule/certificates.yml
@@ -26,13 +26,13 @@
       file:
         path: /var/ssl/private/generation
         state: directory
-        mode: 0755
+        mode: '755'
 
     - name: Copy in cert generation files in
       copy:
         src: "{{item}}"
         dest: "/var/ssl/private/generation/{{item|basename}}"
-        mode: 0777
+        mode: '777'
       loop:
         - certs-create.sh
 
@@ -42,7 +42,7 @@
           copy:
             src: "{{item}}"
             dest: "/var/ssl/private/generation/{{item|basename}}"
-            mode: 0777
+            mode: '777'
           loop:
             - "{{scenario_name}}/certificate-hosts"
       rescue:

--- a/roles/confluent.test/molecule/custom-user-plaintext-rhel/verify.yml
+++ b/roles/confluent.test/molecule/custom-user-plaintext-rhel/verify.yml
@@ -21,7 +21,7 @@
         recurse: true
         group: cp-test-group
         owner: "{{zookeeper_user}}"
-        mode: 0770
+        mode: '770'
 
     - name: Restart Service
       systemd:

--- a/roles/confluent.test/molecule/mtls-custombundle-rhel/prepare.yml
+++ b/roles/confluent.test/molecule/mtls-custombundle-rhel/prepare.yml
@@ -26,13 +26,13 @@
       file:
         path: /var/ssl/private/generation
         state: directory
-        mode: 0755
+        mode: '755'
 
     - name: Copy in cert generation files in
       copy:
         src: "{{item}}"
         dest: "/var/ssl/private/generation/{{item|basename}}"
-        mode: 0777
+        mode: '777'
       loop:
         - ca1-hosts
         - ca2-hosts

--- a/roles/confluent.test/molecule/plaintext-rhel/molecule.yml
+++ b/roles/confluent.test/molecule/plaintext-rhel/molecule.yml
@@ -139,7 +139,7 @@ provisioner:
             destination_path: /tmp/molecule.yml
           - source_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/molecule.yml"
             destination_path: /tmp/molecule2.yml
-            file_mode: '0666'
+            file_mode: '666'
 
         kafka_broker_copy_files: "{{zookeeper_copy_files}}"
         schema_registry_copy_files: "{{zookeeper_copy_files}}"

--- a/roles/confluent.test/molecule/plaintext-rhel/verify.yml
+++ b/roles/confluent.test/molecule/plaintext-rhel/verify.yml
@@ -191,7 +191,7 @@
           - copied_file.stat.exists
           - copied_file.stat.gr_name == 'confluent'
           - copied_file.stat.pw_name == 'cp-kafka'
-          - copied_file.stat.mode == '0640'
+          - copied_file.stat.mode == '640'
         quiet: true
 
     - name: Get stats on second copied file
@@ -205,7 +205,7 @@
           - copied_file2.stat.exists
           - copied_file2.stat.gr_name == 'confluent'
           - copied_file2.stat.pw_name == 'cp-kafka'
-          - copied_file2.stat.mode == '0666'
+          - copied_file2.stat.mode == '666'
         quiet: true
 
 - name: Verify - kafka_broker

--- a/roles/confluent.variables/defaults/main.yml
+++ b/roles/confluent.variables/defaults/main.yml
@@ -268,7 +268,7 @@ zookeeper_peer_port: 2888
 ### Zookeeper leader port
 zookeeper_leader_port: 3888
 
-### Use to copy files from control node to zookeeper hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode (default: '0640') to set directory and file permissions.
+### Use to copy files from control node to zookeeper hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '750') and file_mode (default: '640') to set directory and file permissions.
 zookeeper_copy_files: []
 
 # User provided properties, merged into the final properties dictionary with precedence
@@ -378,7 +378,7 @@ kafka_broker_jmxexporter_port: 8080
 
 kafka_broker_jmxexporter_config_path: /opt/prometheus/kafka.yml
 
-### Use to copy files from control node to kafka hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode (default: '0640') to set directory and file permissions.
+### Use to copy files from control node to kafka hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '750') and file_mode (default: '640') to set directory and file permissions.
 kafka_broker_copy_files: []
 
 ### Replication Factor for internal topics. Defaults to the minimum of the number of brokers and 3
@@ -454,7 +454,7 @@ schema_registry_jmxexporter_config_path: /opt/prometheus/schema_registry.yml
 ### Port to expose prometheus metrics. Beware of port collisions if colocating components on same host
 schema_registry_jmxexporter_port: 8078
 
-### Use to copy files from control node to schema registry hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode (default: '0640') to set directory and file permissions.
+### Use to copy files from control node to schema registry hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '750') and file_mode (default: '640') to set directory and file permissions.
 schema_registry_copy_files: []
 
 ### Use to set custom schema registry properties. This variable is a dictionary. Put values true/false in quotation marks to perserve case. NOTE- kafka_broker.properties is deprecated.
@@ -522,7 +522,7 @@ kafka_rest_jmxexporter_config_path: /opt/prometheus/kafka_rest.yml
 ### Port to expose prometheus metrics. Beware of port collisions if colocating components on same host
 kafka_rest_jmxexporter_port: 8075
 
-### Use to copy files from control node to schema registry hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode (default: '0640') to set directory and file permissions.
+### Use to copy files from control node to schema registry hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '750') and file_mode (default: '640') to set directory and file permissions.
 kafka_rest_copy_files: []
 
 ### Use to set custom Rest Proxy properties. This variable is a dictionary. Put values true/false in quotation marks to perserve case. NOTE- kafka_rest.properties is deprecated.
@@ -597,7 +597,7 @@ kafka_connect_jmxexporter_config_path: /opt/prometheus/kafka_connect.yml
 ### Port to expose connect prometheus metrics. Beware of port collisions if colocating components on same host
 kafka_connect_jmxexporter_port: 8077
 
-### Use to copy files from control node to connect hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode (default: '0640') to set directory and file permissions.
+### Use to copy files from control node to connect hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '750') and file_mode (default: '640') to set directory and file permissions.
 kafka_connect_copy_files: []
 
 ### Connect Service Group Id. Customize when configuring multiple connect clusters in same inventory
@@ -691,7 +691,7 @@ ksql_jmxexporter_config_path: /opt/prometheus/ksql.yml
 ### Port to expose ksqlDB prometheus metrics. Beware of port collisions if colocating components on same host
 ksql_jmxexporter_port: 8076
 
-### Use to copy files from control node to ksqlDB hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode (default: '0640') to set directory and file permissions.
+### Use to copy files from control node to ksqlDB hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '750') and file_mode (default: '640') to set directory and file permissions.
 ksql_copy_files: []
 
 ### Replication Factor for ksqlDB internal topics. Defaults to the minimum of the number of brokers and 3
@@ -745,7 +745,7 @@ control_center:
   # Deprecated way of providing custom properties
   properties: {}
 
-### Use to copy files from control node to Control Center hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode (default: '0640') to set directory and file permissions.
+### Use to copy files from control node to Control Center hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '750') and file_mode (default: '640') to set directory and file permissions.
 control_center_copy_files: []
 
 ### Replication Factor for Control Center internal topics. Defaults to the minimum of the number of brokers and 3

--- a/roles/confluent.zookeeper/tasks/main.yml
+++ b/roles/confluent.zookeeper/tasks/main.yml
@@ -64,7 +64,7 @@
     src: "{{binary_base_path}}/lib/systemd/system/{{zookeeper.systemd_file|basename}}"
     remote_src: true
     dest: "{{zookeeper.systemd_file}}"
-    mode: 0644
+    mode: '644'
     force: true
   when: installation_method == "archive"
 
@@ -112,7 +112,7 @@
     owner: "{{zookeeper_user}}"
     group: "{{zookeeper_group}}"
     state: directory
-    mode: 0750
+    mode: '750'
 
 - name: Set Ownership of Data Dir files
   file:
@@ -125,7 +125,7 @@
   template:
     src: myid.j2
     dest: "{{zookeeper_final_properties.dataDir}}/myid"
-    mode: 0640
+    mode: '640'
     owner: "{{zookeeper_user}}"
     group: "{{zookeeper_group}}"
 
@@ -133,7 +133,7 @@
   file:
     path: "{{ zookeeper.config_file | dirname }}"
     state: directory
-    mode: 0750
+    mode: '750'
     owner: "{{zookeeper_user}}"
     group: "{{zookeeper_group}}"
 
@@ -141,7 +141,7 @@
   template:
     src: zookeeper.properties.j2
     dest: "{{zookeeper.config_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{zookeeper_user}}"
     group: "{{zookeeper_group}}"
   register: zookeeper_config
@@ -154,7 +154,7 @@
     state: directory
     group: "{{zookeeper_group}}"
     owner: "{{zookeeper_user}}"
-    mode: 0770
+    mode: '770'
 
 - name: Create log4j Directory
   file:
@@ -162,13 +162,13 @@
     owner: "{{zookeeper_user}}"
     group: "{{zookeeper_group}}"
     state: directory
-    mode: 0750
+    mode: '750'
 
 - name: Create Zookeeper log4j config
   template:
     src: zookeeper_log4j.properties.j2
     dest: "{{zookeeper.log4j_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{zookeeper_user}}"
     group: "{{zookeeper_group}}"
   when: zookeeper_custom_log4j|bool
@@ -178,7 +178,7 @@
   template:
     src: zookeeper_jolokia.properties.j2
     dest: "{{zookeeper_jolokia_config}}"
-    mode: 0640
+    mode: '640'
     owner: "{{zookeeper_user}}"
     group: "{{zookeeper_group}}"
   when: zookeeper_jolokia_enabled|bool
@@ -189,7 +189,7 @@
   template:
     src: zookeeper_jaas.conf.j2
     dest: "{{zookeeper.jaas_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{zookeeper_user}}"
     group: "{{zookeeper_group}}"
   when: zookeeper_sasl_protocol in ['kerberos', 'digest']
@@ -200,7 +200,7 @@
   copy:
     src: "zookeeper.yml"
     dest: "{{zookeeper_jmxexporter_config_path}}"
-    mode: 0640
+    mode: '640'
     owner: "{{zookeeper_user}}"
     group: "{{zookeeper_group}}"
   when: zookeeper_jmxexporter_enabled|bool
@@ -211,13 +211,13 @@
     owner: "{{zookeeper_user}}"
     group: "{{zookeeper_group}}"
     state: directory
-    mode: 0640
+    mode: '640'
 
 - name: Write Service Overrides
   template:
     src: override.conf.j2
     dest: "{{zookeeper.systemd_override}}"
-    mode: 0640
+    mode: '640'
     owner: root
     group: root
   notify: restart zookeeper

--- a/tasks/certificate_authority.yml
+++ b/tasks/certificate_authority.yml
@@ -35,7 +35,7 @@
   file:
     path: /var/ssl/private/generation
     state: directory
-    mode: 0755
+    mode: '755'
 
 - name: Create Certificate Authority
   tags: certificate_authority

--- a/tasks/copy_files.yml
+++ b/tasks/copy_files.yml
@@ -3,7 +3,7 @@
   file:
     path: "{{ item.destination_path | dirname }}"
     state: directory
-    mode: "{{ item.directory_mode | default('0750') }}"
+    mode: "{{ item.directory_mode | default('750') }}"
     owner: "{{user}}"
     group: "{{group}}"
   loop: "{{ copy_files }}"
@@ -12,7 +12,7 @@
   copy:
     src: "{{ item.source_path }}"
     dest: "{{ item.destination_path }}"
-    mode: "{{ item.file_mode | default('0640') }}"
+    mode: "{{ item.file_mode | default('640') }}"
     owner: "{{user}}"
     group: "{{group}}"
   loop: "{{ copy_files }}"

--- a/tasks/rbac_setup.yml
+++ b/tasks/rbac_setup.yml
@@ -40,7 +40,7 @@
   file:
     path: /var/ssl/private
     state: directory
-    mode: 0755
+    mode: '755'
 
 - name: Check if MDS public pem file exists on Ansible Controller
   stat:
@@ -60,7 +60,7 @@
   copy:
     src: "{{token_services_public_pem_file}}"
     dest: "{{rbac_enabled_public_pem_path}}"
-    mode: 0640
+    mode: '640'
     owner: "{{user}}"
     group: "{{group}}"
   when: public_pem_file.stat.exists|bool

--- a/tasks/secrets_protection.yml
+++ b/tasks/secrets_protection.yml
@@ -9,7 +9,7 @@
     src: "{{ config_path }}"
     dest: "{{ config_path }}-backup"
     remote_src: true
-    mode: 0640
+    mode: '640'
     owner: "{{secrets_file_owner}}"
     group: "{{secrets_file_group}}"
   when: config_stat.stat.exists
@@ -18,7 +18,7 @@
   template:
     src: "{{ config_template }}"
     dest: "{{ config_path }}"
-    mode: 0640
+    mode: '640'
     owner: "{{ secrets_file_owner }}"
     group: "{{ secrets_file_group }}"
   diff: "{{ not mask_sensitive_diff|bool }}"
@@ -27,7 +27,7 @@
   file:
     path: /var/ssl/private/
     state: directory
-    mode: 0755
+    mode: '755'
 
 - name: Copy security.properties file to Host
   copy:
@@ -35,7 +35,7 @@
     dest: "{{ secrets_file }}"
     owner: "{{ secrets_file_owner }}"
     group: "{{ secrets_file_group }}"
-    mode: 0640
+    mode: '640'
   diff: "{{ not mask_sensitive_diff|bool }}"
 
 - name: Load masterkey
@@ -79,7 +79,7 @@
     src: "{{ config_path }}"
     dest: "{{ config_path }}-backup"
     remote_src: true
-    mode: 0640
+    mode: '640'
     owner: "{{ secrets_file_owner }}"
     group: "{{ secrets_file_group }}"
   notify: "{{handler}}"

--- a/tasks/upgrade_component.yml
+++ b/tasks/upgrade_component.yml
@@ -4,7 +4,7 @@
     # TODO configurable
     path: "/tmp/upgrade/{{ service_name }}"
     state: directory
-    mode: 0640
+    mode: '640'
 
 - set_fact:
     timestamp: "{{ lookup('pipe', 'date +%Y%m%d%H%M%S') }}"

--- a/upgrade_kafka_broker.yml
+++ b/upgrade_kafka_broker.yml
@@ -133,7 +133,7 @@
       file:
         path: "/tmp/upgrade/{{ kafka_broker_service_name }}"
         state: directory
-        mode: 0640
+        mode: '640'
 
     - set_fact:
         timestamp: "{{ lookup('pipe', 'date +%Y%m%d%H%M%S') }}"

--- a/upgrade_ksql.yml
+++ b/upgrade_ksql.yml
@@ -46,7 +46,7 @@
         # TODO configurable
         path: "/tmp/upgrade/{{ ksql_service_name }}"
         state: directory
-        mode: 0640
+        mode: '640'
 
     - set_fact:
         timestamp: "{{ lookup('pipe', 'date +%Y%m%d%H%M%S') }}"

--- a/upgrade_zookeeper.yml
+++ b/upgrade_zookeeper.yml
@@ -106,7 +106,7 @@
       file:
         path: "/tmp/upgrade/{{ zookeeper_service_name }}"
         state: directory
-        mode: 0640
+        mode: '640'
 
     - set_fact:
         timestamp: "{{ lookup('pipe', 'date +%Y%m%d%H%M%S') }}"


### PR DESCRIPTION
# Description
As per Ansible official documentation in the file module mode should be in qoutes. If mode is in octal format then in certain cases like loops it might fail. [docs](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/file_module.html)

Fixes # [ANSIENG-2525](https://confluentinc.atlassian.net/browse/ANSIENG-2525)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Jenkins test [1722](https://jenkins.confluent.io/job/cp-ansible-on-demand/1722)


# Checklist:

- [X] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [X] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules


[ANSIENG-2525]: https://confluentinc.atlassian.net/browse/ANSIENG-2525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ