### PR TITLE
bump cli version to 2.38.1 for 7.0.x

### DIFF
--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -312,7 +312,7 @@ Default:  "/usr/local/bin/confluent"
 
 Confluent CLI version to download (e.g. "1.9.0"). Support matrix https://docs.confluent.io/platform/current/installation/versions-interoperability.html#confluent-cli
 
-Default:  1.43.0
+Default:  2.38.1
 
 ***
 

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -143,7 +143,7 @@ confluent_cli_base_path: /opt/confluent-cli
 confluent_cli_path: "/usr/local/bin/confluent"
 
 ### Confluent CLI version to download (e.g. "1.9.0"). Support matrix https://docs.confluent.io/platform/current/installation/versions-interoperability.html#confluent-cli
-confluent_cli_version: 1.43.0
+confluent_cli_version: 2.38.1
 
 ### Recommended replication factor, defaults to 3. When splitting your cluster across 2 DCs with 4 or more Brokers, this should be increased to 4 to balance topic replicas.
 default_internal_replication_factor: 3


### PR DESCRIPTION
# Description

Bumping up pinned cli version for cp 7.0 from 1.43.0 to 2.38.1
Reference thread - https://app.slack.com/client/T038ZHM0B/C05R105R1R8/thread/C05R105R1R8-1693985687.688209

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
[1752](https://jenkins.confluent.io/job/cp-ansible-on-demand/1752/) ✅ 
[1764](https://jenkins.confluent.io/job/cp-ansible-on-demand/1764/) ✅ 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible