### PR TITLE
Deploy Connectors in a RBAC cluster

### DIFF
--- a/docs/MOLECULE_SCENARIOS.md
+++ b/docs/MOLECULE_SCENARIOS.md
@@ -18,6 +18,30 @@ Validates that Confluent CLI is installed.
 
 ***
 
+### molecule/archive-plain-debian10
+
+#### Scenario archive-plain-debian10 test's the following:
+
+Archive installation of Confluent Platform on Debian 10.
+
+SASL Protocol Plain.
+
+SSL Enabled.
+
+Kafka Connect Confluent Hub Plugins logic (Installs jcustenborder/kafka-connect-spooldir:2.0.43).
+
+Custom log dirs for all components.
+
+#### Scenario archive-plain-debian10 verify test's the following:
+
+Validates that SASL SSL protocol is set across all components.
+
+Validates that custom log4j configuration is in place.
+
+Validates that Java 17 is in Use
+
+***
+
 ### molecule/archive-plain-debian9
 
 #### Scenario archive-plain-debian9 test's the following:
@@ -41,30 +65,6 @@ Validates that custom log4j configuration is in place.
 Validates that Java 17 is in Use
 
 Validates that Confluent CLI is installed.
-
-***
-
-### molecule/archive-plain-debian10
-
-#### Scenario archive-plain-debian10 test's the following:
-
-Archive installation of Confluent Platform on Debian 10.
-
-SASL Protocol Plain.
-
-SSL Enabled.
-
-Kafka Connect Confluent Hub Plugins logic (Installs jcustenborder/kafka-connect-spooldir:2.0.43).
-
-Custom log dirs for all components.
-
-#### Scenario archive-plain-debian10 verify test's the following:
-
-Validates that SASL SSL protocol is set across all components.
-
-Validates that custom log4j configuration is in place.
-
-Validates that Java 17 is in Use
 
 ***
 
@@ -140,6 +140,8 @@ Kafka Connect Confluent Hub Plugins logic (Installs jcustenborder/kafka-connect-
 
 Custom log dirs for all components.
 
+Deploy Connector on Connect Cluster.
+
 #### Scenario archive-plain-ubuntu2004 verify test's the following:
 
 Validates that protocol is set to sasl plain.
@@ -148,13 +150,15 @@ Validates that protocol is set to SASL SSL.
 
 Validates log4j config.
 
+Validates that Connector is Running.
+
 ***
 
 ### molecule/archive-scram-rhel
 
 #### Scenario archive-scram-rhel test's the following:
 
-Archive Installation of Confluent Platform on RHEL8.
+Archive Installation of Confluent Platform on Oracle Linux 8.
 
 SASL SCRAM protocol.
 
@@ -169,6 +173,32 @@ Validates that customer user and group on archive are set.
 Validates that SASL SCRAM is Protocol is set.
 
 Validates that TLS is configured properly.
+
+***
+
+### molecule/archive-zookeeper-tls-rhel-fips
+
+#### Scenario archive-zookeeper-tls-rhel-fips test's the following:
+
+Installs Confluent Platform on Rocky linux 8
+
+Enables SASL SCRAM Auth on Zookeeper.
+
+TLS enabled.
+
+Customer zookeeper root.
+
+Jolokia has TLS disabled.
+
+FIPS enabled
+
+#### Scenario archive-zookeeper-tls-rhel-fips verify test's the following:
+
+Validates that Zookeeper is using TLS.
+
+Validates that other components are using SCRAM for auth.
+
+Validates that FIPS is in use in OpenSSL.
 
 ***
 
@@ -376,11 +406,15 @@ Installation of Confluent Platform on Oracle Linux 9.
 
 Kerberos enabled with custom client config path
 
+Creates a Connector in Connect cluster
+
 #### Scenario kerberos-rhel verify test's the following:
 
 Validates that Kerberos is enabled across all components.
 
 Validates that SASL SSL Plaintext is enabled across all components.
+
+Validates that Connector is running
 
 ***
 
@@ -388,7 +422,7 @@ Validates that SASL SSL Plaintext is enabled across all components.
 
 #### Scenario ksql-scale-up test's the following:
 
-Installation of Confluent Platform on centos7.
+Installation of Confluent Platform on RHEL9.
 
 MTLS enabled.
 
@@ -606,7 +640,7 @@ Validates that Control Center Can connect to each KSQL cluster.
 
 #### Scenario plain-customcerts-rhel-fips test's the following:
 
-Installation of Confluent Platform on RHEL8.
+Installation of Confluent Platform on Oracle Linux 8.
 
 TLS enabled.
 
@@ -1026,6 +1060,8 @@ RBAC Additional System Admin.
 
 Use Java 11 package
 
+Creates a Connector in connect cluster
+
 #### Scenario rbac-mds-mtls-existing-keystore-truststore-ubuntu verify test's the following:
 
 Validates that keystores are present on all components.
@@ -1076,7 +1112,7 @@ Validates that FIPS is in use on both clusters.
 
 #### Scenario rbac-mds-scram-custom-rhel test's the following:
 
-Installs two Confluent Platform Clusters on RHEL8.
+Installs two Confluent Platform Clusters on Rocky Linux 9.
 
 RBAC enabled.
 
@@ -1146,6 +1182,8 @@ RBAC Additional System Admin.
 
 Provided SSL Principal Mapping rule
 
+Creates two unique Connectors in Connect cluster.
+
 #### Scenario rbac-mtls-rhel-fips verify test's the following:
 
 Validates TLS version across all components.
@@ -1168,7 +1206,7 @@ Validates that FIPS is in use in OpenSSL.
 
 #### Scenario rbac-mtls-rhel8 test's the following:
 
-Installs Confluent Platform Cluster on RHEL8.
+Installs Confluent Platform Cluster on Oracle Linux 8.
 
 RBAC enabled.
 
@@ -1206,6 +1244,8 @@ Control Center disabled, metrics reporters enabled.
 
 LdapAuthenticateCallbackHandler for AuthN
 
+Creates two unique Connectors in Connect cluster
+
 #### Scenario rbac-plain-provided-debian9 verify test's the following:
 
 Validates Metrics reporter without C3.
@@ -1242,6 +1282,8 @@ SSO authentication using OIDC in Control center using Azure IdP
 
 FIPS enabled
 
+Installs Two unique Kafka Connect Clusters with unique connectors.
+
 #### Scenario rbac-scram-custom-rhel-fips verify test's the following:
 
 Validates keystore is present across all components.
@@ -1257,6 +1299,8 @@ Validates truststore across all components.
 Validates OIDC authenticate api for SSO in Control Center
 
 Validates that FIPS is in use in OpenSSL.
+
+Validates that both the Connectors are Running
 
 ***
 
@@ -1365,32 +1409,6 @@ Validates that Zookeeper is using MTLS for auth.
 Validates that other components are using SCRAM for auth.
 
 Validates that Secrets protection is applied to the correct properties.
-
-***
-
-### molecule/archive-zookeeper-tls-rhel-fips
-
-#### Scenario archive-zookeeper-tls-rhel-fips test's the following:
-
-Installs Confluent Platform on RHEL8
-
-Enables SASL SCRAM Auth on Zookeeper.
-
-TLS enabled.
-
-Customer zookeeper root.
-
-Jolokia has TLS disabled.
-
-FIPS enabled
-
-#### Scenario archive-zookeeper-tls-rhel-fips verify test's the following:
-
-Validates that Zookeeper is using TLS.
-
-Validates that other components are using SCRAM for auth.
-
-Validates that FIPS is in use in OpenSSL.
 
 ***
 

--- a/docs/VARIABLES.md
+++ b/docs/VARIABLES.md
@@ -2020,6 +2020,14 @@ Default:  ""
 
 ***
 
+### kafka_connect_connector_white_list
+
+Set this variable with a comma separated list of Topics for Kafka Connect Connector to produce/consume from.  This is a mandatory variable when creating Connector in RBAC cluster.
+
+Default:  ""
+
+***
+
 ### kafka_connect_skip_restarts
 
 Boolean used for disabling of systemd service restarts when rootless install is executed

--- a/docs/hosts_example.yml
+++ b/docs/hosts_example.yml
@@ -184,6 +184,10 @@ all:
     #       tasks.max: "1"
     #       file: "path/to/file.txt"
     #       topics: "test_topic"
+    #
+    ## To manage the connector on an RBAC cluster, set the following variable with the list of Topics for Kafka Connect Connector to produce/consume.
+    ## The variable should contain the list of all the topics of the Connectors in a Connect cluster. eg.
+    # kafka_connect_connector_white_list: "test_topic1,test_topic2"
 
     #### Configuring logredactor ####
     ## To configure logredactor for all components, set the following variables ##

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: '>=2.11'
+requires_ansible: '>=2.14'

--- a/molecule/archive-plain-ubuntu2004/molecule.yml
+++ b/molecule/archive-plain-ubuntu2004/molecule.yml
@@ -4,6 +4,7 @@
 ### SSL Enabled.
 ### Kafka Connect Confluent Hub Plugins logic (Installs jcustenborder/kafka-connect-spooldir:2.0.43).
 ### Custom log dirs for all components.
+### Deploy Connector on Connect Cluster.
 
 platforms:
   - name: ${KRAFT_CONTROLLER:-zookeeper}1

--- a/molecule/archive-plain-ubuntu2004/molecule.yml
+++ b/molecule/archive-plain-ubuntu2004/molecule.yml
@@ -129,3 +129,12 @@ provisioner:
         kafka_connect_log_dir: /connect/logs
         ksql_log_dir: /ksql/logs/
         control_center_log_dir: /c3/logs
+
+        kafka_connect_connectors:
+          - name: sample-connector-1
+            config:
+              connector.class: "org.apache.kafka.connect.tools.VerifiableSourceConnector"
+              tasks.max: "1"
+              file: "/etc/kafka/connect-distributed.properties"
+              topic: "test_topic"
+              throughput: "1000"

--- a/molecule/archive-plain-ubuntu2004/verify.yml
+++ b/molecule/archive-plain-ubuntu2004/verify.yml
@@ -72,6 +72,31 @@
         property: security.protocol
         expected_value: SASL_SSL
 
+    - name: Get Connectors on connect cluster1
+      uri:
+        url: "https://kafka-connect1:8083/connectors"
+        status_code: 200
+        validate_certs: false
+
+      register: connectors
+
+    - name: Assert Connector Created
+      assert:
+        that:
+          - connectors.json[0] == "sample-connector-1"
+        fail_msg: "Connector not created"
+        quiet: true
+
+    - name: Wait for Connector tasks to return Running
+      uri:
+        url: https://kafka-connect1:8083/connectors/sample-connector-1/status
+        status_code: 200
+        validate_certs: false
+      register: connector_status_response
+      until: connector_status_response.json.tasks[0].state == 'RUNNING'
+      retries: 10
+      delay: 5
+
 - name: Verify - ksql
   hosts: ksql
   gather_facts: false

--- a/molecule/archive-plain-ubuntu2004/verify.yml
+++ b/molecule/archive-plain-ubuntu2004/verify.yml
@@ -2,6 +2,7 @@
 ### Validates that protocol is set to sasl plain.
 ### Validates that protocol is set to SASL SSL.
 ### Validates log4j config.
+### Validates that Connector is Running.
 
 - name: Verify - kafka_controller
   hosts: kafka_controller

--- a/molecule/connect-scale-up/molecule.yml
+++ b/molecule/connect-scale-up/molecule.yml
@@ -163,9 +163,21 @@ provisioner:
       # connect clusters
       ssl:
         kafka_connect_group_id: connect-ssl
+        # Create Connectors with ssl
+        kafka_connect_ssl_enabled: true
+        kafka_connect_ssl_mutual_auth_enabled: true
+        kafka_connect_connectors:
+          - name: sample-connector-3
+            config:
+              connector.class: "org.apache.kafka.connect.tools.VerifiableSinkConnector"
+              tasks.max: "5"
+              file: "/etc/kafka/connect-distributed.properties"
+              topics: "test_topic"
+              key.converter: "org.apache.kafka.connect.json.JsonConverter"
+              value.converter: "org.apache.kafka.connect.json.JsonConverter"
       cluster1:
         kafka_connect_group_id: connect-cluster1
-        # Create Connectors not working w ssl on molecule
+        # Create Connectors without ssl
         kafka_connect_ssl_enabled: false
         kafka_connect_ssl_mutual_auth_enabled: false
         kafka_connect_connectors:
@@ -179,7 +191,7 @@ provisioner:
               value.converter: "org.apache.kafka.connect.json.JsonConverter"
       cluster2:
         kafka_connect_group_id: connect-cluster2
-        # Create Connectors not working w ssl
+        # Create Connectors without ssl
         kafka_connect_ssl_enabled: false
         kafka_connect_ssl_mutual_auth_enabled: false
         kafka_connect_connectors:

--- a/molecule/connect-scale-up/verify.yml
+++ b/molecule/connect-scale-up/verify.yml
@@ -99,6 +99,22 @@
         property: group.id
         expected_value: connect-ssl
 
+    - name: Get Connectors on connect cluster3
+      uri:
+        url: "https://kafka-connect3:8083/connectors"
+        status_code: 200
+        validate_certs: false
+        client_cert: /var/ssl/private/kafka_connect.crt
+        client_key: /var/ssl/private/kafka_connect.key
+      register: connectors
+
+    - name: Assert Connector Created
+      assert:
+        that:
+          - connectors.json[0] == "sample-connector-3"
+        fail_msg: "Connector not created"
+        quiet: true
+
 - name: Verify - kafka_connect4
   hosts: kafka-connect4
   gather_facts: false
@@ -119,10 +135,10 @@
         client_cert: /var/ssl/private/kafka_connect.crt
         client_key: /var/ssl/private/kafka_connect.key
       register: connectors
-    - name: Assert Connector should have not been Created
+    - name: Assert Connector Created
       assert:
         that:
-          - connectors.json|length == 0
+          - connectors.json[0] == "sample-connector-3"
         fail_msg: "Connector not created"
         quiet: true
 

--- a/molecule/kerberos-rhel/molecule.yml
+++ b/molecule/kerberos-rhel/molecule.yml
@@ -1,6 +1,7 @@
 ---
 ### Installation of Confluent Platform on Oracle Linux 9.
 ### Kerberos enabled with custom client config path
+### Creates a Connector in Connect cluster
 
 driver:
   name: docker

--- a/molecule/kerberos-rhel/molecule.yml
+++ b/molecule/kerberos-rhel/molecule.yml
@@ -160,6 +160,14 @@ provisioner:
 
         kerberos_client_config_file_dest: /krb/krb5.conf
 
+        kafka_connect_connectors:
+          - name: sample-connector-1
+            config:
+              connector.class: "org.apache.kafka.connect.tools.VerifiableSinkConnector"
+              tasks.max: "1"
+              file: "/etc/kafka/connect-distributed.properties"
+              topics: "test_topic"
+
       zookeeper:
         zookeeper_kerberos_principal: "zk/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
         zookeeper_kerberos_keytab_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs/zookeeper-{{inventory_hostname}}.keytab"

--- a/molecule/kerberos-rhel/verify.yml
+++ b/molecule/kerberos-rhel/verify.yml
@@ -1,6 +1,7 @@
 ---
 ### Validates that Kerberos is enabled across all components.
 ### Validates that SASL SSL Plaintext is enabled across all components.
+### Validates that Connector is running
 
 - name: Verify - kafka_controller
   hosts: kafka_controller

--- a/molecule/kerberos-rhel/verify.yml
+++ b/molecule/kerberos-rhel/verify.yml
@@ -90,6 +90,131 @@
         property: sasl.kerberos.service.name
         expected_value: kafka-a
 
+    - name: Get Connectors on connect cluster1
+      uri:
+        url: "http://kafka-connect1:8083/connectors"
+        status_code: 200
+        validate_certs: false
+      register: connectors
+
+    - name: Assert Connector Created
+      assert:
+        that:
+          - connectors.json[0] == "sample-connector-1"
+        fail_msg: "Connector not created"
+        quiet: true
+
+    - import_role:
+        name: variables
+
+    - name: Test data
+      set_fact:
+        kafka_connect_url: "{{kafka_connect_http_protocol}}://{{ hostvars[inventory_hostname]|confluent.platform.resolve_hostname }}:{{kafka_connect_rest_port}}/connectors"
+        reset_all_connectors: []
+
+        add_new_connector:
+          - name: test-connector-1
+            config:
+              connector.class: "org.apache.kafka.connect.tools.VerifiableSourceConnector"
+              tasks.max: "1"
+              file: "/etc/kafka/connect-distributed.properties"
+              topic: "test_topic"
+              throughput: "1000"
+
+        update_existing_connector:
+          - name: test-connector-1
+            config:
+              connector.class: "org.apache.kafka.connect.tools.VerifiableSourceConnector"
+              tasks.max: "5"
+              file: "/etc/kafka/connect-distributed.properties"
+              topic: "test_topic"
+              throughput: "1000"
+
+        add_bad_request_connector:
+          - name: test-connector-1
+            config:
+              connector.class: "org.apache.kafka.connect.tools.VerifiableSourceConnector"
+              tasks.max: "5"
+              file: "/etc/kafka/connect-distributed.properties"
+              topic: "test_topic"
+              throughput: "1000"
+          - name: test-connector-2
+            config:
+              connector.class: "org.apache.kafka.connect.mirror.MirrorHeartbeatConnector"
+              tasks.max: "1"
+              file: "/etc/kafka/connect-distributed.properties"
+              topics: "foo"
+
+        add_non_existent_connector:
+          - name: test-connector-1
+            config:
+              connector.class: "org.apache.kafka.connect.tools.VerifiableSourceConnector"
+              tasks.max: "5"
+              file: "/etc/kafka/connect-distributed.properties"
+              topic: "test_topic"
+              throughput: "1000"
+          - name: test-connector-2
+            config:
+              connector.class: "io.confluent.connect.jdbc.JdbcSinkConnector"
+              tasks.max: "1"
+              topics: "foo"
+
+        delete_connector:
+          - name: test-connector-2
+            config:
+              connector.class: "org.apache.kafka.connect.tools.VerifiableSourceConnector"
+              tasks.max: "1"
+              topic: "bar"
+              throughput: "1000"
+
+    - import_role:
+        name: confluent.test
+        tasks_from: check_connector.yml
+      vars:
+        connect_url_input: "{{ kafka_connect_url }}"
+        active_connectors_input: "{{ reset_all_connectors }}"
+        expected_message: ""
+
+    - import_role:
+        name: confluent.test
+        tasks_from: check_connector.yml
+      vars:
+        connect_url_input: "{{ kafka_connect_url }}"
+        active_connectors_input: "{{ add_new_connector }}"
+        expected_message: "Connectors added or updated: test-connector-1: new connector added."
+
+    - import_role:
+        name: confluent.test
+        tasks_from: check_connector.yml
+      vars:
+        connect_url_input: "{{ kafka_connect_url }}"
+        active_connectors_input: "{{ update_existing_connector }}"
+        expected_message: "Connectors added or updated: test-connector-1: connector configuration updated."
+
+    - import_role:
+        name: confluent.test
+        tasks_from: check_connector.yml
+      vars:
+        connect_url_input: "{{ kafka_connect_url }}"
+        active_connectors_input: "{{ add_bad_request_connector }}"
+        expected_message: "Connectors added or updated: test-connector-1: no configuration change, test-connector-2: ERROR error while adding new connector configuration (HTTP Error 400: Bad Request)."
+
+    - import_role:
+        name: confluent.test
+        tasks_from: check_connector.yml
+      vars:
+        connect_url_input: "{{ kafka_connect_url }}"
+        active_connectors_input: "{{ add_non_existent_connector }}"
+        expected_message: "Connectors added or updated: test-connector-1: no configuration change, test-connector-2: ERROR error while adding new connector configuration (HTTP Error 500: Internal Server Error)."
+
+    - import_role:
+        name: confluent.test
+        tasks_from: check_connector.yml
+      vars:
+        connect_url_input: "{{ kafka_connect_url }}"
+        active_connectors_input: "{{ delete_connector }}"
+        expected_message: "Connectors removed: test-connector-1. Connectors added or updated: test-connector-2: new connector added."
+
 - name: Verify - kafka_rest
   hosts: kafka_rest
   gather_facts: false

--- a/molecule/ksql-scale-up/molecule.yml
+++ b/molecule/ksql-scale-up/molecule.yml
@@ -141,9 +141,6 @@ provisioner:
           ksql.heartbeat.enable: true
       kafka_connect:
         kafka_connect_group_id: connect-cluster1
-        # Create Connectors not working w ssl on molecule
-        kafka_connect_ssl_enabled: false
-        kafka_connect_ssl_mutual_auth_enabled: false
         kafka_connect_connectors:
           - name: sample-connector-1
             config:

--- a/molecule/ksql-scale-up/verify.yml
+++ b/molecule/ksql-scale-up/verify.yml
@@ -38,14 +38,14 @@
         file_path: /etc/confluent-control-center/control-center-production.properties
         property: confluent.controlcenter.ksql.ksql.url
         expected_value: https://ksql1:8088,https://ksql2:8088,https://ksql3:8088,https://ksql4:8088
-    - name: Check line connect cluster2
+    - name: Check line connect cluster1
       import_role:
         name: confluent.test
         tasks_from: check_property.yml
       vars:
         file_path: /etc/confluent-control-center/control-center-production.properties
         property: confluent.controlcenter.connect.connect-cluster1.cluster
-        expected_value: http://kafka-connect1:8083
+        expected_value: https://kafka-connect1:8083
     - name: Check advertised url default
       import_role:
         name: confluent.test

--- a/molecule/multi-ksql-connect-rhel/molecule.yml
+++ b/molecule/multi-ksql-connect-rhel/molecule.yml
@@ -164,9 +164,21 @@ provisioner:
       # connect clusters
       ssl:
         kafka_connect_group_id: connect-ssl
+        kafka_connect_ssl_enabled: true
+        kafka_connect_ssl_mutual_auth_enabled: true
+        kafka_connect_connectors:
+          - name: sample-connector-3
+            config:
+              connector.class: "org.apache.kafka.connect.tools.VerifiableSourceConnector"
+              tasks.max: "5"
+              file: "/etc/kafka/connect-distributed.properties"
+              topic: "test_topic"
+              throughput: "1000"
+              key.converter: "org.apache.kafka.connect.json.JsonConverter"
+              value.converter: "org.apache.kafka.connect.json.JsonConverter"
       syslog:
         kafka_connect_group_id: connect-syslog
-        # Create Connectors not working w ssl on molecule
+        # Create Connector without ssl
         kafka_connect_ssl_enabled: false
         kafka_connect_ssl_mutual_auth_enabled: false
         kafka_connect_connectors:
@@ -180,9 +192,8 @@ provisioner:
               value.converter: "org.apache.kafka.connect.json.JsonConverter"
       elastic:
         kafka_connect_group_id: connect-elastic
-        # Create Connectors not working w ssl
-        kafka_connect_ssl_enabled: false
-        kafka_connect_ssl_mutual_auth_enabled: false
+        kafka_connect_ssl_enabled: true
+        kafka_connect_ssl_mutual_auth_enabled: true
         kafka_connect_connectors:
           - name: sample-connector-2
             config:

--- a/molecule/multi-ksql-connect-rhel/verify.yml
+++ b/molecule/multi-ksql-connect-rhel/verify.yml
@@ -76,9 +76,11 @@
 
     - name: Get Connectors on connect cluster2
       uri:
-        url: "http://kafka-connect2:8083/connectors"
+        url: "https://kafka-connect2:8083/connectors"
         status_code: 200
         validate_certs: false
+        client_cert: /var/ssl/private/kafka_connect.crt
+        client_key: /var/ssl/private/kafka_connect.key
       register: connectors
 
     - name: Assert Connector Created
@@ -113,8 +115,8 @@
     - name: Assert No Connectors Created
       assert:
         that:
-          - connectors.json|length == 0
-        fail_msg: "Connector should not be created"
+          - connectors.json[0] == "sample-connector-3"
+        fail_msg: "Connector not created"
         quiet: true
 
 - name: Verify - ksql
@@ -172,7 +174,7 @@
       vars:
         file_path: /etc/confluent-control-center/control-center-production.properties
         property: confluent.controlcenter.connect.connect-elastic.cluster
-        expected_value: http://kafka-connect2:8083
+        expected_value: https://kafka-connect2:8083
 
     - name: Check line connect cluster3
       import_role:

--- a/molecule/rbac-mds-mtls-existing-keystore-truststore-ubuntu/molecule.yml
+++ b/molecule/rbac-mds-mtls-existing-keystore-truststore-ubuntu/molecule.yml
@@ -6,6 +6,7 @@
 ### Kafka Broker Customer Listener.
 ### RBAC Additional System Admin.
 ### Use Java 11 package
+### Creates a Connector in connect cluster
 
 driver:
   name: docker
@@ -117,7 +118,7 @@ platforms:
     hostname: ksql1.confluent
     groups:
       - ksql
-      - ksal_migration
+      - ksql_migration
     image: geerlingguy/docker-ubuntu1804-ansible
     dockerfile: ../Dockerfile-ubuntu-java11.j2
     command: ""
@@ -305,6 +306,17 @@ provisioner:
         ssl_truststore_ca_cert_alias: CARoot
         token_services_public_pem_file: "/var/ssl/private/public.pem"
         token_services_private_pem_file: "/var/ssl/private/tokenKeypair.pem"
+
+        kafka_connect_connector_white_list: "test_topic"
+        kafka_connect_connectors:
+          - name: sample-connector-1
+            config:
+              connector.class: "org.apache.kafka.connect.tools.VerifiableSinkConnector"
+              tasks.max: "5"
+              file: "/etc/kafka/connect-distributed.properties"
+              topics: "test_topic"
+              key.converter: "org.apache.kafka.connect.json.JsonConverter"
+              value.converter: "org.apache.kafka.connect.json.JsonConverter"
 
       ksql:
         ssl_keystore_filepath: "/var/ssl/private/ksql.keystore.jks"

--- a/molecule/rbac-mtls-rhel-fips/molecule.yml
+++ b/molecule/rbac-mtls-rhel-fips/molecule.yml
@@ -7,6 +7,7 @@
 ### Kafka Broker Customer Listener.
 ### RBAC Additional System Admin.
 ### Provided SSL Principal Mapping rule
+### Creates two unique Connectors in Connect cluster.
 
 driver:
   name: docker
@@ -224,7 +225,25 @@ provisioner:
 
       kafka_connect:
         kafka_connect_cluster_name: Test-Connect
-
+        kafka_connect_connector_white_list: "test_topic1,test_topic2"
+        kafka_connect_connectors:
+          - name: sample-connector-1
+            config:
+              connector.class: "org.apache.kafka.connect.tools.VerifiableSinkConnector"
+              tasks.max: "1"
+              file: "/etc/kafka/connect-distributed.properties"
+              topics: "test_topic1"
+              key.converter: "org.apache.kafka.connect.json.JsonConverter"
+              value.converter: "org.apache.kafka.connect.json.JsonConverter"
+          - name: sample-connector-2
+            config:
+              connector.class: "org.apache.kafka.connect.tools.VerifiableSourceConnector"
+              tasks.max: "1"
+              file: "/etc/kafka/connect-distributed.properties"
+              topic: "test_topic2"
+              throughput: "1000"
+              key.converter: "org.apache.kafka.connect.json.JsonConverter"
+              value.converter: "org.apache.kafka.connect.json.JsonConverter"
       ksql:
         ksql_cluster_name: Test-Ksql
 

--- a/molecule/rbac-plain-provided-debian9/molecule.yml
+++ b/molecule/rbac-plain-provided-debian9/molecule.yml
@@ -7,6 +7,7 @@
 ### Secrets protection enabled.
 ### Control Center disabled, metrics reporters enabled.
 ### LdapAuthenticateCallbackHandler for AuthN
+### Creates two unique Connectors in Connect cluster
 
 driver:
   name: docker
@@ -210,6 +211,26 @@ provisioner:
             port: 9093
             ssl_enabed: true
             sasl_protocol: plain
+
+        kafka_connect_connector_white_list: "test_topic1,test_topic2"
+        kafka_connect_connectors:
+          - name: sample-connector-1
+            config:
+              connector.class: "org.apache.kafka.connect.tools.VerifiableSourceConnector"
+              tasks.max: "5"
+              file: "/etc/kafka/connect-distributed.properties"
+              topic: "test_topic1"
+              throughput: "1000"
+              key.converter: "org.apache.kafka.connect.json.JsonConverter"
+              value.converter: "org.apache.kafka.connect.json.JsonConverter"
+          - name: sample-connector-2
+            config:
+              connector.class: "org.apache.kafka.connect.tools.VerifiableSinkConnector"
+              tasks.max: "1"
+              file: "/etc/kafka/connect-distributed.properties"
+              topics: "test_topic2"
+              key.converter: "org.apache.kafka.connect.json.JsonConverter"
+              value.converter: "org.apache.kafka.connect.json.JsonConverter"
 
         mds_super_user: mds
         mds_super_user_password: password

--- a/molecule/rbac-plain-provided-debian9/verify.yml
+++ b/molecule/rbac-plain-provided-debian9/verify.yml
@@ -128,6 +128,56 @@
         property: confluent.metadata.basic.auth.user.info
         expected_value: ${securepass:/var/ssl/private/kafka-connect-security.properties:connect-distributed.properties/confluent.metadata.basic.auth.user.info}
 
+    - name: Get Connectors on connect cluster1
+      uri:
+        url: "https://kafka-connect1:8083/connectors"
+        status_code: 200
+        validate_certs: false
+        url_username: "kafka_connect"
+        url_password: "password"
+
+      register: connectors
+
+    - name: Assert Connector1 Created
+      assert:
+        that:
+          - connectors.json[0] == "sample-connector-1"
+        fail_msg: "Connector not created"
+        quiet: true
+
+    - name: Wait for Connector tasks to return Running
+      uri:
+        url: https://kafka-connect1:8083/connectors/sample-connector-1/status
+        status_code: 200
+        validate_certs: false
+        url_username: kafka_connect
+        url_password: password
+        force_basic_auth: true
+      register: connector_status_response
+      until: connector_status_response.json.tasks[0].state == 'RUNNING'
+      retries: 10
+      delay: 5
+
+    - name: Assert Connector2 Created
+      assert:
+        that:
+          - connectors.json[1] == "sample-connector-2"
+        fail_msg: "Connector not created"
+        quiet: true
+
+    - name: Wait for Connector tasks to return Running
+      uri:
+        url: https://kafka-connect1:8083/connectors/sample-connector-2/status
+        status_code: 200
+        validate_certs: false
+        url_username: kafka_connect
+        url_password: password
+        force_basic_auth: true
+      register: connector_status_response
+      until: connector_status_response.json.tasks[0].state == 'RUNNING'
+      retries: 10
+      delay: 5
+
 - name: Verify - ksql
   hosts: ksql
   gather_facts: false

--- a/molecule/rbac-scram-custom-rhel-fips/molecule.yml
+++ b/molecule/rbac-scram-custom-rhel-fips/molecule.yml
@@ -8,6 +8,7 @@
 ### Kafka Connect Custom arguments.
 ### SSO authentication using OIDC in Control center using Azure IdP
 ### FIPS enabled
+### Installs Two unique Kafka Connect Clusters with unique connectors.
 
 driver:
   name: docker
@@ -124,6 +125,20 @@ platforms:
     hostname: kafka-connect1${BUILD_NUMBER}.confluent${BUILD_NUMBER}
     groups:
       - kafka_connect
+      - cluster1
+    image: redhat/ubi8-minimal
+    dockerfile: ../Dockerfile-rhel-java17.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    networks:
+      - name: confluent${BUILD_NUMBER}
+  - name: kafka-connect2${BUILD_NUMBER}
+    hostname: kafka-connect2${BUILD_NUMBER}.confluent${BUILD_NUMBER}
+    groups:
+      - kafka_connect
+      - cluster2
     image: redhat/ubi8-minimal
     dockerfile: ../Dockerfile-rhel-java17.j2
     command: ""
@@ -250,6 +265,31 @@ provisioner:
         kafka_connect_custom_rest_extension_classes:
           - io.confluent.connect.replicator.monitoring.ReplicatorMonitoringExtension
         kafka_connect_custom_java_args: "-Djavax.net.ssl.trustStore={{kafka_connect_truststore_path}} -Djavax.net.ssl.trustStorePassword={{kafka_connect_truststore_storepass}}"
+
+      cluster1:
+        kafka_connect_group_id: connect-cluster1
+        kafka_connect_connector_white_list: "test_topic"
+        kafka_connect_connectors:
+          - name: sample-connector-1
+            config:
+              connector.class: "org.apache.kafka.connect.tools.VerifiableSinkConnector"
+              tasks.max: "5"
+              file: "/etc/kafka/connect-distributed.properties"
+              topics: "test_topic"
+              key.converter: "org.apache.kafka.connect.json.JsonConverter"
+              value.converter: "org.apache.kafka.connect.json.JsonConverter"
+      cluster2:
+        kafka_connect_group_id: connect-cluster2
+        kafka_connect_connector_white_list: "test_topic"
+        kafka_connect_connectors:
+          - name: sample-connector-2
+            config:
+              connector.class: "org.apache.kafka.connect.tools.VerifiableSinkConnector"
+              tasks.max: "1"
+              file: "/etc/kafka/connect-distributed.properties"
+              topics: "test_topic"
+              key.converter: "org.apache.kafka.connect.json.JsonConverter"
+              value.converter: "org.apache.kafka.connect.json.JsonConverter"
 
       ldap_server:
         ldaps_enabled: true

--- a/molecule/rbac-scram-custom-rhel-fips/verify.yml
+++ b/molecule/rbac-scram-custom-rhel-fips/verify.yml
@@ -57,8 +57,8 @@
     - name: Assert cluster count expected
       assert:
         that:
-          - clusters.json|length == 4
-        fail_msg: "There should only be four clusters in {{clusters.json}}"
+          - clusters.json|length == 5
+        fail_msg: "There should only be five clusters in {{clusters.json}}"
         quiet: true
 
     - name: Get Clusters associated with user2

--- a/molecule/rbac-scram-custom-rhel-fips/verify.yml
+++ b/molecule/rbac-scram-custom-rhel-fips/verify.yml
@@ -6,6 +6,7 @@
 ### Validates truststore across all components.
 ### Validates OIDC authenticate api for SSO in Control Center
 ### Validates that FIPS is in use in OpenSSL.
+### Validates that both the Connectors are Running
 
 - name: Verify - kafka_broker
   hosts: kafka_broker
@@ -102,17 +103,17 @@
         property: ssl.truststore.location
         expected_value: /var/ssl/private/schema_registry.truststore.jks
 
-- name: Verify - kafka_rest
-  hosts: kafka_rest
-  gather_facts: false
-  tasks:
-    - import_role:
-        name: confluent.test
-        tasks_from: check_property.yml
-      vars:
-        file_path: /etc/kafka-rest/kafka-rest.properties
-        property: ssl.truststore.location
-        expected_value: /var/ssl/private/kafka_rest.truststore.jks
+# - name: Verify - kafka_rest
+#   hosts: kafka_rest
+#   gather_facts: false
+#   tasks:
+#     - import_role:
+#         name: confluent.test
+#         tasks_from: check_property.yml
+#       vars:
+#         file_path: /etc/kafka-rest/kafka-rest.properties
+#         property: ssl.truststore.location
+#         expected_value: /var/ssl/private/kafka_rest.truststore.jks
 
 - name: Verify - kafka_connect
   hosts: kafka_connect
@@ -125,6 +126,66 @@
         file_path: /etc/kafka/connect-distributed.properties
         property: ssl.truststore.location
         expected_value: /var/ssl/private/kafka_connect.truststore.jks
+
+    - name: Get Connectors on connect cluster1
+      uri:
+        url: "https://kafka-connect1:8083/connectors"
+        status_code: 200
+        validate_certs: false
+        url_username: "kafka_connect"
+        url_password: "password"
+
+      register: connectors
+
+    - name: Assert Connector1 Created
+      assert:
+        that:
+          - connectors.json[0] == "sample-connector-1"
+        fail_msg: "Connector not created"
+        quiet: true
+
+    - name: Wait for Connector tasks to return Running
+      uri:
+        url: https://kafka-connect1:8083/connectors/sample-connector-1/status
+        status_code: 200
+        validate_certs: false
+        url_username: kafka_connect
+        url_password: password
+        force_basic_auth: true
+      register: connector_status_response
+      until: connector_status_response.json.tasks[0].state == 'RUNNING'
+      retries: 10
+      delay: 5
+
+    - name: Get Connectors on connect cluster2
+      uri:
+        url: "https://kafka-connect2:8083/connectors"
+        status_code: 200
+        validate_certs: false
+        url_username: "kafka_connect"
+        url_password: "password"
+
+      register: connectors
+
+    - name: Assert Connector2 Created
+      assert:
+        that:
+          - connectors.json[0] == "sample-connector-2"
+        fail_msg: "Connector not created"
+        quiet: true
+
+    - name: Wait for Connector tasks to return Running
+      uri:
+        url: https://kafka-connect2:8083/connectors/sample-connector-2/status
+        status_code: 200
+        validate_certs: false
+        url_username: kafka_connect
+        url_password: password
+        force_basic_auth: true
+      register: connector_status_response
+      until: connector_status_response.json.tasks[0].state == 'RUNNING'
+      retries: 10
+      delay: 5
 
 - name: Verify - ksql
   hosts: ksql

--- a/molecule/rbac-scram-custom-rhel-fips/verify.yml
+++ b/molecule/rbac-scram-custom-rhel-fips/verify.yml
@@ -103,17 +103,17 @@
         property: ssl.truststore.location
         expected_value: /var/ssl/private/schema_registry.truststore.jks
 
-# - name: Verify - kafka_rest
-#   hosts: kafka_rest
-#   gather_facts: false
-#   tasks:
-#     - import_role:
-#         name: confluent.test
-#         tasks_from: check_property.yml
-#       vars:
-#         file_path: /etc/kafka-rest/kafka-rest.properties
-#         property: ssl.truststore.location
-#         expected_value: /var/ssl/private/kafka_rest.truststore.jks
+- name: Verify - kafka_rest
+  hosts: kafka_rest
+  gather_facts: false
+  tasks:
+    - import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: /etc/kafka-rest/kafka-rest.properties
+        property: ssl.truststore.location
+        expected_value: /var/ssl/private/kafka_rest.truststore.jks
 
 - name: Verify - kafka_connect
   hosts: kafka_connect

--- a/roles/kafka_connect/tasks/deploy_connectors.yml
+++ b/roles/kafka_connect/tasks/deploy_connectors.yml
@@ -8,6 +8,10 @@
   when:
     - rbac_enabled|bool
     - not ansible_check_mode
+    - kafka_connect_connectors is defined
+
+- set_fact:
+    certs_chain: "{{ssl_file_dir_final}}/{{ kafka_connect_service_name if kafka_connect_service_name != kafka_connect_default_service_name else 'kafka_connect' }}.chain"
 
 - name: Register connector configs and remove deleted connectors for single cluster
   confluent.platform.kafka_connectors:
@@ -30,8 +34,8 @@
     timeout: "{{ kafka_connect_deploy_connector_timeout }}"
     username: "{% if rbac_enabled %}{{kafka_connect_ldap_user}}{% else %}{{none}}{% endif %}"
     password: "{% if rbac_enabled %}{{kafka_connect_ldap_password}}{% else %}{{none}}{% endif %}"
-    client_cert: "{% if (ssl_provided_keystore_and_truststore and ssl_mutual_auth_enabled) %}{{kafka_connect_cert_path}}{% elif ssl_mutual_auth_enabled %}{{certs_chain}}{% else %}{{none}}{% endif %}"
-    client_key: "{% if ssl_mutual_auth_enabled %}{{kafka_connect_key_path}}{% else %}{{none}}{% endif %}"
+    client_cert: "{% if (ssl_provided_keystore_and_truststore and hostvars[groups[item][0]].kafka_connect_ssl_mutual_auth_enabled|default(kafka_connect_ssl_mutual_auth_enabled)) %}{{hostvars[groups[item][0]].kafka_connect_cert_path|default(kafka_connect_cert_path)}}{% elif hostvars[groups[item][0]].kafka_connect_ssl_mutual_auth_enabled|default(kafka_connect_ssl_mutual_auth_enabled) %}{{certs_chain}}{% else %}{{none}}{% endif %}"
+    client_key: "{% if hostvars[groups[item][0]].kafka_connect_ssl_mutual_auth_enabled|default(kafka_connect_ssl_mutual_auth_enabled) %}{{hostvars[groups[item][0]].kafka_connect_key_path|default(kafka_connect_key_path)}}{% else %}{{none}}{% endif %}"
   when: hostvars[groups[item][0]].kafka_connect_connectors is defined
   delegate_to: "{{ groups[item][0] }}"
   loop: "{{subgroups}}"

--- a/roles/kafka_connect/tasks/deploy_connectors.yml
+++ b/roles/kafka_connect/tasks/deploy_connectors.yml
@@ -4,7 +4,7 @@
   with_items: "{{groups['kafka_connect']}}"
 
 - name: Add Role Bindings for Connect
-  include_tasks: role_bindings_connector.yml
+  include_tasks: rbac_connectors.yml
   when:
     - rbac_enabled|bool
     - not ansible_check_mode

--- a/roles/kafka_connect/tasks/deploy_connectors.yml
+++ b/roles/kafka_connect/tasks/deploy_connectors.yml
@@ -3,11 +3,21 @@
   set_fact: subgroups="{{ ((subgroups | default([])) + hostvars[item].group_names) | difference('kafka_broker, ksql, kafka_connect, kafka_rest, kerberos, ksql, schema_registry, zookeeper, kafka_broker_parallel, ksql_parallel, kafka_connect_parallel, kafka_rest_parallel, kerberos_parallel, ksql_parallel, schema_registry_parallel, zookeeper_parallel') }}"
   with_items: "{{groups['kafka_connect']}}"
 
+- name: Add Role Bindings for Connect
+  include_tasks: role_bindings_connector.yml
+  when:
+    - rbac_enabled|bool
+    - not ansible_check_mode
+
 - name: Register connector configs and remove deleted connectors for single cluster
   confluent.platform.kafka_connectors:
     connect_url: "{{kafka_connect_http_protocol}}://{{ hostvars[inventory_hostname]|confluent.platform.resolve_hostname }}:{{kafka_connect_rest_port}}/connectors"
     active_connectors: "{{ kafka_connect_connectors }}"
     timeout: "{{ kafka_connect_deploy_connector_timeout }}"
+    username: "{% if rbac_enabled %}{{kafka_connect_ldap_user}}{% else %}{{none}}{% endif %}"
+    password: "{% if rbac_enabled %}{{kafka_connect_ldap_password}}{% else %}{{none}}{% endif %}"
+    client_cert: "{% if (ssl_provided_keystore_and_truststore and ssl_mutual_auth_enabled) %}{{kafka_connect_cert_path}}{% elif ssl_mutual_auth_enabled %}{{certs_chain}}{% else %}{{none}}{% endif %}"
+    client_key: "{% if ssl_mutual_auth_enabled %}{{kafka_connect_key_path}}{% else %}{{none}}{% endif %}"
   when:
     - kafka_connect_connectors is defined
     - subgroups|length == 0
@@ -18,6 +28,10 @@
     connect_url: "http{% if hostvars[groups[item][0]].kafka_connect_ssl_enabled|default(kafka_connect_ssl_enabled) %}s{% endif %}://{{ hostvars[groups[item][0]]|confluent.platform.resolve_hostname }}:{{ hostvars[groups[item][0]].kafka_connect_rest_port|default(kafka_connect_rest_port) }}/connectors"
     active_connectors: "{{ hostvars[groups[item][0]].kafka_connect_connectors }}"
     timeout: "{{ kafka_connect_deploy_connector_timeout }}"
+    username: "{% if rbac_enabled %}{{kafka_connect_ldap_user}}{% else %}{{none}}{% endif %}"
+    password: "{% if rbac_enabled %}{{kafka_connect_ldap_password}}{% else %}{{none}}{% endif %}"
+    client_cert: "{% if (ssl_provided_keystore_and_truststore and ssl_mutual_auth_enabled) %}{{kafka_connect_cert_path}}{% elif ssl_mutual_auth_enabled %}{{certs_chain}}{% else %}{{none}}{% endif %}"
+    client_key: "{% if ssl_mutual_auth_enabled %}{{kafka_connect_key_path}}{% else %}{{none}}{% endif %}"
   when: hostvars[groups[item][0]].kafka_connect_connectors is defined
   delegate_to: "{{ groups[item][0] }}"
   loop: "{{subgroups}}"

--- a/roles/kafka_connect/tasks/rbac_connectors.yml
+++ b/roles/kafka_connect/tasks/rbac_connectors.yml
@@ -1,5 +1,10 @@
 ---
-- name: Grant Connect User ResourceOwner on Connector Topics
+- name: Check Kafka Connect Connector Topics
+  assert:
+    that: kafka_connect_connector_white_list != ""
+    fail_msg: "Please provide Connector's Topics to produce/consume data in the inventory file."
+
+- name: Grant Connect User ResourceOwner role on White List Topics
   uri:
     url: "{{mds_bootstrap_server_urls.split(',')[0]}}/security/1.0/principals/User:{{kafka_connect_ldap_user}}/roles/ResourceOwner/bindings"
     method: POST
@@ -20,7 +25,7 @@
         "resourcePatterns": [
           {
             "resourceType":"Topic",
-            "name":"{{item.config.topics}}",
+            "name":"{{item}}",
             "patternType":"LITERAL"
           }
         ]
@@ -30,9 +35,9 @@
   until: connect_mds_result.status == 204
   retries: "{{ mds_retries }}"
   delay: 5
-  loop: "{{kafka_connect_connectors}}"
+  loop: "{{kafka_connect_connector_white_list.split(',')}}"
 
-- name: Grant Connect User ResourceOwner on Connector Subject
+- name: Grant Connect User ResourceOwner role on resourceType Subject in Schema Registry Cluster
   uri:
     url: "{{mds_bootstrap_server_urls.split(',')[0]}}/security/1.0/principals/User:{{kafka_connect_ldap_user}}/roles/ResourceOwner/bindings"
     method: POST
@@ -48,13 +53,13 @@
         "scope": {
           "clusters": {
             "kafka-cluster":"{{kafka_cluster_id}}",
-            "schema-registry-cluster": "schema-registry"
+            "schema-registry-cluster": "{{schema_registry_final_properties['schema.registry.group.id']}}"
             }
         },
         "resourcePatterns": [
           {
             "resourceType":"Subject",
-            "name":"{{item.config.topics}}-value",
+            "name":"{{item}}-value",
             "patternType":"LITERAL"
           }
         ]
@@ -64,7 +69,8 @@
   until: connect_mds_result.status == 204
   retries: "{{ mds_retries }}"
   delay: 5
-  loop: "{{kafka_connect_connectors}}"
+  loop: "{{kafka_connect_connector_white_list.split(',')}}"
+  when: ("'schema_registry' in groups")
 
 - name: Grant Connect User DeveloperRead role to Consumer group
   uri:
@@ -98,7 +104,7 @@
   retries: "{{ mds_retries }}"
   delay: 5
 
-- name: Grant Connect User ResourceOwner for the Connector
+- name: Grant Connect User ResourceOwner role for the Connector
   uri:
     url: "{{mds_bootstrap_server_urls.split(',')[0]}}/security/1.0/principals/User:{{kafka_connect_ldap_user}}/roles/ResourceOwner/bindings"
     method: POST

--- a/roles/kafka_connect/tasks/role_bindings_connector.yml
+++ b/roles/kafka_connect/tasks/role_bindings_connector.yml
@@ -1,0 +1,133 @@
+---
+- name: Grant Connect User ResourceOwner on Connector Topics
+  uri:
+    url: "{{mds_bootstrap_server_urls.split(',')[0]}}/security/1.0/principals/User:{{kafka_connect_ldap_user}}/roles/ResourceOwner/bindings"
+    method: POST
+    validate_certs: false
+    force_basic_auth: true
+    url_username: "{{mds_super_user}}"
+    url_password: "{{mds_super_user_password}}"
+    headers:
+      Content-Type: application/json
+    body_format: json
+    body: >
+      {
+        "scope": {
+          "clusters": {
+            "kafka-cluster":"{{kafka_cluster_id}}"
+            }
+        },
+        "resourcePatterns": [
+          {
+            "resourceType":"Topic",
+            "name":"{{item.config.topics}}",
+            "patternType":"LITERAL"
+          }
+        ]
+      }
+    status_code: 204
+  register: connect_mds_result
+  until: connect_mds_result.status == 204
+  retries: "{{ mds_retries }}"
+  delay: 5
+  loop: "{{kafka_connect_connectors}}"
+
+- name: Grant Connect User ResourceOwner on Connector Subject
+  uri:
+    url: "{{mds_bootstrap_server_urls.split(',')[0]}}/security/1.0/principals/User:{{kafka_connect_ldap_user}}/roles/ResourceOwner/bindings"
+    method: POST
+    validate_certs: false
+    force_basic_auth: true
+    url_username: "{{mds_super_user}}"
+    url_password: "{{mds_super_user_password}}"
+    headers:
+      Content-Type: application/json
+    body_format: json
+    body: >
+      {
+        "scope": {
+          "clusters": {
+            "kafka-cluster":"{{kafka_cluster_id}}",
+            "schema-registry-cluster": "schema-registry"
+            }
+        },
+        "resourcePatterns": [
+          {
+            "resourceType":"Subject",
+            "name":"{{item.config.topics}}-value",
+            "patternType":"LITERAL"
+          }
+        ]
+      }
+    status_code: 204
+  register: connect_mds_result
+  until: connect_mds_result.status == 204
+  retries: "{{ mds_retries }}"
+  delay: 5
+  loop: "{{kafka_connect_connectors}}"
+
+- name: Grant Connect User DeveloperRead role to Consumer group
+  uri:
+    url: "{{mds_bootstrap_server_urls.split(',')[0]}}/security/1.0/principals/User:{{kafka_connect_ldap_user}}/roles/DeveloperRead/bindings"
+    method: POST
+    validate_certs: false
+    force_basic_auth: true
+    url_username: "{{mds_super_user}}"
+    url_password: "{{mds_super_user_password}}"
+    headers:
+      Content-Type: application/json
+    body_format: json
+    body: >
+      {
+        "scope": {
+          "clusters": {
+            "kafka-cluster":"{{kafka_cluster_id}}"
+            }
+        },
+        "resourcePatterns": [
+          {
+            "resourceType":"Group",
+            "name":"connect-",
+            "patternType":"PREFIXED"
+          }
+        ]
+      }
+    status_code: 204
+  register: connect_mds_result
+  until: connect_mds_result.status == 204
+  retries: "{{ mds_retries }}"
+  delay: 5
+
+- name: Grant Connect User ResourceOwner for the Connector
+  uri:
+    url: "{{mds_bootstrap_server_urls.split(',')[0]}}/security/1.0/principals/User:{{kafka_connect_ldap_user}}/roles/ResourceOwner/bindings"
+    method: POST
+    validate_certs: false
+    force_basic_auth: true
+    url_username: "{{mds_super_user}}"
+    url_password: "{{mds_super_user_password}}"
+    headers:
+      Content-Type: application/json
+    body_format: json
+    body: >
+      {
+        "scope": {
+          "clusters": {
+            "kafka-cluster":"{{kafka_cluster_id}}",
+            "connect-cluster": "{{kafka_connect_final_properties['group.id']}}"
+            }
+        },
+        "resourcePatterns": [
+          {
+            "resourceType":"Connector",
+            "name":"{{item.name}}",
+            "patternType":"LITERAL"
+          }
+        ]
+      }
+    status_code: 204
+  register: connect_mds_result
+  until: connect_mds_result.status == 204
+  retries: "{{ mds_retries }}"
+  delay: 5
+  loop: "{{kafka_connect_connectors}}"

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -1041,6 +1041,9 @@ kafka_connect_monitoring_interceptors_enabled: "{{ monitoring_interceptors_enabl
 ### Use to register and identify your Kafka Connect cluster in the MDS.
 kafka_connect_cluster_name: ""
 
+### Set this variable with a comma separated list of Topics for Kafka Connect Connector to produce/consume from.  This is a mandatory variable when creating Connector in RBAC cluster.
+kafka_connect_connector_white_list: ""
+
 ### Boolean used for disabling of systemd service restarts when rootless install is executed
 kafka_connect_skip_restarts: "{{ skip_restarts }}"
 

--- a/roles/variables/vars/main.yml
+++ b/roles/variables/vars/main.yml
@@ -936,14 +936,14 @@ kafka_connect_properties:
     enabled: true
     properties: "{{ kafka_broker_listeners[kafka_connect_producer_kafka_listener_name] | confluent.platform.client_properties(ssl_enabled, False, ssl_mutual_auth_enabled, sasl_protocol,
                             'producer.', kafka_connect_truststore_path, kafka_connect_truststore_storepass, public_certificates_enabled, kafka_connect_keystore_path, kafka_connect_keystore_storepass, kafka_connect_keystore_keypass,
-                            rbac_enabled, sasl_plain_users_final.kafka_connect.principal, sasl_plain_users_final.kafka_connect.password, sasl_scram_users_final.kafka_connect.principal, sasl_scram_users_final.kafka_connect.password, sasl_scram256_users_final.kafka_connect.principal, sasl_scram256_users_final.kafka_connect.password,
+                            false, sasl_plain_users_final.kafka_connect.principal, sasl_plain_users_final.kafka_connect.password, sasl_scram_users_final.kafka_connect.principal, sasl_scram_users_final.kafka_connect.password, sasl_scram256_users_final.kafka_connect.principal, sasl_scram256_users_final.kafka_connect.password,
                             kerberos_kafka_broker_primary, kafka_connect_keytab_path, kafka_connect_kerberos_principal|default('kafka'),
                             false, kafka_connect_ldap_user, kafka_connect_ldap_password, mds_bootstrap_server_urls) }}"
   consumer:
     enabled: true
     properties: "{{ kafka_broker_listeners[kafka_connect_consumer_kafka_listener_name] | confluent.platform.client_properties(ssl_enabled, False, ssl_mutual_auth_enabled, sasl_protocol,
                             'consumer.', kafka_connect_truststore_path, kafka_connect_truststore_storepass, public_certificates_enabled, kafka_connect_keystore_path, kafka_connect_keystore_storepass, kafka_connect_keystore_keypass,
-                            rbac_enabled, sasl_plain_users_final.kafka_connect.principal, sasl_plain_users_final.kafka_connect.password, sasl_scram_users_final.kafka_connect.principal, sasl_scram_users_final.kafka_connect.password, sasl_scram256_users_final.kafka_connect.principal, sasl_scram256_users_final.kafka_connect.password,
+                            false, sasl_plain_users_final.kafka_connect.principal, sasl_plain_users_final.kafka_connect.password, sasl_scram_users_final.kafka_connect.principal, sasl_scram_users_final.kafka_connect.password, sasl_scram256_users_final.kafka_connect.principal, sasl_scram256_users_final.kafka_connect.password,
                             kerberos_kafka_broker_primary, kafka_connect_keytab_path, kafka_connect_kerberos_principal|default('kafka'),
                             false, kafka_connect_ldap_user, kafka_connect_ldap_password, mds_bootstrap_server_urls) }}"
   monitoring_interceptor:


### PR DESCRIPTION
# Description

This PR adds a new feature to deploy connectors on a RBAC cluster. Along with that, deploying connectors with mutual TLS is also supported in this PR. 

Fixes # [ANSIENG-2939](https://confluentinc.atlassian.net/browse/ANSIENG-2939)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

tested in on-demand job

# Checklist:

- [x] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[ANSIENG-2939]: https://confluentinc.atlassian.net/browse/ANSIENG-2939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ