### PR TITLE
[ANSIENG-3230]  | Add broker's jaas configs in Kraft Controller

### DIFF
--- a/roles/variables/vars/main.yml
+++ b/roles/variables/vars/main.yml
@@ -180,8 +180,8 @@ kafka_controller_properties:
     enabled: "{{ zookeeper_client_authentication_type in ['kerberos', 'digest'] and kraft_migration|bool }}"
     properties:
       zookeeper.set.acl: 'true'
-  migration_broker_listener:
-    enabled: "{{ sasl_protocol=='plain' and kraft_migration|bool }}"
+  broker_listener:
+    enabled: "{{ sasl_protocol=='plain' }}" # might need to add for kerberos also in later release
     properties: "{{  {'broker_listener': kafka_broker_listeners[kafka_broker_inter_broker_listener_name]} | confluent.platform.listener_properties(ssl_enabled, fips_enabled, ssl_mutual_auth_enabled, sasl_protocol,
                     kafka_controller_truststore_path, kafka_controller_truststore_storepass, kafka_controller_keystore_path, kafka_controller_keystore_storepass, kafka_controller_keystore_keypass,
                     plain_jaas_config, kafka_controller_keytab_path, kafka_controller_kerberos_principal|default('kafka'), kerberos_kafka_controller_primary,


### PR DESCRIPTION
# Description

This PR aims to add broker's jaas configs in Kraft Controller. With kip 966, Controller now needs to communicate with Broker as well. Earlier it was one way communication broker-> controller. Starting CP 7.6, both controller-> broker and broker->controller communication happens internally. For this, Controller needs the jaas configs of broker when sasl protocol is plain.

Fixes # [ANSIENG-3230](https://confluentinc.atlassian.net/browse/ANSIENG-3230)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

jenkins jobs

# Checklist:

- [x] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[ANSIENG-3230]: https://confluentinc.atlassian.net/browse/ANSIENG-3230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ