### PR TITLE
avoid create credentials related to empty groups

### DIFF
--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -1226,27 +1226,27 @@ _sasl_scram_users: "{
   'client': {
     'principal': 'client',
     'password': 'client-secret'
-  }{% if 'schema_registry' in groups %},
+  }{% if 'schema_registry' in groups and groups['schema_registry']|length > 0 %},
   'schema_registry': {
     'principal': 'schema_registry',
     'password': 'schema_registry-secret'
-  }{% endif %}{% if 'kafka_connect' in groups %},
+  }{% endif %}{% if 'kafka_connect' in groups and groups['kafka_connect']|length > 0 %},
   'kafka_connect': {
     'principal': 'kafka_connect',
     'password': 'kafka_connect-secret'
-  }{% endif %}{% if 'kafka_rest' in groups %},
+  }{% endif %}{% if 'kafka_rest' in groups and groups['kafka_rest']|length > 0 %},
   'kafka_rest': {
     'principal': 'kafka_rest',
     'password': 'kafka_rest-secret'
-  }{% endif %}{% if 'ksql' in groups %},
+  }{% endif %}{% if 'ksql' in groups and groups['ksql']|length > 0 %},
   'ksql': {
     'principal': 'ksql',
     'password': 'ksql-secret'
-  }{% endif %}{% if 'control_center' in groups %},
+  }{% endif %}{% if 'control_center' in groups and groups['control_center']|length > 0 %},
   'control_center': {
     'principal': 'control_center',
     'password': 'control_center-secret'
-  }{% endif %}{% if 'kafka_connect_replicator' in groups %},
+  }{% endif %}{% if 'kafka_connect_replicator' in groups and groups['kafka_connect_replicator']|length > 0 %},
   'kafka_connect_replicator': {
     'principal': 'kafka_connect_replicator',
     'password': 'kafka_connect_replicator-secret'
@@ -1267,27 +1267,27 @@ _sasl_scram256_users: "{
   'client': {
     'principal': 'client',
     'password': 'client-secret'
-  }{% if 'schema_registry' in groups %},
+  }{% if 'schema_registry' in groups and groups['schema_registry']|length > 0 %},
   'schema_registry': {
     'principal': 'schema_registry',
     'password': 'schema_registry-secret'
-  }{% endif %}{% if 'kafka_connect' in groups %},
+  }{% endif %}{% if 'kafka_connect' in groups and groups['kafka_connect']|length > 0 %},
   'kafka_connect': {
     'principal': 'kafka_connect',
     'password': 'kafka_connect-secret'
-  }{% endif %}{% if 'kafka_rest' in groups %},
+  }{% endif %}{% if 'kafka_rest' in groups and groups['kafka_rest']|length > 0 %},
   'kafka_rest': {
     'principal': 'kafka_rest',
     'password': 'kafka_rest-secret'
-  }{% endif %}{% if 'ksql' in groups %},
+  }{% endif %}{% if 'ksql' in groups and groups['ksql']|length > 0 %},
   'ksql': {
     'principal': 'ksql',
     'password': 'ksql-secret'
-  }{% endif %}{% if 'control_center' in groups %},
+  }{% endif %}{% if 'control_center' in groups and groups['control_center']|length > 0 %},
   'control_center': {
     'principal': 'control_center',
     'password': 'control_center-secret'
-  }{% endif %}{% if 'kafka_connect_replicator' in groups %},
+  }{% endif %}{% if 'kafka_connect_replicator' in groups and groups['kafka_connect_replicator']|length > 0 %},
   'kafka_connect_replicator': {
     'principal': 'kafka_connect_replicator',
     'password': 'kafka_connect_replicator-secret'
@@ -1308,27 +1308,27 @@ _sasl_plain_users: "{
   'client': {
     'principal': 'client',
     'password': 'client-secret'
-  }{% if 'schema_registry' in groups %},
+  }{% if 'schema_registry' in groups and groups['schema_registry']|length > 0 %},
   'schema_registry': {
     'principal': '{% if ccloud_kafka_enabled|bool %}{{ccloud_kafka_key}}{% else %}schema_registry{% endif %}',
     'password': '{% if ccloud_kafka_enabled|bool %}{{ccloud_kafka_secret}}{% else %}schema_registry-secret{% endif %}'
-  }{% endif %}{% if 'kafka_connect' in groups %},
+  }{% endif %}{% if 'kafka_connect' in groups and groups['kafka_connect']|length > 0 %},
   'kafka_connect': {
     'principal': '{% if ccloud_kafka_enabled|bool %}{{ccloud_kafka_key}}{% else %}kafka_connect{% endif %}',
     'password': '{% if ccloud_kafka_enabled|bool %}{{ccloud_kafka_secret}}{% else %}kafka_connect-secret{% endif %}'
-  }{% endif %}{% if 'kafka_rest' in groups %},
+  }{% endif %}{% if 'kafka_rest' in groups and groups['kafka_rest']|length > 0 %},
   'kafka_rest': {
     'principal': '{% if ccloud_kafka_enabled|bool %}{{ccloud_kafka_key}}{% else %}kafka_rest{% endif %}',
     'password': '{% if ccloud_kafka_enabled|bool %}{{ccloud_kafka_secret}}{% else %}kafka_rest-secret{% endif %}'
-  }{% endif %}{% if 'ksql' in groups %},
+  }{% endif %}{% if 'ksql' in groups and groups['ksql']|length > 0 %},
   'ksql': {
     'principal': '{% if ccloud_kafka_enabled|bool %}{{ccloud_kafka_key}}{% else %}ksql{% endif %}',
     'password': '{% if ccloud_kafka_enabled|bool %}{{ccloud_kafka_secret}}{% else %}ksql-secret{% endif %}'
-  }{% endif %}{% if 'control_center' in groups %},
+  }{% endif %}{% if 'control_center' in groups and groups['control_center']|length > 0 %},
   'control_center': {
     'principal': '{% if ccloud_kafka_enabled|bool %}{{ccloud_kafka_key}}{% else %}control_center{% endif %}',
     'password': '{% if ccloud_kafka_enabled|bool %}{{ccloud_kafka_secret}}{% else %}control_center-secret{% endif %}'
-  }{% endif %}{% if 'kafka_connect_replicator' in groups %},
+  }{% endif %}{% if 'kafka_connect_replicator' in groups and groups['kafka_connect_replicator']|length > 0 %},
   'kafka_connect_replicator': {
     'principal': 'kafka_connect_replicator',
     'password': 'kafka_connect_replicator-secret'


### PR DESCRIPTION
# Description

Playbook warns if there are missing groups like "schema-registry" or "kafka-rest", thus we define them with no entries.

Because the groups exist, playbook generate useless credentials to related users

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested with empty groups in inventory

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
