### PR TITLE
Improve error handling when RBAC cluster has no auth

### DIFF
--- a/roles/kafka_controller/tasks/rbac.yml
+++ b/roles/kafka_controller/tasks/rbac.yml
@@ -12,6 +12,13 @@
       delegate_facts: true
   run_once: true
 
+- name: Fail if No Authentication is set
+  fail:
+    msg: "Please configure Authentication on the Kraft cluster."
+  loop: "{{ groups['kafka_controller'] }}"
+  when: hostvars[item]['kafka_controller_principal'] is undefined
+  run_once: true
+
 - name: Show principals
   debug:
     msg: "Principal for {{item}} is  {{ hostvars[item]['kafka_controller_principal'] }}"


### PR DESCRIPTION
# Description

improves error handling for Kraft controller

Fixes # [ANSIENG-2857](https://confluentinc.atlassian.net/browse/ANSIENG-2857)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

locally

# Checklist:

- [x] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[ANSIENG-2857]: https://confluentinc.atlassian.net/browse/ANSIENG-2857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ