### PR TITLE
[ANSIENG-2966] | Add custom port for Kraft Controller

### DIFF
--- a/docs/MOLECULE_SCENARIOS.md
+++ b/docs/MOLECULE_SCENARIOS.md
@@ -250,6 +250,12 @@ Installation of Confluent Community Edition on centos8.
 
 SASL Plain Auth.
 
+Kafka Controller and broker are colocated
+
+Kafka broker has custom listener at port 9093
+
+Kraft Controller is running at port 9094
+
 #### Scenario cp-kafka-plain-rhel verify test's the following:
 
 Validates that SASL Plaintext protocol is set.

--- a/docs/VARIABLES.md
+++ b/docs/VARIABLES.md
@@ -940,6 +940,14 @@ Default:  "{{ config_prefix }}/controller"
 
 ***
 
+### kafka_controller_port
+
+Port to expose Kraft Controller
+
+Default:  9093
+
+***
+
 ### kafka_controller_ssl_enabled
 
 Boolean to configure controller with TLS Encryption. Also manages Java Keystore creation

--- a/molecule/cp-kafka-plain-rhel/molecule.yml
+++ b/molecule/cp-kafka-plain-rhel/molecule.yml
@@ -1,6 +1,9 @@
 ---
 ### Installation of Confluent Community Edition on centos8.
 ### SASL Plain Auth.
+### Kafka Controller and broker are colocated
+### Kafka broker has custom listener at port 9093
+### Kraft Controller is running at port 9094
 
 driver:
   name: docker
@@ -105,3 +108,10 @@ provisioner:
         sasl_protocol: plain
 
         confluent_server_enabled: false
+
+        kafka_broker_custom_listeners:
+          client_listener:
+            name: CLIENT
+            port: 9093
+
+        kafka_controller_port: 9094 # Since port 9093 is getting used by client listener

--- a/roles/kafka_controller/tasks/health_check.yml
+++ b/roles/kafka_controller/tasks/health_check.yml
@@ -2,7 +2,7 @@
 # health check for kafka controller
 - name: Check Kafka Metadata Quorum
   shell: |
-    {{ binary_base_path }}/bin/kafka-metadata-quorum --bootstrap-server {{inventory_hostname}}:9093 \
+    {{ binary_base_path }}/bin/kafka-metadata-quorum --bootstrap-server {{inventory_hostname}}:{{kafka_controller_port}} \
       --command-config {{kafka_controller.client_config_file}} describe --replication
   environment:
     KAFKA_OPTS: "-Xlog:all=error -XX:+IgnoreUnrecognizedVMOptions {% if kerberos_client_config_file_dest != '/etc/krb5.conf' %}-Djava.security.krb5.conf={{kerberos_client_config_file_dest}}{% endif %}"
@@ -13,7 +13,7 @@
 #Registers LEO of controllers only if Metadata Quorum passed in the above task
 - name: Register LogEndOffset
   shell: |
-    {{ binary_base_path }}/bin/kafka-metadata-quorum --bootstrap-server {{inventory_hostname}}:9093 \
+    {{ binary_base_path }}/bin/kafka-metadata-quorum --bootstrap-server {{inventory_hostname}}:{{kafka_controller_port}} \
       --command-config {{kafka_controller.client_config_file}} describe --replication |  grep -v Observer | awk '{print $2}'
   environment:
     KAFKA_OPTS: "-Xlog:all=error -XX:+IgnoreUnrecognizedVMOptions {% if kerberos_client_config_file_dest != '/etc/krb5.conf' %}-Djava.security.krb5.conf={{kerberos_client_config_file_dest}}{% endif %}"

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -425,12 +425,15 @@ kafka_controller_config_prefix: "{{ config_prefix }}/controller"
 kafka_controller_listeners: "{
   'controller': {
     'name': 'CONTROLLER',
-    'port': 9093,
+    'port': {{kafka_controller_port}},
     'ssl_enabled': {{kafka_controller_ssl_enabled|string|lower}},
     'ssl_mutual_auth_enabled': {{kafka_controller_ssl_mutual_auth_enabled|string|lower}},
     'sasl_protocol': '{{kafka_controller_sasl_protocol}}'
   }
 }"
+
+### Port to expose Kraft Controller
+kafka_controller_port: 9093
 
 ### Boolean to configure controller with TLS Encryption. Also manages Java Keystore creation
 kafka_controller_ssl_enabled: "{{ssl_enabled}}"


### PR DESCRIPTION
# Description

This PR adds support for custom Kraft Controller port. Customers can now use `kafka_controller_port` to expose the kraft port, with default being 9093

Fixes # [ANSIENG-3149](https://confluentinc.atlassian.net/browse/ANSIENG-3149)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

tested on scenario cp-kafka-plain-rhel

# Checklist:

- [x] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[ANSIENG-3149]: https://confluentinc.atlassian.net/browse/ANSIENG-3149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ