### PR TITLE
converted mode from octal to string 7.1.x

### DIFF
--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -26,7 +26,7 @@ Each Confluent component has its own role, with the name `<component_name>`. Wit
   template:	(2)
     src: override.conf.j2
     dest: "{{ kafka_broker.systemd_override }}"	(3)
-    mode: 0640	(4)
+    mode: '640'	(4)
     owner: "{{kafka_broker_user}}"	(5)
     group: "{{kafka_broker_group}}"
   notify: restart kafka	(6)
@@ -35,7 +35,7 @@ Each Confluent component has its own role, with the name `<component_name>`. Wit
 1. A name clearly defining what the task accomplishes, using capital letters
 2. Uses an idempotent ansible module whenever possible
 3. Make use of variables instead of hard coding paths
-4. For file creation use 0640 permission, for directory creation use 0750 permission. There are some exceptions, but be sure to secure files.
+4. For file creation use '640' permission, for directory creation use '750' permission. There are some exceptions, but be sure to secure files.
 5. Proper ownership set
 6. Trigger component restart handler when necessary
 
@@ -168,7 +168,7 @@ Now the schema_registry_final_properties property set eventually gets written to
     owner: "{{kafka_broker_user}}"
     group: "{{kafka_broker_group}}"
     state: directory
-    mode: 0750
+    mode: '750'
   with_items: "{{ kafka_broker_final_properties['log.dirs'].split(',') }}"
 ```
 

--- a/playbooks/tasks/certificate_authority.yml
+++ b/playbooks/tasks/certificate_authority.yml
@@ -91,7 +91,7 @@
       file:
         path: "{{ ssl_file_dir_final }}/generation"
         state: directory
-        mode: 0755
+        mode: '755'
 
     - name: Create Certificate Authority
       tags: certificate_authority

--- a/roles/common/tasks/debian.yml
+++ b/roles/common/tasks/debian.yml
@@ -89,7 +89,7 @@
   copy:
     content: 'Acquire::Check-Valid-Until "0";'
     dest: /etc/apt/apt.conf.d/skip-check
-    mode: 0644
+    mode: '644'
   notify:
     - debian apt-get update
   when:

--- a/roles/common/tasks/fetch_logs.yml
+++ b/roles/common/tasks/fetch_logs.yml
@@ -3,7 +3,7 @@
   file:
     state: directory
     path: "troubleshooting"
-    mode: 0755
+    mode: '755'
   delegate_to: localhost
   vars:
     ansible_connection: local
@@ -24,7 +24,7 @@
   file:
     path: "/tmp/troubleshooting/{{inventory_hostname}}/"
     state: directory
-    mode: 0750
+    mode: '750'
     owner: "{{user}}"
     group: "{{group}}"
 
@@ -33,7 +33,7 @@
     dest: "/tmp/troubleshooting/{{inventory_hostname}}/"
     src: "{{ item }}"
     remote_src: true
-    mode: 0750
+    mode: '750'
     owner: "{{user}}"
     group: "{{group}}"
   loop: "{{ find_output.files | map(attribute='path') | list + [config_file] }}"
@@ -45,7 +45,7 @@
     remove: true
     format: gz
     force_archive: true
-    mode: 0750
+    mode: '750'
     owner: "{{user}}"
     group: "{{group}}"
 

--- a/roles/common/tasks/masterkey.yml
+++ b/roles/common/tasks/masterkey.yml
@@ -20,7 +20,7 @@
   copy:
     content: "{{ masterkey.stdout }}"
     dest: /tmp/masterkey
-    mode: 0640
+    mode: '640'
   diff: "{{ not mask_sensitive_diff|bool }}"
 
 - name: Copy Security File Back to Ansible Host

--- a/roles/common/tasks/redhat.yml
+++ b/roles/common/tasks/redhat.yml
@@ -3,7 +3,7 @@
   template:
     src: confluent.repo.j2
     dest: /etc/yum.repos.d/confluent.repo
-    mode: 0644
+    mode: '644'
   register: confluent_repo_result
   until: confluent_repo_result is success
   retries: 5
@@ -16,7 +16,7 @@
   copy:
     src: "{{custom_yum_repofile_filepath}}"
     dest: /etc/yum.repos.d/custom-confluent.repo
-    mode: 0644
+    mode: '644'
   register: custom_repo_result
   until: custom_repo_result is success
   retries: 5

--- a/roles/common/tasks/ubuntu.yml
+++ b/roles/common/tasks/ubuntu.yml
@@ -80,7 +80,7 @@
   file:
     path: /usr/share/man/man1
     state: directory
-    mode: 0755
+    mode: '755'
 
 - name: Add open JDK repo
   apt_repository:

--- a/roles/control_center/tasks/main.yml
+++ b/roles/control_center/tasks/main.yml
@@ -182,7 +182,7 @@
   template:
     src: control-center.properties.j2
     dest: "{{control_center.config_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{control_center_user}}"
     group: "{{control_center_group}}"
   notify: restart control center
@@ -237,7 +237,7 @@
     path: "{{control_center.log4j_file}}"
     group: "{{control_center_group}}"
     owner: "{{control_center_user}}"
-    mode: 0640
+    mode: '640'
   tags:
     - filesystem
 
@@ -266,7 +266,7 @@
   template:
     src: jaas.conf.j2
     dest: "{{control_center.jaas_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{control_center_user}}"
     group: "{{control_center_group}}"
   notify: restart control center
@@ -276,7 +276,7 @@
   template:
     src: password.properties.j2
     dest: "{{control_center.password_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{control_center_user}}"
     group: "{{control_center_group}}"
   notify: restart control center

--- a/roles/kafka_broker/tasks/dynamic_groups.yml
+++ b/roles/kafka_broker/tasks/dynamic_groups.yml
@@ -18,7 +18,7 @@
   template:
     src: zookeeper-tls-client.properties.j2
     dest: "{{ kafka_broker.zookeeper_tls_client_config_file }}"
-    mode: 0640
+    mode: '640'
     owner: "{{ kafka_broker_user }}"
     group: "{{ kafka_broker_group }}"
   when: zookeeper_ssl_enabled|bool

--- a/roles/kafka_broker/tasks/main.yml
+++ b/roles/kafka_broker/tasks/main.yml
@@ -228,7 +228,7 @@
   template:
     src: client.properties.j2
     dest: "{{kafka_broker.client_config_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_broker_user}}"
     group: "{{kafka_broker_group}}"
   diff: "{{ not mask_sensitive_diff|bool }}"
@@ -240,7 +240,7 @@
   template:
     src: zookeeper-tls-client.properties.j2
     dest: "{{kafka_broker.zookeeper_tls_client_config_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_broker_user}}"
     group: "{{kafka_broker_group}}"
   when: zookeeper_ssl_enabled|bool
@@ -276,7 +276,7 @@
     path: "{{kafka_broker.log4j_file}}"
     group: "{{kafka_broker_group}}"
     owner: "{{kafka_broker_user}}"
-    mode: 0640
+    mode: '640'
   tags:
     - filesystem
 
@@ -311,7 +311,7 @@
   template:
     src: password.properties.j2
     dest: "{{kafka_broker.rest_proxy_password_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_broker_user}}"
     group: "{{kafka_broker_group}}"
   when: kafka_broker_rest_proxy_enabled and (not rbac_enabled or (rbac_enabled and external_mds_enabled)) and kafka_broker_rest_proxy_authentication_type == 'basic'
@@ -402,7 +402,7 @@
   file:
     path: /usr/lib/sysctl.d
     state: directory
-    mode: 0755
+    mode: '755'
   when: ansible_distribution == "Debian"
   tags:
     - sysctl

--- a/roles/kafka_broker/tasks/secrets_protection.yml
+++ b/roles/kafka_broker/tasks/secrets_protection.yml
@@ -37,7 +37,7 @@
   template:
     src: override.conf.j2
     dest: "{{ kafka_broker.systemd_override }}"
-    mode: 0640
+    mode: '640'
     owner: root
     group: root
   diff: "{{ not mask_sensitive_diff|bool }}"

--- a/roles/kafka_connect_replicator/tasks/main.yml
+++ b/roles/kafka_connect_replicator/tasks/main.yml
@@ -264,7 +264,7 @@
   file:
     path: "{{ kafka_connect_replicator.replication_config_file | dirname }}"
     state: directory
-    mode: 0750
+    mode: '750'
     owner: "{{kafka_connect_replicator_user}}"
     group: "{{kafka_connect_replicator_group}}"
   tags:
@@ -276,7 +276,7 @@
     state: directory
     group: "{{kafka_connect_replicator_group}}"
     owner: "{{kafka_connect_replicator_user}}"
-    mode: 0770
+    mode: '770'
   tags:
     - filesystem
 
@@ -284,7 +284,7 @@
   template:
     src: kafka-connect-replicator-log4j.properties.j2
     dest: "{{kafka_connect_replicator.log4j_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_connect_replicator_user}}"
     group: "{{kafka_connect_replicator_group}}"
   when: kafka_connect_replicator_custom_log4j|bool
@@ -296,7 +296,7 @@
   template:
     src: kafka-connect-replicator-jolokia.properties.j2
     dest: "{{kafka_connect_replicator_jolokia_config}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_connect_replicator_user}}"
     group: "{{kafka_connect_replicator_group}}"
   when: kafka_connect_replicator_jolokia_enabled|bool
@@ -308,7 +308,7 @@
   template:
     src: kafka-connect-replicator.properties.j2
     dest: "{{kafka_connect_replicator.replication_config_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_connect_replicator_user}}"
     group: "{{kafka_connect_replicator_group}}"
   notify: Restart Kafka Connect Replicator
@@ -319,7 +319,7 @@
   template:
     src: kafka-connect-replicator-consumer.properties.j2
     dest: "{{kafka_connect_replicator.consumer_config_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_connect_replicator_user}}"
     group: "{{kafka_connect_replicator_group}}"
   notify: Restart Kafka Connect Replicator
@@ -330,7 +330,7 @@
   template:
     src: kafka-connect-replicator-producer.properties.j2
     dest: "{{kafka_connect_replicator.producer_config_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_connect_replicator_user}}"
     group: "{{kafka_connect_replicator_group}}"
   notify: Restart Kafka Connect Replicator
@@ -341,7 +341,7 @@
   template:
     src: kafka-connect-replicator-interceptors.properties.j2
     dest: "{{kafka_connect_replicator.interceptors_config_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_connect_replicator_user}}"
     group: "{{kafka_connect_replicator_group}}"
   notify: Restart Kafka Connect Replicator
@@ -352,7 +352,7 @@
   template:
     src: kafka-connect-replicator.service.j2
     dest:  "{{kafka_connect_replicator.systemd_file}}"
-    mode: 0640
+    mode: '640'
     owner: root
     group: root
   notify: Restart Kafka Connect Replicator
@@ -365,7 +365,7 @@
     owner: "{{kafka_connect_replicator_user}}"
     group: "{{kafka_connect_replicator_group}}"
     state: directory
-    mode: 0640
+    mode: '640'
   tags:
     - systemd
 
@@ -373,7 +373,7 @@
   template:
     src: override.conf.j2
     dest: "{{ kafka_connect_replicator.systemd_override }}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_connect_replicator_user}}"
     group: "{{kafka_connect_replicator_group}}"
   notify: Restart Kafka Connect Replicator

--- a/roles/kafka_connect_replicator/tasks/rbac_replicator.yml
+++ b/roles/kafka_connect_replicator/tasks/rbac_replicator.yml
@@ -3,7 +3,7 @@
   file:
     path: /var/ssl/private/kafka_connect_replicator
     state: directory
-    mode: 0755
+    mode: '755'
 
 - name: Check if MDS pem file exists on Ansible Controller
   stat:
@@ -23,7 +23,7 @@
   copy:
     src: "{{ kafka_connect_replicator_erp_pem_file }}"
     dest: "{{ kafka_connect_replicator_rbac_enabled_public_pem_path }}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_connect_replicator_user}}"
     group: "{{kafka_connect_replicator_group}}"
   diff: "{{ not mask_sensitive_diff|bool }}"

--- a/roles/kafka_connect_replicator/tasks/rbac_replicator_consumer.yml
+++ b/roles/kafka_connect_replicator/tasks/rbac_replicator_consumer.yml
@@ -3,7 +3,7 @@
   file:
     path: /var/ssl/private/kafka_connect_replicator_consumer
     state: directory
-    mode: 0755
+    mode: '755'
 
 - name: Check if MDS pem file exists on Ansible Controller
   stat:
@@ -23,7 +23,7 @@
   copy:
     src: "{{ kafka_connect_replicator_consumer_erp_pem_file }}"
     dest: "{{ kafka_connect_replicator_consumer_rbac_enabled_public_pem_path }}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_connect_replicator_user}}"
     group: "{{kafka_connect_replicator_group}}"
   when: replicator_pem_file.stat.exists|bool

--- a/roles/kafka_connect_replicator/tasks/rbac_replicator_monitoring.yml
+++ b/roles/kafka_connect_replicator/tasks/rbac_replicator_monitoring.yml
@@ -3,7 +3,7 @@
   file:
     path: /var/ssl/private/kafka_connect_replicator_monitoring_interceptor
     state: directory
-    mode: 0755
+    mode: '755'
 
 - name: Check if MDS pem file exists on Ansible Controller
   stat:
@@ -23,7 +23,7 @@
   copy:
     src: "{{ kafka_connect_replicator_monitoring_interceptor_erp_pem_file }}"
     dest: "{{ kafka_connect_replicator_monitoring_interceptor_rbac_enabled_public_pem_path }}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_connect_replicator_user}}"
     group: "{{kafka_connect_replicator_group}}"
   when: replicator_pem_file.stat.exists|bool

--- a/roles/kafka_connect_replicator/tasks/rbac_replicator_producer.yml
+++ b/roles/kafka_connect_replicator/tasks/rbac_replicator_producer.yml
@@ -3,7 +3,7 @@
   file:
     path: /var/ssl/private/kafka_connect_replicator_producer
     state: directory
-    mode: 0755
+    mode: '755'
 
 - name: Check if MDS pem file exists on Ansible Controller
   stat:
@@ -23,7 +23,7 @@
   copy:
     src: "{{ kafka_connect_replicator_producer_erp_pem_file }}"
     dest: "{{ kafka_connect_replicator_producer_rbac_enabled_public_pem_path }}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_connect_replicator_user}}"
     group: "{{kafka_connect_replicator_group}}"
   when: replicator_pem_file.stat.exists|bool

--- a/roles/kafka_rest/tasks/main.yml
+++ b/roles/kafka_rest/tasks/main.yml
@@ -198,7 +198,7 @@
   template:
     src: kafka-rest.properties.j2
     dest: "{{kafka_rest.config_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_rest_user}}"
     group: "{{kafka_rest_group}}"
   notify: restart kafka-rest

--- a/roles/kerberos/tasks/main.yml
+++ b/roles/kerberos/tasks/main.yml
@@ -3,13 +3,13 @@
   ansible.builtin.file:
     path: "{{ kerberos_client_config_file_dest | dirname }}"
     state: directory
-    mode: '0755'
+    mode: '755'
 
 - name: Copy the client configuration file
   template:
     src: krb5.conf.j2
     dest: "{{ kerberos_client_config_file_dest }}"
-    mode: 0755
+    mode: '755'
   when: kerberos_configure|bool
 
 - name: Create Keytabs Directory

--- a/roles/ksql/tasks/ccloud_certs.yml
+++ b/roles/ksql/tasks/ccloud_certs.yml
@@ -3,7 +3,7 @@
   get_url:
     url: "https://letsencrypt.org/certs/{{item}}"
     dest: /tmp/{{item}}
-    mode: 0755
+    mode: '755'
   loop:
     - isrgrootx1.der
     - isrg-root-x2.der

--- a/roles/ksql/tasks/main.yml
+++ b/roles/ksql/tasks/main.yml
@@ -179,7 +179,7 @@
   template:
     src: ksql-server.properties.j2
     dest: "{{ksql.config_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{ksql_user}}"
     group: "{{ksql_group}}"
   notify: restart ksql
@@ -288,7 +288,7 @@
   template:
     src: jaas.conf.j2
     dest: "{{ksql.jaas_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{ksql_user}}"
     group: "{{ksql_group}}"
   notify: restart ksql
@@ -298,7 +298,7 @@
   template:
     src: password.properties.j2
     dest: "{{ksql.password_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{ksql_user}}"
     group: "{{ksql_group}}"
   notify: restart ksql

--- a/roles/schema_registry/tasks/main.yml
+++ b/roles/schema_registry/tasks/main.yml
@@ -216,7 +216,7 @@
     path: "{{schema_registry.log4j_file}}"
     group: "{{schema_registry_group}}"
     owner: "{{schema_registry_user}}"
-    mode: 0640
+    mode: '640'
   tags:
     - configuration
 
@@ -248,7 +248,7 @@
   template:
     src: jaas.conf.j2
     dest: "{{schema_registry.jaas_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{schema_registry_user}}"
     group: "{{schema_registry_group}}"
   notify: restart schema-registry
@@ -258,7 +258,7 @@
   template:
     src: password.properties.j2
     dest: "{{schema_registry.password_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{schema_registry_user}}"
     group: "{{schema_registry_group}}"
   notify: restart schema-registry

--- a/roles/zookeeper/tasks/main.yml
+++ b/roles/zookeeper/tasks/main.yml
@@ -163,7 +163,7 @@
     owner: "{{zookeeper_user}}"
     group: "{{zookeeper_group}}"
     state: directory
-    mode: 0750
+    mode: '750'
   when: zookeeper_final_properties.dataLogDir is defined
   tags:
     - filesystem


### PR DESCRIPTION
# Description
As per Ansible official documentation in the file module mode should be in qoutes. If mode is in octal format then in certain cases like loops it might fail. [docs](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/file_module.html)

Fixes # [ANSIENG-2525](https://confluentinc.atlassian.net/browse/ANSIENG-2525)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist:

- [X] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [X] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules