### PR TITLE
[ANSIENG-3153] | Resolve node id in Colocated Kraft Controller and broker

### DIFF
--- a/roles/kafka_broker/tasks/rbac.yml
+++ b/roles/kafka_broker/tasks/rbac.yml
@@ -54,6 +54,13 @@
       }
     ) }}"
 
+# store the original Controller properties when Controller and Broker colocated
+- set_fact:
+    kafka_controller_initial_properties: "{{hostvars[inventory_hostname]['kafka_controller_final_properties']}}"
+  when:
+    - kraft_enabled|bool
+    - "inventory_hostname in groups.kafka_controller"
+
 #this is required when we have mTLS enabled
 - name: Add Broker's Principal to Controller's Super Users List
   include_tasks: set_controller_principal.yml
@@ -65,6 +72,13 @@
       delegate_to: "{{item}}"
   when: kraft_enabled|bool and kafka_controller_ssl_mutual_auth_enabled|bool
   run_once: true
+
+# reset the Controller's properties to the original properties when Controller and Broker colocated
+- set_fact:
+    kafka_controller_final_properties: "{{kafka_controller_initial_properties}}"
+  when:
+    - kraft_enabled|bool
+    - "inventory_hostname in groups.kafka_controller"
 
 - name: Create SSL Certificate Directory
   file:

--- a/roles/kafka_broker/tasks/set_controller_principal.yml
+++ b/roles/kafka_broker/tasks/set_controller_principal.yml
@@ -26,3 +26,8 @@
   include_role:
     name: kafka_controller
     tasks_from: create_config.yml
+
+# reset the Controller's properties to the original properties when Controller and Broker colocated
+- set_fact:
+    kafka_controller_final_properties: "{{kafka_controller_initial_properties}}"
+  when: "inventory_hostname in groups.kafka_controller"


### PR DESCRIPTION
# Description

Fix to get correct node id for Colocated Kraft and broker having RBAC enabled and mutual TLS

Fixes # [ANSIENG-3153](https://confluentinc.atlassian.net/browse/ANSIENG-3153)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

tested different combinations with 7.6.x branch, back-porting to 7.4.x

- Greenfield kraft setup having RBAC + mtls + all colocated Controller and Broker
- Greenfield kraft setup having RBAC + mtls + some Controllers are colocated with Broker
- Greenfield kraft setup having RBAC + mtls + no colocation
- Migration to Kraft setup having RBAC + mtls + all colocated Controller and Broker 
- Migration to kraft setup having RBAC + mtls + some Controllers are colocated with Broker
- Migration to kraft setup having RBAC + mtls + no colocation

# Checklist:

- [x] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[ANSIENG-3153]: https://confluentinc.atlassian.net/browse/ANSIENG-3153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ