### PR TITLE
Add test for Apache kafka ACL

### DIFF
--- a/roles/confluent.test/molecule/mtls-ubuntu-acl/molecule.yml
+++ b/roles/confluent.test/molecule/mtls-ubuntu-acl/molecule.yml
@@ -97,7 +97,7 @@ provisioner:
           authorizer.class.name: "kafka.security.authorizer.AclAuthorizer"
           # be aware of the double $$ to escape it https://github.com/ansible-community/molecule/issues/993
           ssl.principal.mapping.rules: "RULE:^.*[Cc][Nn]=([a-zA-Z0-9._-]*).*$$/$$1/L,DEFAULT"
-          super.users: "User:kafka_broker;User:schema_registry;User:kafka_connect;User:ksql;User:control_center"
+          allow.everyone.if.no.acl.found: true
 
 verifier:
   name: ansible

--- a/roles/confluent.test/molecule/mtls-ubuntu-acl/verify.yml
+++ b/roles/confluent.test/molecule/mtls-ubuntu-acl/verify.yml
@@ -2,6 +2,7 @@
 ### Validates that MTLS is enabled.
 ### Validates mapping rules for ACLs.
 ### Validates ACL users.
+### Validated ACL creation.
 
 - name: Verify - kafka_broker
   hosts: kafka_broker
@@ -21,13 +22,56 @@
         file_path: /etc/kafka/server.properties
         property: ssl.principal.mapping.rules
         expected_value: RULE:^.*[Cc][Nn]=([a-zA-Z0-9._-]*).*$/$1/L,DEFAULT
-    - import_role:
-        name: confluent.test
-        tasks_from: check_property.yml
-      vars:
-        file_path: /etc/kafka/server.properties
-        property: super.users
-        expected_value: User:kafka_broker;User:schema_registry;User:kafka_connect;User:ksql;User:control_center
+
+    - name: Create Kafka topic
+      shell: kafka-topics --create --topic test-topic \
+             --bootstrap-server kafka-broker1:9091 --command-config /etc/kafka/client.properties \
+             --replication-factor 1 --partitions 6
+      run_once: true
+      register: output
+      failed_when:
+        - "'Topic test-topic already exists' not in output.stdout"
+        - "'Created topic test-topic' not in output.stdout"
+
+    - name: Create Topic Data
+      shell: |
+        seq 10 | kafka-console-producer --topic test-topic \
+        --bootstrap-server kafka-broker1:9091 --producer.config /etc/kafka/client.properties
+      run_once: true
+
+    - name: Read Topic Data
+      shell: kafka-console-consumer --topic test-topic \
+             --bootstrap-server kafka-broker1:9091 --timeout-ms 10000 \
+             --from-beginning --consumer.config /etc/kafka/client.properties
+      run_once: true
+      register: consumer_output
+      failed_when:
+        - "'1\n2\n3\n4\n5\n6\n7\n8\n9\n10' not in consumer_output.stdout"
+
+    - name: Create ACL with write only permission
+      shell: kafka-acls --bootstrap-server kafka-broker1:9091 --add
+              --topic test-topic --allow-principal User:* --operation write
+              --command-config /etc/kafka/client.properties
+      run_once: true
+      register: acl_output
+      failed_when:
+        - "'Adding ACLs for resource' not in acl_output.stdout"
+        - "'Current ACLs for resource' not in acl_output.stdout"
+
+    - name: Create Topic Data
+      shell: |
+        seq 5 | kafka-console-producer --topic test-topic \
+        --bootstrap-server kafka-broker1:9091 --producer.config /etc/kafka/client.properties
+      run_once: true
+
+    - name: Read Topic Data
+      shell: kafka-console-consumer --topic test-topic \
+             --bootstrap-server kafka-broker1:9091 --timeout-ms 10000 \
+             --from-beginning --consumer.config /etc/kafka/client.properties
+      run_once: true
+      register: consumer_output
+      failed_when:
+        - consumer_output.stdout != ""    # not authorized to read data
 
 - name: Verify - schema_registry
   hosts: schema_registry


### PR DESCRIPTION
# Description

added test for kafka ACL. removed super.users from the test since it defeats the purpose of ACL

Fixes # [ANSIENG-2551](https://confluentinc.atlassian.net/browse/ANSIENG-2551)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

https://jenkins.confluent.io/job/cp-ansible-on-demand/1727/

# Checklist:

- [x] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[ANSIENG-2551]: https://confluentinc.atlassian.net/browse/ANSIENG-2551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ