### PR TITLE
converted mode from octal to string 7.4.x

### DIFF
--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -26,7 +26,7 @@ Each Confluent component has its own role, with the name `<component_name>`. Wit
   template:	(2)
     src: override.conf.j2
     dest: "{{ kafka_broker.systemd_override }}"	(3)
-    mode: 0640	(4)
+    mode: '640'	(4)
     owner: "{{kafka_broker_user}}"	(5)
     group: "{{kafka_broker_group}}"
   notify: restart kafka	(6)
@@ -35,7 +35,7 @@ Each Confluent component has its own role, with the name `<component_name>`. Wit
 1. A name clearly defining what the task accomplishes, using capital letters
 2. Uses an idempotent ansible module whenever possible
 3. Make use of variables instead of hard coding paths
-4. For file creation use 0640 permission, for directory creation use 0750 permission. There are some exceptions, but be sure to secure files.
+4. For file creation use '640' permission, for directory creation use '750' permission. There are some exceptions, but be sure to secure files.
 5. Proper ownership set
 6. Trigger component restart handler when necessary
 
@@ -168,7 +168,7 @@ Now the schema_registry_final_properties property set eventually gets written to
     owner: "{{kafka_broker_user}}"
     group: "{{kafka_broker_group}}"
     state: directory
-    mode: 0750
+    mode: '750'
   with_items: "{{ kafka_broker_final_properties['log.dirs'].split(',') }}"
 ```
 

--- a/docs/VARIABLES.md
+++ b/docs/VARIABLES.md
@@ -901,7 +901,7 @@ Default:  3888
 
 ### zookeeper_copy_files
 
-Use to copy files from control node to zookeeper hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode (default: '0640') to set directory and file permissions.
+Use to copy files from control node to zookeeper hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '750') and file_mode (default: '640') to set directory and file permissions.
 
 Default:  []
 
@@ -1077,7 +1077,7 @@ Default:  /opt/prometheus/kafka.yml
 
 ### kafka_controller_copy_files
 
-Use to copy files from control node to kafka hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode (default: '0640') to set directory and file permissions.
+Use to copy files from control node to kafka hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '750') and file_mode (default: '640') to set directory and file permissions.
 
 Default:  []
 
@@ -1301,7 +1301,7 @@ Default:  /opt/prometheus/kafka.yml
 
 ### kafka_broker_copy_files
 
-Use to copy files from control node to kafka hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode (default: '0640') to set directory and file permissions.
+Use to copy files from control node to kafka hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '750') and file_mode (default: '640') to set directory and file permissions.
 
 Default:  []
 
@@ -1533,7 +1533,7 @@ Default:  8078
 
 ### schema_registry_copy_files
 
-Use to copy files from control node to schema registry hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode (default: '0640') to set directory and file permissions.
+Use to copy files from control node to schema registry hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '750') and file_mode (default: '640') to set directory and file permissions.
 
 Default:  []
 
@@ -1717,7 +1717,7 @@ Default:  8075
 
 ### kafka_rest_copy_files
 
-Use to copy files from control node to schema registry hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode (default: '0640') to set directory and file permissions.
+Use to copy files from control node to schema registry hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '750') and file_mode (default: '640') to set directory and file permissions.
 
 Default:  []
 
@@ -1941,7 +1941,7 @@ Default:  8077
 
 ### kafka_connect_copy_files
 
-Use to copy files from control node to connect hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode (default: '0640') to set directory and file permissions.
+Use to copy files from control node to connect hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '750') and file_mode (default: '640') to set directory and file permissions.
 
 Default:  []
 
@@ -2165,7 +2165,7 @@ Default:  8076
 
 ### ksql_copy_files
 
-Use to copy files from control node to ksqlDB hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode (default: '0640') to set directory and file permissions.
+Use to copy files from control node to ksqlDB hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '750') and file_mode (default: '640') to set directory and file permissions.
 
 Default:  []
 
@@ -2293,7 +2293,7 @@ Default:  "{{control_center_default_log_dir}}"
 
 ### control_center_copy_files
 
-Use to copy files from control node to Control Center hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode (default: '0640') to set directory and file permissions.
+Use to copy files from control node to Control Center hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '750') and file_mode (default: '640') to set directory and file permissions.
 
 Default:  []
 

--- a/playbooks/tasks/certificate_authority.yml
+++ b/playbooks/tasks/certificate_authority.yml
@@ -92,7 +92,7 @@
       file:
         path: "{{ ssl_file_dir_final }}/generation"
         state: directory
-        mode: 0755
+        mode: '755'
 
     - name: Create Certificate Authority
       tags: certificate_authority

--- a/roles/common/tasks/confluent_cli.yml
+++ b/roles/common/tasks/confluent_cli.yml
@@ -19,7 +19,7 @@
   file:
     path: "{{confluent_cli_base_path}}/{{confluent_cli_dir}}"
     state: directory
-    mode: '0755'
+    mode: '755'
     recurse: true
 
 - name: Expand remote Confluent CLI archive
@@ -29,7 +29,7 @@
     dest: "{{confluent_cli_base_path}}/{{confluent_cli_dir}}"
     group: "{{ omit if archive_group == '' else archive_group }}"
     owner: "{{ omit if archive_owner == '' else archive_owner }}"
-    mode: 0755
+    mode: '755'
     extra_opts: [--strip-components=1]
     creates: "{{confluent_cli_base_path}}/{{confluent_cli_dir}}/{{confluent_cli_binary}}"
   when: confluent_cli_custom_download_url is not defined
@@ -38,7 +38,7 @@
   get_url:
     url: "{{ confluent_cli_custom_download_url }}"
     dest: "{{confluent_cli_base_path}}/{{confluent_cli_dir}}/{{confluent_cli_binary}}"
-    mode: 0755
+    mode: '755'
   register: cli_download_result
   until: cli_download_result is success
   retries: 5

--- a/roles/common/tasks/debian.yml
+++ b/roles/common/tasks/debian.yml
@@ -112,7 +112,7 @@
   copy:
     content: 'Acquire::Check-Valid-Until "0";'
     dest: /etc/apt/apt.conf.d/skip-check
-    mode: 0644
+    mode: '644'
   notify:
     - debian apt-get update
   when:

--- a/roles/common/tasks/fetch_logs.yml
+++ b/roles/common/tasks/fetch_logs.yml
@@ -3,7 +3,7 @@
   file:
     state: directory
     path: "troubleshooting"
-    mode: 0755
+    mode: '755'
   delegate_to: localhost
   vars:
     ansible_connection: local
@@ -24,7 +24,7 @@
   file:
     path: "{{fetch_logs_path}}/troubleshooting/{{inventory_hostname}}/"
     state: directory
-    mode: 0750
+    mode: '750'
     owner: "{{user}}"
     group: "{{group}}"
 
@@ -33,7 +33,7 @@
     dest: "{{fetch_logs_path}}/troubleshooting/{{inventory_hostname}}/"
     src: "{{ item }}"
     remote_src: true
-    mode: 0750
+    mode: '750'
     owner: "{{user}}"
     group: "{{group}}"
   loop: "{{ find_output.files | map(attribute='path') | list + [config_file] }}"
@@ -45,7 +45,7 @@
     remove: true
     format: gz
     force_archive: true
-    mode: 0750
+    mode: '750'
     owner: "{{user}}"
     group: "{{group}}"
 

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -70,7 +70,7 @@
     group: "{{ omit if archive_group == '' else archive_group }}"
     owner: "{{ omit if archive_owner == '' else archive_owner }}"
     state: directory
-    mode: 0755
+    mode: '755'
   when: installation_method == "archive"
 
 # If the target directory (i.e. creates) doesn't exist then download and expand the remote archive into target
@@ -81,7 +81,7 @@
     dest: "{{archive_destination_path}}"
     group: "{{ omit if archive_group == '' else archive_group }}"
     owner: "{{ omit if archive_owner == '' else archive_owner }}"
-    mode: 0755
+    mode: '755'
     creates: "{{binary_base_path}}"
   when: installation_method == "archive"
 
@@ -89,14 +89,14 @@
   file:
     path: "{{ jolokia_jar_path | dirname }}"
     state: directory
-    mode: 0755
+    mode: '755'
   when: jolokia_enabled|bool
 
 - name: Copy Jolokia Jar
   copy:
     src: "{{ jolokia_jar_url }}"
     dest: "{{ jolokia_jar_path }}"
-    mode: 0755
+    mode: '755'
   when:
     - jolokia_enabled|bool
     - not jolokia_url_remote|bool
@@ -106,7 +106,7 @@
     url: "{{ jolokia_jar_url }}"
     dest: "{{ jolokia_jar_path }}"
     force: "{{ jolokia_jar_url_force }}"
-    mode: 0755
+    mode: '755'
   register: jolokia_download_result
   until: jolokia_download_result is success
   retries: 5
@@ -120,14 +120,14 @@
   file:
     path: "{{ jmxexporter_jar_path | dirname }}"
     state: directory
-    mode: 0755
+    mode: '755'
   when: jmxexporter_enabled|bool
 
 - name: Copy Prometheus Jar
   copy:
     src: "{{ jmxexporter_jar_url }}"
     dest: "{{ jmxexporter_jar_path }}"
-    mode: 0755
+    mode: '755'
   when:
     - jmxexporter_enabled|bool
     - not jmxexporter_url_remote|bool
@@ -137,7 +137,7 @@
     url: "{{ jmxexporter_jar_url }}"
     dest: "{{ jmxexporter_jar_path }}"
     force: "{{ jmxexporter_jar_url_force }}"
-    mode: 0755
+    mode: '755'
   register: prometheus_download_result
   until: prometheus_download_result is success
   retries: 5

--- a/roles/common/tasks/masterkey.yml
+++ b/roles/common/tasks/masterkey.yml
@@ -20,7 +20,7 @@
   copy:
     content: "{{ masterkey.stdout }}"
     dest: /tmp/masterkey
-    mode: 0640
+    mode: '640'
   diff: "{{ not mask_sensitive_diff|bool }}"
 
 - name: Copy Security File Back to Ansible Host

--- a/roles/common/tasks/rbac_setup.yml
+++ b/roles/common/tasks/rbac_setup.yml
@@ -43,7 +43,7 @@
   file:
     path: "{{ ssl_file_dir_final }}"
     state: directory
-    mode: 0755
+    mode: '755'
   tags:
     - privileged
     - filesystem
@@ -66,7 +66,7 @@
   copy:
     src: "{{token_services_public_pem_file}}"
     dest: "{{rbac_enabled_public_pem_path}}"
-    mode: 0640
+    mode: '640'
     owner: "{{user}}"
     group: "{{group}}"
   when:

--- a/roles/common/tasks/redhat.yml
+++ b/roles/common/tasks/redhat.yml
@@ -11,7 +11,7 @@
   template:
     src: confluent.repo.j2
     dest: /etc/yum.repos.d/confluent.repo
-    mode: 0644
+    mode: '644'
   register: confluent_repo_result
   until: confluent_repo_result is success
   retries: 5
@@ -31,7 +31,7 @@
   copy:
     src: "{{custom_yum_repofile_filepath}}"
     dest: /etc/yum.repos.d/custom-confluent.repo
-    mode: 0644
+    mode: '644'
   register: custom_repo_result
   until: custom_repo_result is success
   retries: 5

--- a/roles/common/tasks/secrets_protection.yml
+++ b/roles/common/tasks/secrets_protection.yml
@@ -32,7 +32,7 @@
     src: "{{ config_path }}"
     dest: "{{ config_path }}-backup"
     remote_src: true
-    mode: 0640
+    mode: '640'
     owner: "{{ secrets_file_owner }}"
     group: "{{ secrets_file_group }}"
   when: config_stat.stat.exists
@@ -41,7 +41,7 @@
   template:
     src: properties.j2
     dest: "{{ config_path }}"
-    mode: 0640
+    mode: '640'
     owner: "{{ secrets_file_owner }}"
     group: "{{ secrets_file_group }}"
   vars:
@@ -53,7 +53,7 @@
   file:
     path: "{{ ssl_file_dir_final }}"
     state: directory
-    mode: 0755
+    mode: '755'
   tags:
     - filesystem
     - privileged
@@ -64,7 +64,7 @@
     dest: "{{ secrets_file }}"
     owner: "{{ secrets_file_owner }}"
     group: "{{ secrets_file_group }}"
-    mode: 0640
+    mode: '640'
   diff: "{{ not mask_sensitive_diff|bool }}"
 
 - name: Load masterkey
@@ -116,7 +116,7 @@
     src: "{{ config_path }}"
     dest: "{{ config_path }}-backup"
     remote_src: true
-    mode: 0640
+    mode: '640'
     owner: "{{ secrets_file_owner }}"
     group: "{{ secrets_file_group }}"
   notify: "{{handler}}"

--- a/roles/common/tasks/ubuntu.yml
+++ b/roles/common/tasks/ubuntu.yml
@@ -104,7 +104,7 @@
   file:
     path: /usr/share/man/man1
     state: directory
-    mode: 0755
+    mode: '755'
 
 - name: Custom Java Install
   include_tasks: custom_java_install.yml

--- a/roles/control_center/tasks/main.yml
+++ b/roles/control_center/tasks/main.yml
@@ -88,7 +88,7 @@
     owner: "{{control_center_user}}"
     group: "{{control_center_group}}"
     state: directory
-    mode: 0750
+    mode: '750'
   tags:
     - filesystem
 
@@ -108,7 +108,7 @@
     src: "{{binary_base_path}}/lib/systemd/system/{{control_center.systemd_file|basename}}"
     remote_src: true
     dest: "{{control_center.systemd_file}}"
-    mode: 0644
+    mode: '644'
     force: true
   when: installation_method == "archive"
   tags:
@@ -171,7 +171,7 @@
   file:
     path: "{{ control_center.config_file | dirname }}"
     state: directory
-    mode: 0750
+    mode: '750'
     owner: "{{control_center_user}}"
     group: "{{control_center_group}}"
   tags:
@@ -182,7 +182,7 @@
   template:
     src: control-center.properties.j2
     dest: "{{control_center.config_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{control_center_user}}"
     group: "{{control_center_group}}"
   notify: restart control center
@@ -216,7 +216,7 @@
     state: directory
     group: "{{control_center_group}}"
     owner: "{{control_center_user}}"
-    mode: 0770
+    mode: '770'
   tags:
     - filesystem
     - log
@@ -240,7 +240,7 @@
     path: "{{control_center.log4j_file}}"
     group: "{{control_center_group}}"
     owner: "{{control_center_user}}"
-    mode: 0640
+    mode: '640'
   tags:
     - filesystem
     - log
@@ -249,7 +249,7 @@
   file:
     path: "{{ logredactor_rule_path | dirname }}"
     state: directory
-    mode: 0755
+    mode: '755'
   when: (control_center_custom_log4j|bool) and (logredactor_enabled|bool) and (logredactor_rule_url == '')
   tags:
     - log
@@ -258,7 +258,7 @@
   copy:
     src: "{{ logredactor_rule_path_local }}"
     dest: "{{ logredactor_rule_path }}"
-    mode: 0644
+    mode: '644'
   when: (control_center_custom_log4j|bool) and (logredactor_enabled|bool) and (logredactor_rule_url == '')
   tags:
     - log
@@ -289,7 +289,7 @@
     path: "{{control_center_rocksdb_path}}"
     group: "{{control_center_group}}"
     owner: "{{control_center_user}}"
-    mode: 0750
+    mode: '750'
     state: directory
   when: control_center_rocksdb_path != ""
   tags:
@@ -309,7 +309,7 @@
   template:
     src: jaas.conf.j2
     dest: "{{control_center.jaas_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{control_center_user}}"
     group: "{{control_center_group}}"
   notify: restart control center
@@ -319,7 +319,7 @@
   template:
     src: password.properties.j2
     dest: "{{control_center.password_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{control_center_user}}"
     group: "{{control_center_group}}"
   notify: restart control center
@@ -331,7 +331,7 @@
     state: directory
     owner: "{{control_center_user}}"
     group: "{{control_center_group}}"
-    mode: 0640
+    mode: '640'
   tags:
     - systemd
     - privileged
@@ -340,7 +340,7 @@
   template:
     src: override.conf.j2
     dest: "{{control_center.systemd_override}}"
-    mode: 0640
+    mode: '640'
     owner: root
     group: root
   notify: restart control center

--- a/roles/kafka_broker/tasks/dynamic_groups.yml
+++ b/roles/kafka_broker/tasks/dynamic_groups.yml
@@ -18,7 +18,7 @@
   template:
     src: zookeeper-tls-client.properties.j2
     dest: "{{ kafka_broker.zookeeper_tls_client_config_file }}"
-    mode: 0640
+    mode: '640'
     owner: "{{ kafka_broker_user }}"
     group: "{{ kafka_broker_group }}"
   when: zookeeper_ssl_enabled|bool

--- a/roles/kafka_broker/tasks/main.yml
+++ b/roles/kafka_broker/tasks/main.yml
@@ -109,7 +109,7 @@
     src: "{{binary_base_path}}/lib/systemd/system/{{kafka_broker.systemd_file|basename}}"
     remote_src: true
     dest: "{{kafka_broker.systemd_file}}"
-    mode: 0644
+    mode: '644'
     force: true
   when: installation_method == "archive"
   tags:
@@ -176,7 +176,7 @@
     owner: "{{kafka_broker_user}}"
     group: "{{kafka_broker_group}}"
     state: directory
-    mode: 0750
+    mode: '750'
   tags:
     - privileged
     - filesystem
@@ -187,7 +187,7 @@
     owner: "{{kafka_broker_user}}"
     group: "{{kafka_broker_group}}"
     state: directory
-    mode: 0750
+    mode: '750'
   with_items: "{{ kafka_broker_final_properties['log.dirs'].split(',') }}"
   tags:
     - filesystem
@@ -206,7 +206,7 @@
   file:
     path: "{{ kafka_broker.config_file | dirname }}"
     state: directory
-    mode: 0750
+    mode: '750'
     owner: "{{kafka_broker_user}}"
     group: "{{kafka_broker_group}}"
   tags:
@@ -216,7 +216,7 @@
   template:
     src: server.properties.j2
     dest: "{{kafka_broker.config_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_broker_user}}"
     group: "{{kafka_broker_group}}"
   notify: restart kafka
@@ -228,7 +228,7 @@
   template:
     src: client.properties.j2
     dest: "{{kafka_broker.client_config_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_broker_user}}"
     group: "{{kafka_broker_group}}"
   diff: "{{ not mask_sensitive_diff|bool }}"
@@ -244,7 +244,7 @@
   template:
     src: zookeeper-tls-client.properties.j2
     dest: "{{kafka_broker.zookeeper_tls_client_config_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_broker_user}}"
     group: "{{kafka_broker_group}}"
   when: zookeeper_ssl_enabled|bool and not kraft_enabled|bool
@@ -257,7 +257,7 @@
     state: directory
     group: "{{kafka_broker_group}}"
     owner: "{{kafka_broker_user}}"
-    mode: 0770
+    mode: '770'
   tags:
     - filesystem
     - log
@@ -282,7 +282,7 @@
     path: "{{kafka_broker.log4j_file}}"
     group: "{{kafka_broker_group}}"
     owner: "{{kafka_broker_user}}"
-    mode: 0640
+    mode: '640'
   tags:
     - filesystem
     - log
@@ -291,7 +291,7 @@
   file:
     path: "{{ logredactor_rule_path | dirname }}"
     state: directory
-    mode: 0755
+    mode: '755'
   when: (kafka_broker_custom_log4j|bool) and (logredactor_enabled|bool) and (logredactor_rule_url == '')
   tags:
     - log
@@ -300,7 +300,7 @@
   copy:
     src: "{{ logredactor_rule_path_local }}"
     dest: "{{ logredactor_rule_path }}"
-    mode: 0644
+    mode: '644'
   when: (kafka_broker_custom_log4j|bool) and (logredactor_enabled|bool) and (logredactor_rule_url == '')
   tags:
     - log
@@ -330,7 +330,7 @@
   template:
     src: kafka_jolokia.properties.j2
     dest: "{{kafka_broker_jolokia_config}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_broker_user}}"
     group: "{{kafka_broker_group}}"
   when: kafka_broker_jolokia_enabled|bool
@@ -343,7 +343,7 @@
   template:
     src: kafka_server_jaas.conf.j2
     dest: "{{kafka_broker.jaas_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_broker_user}}"
     group: "{{kafka_broker_group}}"
   when: "'GSSAPI' in kafka_broker_sasl_enabled_mechanisms or
@@ -357,7 +357,7 @@
   template:
     src: password.properties.j2
     dest: "{{kafka_broker.rest_proxy_password_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_broker_user}}"
     group: "{{kafka_broker_group}}"
   when: kafka_broker_rest_proxy_enabled and (not rbac_enabled or (rbac_enabled and external_mds_enabled)) and kafka_broker_rest_proxy_authentication_type == 'basic'
@@ -411,7 +411,7 @@
   template:
     src: "{{kafka_broker_jmxexporter_config_source_path}}"
     dest: "{{kafka_broker_jmxexporter_config_path}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_broker_user}}"
     group: "{{kafka_broker_group}}"
   when: kafka_broker_jmxexporter_enabled|bool
@@ -424,7 +424,7 @@
     owner: "{{kafka_broker_user}}"
     group: "{{kafka_broker_group}}"
     state: directory
-    mode: 0640
+    mode: '640'
   tags:
     - systemd
     - privileged
@@ -433,7 +433,7 @@
   template:
     src: override.conf.j2
     dest: "{{ kafka_broker.systemd_override }}"
-    mode: 0640
+    mode: '640'
     owner: root
     group: root
   notify: restart kafka
@@ -446,7 +446,7 @@
   file:
     path: /usr/lib/sysctl.d
     state: directory
-    mode: 0755
+    mode: '755'
   when: ansible_distribution == "Debian"
   tags:
     - sysctl

--- a/roles/kafka_broker/tasks/rbac.yml
+++ b/roles/kafka_broker/tasks/rbac.yml
@@ -63,7 +63,7 @@
   file:
     path: /var/ssl/private
     state: directory
-    mode: 0755
+    mode: '755'
   tags:
     - privileged
     - filesystem
@@ -86,7 +86,7 @@
   copy:
     src: "{{token_services_public_pem_file}}"
     dest: "{{rbac_enabled_public_pem_path}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_broker_user}}"
     group: "{{kafka_broker_group}}"
   when:
@@ -112,7 +112,7 @@
   copy:
     src: "{{token_services_private_pem_file}}"
     dest: "{{rbac_enabled_private_pem_path}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_broker_user}}"
     group: "{{kafka_broker_group}}"
   when:

--- a/roles/kafka_broker/tasks/secrets_protection.yml
+++ b/roles/kafka_broker/tasks/secrets_protection.yml
@@ -37,7 +37,7 @@
   template:
     src: override.conf.j2
     dest: "{{ kafka_broker.systemd_override }}"
-    mode: 0640
+    mode: '640'
     owner: root
     group: root
   diff: "{{ not mask_sensitive_diff|bool }}"

--- a/roles/kafka_connect/tasks/confluent_hub.yml
+++ b/roles/kafka_connect/tasks/confluent_hub.yml
@@ -30,7 +30,7 @@
     owner: "{{kafka_connect_user}}"
     group: "{{kafka_connect_group}}"
     state: directory
-    mode: 0750
+    mode: '750'
   loop: "{{ kafka_connect_confluent_hub_plugins }}"
   when: kafka_connect_confluent_hub_plugins|length > 0
 

--- a/roles/kafka_connect/tasks/connect_plugins.yml
+++ b/roles/kafka_connect/tasks/connect_plugins.yml
@@ -5,7 +5,7 @@
     state: directory
     group: "{{kafka_connect_group}}"
     owner: "{{kafka_connect_user}}"
-    mode: 0755
+    mode: '755'
   when: item != '/usr/share/java'
   with_items: "{{ kafka_connect_final_properties['plugin.path'].split(',') }}"
 
@@ -41,7 +41,7 @@
   file:
     path: /tmp/remote_plugins
     state: directory
-    mode: 0755
+    mode: '755'
     owner: "{{kafka_connect_user}}"
     group: "{{kafka_connect_group}}"
 
@@ -49,7 +49,7 @@
   get_url:
     url: "{{item}}"
     dest: /tmp/remote_plugins
-    mode: 0755
+    mode: '755'
     owner: "{{kafka_connect_user}}"
     group: "{{kafka_connect_group}}"
   register: download_remote_plugin_result

--- a/roles/kafka_connect/tasks/main.yml
+++ b/roles/kafka_connect/tasks/main.yml
@@ -89,7 +89,7 @@
     src: "{{binary_base_path}}/lib/systemd/system/{{kafka_connect_default_service_name}}.service"
     remote_src: true
     dest: "{{kafka_connect.systemd_file}}"
-    mode: 0644
+    mode: '644'
     force: true
   when: installation_method == "archive"
   tags:
@@ -102,7 +102,7 @@
     src: "{{systemd_base_dir}}/{{kafka_connect_default_service_name}}.service"
     remote_src: true
     dest: "{{kafka_connect.systemd_file}}"
-    mode: 0644
+    mode: '644'
     force: true
   when: installation_method != "archive" and kafka_connect_default_service_name != kafka_connect_service_name
   tags:
@@ -163,7 +163,7 @@
   file:
     path: "{{ kafka_connect.config_file | dirname }}"
     state: directory
-    mode: 0750
+    mode: '750'
     owner: "{{kafka_connect_user}}"
     group: "{{kafka_connect_group}}"
   tags:
@@ -173,7 +173,7 @@
   template:
     src: connect-distributed.properties.j2
     dest: "{{kafka_connect.config_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_connect_user}}"
     group: "{{kafka_connect_group}}"
   notify: restart connect distributed
@@ -210,7 +210,7 @@
     state: directory
     group: "{{kafka_connect_group}}"
     owner: "{{kafka_connect_user}}"
-    mode: 0770
+    mode: '770'
   tags:
     - filesystem
     - log
@@ -235,7 +235,7 @@
     path: "{{kafka_connect.log4j_file}}"
     group: "{{kafka_connect_group}}"
     owner: "{{kafka_connect_user}}"
-    mode: 0640
+    mode: '640'
   tags:
     - filesystem
     - log
@@ -244,7 +244,7 @@
   file:
     path: "{{ logredactor_rule_path | dirname }}"
     state: directory
-    mode: 0755
+    mode: '755'
   when: (kafka_connect_custom_log4j|bool) and (logredactor_enabled|bool) and (logredactor_rule_url == '')
   tags:
     - log
@@ -253,7 +253,7 @@
   copy:
     src: "{{ logredactor_rule_path_local }}"
     dest: "{{ logredactor_rule_path }}"
-    mode: 0644
+    mode: '644'
   when: (kafka_connect_custom_log4j|bool) and (logredactor_enabled|bool) and (logredactor_rule_url == '')
   tags:
     - log
@@ -283,7 +283,7 @@
   template:
     src: kafka_connect_jolokia.properties.j2
     dest: "{{kafka_connect_jolokia_config}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_connect_user}}"
     group: "{{kafka_connect_group}}"
   when: kafka_connect_jolokia_enabled|bool
@@ -296,7 +296,7 @@
   copy:
     src: "{{kafka_connect_jmxexporter_config_source_path}}"
     dest: "{{kafka_connect_jmxexporter_config_path}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_connect_user}}"
     group: "{{kafka_connect_group}}"
   when: kafka_connect_jmxexporter_enabled|bool
@@ -307,7 +307,7 @@
   template:
     src: jaas.conf.j2
     dest: "{{kafka_connect.jaas_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_connect_user}}"
     group: "{{kafka_connect_group}}"
   notify: restart connect distributed
@@ -317,7 +317,7 @@
   template:
     src: password.properties.j2
     dest: "{{kafka_connect.password_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_connect_user}}"
     group: "{{kafka_connect_group}}"
   notify: restart connect distributed
@@ -329,7 +329,7 @@
     owner: "{{kafka_connect_user}}"
     group: "{{kafka_connect_group}}"
     state: directory
-    mode: 0640
+    mode: '640'
   tags:
     - systemd
     - privileged
@@ -338,7 +338,7 @@
   template:
     src: override.conf.j2
     dest: "{{ kafka_connect.systemd_override }}"
-    mode: 0640
+    mode: '640'
     owner: root
     group: root
   notify: restart connect distributed

--- a/roles/kafka_connect_replicator/tasks/main.yml
+++ b/roles/kafka_connect_replicator/tasks/main.yml
@@ -264,7 +264,7 @@
   file:
     path: "{{ kafka_connect_replicator.replication_config_file | dirname }}"
     state: directory
-    mode: 0750
+    mode: '750'
     owner: "{{kafka_connect_replicator_user}}"
     group: "{{kafka_connect_replicator_group}}"
   tags:
@@ -276,7 +276,7 @@
     state: directory
     group: "{{kafka_connect_replicator_group}}"
     owner: "{{kafka_connect_replicator_user}}"
-    mode: 0770
+    mode: '770'
   tags:
     - filesystem
 
@@ -284,7 +284,7 @@
   template:
     src: kafka-connect-replicator-log4j.properties.j2
     dest: "{{kafka_connect_replicator.log4j_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_connect_replicator_user}}"
     group: "{{kafka_connect_replicator_group}}"
   when: kafka_connect_replicator_custom_log4j|bool
@@ -296,7 +296,7 @@
   template:
     src: kafka-connect-replicator-jolokia.properties.j2
     dest: "{{kafka_connect_replicator_jolokia_config}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_connect_replicator_user}}"
     group: "{{kafka_connect_replicator_group}}"
   when: kafka_connect_replicator_jolokia_enabled|bool
@@ -308,7 +308,7 @@
   template:
     src: kafka-connect-replicator.properties.j2
     dest: "{{kafka_connect_replicator.replication_config_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_connect_replicator_user}}"
     group: "{{kafka_connect_replicator_group}}"
   notify: Restart Kafka Connect Replicator
@@ -319,7 +319,7 @@
   template:
     src: kafka-connect-replicator-consumer.properties.j2
     dest: "{{kafka_connect_replicator.consumer_config_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_connect_replicator_user}}"
     group: "{{kafka_connect_replicator_group}}"
   notify: Restart Kafka Connect Replicator
@@ -330,7 +330,7 @@
   template:
     src: kafka-connect-replicator-producer.properties.j2
     dest: "{{kafka_connect_replicator.producer_config_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_connect_replicator_user}}"
     group: "{{kafka_connect_replicator_group}}"
   notify: Restart Kafka Connect Replicator
@@ -341,7 +341,7 @@
   template:
     src: kafka-connect-replicator-interceptors.properties.j2
     dest: "{{kafka_connect_replicator.interceptors_config_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_connect_replicator_user}}"
     group: "{{kafka_connect_replicator_group}}"
   notify: Restart Kafka Connect Replicator
@@ -352,7 +352,7 @@
   template:
     src: kafka-connect-replicator.service.j2
     dest:  "{{kafka_connect_replicator.systemd_file}}"
-    mode: 0640
+    mode: '640'
     owner: root
     group: root
   notify: Restart Kafka Connect Replicator
@@ -365,7 +365,7 @@
     owner: "{{kafka_connect_replicator_user}}"
     group: "{{kafka_connect_replicator_group}}"
     state: directory
-    mode: 0640
+    mode: '640'
   tags:
     - systemd
 
@@ -373,7 +373,7 @@
   template:
     src: override.conf.j2
     dest: "{{ kafka_connect_replicator.systemd_override }}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_connect_replicator_user}}"
     group: "{{kafka_connect_replicator_group}}"
   notify: Restart Kafka Connect Replicator

--- a/roles/kafka_connect_replicator/tasks/rbac_replicator.yml
+++ b/roles/kafka_connect_replicator/tasks/rbac_replicator.yml
@@ -3,7 +3,7 @@
   file:
     path: /var/ssl/private/kafka_connect_replicator
     state: directory
-    mode: 0755
+    mode: '755'
   tags:
     - privileged
 
@@ -25,7 +25,7 @@
   copy:
     src: "{{ kafka_connect_replicator_erp_pem_file }}"
     dest: "{{ kafka_connect_replicator_rbac_enabled_public_pem_path }}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_connect_replicator_user}}"
     group: "{{kafka_connect_replicator_group}}"
   diff: "{{ not mask_sensitive_diff|bool }}"

--- a/roles/kafka_connect_replicator/tasks/rbac_replicator_consumer.yml
+++ b/roles/kafka_connect_replicator/tasks/rbac_replicator_consumer.yml
@@ -3,7 +3,7 @@
   file:
     path: /var/ssl/private/kafka_connect_replicator_consumer
     state: directory
-    mode: 0755
+    mode: '755'
   tags:
     - privileged
 
@@ -25,7 +25,7 @@
   copy:
     src: "{{ kafka_connect_replicator_consumer_erp_pem_file }}"
     dest: "{{ kafka_connect_replicator_consumer_rbac_enabled_public_pem_path }}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_connect_replicator_user}}"
     group: "{{kafka_connect_replicator_group}}"
   when: replicator_pem_file.stat.exists|bool

--- a/roles/kafka_connect_replicator/tasks/rbac_replicator_monitoring.yml
+++ b/roles/kafka_connect_replicator/tasks/rbac_replicator_monitoring.yml
@@ -3,7 +3,7 @@
   file:
     path: /var/ssl/private/kafka_connect_replicator_monitoring_interceptor
     state: directory
-    mode: 0755
+    mode: '755'
   tags:
     - privileged
 
@@ -25,7 +25,7 @@
   copy:
     src: "{{ kafka_connect_replicator_monitoring_interceptor_erp_pem_file }}"
     dest: "{{ kafka_connect_replicator_monitoring_interceptor_rbac_enabled_public_pem_path }}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_connect_replicator_user}}"
     group: "{{kafka_connect_replicator_group}}"
   when: replicator_pem_file.stat.exists|bool

--- a/roles/kafka_connect_replicator/tasks/rbac_replicator_producer.yml
+++ b/roles/kafka_connect_replicator/tasks/rbac_replicator_producer.yml
@@ -3,7 +3,7 @@
   file:
     path: /var/ssl/private/kafka_connect_replicator_producer
     state: directory
-    mode: 0755
+    mode: '755'
   tags:
     - privileged
 
@@ -25,7 +25,7 @@
   copy:
     src: "{{ kafka_connect_replicator_producer_erp_pem_file }}"
     dest: "{{ kafka_connect_replicator_producer_rbac_enabled_public_pem_path }}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_connect_replicator_user}}"
     group: "{{kafka_connect_replicator_group}}"
   when: replicator_pem_file.stat.exists|bool

--- a/roles/kafka_controller/tasks/create_config.yml
+++ b/roles/kafka_controller/tasks/create_config.yml
@@ -3,7 +3,7 @@
   template:
     src: server.properties.j2
     dest: "{{kafka_controller.config_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_controller_user}}"
     group: "{{kafka_controller_group}}"
   diff: "{{ not mask_sensitive_diff|bool }}"

--- a/roles/kafka_controller/tasks/main.yml
+++ b/roles/kafka_controller/tasks/main.yml
@@ -103,7 +103,7 @@
     src: "{{ ((binary_base_path, 'lib/systemd/system') | path_join if installation_method=='archive' else systemd_base_dir, kafka_broker.systemd_file|basename) | path_join }}"
     remote_src: true
     dest: "{{kafka_controller.systemd_file}}"
-    mode: 0644
+    mode: '644'
     force: true
   tags:
     - systemd
@@ -167,7 +167,7 @@
     owner: "{{kafka_controller_user}}"
     group: "{{kafka_controller_group}}"
     state: directory
-    mode: 0750
+    mode: '750'
   tags:
     - privileged
     - filesystem
@@ -178,7 +178,7 @@
     owner: "{{kafka_controller_user}}"
     group: "{{kafka_controller_group}}"
     state: directory
-    mode: 0750
+    mode: '750'
   tags:
     - filesystem
     - privileged
@@ -196,7 +196,7 @@
   file:
     path: "{{ kafka_controller.config_file | dirname }}"
     state: directory
-    mode: 0750
+    mode: '750'
     owner: "{{kafka_controller_user}}"
     group: "{{kafka_controller_group}}"
   tags:
@@ -208,7 +208,7 @@
   template:
     src: server.properties.j2
     dest: "{{kafka_controller.config_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_controller_user}}"
     group: "{{kafka_controller_group}}"
   notify: restart Kafka Controller
@@ -221,7 +221,7 @@
   template:
     src: client.properties.j2
     dest: "{{kafka_controller.client_config_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_controller_user}}"
     group: "{{kafka_controller_group}}"
   diff: "{{ not mask_sensitive_diff|bool }}"
@@ -238,7 +238,7 @@
     state: directory
     group: "{{kafka_controller_group}}"
     owner: "{{kafka_controller_user}}"
-    mode: 0770
+    mode: '770'
   tags:
     - filesystem
     - log
@@ -264,7 +264,7 @@
     path: "{{kafka_controller.log4j_file}}"
     group: "{{kafka_controller_group}}"
     owner: "{{kafka_controller_user}}"
-    mode: 0640
+    mode: '640'
   tags:
     - filesystem
     - log
@@ -274,7 +274,7 @@
   file:
     path: "{{ logredactor_rule_path | dirname }}"
     state: directory
-    mode: 0755
+    mode: '755'
   when: (kafka_controller_custom_log4j|bool) and (logredactor_enabled|bool) and (logredactor_rule_url == '')
   tags:
     - log
@@ -284,7 +284,7 @@
   copy:
     src: "{{ logredactor_rule_path_local }}"
     dest: "{{ logredactor_rule_path }}"
-    mode: 0644
+    mode: '644'
   when: (kafka_controller_custom_log4j|bool) and (logredactor_enabled|bool) and (logredactor_rule_url == '')
   tags:
     - log
@@ -315,7 +315,7 @@
   template:
     src: kafka_jolokia.properties.j2
     dest: "{{kafka_controller_jolokia_config}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_controller_user}}"
     group: "{{kafka_controller_group}}"
   when: kafka_controller_jolokia_enabled|bool
@@ -329,7 +329,7 @@
   template:
     src: kafka_server_jaas.conf.j2
     dest: "{{kafka_controller.jaas_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_controller_user}}"
     group: "{{kafka_controller_group}}"
   when:
@@ -343,7 +343,7 @@
   template:
     src: "{{kafka_controller_jmxexporter_config_source_path}}"
     dest: "{{kafka_controller_jmxexporter_config_path}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_controller_user}}"
     group: "{{kafka_controller_group}}"
   when: kafka_controller_jmxexporter_enabled|bool
@@ -357,7 +357,7 @@
     owner: "{{kafka_controller_user}}"
     group: "{{kafka_controller_group}}"
     state: directory
-    mode: 0640
+    mode: '640'
   tags:
     - systemd
     - privileged
@@ -366,7 +366,7 @@
   template:
     src: override.conf.j2
     dest: "{{ kafka_controller.systemd_override }}"
-    mode: 0640
+    mode: '640'
     owner: root
     group: root
   notify: restart Kafka Controller
@@ -379,7 +379,7 @@
   file:
     path: /usr/lib/sysctl.d
     state: directory
-    mode: 0755
+    mode: '755'
   when: ansible_distribution == "Debian"
   tags:
     - sysctl

--- a/roles/kafka_controller/tasks/rbac.yml
+++ b/roles/kafka_controller/tasks/rbac.yml
@@ -45,7 +45,7 @@
   file:
     path: /var/ssl/private
     state: directory
-    mode: 0755
+    mode: '755'
   tags:
     - privileged
     - filesystem
@@ -68,7 +68,7 @@
   copy:
     src: "{{token_services_public_pem_file}}"
     dest: "{{rbac_enabled_public_pem_path}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_controller_user}}"
     group: "{{kafka_controller_group}}"
   when:
@@ -94,7 +94,7 @@
   copy:
     src: "{{token_services_private_pem_file}}"
     dest: "{{rbac_enabled_private_pem_path}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_controller_user}}"
     group: "{{kafka_controller_group}}"
   when:

--- a/roles/kafka_controller/tasks/secrets_protection.yml
+++ b/roles/kafka_controller/tasks/secrets_protection.yml
@@ -30,7 +30,7 @@
   template:
     src: override.conf.j2
     dest: "{{ kafka_controller.systemd_override }}"
-    mode: 0640
+    mode: '640'
     owner: root
     group: root
   diff: "{{ not mask_sensitive_diff|bool }}"

--- a/roles/kafka_rest/tasks/main.yml
+++ b/roles/kafka_rest/tasks/main.yml
@@ -89,7 +89,7 @@
     src: "{{binary_base_path}}/lib/systemd/system/{{kafka_rest.systemd_file|basename}}"
     remote_src: true
     dest: "{{kafka_rest.systemd_file}}"
-    mode: 0644
+    mode: '644'
     force: true
   when: installation_method == "archive"
   tags:
@@ -150,7 +150,7 @@
   file:
     path: /var/ssl/private
     state: directory
-    mode: 0755
+    mode: '755'
   when: rbac_enabled|bool
   tags:
     - filesystem
@@ -189,7 +189,7 @@
   file:
     path: "{{ kafka_rest.config_file | dirname }}"
     state: directory
-    mode: 0750
+    mode: '750'
     owner: "{{kafka_rest_user}}"
     group: "{{kafka_rest_group}}"
   tags:
@@ -199,7 +199,7 @@
   template:
     src: kafka-rest.properties.j2
     dest: "{{kafka_rest.config_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_rest_user}}"
     group: "{{kafka_rest_group}}"
   notify: restart kafka-rest
@@ -233,7 +233,7 @@
     state: directory
     owner: "{{kafka_rest_user}}"
     group: "{{kafka_rest_group}}"
-    mode: 0770
+    mode: '770'
   tags:
     - filesystem
     - log
@@ -257,7 +257,7 @@
     path: "{{kafka_rest.log4j_file}}"
     group: "{{kafka_rest_group}}"
     owner: "{{kafka_rest_user}}"
-    mode: 0640
+    mode: '640'
   tags:
     - configuration
     - log
@@ -266,7 +266,7 @@
   file:
     path: "{{ logredactor_rule_path | dirname }}"
     state: directory
-    mode: 0755
+    mode: '755'
   when: (kafka_rest_custom_log4j|bool) and (logredactor_enabled|bool) and (logredactor_rule_url == '')
   tags:
     - log
@@ -275,7 +275,7 @@
   copy:
     src: "{{ logredactor_rule_path_local }}"
     dest: "{{ logredactor_rule_path }}"
-    mode: 0644
+    mode: '644'
   when: (kafka_rest_custom_log4j|bool) and (logredactor_enabled|bool) and (logredactor_rule_url == '')
   tags:
     - log
@@ -305,7 +305,7 @@
   template:
     src: kafka_rest_jolokia.properties.j2
     dest: "{{kafka_rest_jolokia_config}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_rest_user}}"
     group: "{{kafka_rest_group}}"
   when: kafka_rest_jolokia_enabled|bool
@@ -318,7 +318,7 @@
   copy:
     src: "{{kafka_rest_jmxexporter_config_source_path}}"
     dest: "{{kafka_rest_jmxexporter_config_path}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_rest_user}}"
     group: "{{kafka_rest_group}}"
   when: kafka_rest_jmxexporter_enabled|bool
@@ -329,7 +329,7 @@
   template:
     src: jaas.conf.j2
     dest: "{{kafka_rest.jaas_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_rest_user}}"
     group: "{{kafka_rest_group}}"
   notify: restart kafka-rest
@@ -339,7 +339,7 @@
   template:
     src: password.properties.j2
     dest: "{{kafka_rest.password_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{kafka_rest_user}}"
     group: "{{kafka_rest_group}}"
   notify: restart kafka-rest
@@ -351,7 +351,7 @@
     owner: "{{kafka_rest_user}}"
     group: "{{kafka_rest_group}}"
     state: directory
-    mode: 0640
+    mode: '640'
   tags:
     - systemd
     - privileged
@@ -360,7 +360,7 @@
   template:
     src: override.conf.j2
     dest: "{{kafka_rest.systemd_override}}"
-    mode: 0640
+    mode: '640'
     owner: root
     group: root
   notify: restart kafka-rest

--- a/roles/kerberos/tasks/main.yml
+++ b/roles/kerberos/tasks/main.yml
@@ -3,7 +3,7 @@
   ansible.builtin.file:
     path: "{{ kerberos_client_config_file_dest | dirname }}"
     state: directory
-    mode: '0755'
+    mode: '755'
 
 - name: Copy the client configuration file
   template:
@@ -16,7 +16,7 @@
     path: "{{ kerberos_keytab_destination_path | dirname }}"
     state: directory
     group: "{{kerberos_group}}"
-    mode: 0750
+    mode: '750'
   tags:
     - privileged
 
@@ -26,7 +26,7 @@
     dest: "{{kerberos_keytab_destination_path}}"
     owner: "{{kerberos_user}}"
     group: "{{kerberos_group}}"
-    mode: 0640
+    mode: '640'
   notify: "{{kerberos_handler}}"
   tags:
     - privileged

--- a/roles/ksql/tasks/ccloud_certs.yml
+++ b/roles/ksql/tasks/ccloud_certs.yml
@@ -3,7 +3,7 @@
   get_url:
     url: "https://letsencrypt.org/certs/{{item}}"
     dest: /tmp/{{item}}
-    mode: 0755
+    mode: '755'
   loop:
     - isrgrootx1.der
     - isrg-root-x2.der

--- a/roles/ksql/tasks/main.yml
+++ b/roles/ksql/tasks/main.yml
@@ -88,7 +88,7 @@
     owner: "{{ksql_user}}"
     group: "{{ksql_group}}"
     state: directory
-    mode: 0750
+    mode: '750'
   tags:
     - filesystem
 
@@ -99,7 +99,7 @@
     src: "{{binary_base_path}}/lib/systemd/system/{{ksql.systemd_file|basename}}"
     remote_src: true
     dest: "{{ksql.systemd_file}}"
-    mode: 0644
+    mode: '644'
     force: true
   when: installation_method == "archive"
   tags:
@@ -169,7 +169,7 @@
   file:
     path: "{{ ksql.config_file | dirname }}"
     state: directory
-    mode: 0750
+    mode: '750'
     owner: "{{ksql_user}}"
     group: "{{ksql_group}}"
   tags:
@@ -179,7 +179,7 @@
   template:
     src: ksql-server.properties.j2
     dest: "{{ksql.config_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{ksql_user}}"
     group: "{{ksql_group}}"
   notify: restart ksql
@@ -213,7 +213,7 @@
     state: directory
     group: "{{ksql_group}}"
     owner: "{{ksql_user}}"
-    mode: 0770
+    mode: '770'
   tags:
     - filesystem
     - log
@@ -224,7 +224,7 @@
     owner: "{{ksql_user}}"
     group: "{{ksql_group}}"
     state: directory
-    mode: 0750
+    mode: '750'
   tags:
     - filesystem
     - log
@@ -233,7 +233,7 @@
   template:
     src: ksql-server_log4j.properties.j2
     dest: "{{ksql.log4j_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{ksql_user}}"
     group: "{{ksql_group}}"
   when: ksql_custom_log4j|bool
@@ -246,7 +246,7 @@
   file:
     path: "{{ logredactor_rule_path | dirname }}"
     state: directory
-    mode: 0755
+    mode: '755'
   when: (ksql_custom_log4j|bool) and (logredactor_enabled|bool) and (logredactor_rule_url == '')
   tags:
     - log
@@ -255,7 +255,7 @@
   copy:
     src: "{{ logredactor_rule_path_local }}"
     dest: "{{ logredactor_rule_path }}"
-    mode: 0644
+    mode: '644'
   when: (ksql_custom_log4j|bool) and (logredactor_enabled|bool) and (logredactor_rule_url == '')
   tags:
     - log
@@ -285,7 +285,7 @@
   template:
     src: ksql_jolokia.properties.j2
     dest: "{{ksql_jolokia_config}}"
-    mode: 0640
+    mode: '640'
     owner: "{{ksql_user}}"
     group: "{{ksql_group}}"
   when: ksql_jolokia_enabled|bool
@@ -299,7 +299,7 @@
     path: "{{ksql_rocksdb_path}}"
     group: "{{ksql_group}}"
     owner: "{{ksql_user}}"
-    mode: 0750
+    mode: '750'
     state: directory
   when: ksql_rocksdb_path != ""
   tags:
@@ -319,7 +319,7 @@
   copy:
     src: "{{ksql_jmxexporter_config_source_path}}"
     dest: "{{ksql_jmxexporter_config_path}}"
-    mode: 0640
+    mode: '640'
     owner: "{{ksql_user}}"
     group: "{{ksql_group}}"
   when: ksql_jmxexporter_enabled|bool
@@ -330,7 +330,7 @@
   template:
     src: jaas.conf.j2
     dest: "{{ksql.jaas_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{ksql_user}}"
     group: "{{ksql_group}}"
   notify: restart ksql
@@ -340,7 +340,7 @@
   template:
     src: password.properties.j2
     dest: "{{ksql.password_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{ksql_user}}"
     group: "{{ksql_group}}"
   notify: restart ksql
@@ -352,7 +352,7 @@
     owner: "{{ksql_user}}"
     group: "{{ksql_group}}"
     state: directory
-    mode: 0640
+    mode: '640'
   tags:
     - systemd
     - privileged
@@ -361,7 +361,7 @@
   template:
     src: override.conf.j2
     dest: "{{ksql.systemd_override}}"
-    mode: 0640
+    mode: '640'
     owner: root
     group: root
   notify: restart ksql

--- a/roles/schema_registry/tasks/main.yml
+++ b/roles/schema_registry/tasks/main.yml
@@ -90,7 +90,7 @@
     src: "{{binary_base_path}}/lib/systemd/system/{{schema_registry.systemd_file|basename}}"
     remote_src: true
     dest: "{{schema_registry.systemd_file}}"
-    mode: 0644
+    mode: '644'
     force: true
   when: installation_method == "archive"
   tags:
@@ -150,7 +150,7 @@
   file:
     path: "{{ schema_registry.config_file | dirname }}"
     state: directory
-    mode: 0750
+    mode: '750'
     owner: "{{schema_registry_user}}"
     group: "{{schema_registry_group}}"
   tags:
@@ -160,7 +160,7 @@
   template:
     src: schema-registry.properties.j2
     dest: "{{schema_registry.config_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{schema_registry_user}}"
     group: "{{schema_registry_group}}"
   notify: restart schema-registry
@@ -195,7 +195,7 @@
     state: directory
     group: "{{schema_registry_group}}"
     owner: "{{schema_registry_user}}"
-    mode: 0770
+    mode: '770'
   tags:
     - filesystem
     - log
@@ -219,7 +219,7 @@
     path: "{{schema_registry.log4j_file}}"
     group: "{{schema_registry_group}}"
     owner: "{{schema_registry_user}}"
-    mode: 0640
+    mode: '640'
   tags:
     - configuration
     - log
@@ -228,7 +228,7 @@
   file:
     path: "{{ logredactor_rule_path | dirname }}"
     state: directory
-    mode: 0755
+    mode: '755'
   when: (schema_registry_custom_log4j|bool) and (logredactor_enabled|bool) and (logredactor_rule_url == '')
   tags:
     - log
@@ -237,7 +237,7 @@
   copy:
     src: "{{ logredactor_rule_path_local }}"
     dest: "{{ logredactor_rule_path }}"
-    mode: 0644
+    mode: '644'
   when: (schema_registry_custom_log4j|bool) and (logredactor_enabled|bool) and (logredactor_rule_url == '')
   tags:
     - log
@@ -267,7 +267,7 @@
   template:
     src: schema_registry_jolokia.properties.j2
     dest: "{{schema_registry_jolokia_config}}"
-    mode: 0640
+    mode: '640'
     owner: "{{schema_registry_user}}"
     group: "{{schema_registry_group}}"
   when: schema_registry_jolokia_enabled|bool
@@ -280,7 +280,7 @@
   copy:
     src: "{{schema_registry_jmxexporter_config_source_path}}"
     dest: "{{schema_registry_jmxexporter_config_path}}"
-    mode: 0640
+    mode: '640'
     owner: "{{schema_registry_user}}"
     group: "{{schema_registry_group}}"
   when: schema_registry_jmxexporter_enabled|bool
@@ -291,7 +291,7 @@
   template:
     src: jaas.conf.j2
     dest: "{{schema_registry.jaas_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{schema_registry_user}}"
     group: "{{schema_registry_group}}"
   notify: restart schema-registry
@@ -301,7 +301,7 @@
   template:
     src: password.properties.j2
     dest: "{{schema_registry.password_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{schema_registry_user}}"
     group: "{{schema_registry_group}}"
   notify: restart schema-registry
@@ -313,7 +313,7 @@
     owner: "{{schema_registry_user}}"
     group: "{{schema_registry_group}}"
     state: directory
-    mode: 0640
+    mode: '640'
   tags:
     - systemd
     - privileged
@@ -322,7 +322,7 @@
   template:
     src: override.conf.j2
     dest: "{{schema_registry.systemd_override}}"
-    mode: 0640
+    mode: '640'
     owner: root
     group: root
   notify: restart schema-registry

--- a/roles/ssl/tasks/import_ca_chain.yml
+++ b/roles/ssl/tasks/import_ca_chain.yml
@@ -3,7 +3,7 @@
   file:
     path: "{{ ssl_file_dir_final }}/generation/trustCAs"
     state: directory
-    mode: 0755
+    mode: '755'
 
 - name: Split CA Certificate Bundle into Cert Files
   shell: |

--- a/roles/ssl/tasks/main.yml
+++ b/roles/ssl/tasks/main.yml
@@ -28,7 +28,7 @@
     path: "{{item}}"
     owner: "{{user}}"
     group: "{{group}}"
-    mode: 0640
+    mode: '640'
   loop:
     - "{{keystore_path}}"
     - "{{truststore_path}}"
@@ -39,7 +39,7 @@
     path: "{{item}}"
     owner: "{{user}}"
     group: "{{group}}"
-    mode: 0640
+    mode: '640'
   loop:
     - "{{ca_cert_path}}"
     - "{{cert_path}}"
@@ -51,7 +51,7 @@
     path: "{{item}}"
     owner: "{{user}}"
     group: "{{group}}"
-    mode: 0640
+    mode: '640'
   loop:
     - "{{bcfks_keystore_path}}"
     - "{{bcfks_truststore_path}}"

--- a/roles/ssl/tasks/manage_keystore_and_truststore.yml
+++ b/roles/ssl/tasks/manage_keystore_and_truststore.yml
@@ -32,7 +32,7 @@
   file:
     path: "{{ ssl_file_dir_final }}/generation"
     state: directory
-    mode: 0755
+    mode: '755'
 
 - name: Create Keystore and Truststore with Self Signed Certs
   include_tasks: self_signed_certs.yml

--- a/roles/ssl/tasks/provided_keystore_and_truststore.yml
+++ b/roles/ssl/tasks/provided_keystore_and_truststore.yml
@@ -5,7 +5,7 @@
     dest: "{{truststore_path}}"
     owner: "{{user}}"
     group: "{{group}}"
-    mode: 0640
+    mode: '640'
   when: not ( ssl_provided_keystore_and_truststore_remote_src|bool )
 
 - name: Copy Host Keystore to Host if on control node
@@ -14,7 +14,7 @@
     dest: "{{keystore_path}}"
     owner: "{{user}}"
     group: "{{group}}"
-    mode: 0640
+    mode: '640'
   when: not ( ssl_provided_keystore_and_truststore_remote_src|bool )
 
 - name: Get stats and permissions of keystore

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -404,7 +404,7 @@ zookeeper_peer_port: 2888
 ### Zookeeper leader port
 zookeeper_leader_port: 3888
 
-### Use to copy files from control node to zookeeper hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode (default: '0640') to set directory and file permissions.
+### Use to copy files from control node to zookeeper hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '750') and file_mode (default: '640') to set directory and file permissions.
 zookeeper_copy_files: []
 
 # User provided properties, merged into the final properties dictionary with precedence
@@ -519,7 +519,7 @@ kafka_controller_jmxexporter_config_source_path: kafka.yml.j2
 ### Destination path for Kafka controller jmx config file
 kafka_controller_jmxexporter_config_path: /opt/prometheus/kafka.yml
 
-### Use to copy files from control node to kafka hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode (default: '0640') to set directory and file permissions.
+### Use to copy files from control node to kafka hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '750') and file_mode (default: '640') to set directory and file permissions.
 kafka_controller_copy_files: []
 
 ### Replication Factor for internal topics. Defaults to the minimum of the number of controllers and can be overridden via default replication factor (see default_internal_replication_factor).
@@ -670,7 +670,7 @@ kafka_broker_jmxexporter_config_source_path: kafka.yml.j2
 ### Destination path for Kafka Broker jmx config file
 kafka_broker_jmxexporter_config_path: /opt/prometheus/kafka.yml
 
-### Use to copy files from control node to kafka hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode (default: '0640') to set directory and file permissions.
+### Use to copy files from control node to kafka hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '750') and file_mode (default: '640') to set directory and file permissions.
 kafka_broker_copy_files: []
 
 ### Replication Factor for internal topics. Defaults to the minimum of the number of brokers and can be overridden via default replication factor (see default_internal_replication_factor).
@@ -785,7 +785,7 @@ schema_registry_jmxexporter_config_path: /opt/prometheus/schema_registry.yml
 ### Port to expose prometheus metrics. Beware of port collisions if colocating components on same host
 schema_registry_jmxexporter_port: 8078
 
-### Use to copy files from control node to schema registry hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode (default: '0640') to set directory and file permissions.
+### Use to copy files from control node to schema registry hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '750') and file_mode (default: '640') to set directory and file permissions.
 schema_registry_copy_files: []
 
 ### Use to set custom schema registry properties. This variable is a dictionary. Put values true/false in quotation marks to perserve case. NOTE- kafka_broker.properties is deprecated.
@@ -882,7 +882,7 @@ kafka_rest_jmxexporter_config_path: /opt/prometheus/kafka_rest.yml
 ### Port to expose prometheus metrics. Beware of port collisions if colocating components on same host
 kafka_rest_jmxexporter_port: 8075
 
-### Use to copy files from control node to schema registry hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode (default: '0640') to set directory and file permissions.
+### Use to copy files from control node to schema registry hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '750') and file_mode (default: '640') to set directory and file permissions.
 kafka_rest_copy_files: []
 
 ### Use to set custom Rest Proxy properties. This variable is a dictionary. Put values true/false in quotation marks to perserve case. NOTE- kafka_rest.properties is deprecated.
@@ -997,7 +997,7 @@ kafka_connect_jmxexporter_config_path: /opt/prometheus/kafka_connect.yml
 ### Port to expose connect prometheus metrics. Beware of port collisions if colocating components on same host
 kafka_connect_jmxexporter_port: 8077
 
-### Use to copy files from control node to connect hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode (default: '0640') to set directory and file permissions.
+### Use to copy files from control node to connect hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '750') and file_mode (default: '640') to set directory and file permissions.
 kafka_connect_copy_files: []
 
 ### Connect Service Group Id. Customize when configuring multiple connect clusters in same inventory
@@ -1125,7 +1125,7 @@ ksql_jmxexporter_config_path: /opt/prometheus/ksql.yml
 ### Port to expose ksqlDB prometheus metrics. Beware of port collisions if colocating components on same host
 ksql_jmxexporter_port: 8076
 
-### Use to copy files from control node to ksqlDB hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode (default: '0640') to set directory and file permissions.
+### Use to copy files from control node to ksqlDB hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '750') and file_mode (default: '640') to set directory and file permissions.
 ksql_copy_files: []
 
 ### Replication Factor for ksqlDB internal topics. Defaults to the minimum of the number of brokers and can be overridden via default replication factor (see default_internal_replication_factor).
@@ -1204,7 +1204,7 @@ control_center_export_certs: "{{ssl_mutual_auth_enabled}}"
 control_center_keytab_path: /etc/security/keytabs/control_center.keytab
 control_center_kafka_listener_name: internal
 
-### Use to copy files from control node to Control Center hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode (default: '0640') to set directory and file permissions.
+### Use to copy files from control node to Control Center hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '750') and file_mode (default: '640') to set directory and file permissions.
 control_center_copy_files: []
 
 ### Replication Factor for Control Center internal topics. Defaults to the minimum of the number of brokers and can be overridden via default replication factor (see default_internal_replication_factor).

--- a/roles/zookeeper/tasks/main.yml
+++ b/roles/zookeeper/tasks/main.yml
@@ -90,7 +90,7 @@
     src: "{{binary_base_path}}/lib/systemd/system/{{zookeeper.systemd_file|basename}}"
     remote_src: true
     dest: "{{zookeeper.systemd_file}}"
-    mode: 0644
+    mode: '644'
     force: true
   when: installation_method == "archive"
   tags:
@@ -144,7 +144,7 @@
     owner: "{{zookeeper_user}}"
     group: "{{zookeeper_group}}"
     state: directory
-    mode: 0750
+    mode: '750'
   tags:
     - filesystem
 
@@ -163,7 +163,7 @@
     owner: "{{zookeeper_user}}"
     group: "{{zookeeper_group}}"
     state: directory
-    mode: 0750
+    mode: '750'
   when: zookeeper_final_properties.dataLogDir is defined
   tags:
     - filesystem
@@ -182,7 +182,7 @@
   template:
     src: myid.j2
     dest: "{{zookeeper_final_properties.dataDir}}/myid"
-    mode: 0640
+    mode: '640'
     owner: "{{zookeeper_user}}"
     group: "{{zookeeper_group}}"
   tags:
@@ -192,7 +192,7 @@
   file:
     path: "{{ zookeeper.config_file | dirname }}"
     state: directory
-    mode: 0750
+    mode: '750'
     owner: "{{zookeeper_user}}"
     group: "{{zookeeper_group}}"
   tags:
@@ -202,7 +202,7 @@
   template:
     src: zookeeper.properties.j2
     dest: "{{zookeeper.config_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{zookeeper_user}}"
     group: "{{zookeeper_group}}"
   register: zookeeper_config
@@ -217,7 +217,7 @@
     state: directory
     group: "{{zookeeper_group}}"
     owner: "{{zookeeper_user}}"
-    mode: 0770
+    mode: '770'
   tags:
     - filesystem
     - log
@@ -228,7 +228,7 @@
     owner: "{{zookeeper_user}}"
     group: "{{zookeeper_group}}"
     state: directory
-    mode: 0750
+    mode: '750'
   tags:
     - filesystem
     - log
@@ -237,7 +237,7 @@
   template:
     src: zookeeper_log4j.properties.j2
     dest: "{{zookeeper.log4j_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{zookeeper_user}}"
     group: "{{zookeeper_group}}"
   when: zookeeper_custom_log4j|bool
@@ -250,7 +250,7 @@
   file:
     path: "{{ logredactor_rule_path | dirname }}"
     state: directory
-    mode: 0755
+    mode: '755'
   when: (zookeeper_custom_log4j|bool) and (logredactor_enabled|bool) and (logredactor_rule_url == '')
   tags:
     - log
@@ -259,7 +259,7 @@
   copy:
     src: "{{ logredactor_rule_path_local }}"
     dest: "{{ logredactor_rule_path }}"
-    mode: 0644
+    mode: '644'
   when: (zookeeper_custom_log4j|bool) and (logredactor_enabled|bool) and (logredactor_rule_url == '')
   tags:
     - log
@@ -289,7 +289,7 @@
   template:
     src: zookeeper_jolokia.properties.j2
     dest: "{{zookeeper_jolokia_config}}"
-    mode: 0640
+    mode: '640'
     owner: "{{zookeeper_user}}"
     group: "{{zookeeper_group}}"
   when: zookeeper_jolokia_enabled|bool
@@ -302,7 +302,7 @@
   template:
     src: zookeeper_jaas.conf.j2
     dest: "{{zookeeper.jaas_file}}"
-    mode: 0640
+    mode: '640'
     owner: "{{zookeeper_user}}"
     group: "{{zookeeper_group}}"
   when: zookeeper_client_authentication_type in ['kerberos', 'digest'] or zookeeper_quorum_authentication_type in ['digest', 'digest_over_tls']
@@ -315,7 +315,7 @@
   copy:
     src: "{{zookeeper_jmxexporter_config_source_path}}"
     dest: "{{zookeeper_jmxexporter_config_path}}"
-    mode: 0640
+    mode: '640'
     owner: "{{zookeeper_user}}"
     group: "{{zookeeper_group}}"
   when: zookeeper_jmxexporter_enabled|bool
@@ -328,7 +328,7 @@
     owner: "{{zookeeper_user}}"
     group: "{{zookeeper_group}}"
     state: directory
-    mode: 0640
+    mode: '640'
   tags:
     - systemd
     - privileged
@@ -337,7 +337,7 @@
   template:
     src: override.conf.j2
     dest: "{{zookeeper.systemd_override}}"
-    mode: 0640
+    mode: '640'
     owner: root
     group: root
   notify: restart zookeeper

--- a/test_roles/confluent.test.kerberos/tasks/main.yml
+++ b/test_roles/confluent.test.kerberos/tasks/main.yml
@@ -9,7 +9,7 @@
   file:
     path: /tmp/keytabs/
     state: directory
-    mode: 0755
+    mode: '755'
 
 - name: "Add Principal: {{item.principal}}"
   shell: "kadmin.local -q 'addprinc -randkey {{item.principal}}'"

--- a/test_roles/confluent.test.ldap/tasks/tls.yml
+++ b/test_roles/confluent.test.ldap/tasks/tls.yml
@@ -3,7 +3,7 @@
   file:
     path: /var/ssl/private/ldaps/
     state: directory
-    mode: 0755
+    mode: '755'
   when:
 
 - name: Generate Self Signed Certificates

--- a/test_roles/confluent.test.ldap/tasks/tls_custom_certs.yml
+++ b/test_roles/confluent.test.ldap/tasks/tls_custom_certs.yml
@@ -3,16 +3,16 @@
   copy:
     src: "{{ssl_ca_cert_filepath}}"
     dest: "/var/ssl/private/ldaps/{{ssl_ca_cert_filepath|basename}}"
-    mode: 0666
+    mode: '666'
 
 - name: Copy Signed Cert to Host
   copy:
     src: "{{ssl_signed_cert_filepath}}"
     dest: "/var/ssl/private/ldaps/{{ssl_signed_cert_filepath|basename}}"
-    mode: 0666
+    mode: '666'
 
 - name: Copy Key to Host
   copy:
     src: "{{ssl_key_filepath}}"
     dest: "/var/ssl/private/ldaps/{{ssl_key_filepath|basename}}"
-    mode: 0666
+    mode: '666'


### PR DESCRIPTION
# Description
As per Ansible official documentation in the file module mode should be in qoutes. If mode is in octal format then in certain cases like loops it might fail. [docs](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/file_module.html)

Fixes # [ANSIENG-2525](https://confluentinc.atlassian.net/browse/ANSIENG-2525)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist:

- [X] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [X] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules

[ANSIENG-2525]: https://confluentinc.atlassian.net/browse/ANSIENG-2525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ