### PR TITLE
Add env variables to use SSO tokens from vault

### DIFF
--- a/molecule/rbac-mds-kerberos-debian/molecule.yml
+++ b/molecule/rbac-mds-kerberos-debian/molecule.yml
@@ -271,8 +271,8 @@ provisioner:
         sso_jwks_uri: https://login.microsoftonline.com/0893715b-959b-4906-a185-2789e1ead045/discovery/v2.0/keys
         sso_authorize_uri: https://login.microsoftonline.com/0893715b-959b-4906-a185-2789e1ead045/oauth2/v2.0/authorize
         sso_token_uri: https://login.microsoftonline.com/0893715b-959b-4906-a185-2789e1ead045/oauth2/v2.0/token
-        sso_client_id: e674334a-de0d-4b28-a9ed-a628285ce7c4
-        sso_client_password: pqb8Q~uNc4AVwLZgXMCE_ONJ6jIEbqnWzp4U_c5c
+        sso_client_id: ${AZURE_CLIENT:-user}
+        sso_client_password: ${AZURE_PASSWORD:-pass}
 
         kafka_broker_custom_properties:
           ldap.java.naming.factory.initial: com.sun.jndi.ldap.LdapCtxFactory

--- a/molecule/rbac-mds-plain-custom-rhel-fips/molecule.yml
+++ b/molecule/rbac-mds-plain-custom-rhel-fips/molecule.yml
@@ -251,8 +251,8 @@ provisioner:
         sso_jwks_uri: http://ec2-35-166-19-61.us-west-2.compute.amazonaws.com:8080/auth/realms/cpsso/protocol/openid-connect/certs
         sso_authorize_uri: http://ec2-35-166-19-61.us-west-2.compute.amazonaws.com:8080/auth/realms/cpsso/protocol/openid-connect/auth
         sso_token_uri: http://ec2-35-166-19-61.us-west-2.compute.amazonaws.com:8080/auth/realms/cpsso/protocol/openid-connect/token
-        sso_client_id: ssologin
-        sso_client_password: 23693f02-017b-4ba2-9126-4348b0ab11a4
+        sso_client_id: ${KEYCLOAK_CLIENT:-user}
+        sso_client_password: ${KEYCLOAK_PASSWORD:-pass}
 
         kafka_broker_custom_properties:
           ldap.java.naming.factory.initial: com.sun.jndi.ldap.LdapCtxFactory

--- a/molecule/rbac-mtls-rhel8/molecule.yml
+++ b/molecule/rbac-mtls-rhel8/molecule.yml
@@ -172,8 +172,8 @@ provisioner:
         sso_jwks_uri: https://dev-59009577.okta.com/oauth2/aus96p2og3u7Cpwu65d7/v1/keys
         sso_authorize_uri: https://dev-59009577.okta.com/oauth2/aus96p2og3u7Cpwu65d7/v1/authorize
         sso_token_uri: https://dev-59009577.okta.com/oauth2/aus96p2og3u7Cpwu65d7/v1/token
-        sso_client_id: 0oa96pg3lgnBnhY9w5d7
-        sso_client_password: AyxTGV157PtQhI6XMI1639Ruv0Sza-ErcPhODz0W
+        sso_client_id: ${OKTA_CLIENT:-user}
+        sso_client_password: ${OKTA_PASSWORD:-pass}
 
         kafka_broker_custom_listeners:
           client_listener:

--- a/molecule/rbac-scram-custom-rhel-fips/molecule.yml
+++ b/molecule/rbac-scram-custom-rhel-fips/molecule.yml
@@ -223,8 +223,8 @@ provisioner:
         sso_jwks_uri: https://login.microsoftonline.com/0893715b-959b-4906-a185-2789e1ead045/discovery/v2.0/keys
         sso_authorize_uri: https://login.microsoftonline.com/0893715b-959b-4906-a185-2789e1ead045/oauth2/v2.0/authorize
         sso_token_uri: https://login.microsoftonline.com/0893715b-959b-4906-a185-2789e1ead045/oauth2/v2.0/token
-        sso_client_id: e674334a-de0d-4b28-a9ed-a628285ce7c4
-        sso_client_password: pqb8Q~uNc4AVwLZgXMCE_ONJ6jIEbqnWzp4U_c5c
+        sso_client_id: ${AZURE_CLIENT:-user}
+        sso_client_password: ${AZURE_PASSWORD:-pass}
 
         kafka_broker_custom_properties:
           ldap.java.naming.factory.initial: com.sun.jndi.ldap.LdapCtxFactory


### PR DESCRIPTION
# Description
SSO credentials need to be stored in vault. Our molecule tests would then use these variables via jenkins. cp-ansible-on-demand and cp-ansible-weekly jobs need to be updated as well. The env variables need to be passed by the user when running a scenario locally.


Fixes # [ANSIENG-2553](https://confluentinc.atlassian.net/browse/ANSIENG-2553)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

[jenkins job](https://jenkins.confluent.io/job/cp-ansible-on-demand/1732/)

# Checklist:

- [x] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[ANSIENG-2553]: https://confluentinc.atlassian.net/browse/ANSIENG-2553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ