### PR TITLE
Removed arm variables from dockerfiles of Rhel7, Debian9

### DIFF
--- a/molecule/Dockerfile-debian-archive.j2
+++ b/molecule/Dockerfile-debian-archive.j2
@@ -1,13 +1,11 @@
 FROM {{ item.image }}
 
-{% set ARCHITECTURE_SHORTHAND = lookup('env', 'ARCHITECTURE_SHORTHAND') | default ('x64', true) %}
-
 # Download Java using wget
 
-RUN wget https://download.java.net/java/GA/jdk17.0.1/2a2082e5a09d4267845be086888add4f/12/GPL/openjdk-17.0.1_linux-{{ ARCHITECTURE_SHORTHAND }}_bin.tar.gz
-RUN tar xvf openjdk-17.0.1_linux-{{ ARCHITECTURE_SHORTHAND }}_bin.tar.gz
+RUN wget https://download.java.net/java/GA/jdk17.0.1/2a2082e5a09d4267845be086888add4f/12/GPL/openjdk-17.0.1_linux-x64_bin.tar.gz
+RUN tar xvf openjdk-17.0.1_linux-x64_bin.tar.gz
 RUN sudo mv jdk-17*/ /opt/jdk17
-RUN rm -rf openjdk-17.0.1_linux-{{ ARCHITECTURE_SHORTHAND }}_bin.tar.gz
+RUN rm -rf openjdk-17.0.1_linux-x64_bin.tar.gz
 
 RUN echo 'deb [check-valid-until=no] http://archive.debian.org/debian stretch-backports main' | sudo tee /etc/apt/sources.list.d/stretch-backports.list
 

--- a/molecule/Dockerfile-debian.j2
+++ b/molecule/Dockerfile-debian.j2
@@ -1,13 +1,10 @@
 FROM {{ item.image }}
 
-{% set ARCHITECTURE_SHORTHAND = lookup('env', 'ARCHITECTURE_SHORTHAND') | default ('x64', true) %}
-
 # Download Java using wget
-
-RUN wget https://download.java.net/java/GA/jdk17.0.1/2a2082e5a09d4267845be086888add4f/12/GPL/openjdk-17.0.1_linux-{{ ARCHITECTURE_SHORTHAND }}_bin.tar.gz
-RUN tar xvf openjdk-17.0.1_linux-{{ ARCHITECTURE_SHORTHAND }}_bin.tar.gz
+RUN wget https://download.java.net/java/GA/jdk17.0.1/2a2082e5a09d4267845be086888add4f/12/GPL/openjdk-17.0.1_linux-x64_bin.tar.gz
+RUN tar xvf openjdk-17.0.1_linux-x64_bin.tar.gz
 RUN sudo mv jdk-17*/ /opt/jdk17
-RUN rm -rf openjdk-17.0.1_linux-{{ ARCHITECTURE_SHORTHAND }}_bin.tar.gz
+RUN rm -rf openjdk-17.0.1_linux-x64_bin.tar.gz
 
 RUN echo 'deb [check-valid-until=no] http://archive.debian.org/debian stretch-backports main' | sudo tee /etc/apt/sources.list.d/stretch-backports.list
 

--- a/molecule/Dockerfile-rhel7-java17.j2
+++ b/molecule/Dockerfile-rhel7-java17.j2
@@ -1,14 +1,12 @@
 FROM {{ item.image }}
 
-{% set ARCHITECTURE_SHORTHAND = lookup('env', 'ARCHITECTURE_SHORTHAND') | default ('x64', true) %}
-
 # Download Java using wget
 
 RUN yum -y install wget curl
-RUN wget https://download.java.net/java/GA/jdk17.0.2/dfd4a8d0985749f896bed50d7138ee7f/8/GPL/openjdk-17.0.2_linux-{{ ARCHITECTURE_SHORTHAND }}_bin.tar.gz
-RUN tar xvf openjdk-17.0.2_linux-{{ ARCHITECTURE_SHORTHAND }}_bin.tar.gz
+RUN wget https://download.java.net/java/GA/jdk17.0.2/dfd4a8d0985749f896bed50d7138ee7f/8/GPL/openjdk-17.0.2_linux-x64_bin.tar.gz
+RUN tar xvf openjdk-17.0.2_linux-x64_bin.tar.gz
 RUN sudo mv jdk-17.0.2/ /opt/jdk17/
-RUN rm -rf openjdk-17.0.2_linux-{{ ARCHITECTURE_SHORTHAND }}_bin.tar.gz
+RUN rm -rf openjdk-17.0.2_linux-x64_bin.tar.gz
 
 RUN yum -y install rsync \
       openssl


### PR DESCRIPTION
# Description

Dockerfiles are used for molecule testing. Rhel7, Debian9 do not support arm architecture and hence from dockerfiles which were used by rhel7, debian9 scenarios removed arm related variables.

Fixes # [2958](https://confluentinc.atlassian.net/browse/ANSIENG-2958)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

# Checklist:

- [X] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
