### PR TITLE
changed mode from octal to string in 6.1.x

### DIFF
--- a/DEVELOPMENT_GUIDE.md
+++ b/DEVELOPMENT_GUIDE.md
@@ -26,7 +26,7 @@ Each Confluent component has its own role, with the name `confluent.<component_n
   template:	(2)
     src: override.conf.j2
     dest: "{{ kafka_broker.systemd_override }}"	(3)
-    mode: 0640	(4)
+    mode: '640'	(4)
     owner: "{{kafka_broker_user}}"	(5)
     group: "{{kafka_broker_group}}"
   notify: restart kafka	(6)
@@ -35,7 +35,7 @@ Each Confluent component has its own role, with the name `confluent.<component_n
 1. A name clearly defining what the task accomplishes, using capital letters
 2. Uses an idempotent ansible module whenever possible
 3. Make use of variables instead of hard coding paths
-4. For file creation use 0640 permission, for directory creation use 0750 permission. There are some exceptions, but be sure to secure files.
+4. For file creation use '640' permission, for directory creation use '750' permission. There are some exceptions, but be sure to secure files.
 5. Proper ownership set
 6. Trigger component restart handler when necessary
 
@@ -168,7 +168,7 @@ Now the schema_registry_final_properties property set eventually gets written to
     owner: "{{kafka_broker_user}}"
     group: "{{kafka_broker_group}}"
     state: directory
-    mode: 0750
+    mode: '750'
   with_items: "{{ kafka_broker_final_properties['log.dirs'].split(',') }}"
 ```
 

--- a/roles/confluent.common/tasks/debian.yml
+++ b/roles/confluent.common/tasks/debian.yml
@@ -67,7 +67,7 @@
   copy:
     content: 'Acquire::Check-Valid-Until "0";'
     dest: /etc/apt/apt.conf.d/skip-check
-    mode: 0644
+    mode: '644'
   notify:
     - debian apt-get update
   when:

--- a/roles/confluent.common/tasks/fetch_logs.yml
+++ b/roles/confluent.common/tasks/fetch_logs.yml
@@ -3,7 +3,7 @@
   file:
     state: directory
     path: "troubleshooting"
-    mode: 0755
+    mode: '755'
   delegate_to: localhost
   vars:
     ansible_connection: local
@@ -24,7 +24,7 @@
   file:
     path: "/tmp/troubleshooting/{{inventory_hostname}}/"
     state: directory
-    mode: 0750
+    mode: '750'
     owner: "{{user}}"
     group: "{{group}}"
 
@@ -33,7 +33,7 @@
     dest: "/tmp/troubleshooting/{{inventory_hostname}}/"
     src: "{{ item }}"
     remote_src: true
-    mode: 0750
+    mode: '750'
     owner: "{{user}}"
     group: "{{group}}"
   loop: "{{ find_output.files | map(attribute='path') | list + [config_file] }}"
@@ -45,7 +45,7 @@
     remove: true
     format: gz
     force_archive: true
-    mode: 0750
+    mode: '750'
     owner: "{{user}}"
     group: "{{group}}"
 

--- a/roles/confluent.common/tasks/redhat.yml
+++ b/roles/confluent.common/tasks/redhat.yml
@@ -37,7 +37,7 @@
   copy:
     src: "{{custom_yum_repofile_filepath}}"
     dest: /etc/yum.repos.d/custom-confluent.repo
-    mode: 0644
+    mode: '644'
   register: custom_repo_result
   until: custom_repo_result is success
   retries: 5

--- a/roles/confluent.common/tasks/ubuntu.yml
+++ b/roles/confluent.common/tasks/ubuntu.yml
@@ -60,7 +60,7 @@
   file:
     path: /usr/share/man/man1
     state: directory
-    mode: 0755
+    mode: '755'
 
 - name: Add open JDK repo
   apt_repository:

--- a/roles/confluent.control_center/tasks/main.yml
+++ b/roles/confluent.control_center/tasks/main.yml
@@ -218,7 +218,7 @@
     path: "{{control_center.log4j_file}}"
     group: "{{control_center_group}}"
     owner: "{{control_center_user}}"
-    mode: 0640
+    mode: '640'
 
 - name: Create RocksDB Directory
   file:

--- a/roles/confluent.kafka_broker/tasks/dynamic_groups.yml
+++ b/roles/confluent.kafka_broker/tasks/dynamic_groups.yml
@@ -18,7 +18,7 @@
   template:
     src: zookeeper-tls-client.properties.j2
     dest: "{{ kafka_broker.zookeeper_tls_client_config_file }}"
-    mode: 0640
+    mode: '640'
     owner: "{{ kafka_broker_user }}"
     group: "{{ kafka_broker_group }}"
   when:

--- a/roles/confluent.kafka_broker/tasks/main.yml
+++ b/roles/confluent.kafka_broker/tasks/main.yml
@@ -225,7 +225,7 @@
   template:
     src: client.properties.j2
     dest: "{{kafka_broker.client_config_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_broker_user}}"
     group: "{{kafka_broker_group}}"
   when: not kafka_broker_client_secrets_protection_enabled|bool
@@ -235,7 +235,7 @@
   template:
     src: zookeeper-tls-client.properties.j2
     dest: "{{kafka_broker.zookeeper_tls_client_config_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_broker_user}}"
     group: "{{kafka_broker_group}}"
   when: zookeeper_ssl_enabled|bool
@@ -265,7 +265,7 @@
     path: "{{kafka_broker.log4j_file}}"
     group: "{{kafka_broker_group}}"
     owner: "{{kafka_broker_user}}"
-    mode: 0640
+    mode: '640'
 
 - name: Create Kafka Broker Jolokia Config
   template:

--- a/roles/confluent.kafka_connect/tasks/main.yml
+++ b/roles/confluent.kafka_connect/tasks/main.yml
@@ -197,7 +197,7 @@
     path: "{{kafka_connect.log4j_file}}"
     group: "{{kafka_connect_group}}"
     owner: "{{kafka_connect_user}}"
-    mode: 0640
+    mode: '640'
 
 - name: Create Kafka Connect Jolokia Config
   template:

--- a/roles/confluent.kafka_connect_replicator/tasks/main.yml
+++ b/roles/confluent.kafka_connect_replicator/tasks/main.yml
@@ -257,7 +257,7 @@
   file:
     path: "{{ kafka_connect_replicator.replication_config_file | dirname }}"
     state: directory
-    mode: 0750
+    mode: '750'
     owner: "{{kafka_connect_replicator_user}}"
     group: "{{kafka_connect_replicator_group}}"
 
@@ -267,13 +267,13 @@
     state: directory
     group: "{{kafka_connect_replicator_group}}"
     owner: "{{kafka_connect_replicator_user}}"
-    mode: 0770
+    mode: '770'
 
 - name: Create Kafka Connect Replicator Log4j Config
   template:
     src: kafka-connect-replicator-log4j.properties.j2
     dest: "{{kafka_connect_replicator.log4j_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_connect_replicator_user}}"
     group: "{{kafka_connect_replicator_group}}"
   when: kafka_connect_replicator_custom_log4j|bool
@@ -283,7 +283,7 @@
   template:
     src: kafka-connect-replicator-jolokia.properties.j2
     dest: "{{kafka_connect_replicator_jolokia_config}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_connect_replicator_user}}"
     group: "{{kafka_connect_replicator_group}}"
   when: kafka_connect_replicator_jolokia_enabled|bool
@@ -293,7 +293,7 @@
   template:
     src: kafka-connect-replicator.properties.j2
     dest: "{{kafka_connect_replicator.replication_config_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_connect_replicator_user}}"
     group: "{{kafka_connect_replicator_group}}"
   notify: Restart Kafka Connect Replicator
@@ -302,7 +302,7 @@
   template:
     src: kafka-connect-replicator-consumer.properties.j2
     dest: "{{kafka_connect_replicator.consumer_config_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_connect_replicator_user}}"
     group: "{{kafka_connect_replicator_group}}"
   notify: Restart Kafka Connect Replicator
@@ -311,7 +311,7 @@
   template:
     src: kafka-connect-replicator-producer.properties.j2
     dest: "{{kafka_connect_replicator.producer_config_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_connect_replicator_user}}"
     group: "{{kafka_connect_replicator_group}}"
   notify: Restart Kafka Connect Replicator
@@ -320,7 +320,7 @@
   template:
     src: kafka-connect-replicator-interceptors.properties.j2
     dest: "{{kafka_connect_replicator.interceptors_config_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_connect_replicator_user}}"
     group: "{{kafka_connect_replicator_group}}"
   notify: Restart Kafka Connect Replicator
@@ -329,7 +329,7 @@
   template:
     src: kafka-connect-replicator.service.j2
     dest:  "{{kafka_connect_replicator.systemd_file}}"
-    mode: 0640
+    mode: '640'
     owner: root
     group: root
   notify: Restart Kafka Connect Replicator
@@ -340,13 +340,13 @@
     owner: "{{kafka_connect_replicator_user}}"
     group: "{{kafka_connect_replicator_group}}"
     state: directory
-    mode: 0640
+    mode: '640'
 
 - name: Write Kafka Connect Replicator Service Overrides
   template:
     src: override.conf.j2
     dest: "{{ kafka_connect_replicator.systemd_override }}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_connect_replicator_user}}"
     group: "{{kafka_connect_replicator_group}}"
   notify: Restart Kafka Connect Replicator

--- a/roles/confluent.kafka_connect_replicator/tasks/rbac_replicator.yml
+++ b/roles/confluent.kafka_connect_replicator/tasks/rbac_replicator.yml
@@ -3,7 +3,7 @@
   file:
     path: /var/ssl/private/kafka_connect_replicator
     state: directory
-    mode: 0755
+    mode: '755'
 
 - name: Check if MDS pem file exists on Ansible Controller
   stat:
@@ -23,7 +23,7 @@
   copy:
     src: "{{ kafka_connect_replicator_erp_pem_file }}"
     dest: "{{ kafka_connect_replicator_rbac_enabled_public_pem_path }}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_connect_replicator_user}}"
     group: "{{kafka_connect_replicator_group}}"
   diff: "{{ not mask_sensitive_diff|bool }}"

--- a/roles/confluent.kafka_connect_replicator/tasks/rbac_replicator_consumer.yml
+++ b/roles/confluent.kafka_connect_replicator/tasks/rbac_replicator_consumer.yml
@@ -3,7 +3,7 @@
   file:
     path: /var/ssl/private/kafka_connect_replicator_consumer
     state: directory
-    mode: 0755
+    mode: '755'
 
 - name: Check if MDS pem file exists on Ansible Controller
   stat:
@@ -23,7 +23,7 @@
   copy:
     src: "{{ kafka_connect_replicator_consumer_erp_pem_file }}"
     dest: "{{ kafka_connect_replicator_consumer_rbac_enabled_public_pem_path }}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_connect_replicator_user}}"
     group: "{{kafka_connect_replicator_group}}"
   when: replicator_pem_file.stat.exists|bool

--- a/roles/confluent.kafka_connect_replicator/tasks/rbac_replicator_monitoring.yml
+++ b/roles/confluent.kafka_connect_replicator/tasks/rbac_replicator_monitoring.yml
@@ -3,7 +3,7 @@
   file:
     path: /var/ssl/private/kafka_connect_replicator_monitoring_interceptor
     state: directory
-    mode: 0755
+    mode: '755'
 
 - name: Check if MDS pem file exists on Ansible Controller
   stat:
@@ -23,7 +23,7 @@
   copy:
     src: "{{ kafka_connect_replicator_monitoring_interceptor_erp_pem_file }}"
     dest: "{{ kafka_connect_replicator_monitoring_interceptor_rbac_enabled_public_pem_path }}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_connect_replicator_user}}"
     group: "{{kafka_connect_replicator_group}}"
   when: replicator_pem_file.stat.exists|bool

--- a/roles/confluent.kafka_connect_replicator/tasks/rbac_replicator_producer.yml
+++ b/roles/confluent.kafka_connect_replicator/tasks/rbac_replicator_producer.yml
@@ -3,7 +3,7 @@
   file:
     path: /var/ssl/private/kafka_connect_replicator_producer
     state: directory
-    mode: 0755
+    mode: '755'
 
 - name: Check if MDS pem file exists on Ansible Controller
   stat:
@@ -23,7 +23,7 @@
   copy:
     src: "{{ kafka_connect_replicator_producer_erp_pem_file }}"
     dest: "{{ kafka_connect_replicator_producer_rbac_enabled_public_pem_path }}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_connect_replicator_user}}"
     group: "{{kafka_connect_replicator_group}}"
   when: replicator_pem_file.stat.exists|bool

--- a/roles/confluent.kafka_rest/tasks/main.yml
+++ b/roles/confluent.kafka_rest/tasks/main.yml
@@ -227,7 +227,7 @@
     path: "{{kafka_rest.log4j_file}}"
     group: "{{kafka_rest_group}}"
     owner: "{{kafka_rest_user}}"
-    mode: 0640
+    mode: '640'
 
 - name: Create Kafka Rest Jolokia Config
   template:

--- a/roles/confluent.schema_registry/tasks/main.yml
+++ b/roles/confluent.schema_registry/tasks/main.yml
@@ -195,7 +195,7 @@
     path: "{{schema_registry.log4j_file}}"
     group: "{{schema_registry_group}}"
     owner: "{{schema_registry_user}}"
-    mode: 0640
+    mode: '640'
 
 - name: Create Schema Registry Jolokia Config
   template:

--- a/roles/confluent.zookeeper/tasks/main.yml
+++ b/roles/confluent.zookeeper/tasks/main.yml
@@ -150,7 +150,7 @@
     owner: "{{zookeeper_user}}"
     group: "{{zookeeper_group}}"
     state: directory
-    mode: 0750
+    mode: '750'
   when: zookeeper_final_properties.dataLogDir is defined
 
 - name: Set Ownership of Transaction Log Data Dir Files

--- a/tasks/certificate_authority.yml
+++ b/tasks/certificate_authority.yml
@@ -91,7 +91,7 @@
       file:
         path: "{{ ssl_file_dir_final }}/generation"
         state: directory
-        mode: 0755
+        mode: '755'
 
     - name: Create Certificate Authority
       tags: certificate_authority

--- a/tasks/masterkey.yml
+++ b/tasks/masterkey.yml
@@ -20,7 +20,7 @@
   copy:
     content: "{{ masterkey.stdout }}"
     dest: /tmp/masterkey
-    mode: 0640
+    mode: '640'
   diff: "{{ not mask_sensitive_diff|bool }}"
 
 - name: Copy Security File Back to Ansible Host

--- a/tasks/upgrade_component.yml
+++ b/tasks/upgrade_component.yml
@@ -16,7 +16,7 @@
     dest: "/tmp/upgrade/{{ service_name }}/{{ item | basename }}-{{timestamp}}"
     owner: "{{ config_owner }}"
     group: "{{ config_group }}"
-    mode: 0640
+    mode: '640'
   loop: "{{ backup_files }}"
   # Files cannot be copied because directory is not created in check mode
   ignore_errors: "{{ ansible_check_mode }}"
@@ -86,7 +86,7 @@
     src: "/tmp/upgrade/{{ service_name }}/{{ item | basename }}-{{timestamp}}"
     owner: "{{ config_owner }}"
     group: "{{ config_group }}"
-    mode: 0640
+    mode: '640'
   loop: "{{ restore_files }}"
   # Files cannot be copied because directory is not created in check mode
   ignore_errors: "{{ ansible_check_mode }}"

--- a/tasks/upgrade_component_archive.yml
+++ b/tasks/upgrade_component_archive.yml
@@ -15,7 +15,7 @@
     src: "{{binary_base_path}}/lib/systemd/system/{{systemd_file|basename}}"
     remote_src: true
     dest: "{{systemd_file}}"
-    mode: 0644
+    mode: '644'
     force: true
 
 - name: Update Override to Use New Version

--- a/upgrade_kafka_broker.yml
+++ b/upgrade_kafka_broker.yml
@@ -74,7 +74,7 @@
         dest: "{{kafka_broker.client_config_file}}"
         owner: "{{kafka_broker_user}}"
         group: "{{kafka_broker_group}}"
-        mode: 0640
+        mode: '640'
 
     - meta: flush_handlers
 
@@ -204,7 +204,7 @@
         dest: "/tmp/upgrade/{{ kafka_broker_service_name }}/{{ item | basename }}-{{timestamp}}"
         owner: "{{kafka_broker_user}}"
         group: "{{kafka_broker_group}}"
-        mode: 0640
+        mode: '640'
       loop:
         - "{{ kafka_broker.config_file }}"
         - "{{ kafka_broker.systemd_override }}"
@@ -276,7 +276,7 @@
         src: "/tmp/upgrade/{{ kafka_broker_service_name }}/{{ item | basename }}-{{timestamp}}"
         owner: "{{kafka_broker_user}}"
         group: "{{kafka_broker_group}}"
-        mode: 0640
+        mode: '640'
       loop:
         - "{{ kafka_broker.config_file }}"
         - "{{ zookeeper.config_file }}"
@@ -289,7 +289,7 @@
         src: "{{binary_base_path}}/lib/systemd/system/{{kafka_broker.systemd_file|basename}}"
         remote_src: true
         dest: "{{kafka_broker.systemd_file}}"
-        mode: 0644
+        mode: '644'
         force: true
       when: installation_method == "archive"
 

--- a/upgrade_ksql.yml
+++ b/upgrade_ksql.yml
@@ -76,7 +76,7 @@
         dest: "/tmp/upgrade/{{ ksql_service_name }}/{{ item | basename }}-{{timestamp}}"
         owner: "{{ ksql_user }}"
         group: "{{ ksql_group}}"
-        mode: 0640
+        mode: '640'
       loop:
         - "{{ ksql.config_file }}"
         - "{{ ksql.systemd_override }}"
@@ -147,7 +147,7 @@
         src: "/tmp/upgrade/{{ ksql_service_name }}/{{ item | basename }}-{{timestamp}}"
         owner: "{{ ksql_user }}"
         group: "{{ ksql_group}}"
-        mode: 0640
+        mode: '640'
       loop:
         - "{{ ksql.config_file }}"
         - "{{ ksql.systemd_override }}"
@@ -160,7 +160,7 @@
         src: "{{binary_base_path}}/lib/systemd/system/{{ksql.systemd_file|basename}}"
         remote_src: true
         dest: "{{ksql.systemd_file}}"
-        mode: 0644
+        mode: '644'
         force: true
       when: installation_method == "archive"
 

--- a/upgrade_zookeeper.yml
+++ b/upgrade_zookeeper.yml
@@ -130,7 +130,7 @@
         dest: "/tmp/upgrade/{{ zookeeper_service_name }}/{{ item | basename }}-{{timestamp}}"
         owner: "{{zookeeper_user}}"
         group: "{{zookeeper_group}}"
-        mode: 0640
+        mode: '640'
       loop:
         - "{{ zookeeper.config_file }}"
         - "{{ zookeeper.systemd_override }}"
@@ -215,7 +215,7 @@
         src: "/tmp/upgrade/{{ zookeeper_service_name }}/{{ item | basename }}-{{timestamp}}"
         owner: "{{zookeeper_user}}"
         group: "{{zookeeper_group}}"
-        mode: 0640
+        mode: '640'
       loop:
         - "{{ zookeeper.config_file }}"
         - "{{ kafka_broker.config_file }}"
@@ -228,7 +228,7 @@
         src: "{{binary_base_path}}/lib/systemd/system/{{zookeeper.systemd_file|basename}}"
         remote_src: true
         dest: "{{zookeeper.systemd_file}}"
-        mode: 0644
+        mode: '644'
         force: true
       when: installation_method == "archive"
 


### PR DESCRIPTION
# Description
As per Ansible official documentation in the file module mode should be in qoutes. If mode is in octal format then in certain cases like loops it might fail. [docs](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/file_module.html)

Fixes # [ANSIENG-2525](https://confluentinc.atlassian.net/browse/ANSIENG-2525)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist:

- [X] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [X] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules

[ANSIENG-2525]: https://confluentinc.atlassian.net/browse/ANSIENG-2525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ