### PR TITLE
bump cli version to 3.30.1 for 7.4.x

### DIFF
--- a/docs/VARIABLES.md
+++ b/docs/VARIABLES.md
@@ -456,7 +456,7 @@ Default:  "/usr/local/bin/confluent"
 
 Confluent CLI version to download (e.g. "1.9.0"). Support matrix https://docs.confluent.io/platform/current/installation/versions-interoperability.html#confluent-cli
 
-Default:  3.2.1
+Default:  3.30.1
 
 ***
 

--- a/molecule/archive-plain-debian/molecule.yml
+++ b/molecule/archive-plain-debian/molecule.yml
@@ -99,7 +99,7 @@ provisioner:
     group_vars:
       all:
         confluent_cli_download_enabled: true
-        confluent_cli_version: 3.2.1
+        confluent_cli_version: 3.30.1
         sasl_protocol: plain
         ssl_enabled: true
         installation_method: "archive"

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -195,7 +195,7 @@ confluent_cli_base_path: /opt/confluent-cli
 confluent_cli_path: "/usr/local/bin/confluent"
 
 ### Confluent CLI version to download (e.g. "1.9.0"). Support matrix https://docs.confluent.io/platform/current/installation/versions-interoperability.html#confluent-cli
-confluent_cli_version: 3.2.1
+confluent_cli_version: 3.30.1
 
 ### Recommended replication factor, defaults to 3. When splitting your cluster across 2 DCs with 4 or more Brokers, this should be increased to 4 to balance topic replicas.
 default_internal_replication_factor: 3


### PR DESCRIPTION
# Description

Bumping up pinned cli version for cp 7.4 from 3.2.1 to 3.30.1
Reference thread - https://app.slack.com/client/T038ZHM0B/C05R105R1R8/thread/C05R105R1R8-1693985687.688209

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
[1756](https://jenkins.confluent.io/job/cp-ansible-on-demand/1756/) [1768](https://jenkins.confluent.io/job/cp-ansible-on-demand/1768/) ✅  (zk)
[1757](https://jenkins.confluent.io/job/cp-ansible-on-demand/1757/) [1775](https://jenkins.confluent.io/job/cp-ansible-on-demand/1775/) ✅  (kraft)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any variable changes have been validated to be backwards compatible