### PR TITLE
Update default number of threads for C3

### DIFF
--- a/roles/confluent.variables/vars/main.yml
+++ b/roles/confluent.variables/vars/main.yml
@@ -974,7 +974,7 @@ control_center_properties:
   defaults:
     enabled: true
     properties:
-      confluent.controlcenter.streams.num.stream.threads: 8
+      confluent.controlcenter.streams.num.stream.threads: 12
       confluent.controlcenter.data.dir: /var/lib/confluent/control-center
       confluent.controlcenter.internal.topics.replication: "{{control_center_default_internal_replication_factor}}"
       confluent.metrics.topic.replication: "{{control_center_default_internal_replication_factor}}"


### PR DESCRIPTION
# Description

Update default number of threads for C3 to 12

Fixes # [ANSIENG-2632](https://confluentinc.atlassian.net/browse/ANSIENG-2632)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

[jenkins](https://jenkins.confluent.io/job/cp-ansible-on-demand/2106/)

# Checklist:

- [x] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[ANSIENG-2632]: https://confluentinc.atlassian.net/browse/ANSIENG-2632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ