### PR TITLE
[ANSIENG-3149] | Add precheck for Kraft Controller port availability

### DIFF
--- a/playbooks/ZKtoKraftMigration.yml
+++ b/playbooks/ZKtoKraftMigration.yml
@@ -22,10 +22,11 @@
       uri:
         url: "{{ 'https' if kafka_controller_jolokia_ssl_enabled|bool else 'http' }}://localhost:{{kafka_controller_jolokia_port}}/jolokia/read/kafka.controller:type=KafkaController,name=ZkMigrationState"
         validate_certs: false
+        return_content: true
         status_code: 200
       retries: "{{ metadata_migration_retries }}"
       delay: 90
-      until: jolokia_output.json.value.Value == 1
+      until: ( jolokia_output.content | from_json ).value.Value == 1
       register: jolokia_output
       when: jolokia_auth_mode == "none"
 
@@ -33,13 +34,14 @@
       uri:
         url: "{{ 'https' if kafka_controller_jolokia_ssl_enabled|bool else 'http' }}://localhost:{{kafka_controller_jolokia_port}}/jolokia/read/kafka.controller:type=KafkaController,name=ZkMigrationState"
         validate_certs: false
+        return_content: true
         force_basic_auth: true
         url_username: "{{ jolokia_user }}"
         url_password: "{{ jolokia_password }}"
         status_code: 200
       retries: "{{ metadata_migration_retries }}"
       delay: 90
-      until: jolokia_output.json.value.Value == 1
+      until: ( jolokia_output.content | from_json ).value.Value == 1
       register: jolokia_output
       when: jolokia_auth_mode == "basic"
 
@@ -138,10 +140,11 @@
       uri:
         url: "{{ 'https' if kafka_controller_jolokia_ssl_enabled|bool else 'http' }}://localhost:{{kafka_controller_jolokia_port}}/jolokia/read/kafka.controller:type=KafkaController,name=ZkMigrationState"
         validate_certs: false
+        return_content: true
         status_code: 200
       retries: "{{ metadata_migration_retries }}"
       delay: 90
-      until: jolokia_output.json.value.Value == 3
+      until: ( jolokia_output.content | from_json ).value.Value == 3
       register: jolokia_output
       when: jolokia_auth_mode == "none"
 
@@ -149,13 +152,14 @@
       uri:
         url: "{{ 'https' if kafka_controller_jolokia_ssl_enabled|bool else 'http' }}://localhost:{{kafka_controller_jolokia_port}}/jolokia/read/kafka.controller:type=KafkaController,name=ZkMigrationState"
         validate_certs: false
+        return_content: true
         force_basic_auth: true
         url_username: "{{ jolokia_user }}"
         url_password: "{{ jolokia_password }}"
         status_code: 200
       retries: "{{ metadata_migration_retries }}"
       delay: 90
-      until: jolokia_output.json.value.Value == 3
+      until: ( jolokia_output.content | from_json ).value.Value == 3
       register: jolokia_output
       when: jolokia_auth_mode == "basic"
 

--- a/playbooks/migration_precheck.yml
+++ b/playbooks/migration_precheck.yml
@@ -3,6 +3,9 @@
   hosts: localhost
   gather_facts: false
   tasks:
+    - import_role:
+        name: variables
+
     - name: Check the presence of Controller in the inventory file
       fail:
         msg:  "Please add Kraft Controller hosts in the inventory file for migration."
@@ -20,6 +23,18 @@
         msg:  "Please enable Kraft Migration flag in the inventory file for migration."
       when:
         - not (kraft_migration | default(false) | bool)
+
+    - name: Get List of Kafka Broker listeners' ports
+      set_fact:
+        kafka_broker_ports: "{% for listener in kafka_broker_listeners|dict2items %}{% if loop.index > 1%},{% endif %}{{ listener['value']['port'] }}{% endfor %}"
+
+    - name: Check Kraft port in colocated Migration
+      fail:
+        msg: "Port {{kafka_controller_port}} is already occupied for {{item}}, Please use a different port for Kraft Controller."
+      when:
+        - item in groups.kafka_broker
+        - kafka_controller_port|string in kafka_broker_ports.split(',')
+      loop: "{{ groups.kafka_controller }}"
 
 - name: Check Current Confluent Version
   hosts: zookeeper,kafka_broker


### PR DESCRIPTION
# Description

Migration pre-check should fail if Kraft Controller port is already occupied by Zk broker. In that case, the customer needs to use some other port for Kraft using kafka_controller_port

Fixes # [ANSIENG-3149](https://confluentinc.atlassian.net/browse/ANSIENG-3149)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

tested locally

# Checklist:

- [x] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[ANSIENG-3149]: https://confluentinc.atlassian.net/browse/ANSIENG-3149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ