### PR TITLE
Update Molecule tests to use FileStream Connector

### DIFF
--- a/molecule/archive-plain-rhel-fips/molecule.yml
+++ b/molecule/archive-plain-rhel-fips/molecule.yml
@@ -147,6 +147,10 @@ provisioner:
         kafka_broker_custom_client_properties:
           abc: xyz
 
+         # To run the FileStream connector, you must add the filestream-connectors path in the plugin.path
+        kafka_connect_custom_properties:
+          plugin.path: "{{binary_base_path}}/share/java/connect_plugins,{{binary_base_path}}/share/filestream-connectors,/usr/share/java/connect_plugins"
+
         ${CONTROLLER_HOSTGROUP:-zookeeper}_log_dir: /${CONTROLLER_HOSTGROUP:-zookeeper}/logs
         kafka_broker_log_dir: /kafka/logs/
         schema_registry_log_dir: /sr/logs

--- a/molecule/archive-plain-rhel-fips/verify.yml
+++ b/molecule/archive-plain-rhel-fips/verify.yml
@@ -122,7 +122,7 @@
         add_new_connector:
           - name: test-connector-1
             config:
-              connector.class: "org.apache.kafka.connect.tools.VerifiableSinkConnector"
+              connector.class: "FileStreamSinkConnector"
               tasks.max: "1"
               file: "/etc/kafka/connect-distributed.properties"
               topics: "test_topic"
@@ -130,7 +130,7 @@
         update_existing_connector:
           - name: test-connector-1
             config:
-              connector.class: "org.apache.kafka.connect.tools.VerifiableSinkConnector"
+              connector.class: "FileStreamSinkConnector"
               tasks.max: "5"
               file: "/etc/kafka/connect-distributed.properties"
               topics: "test_topic"
@@ -138,7 +138,7 @@
         add_bad_request_connector:
           - name: test-connector-1
             config:
-              connector.class: "org.apache.kafka.connect.tools.VerifiableSinkConnector"
+              connector.class: "FileStreamSinkConnector"
               tasks.max: "5"
               file: "/etc/kafka/connect-distributed.properties"
               topics: "test_topic"
@@ -152,7 +152,7 @@
         add_non_existent_connector:
           - name: test-connector-1
             config:
-              connector.class: "org.apache.kafka.connect.tools.VerifiableSinkConnector"
+              connector.class: "FileStreamSinkConnector"
               tasks.max: "5"
               file: "/etc/kafka/connect-distributed.properties"
               topics: "test_topic"
@@ -165,7 +165,7 @@
         delete_connector:
           - name: test-connector-2
             config:
-              connector.class: "org.apache.kafka.connect.tools.VerifiableSinkConnector"
+              connector.class: "FileStreamSinkConnector"
               tasks.max: "1"
               topics: "bar"
 

--- a/molecule/archive-plain-ubuntu2004/molecule.yml
+++ b/molecule/archive-plain-ubuntu2004/molecule.yml
@@ -131,11 +131,14 @@ provisioner:
         ksql_log_dir: /ksql/logs/
         control_center_log_dir: /c3/logs
 
+        # To run the FileStream connector, you must add the filestream-connectors path in the plugin.path
+        kafka_connect_custom_properties:
+          plugin.path: "{{binary_base_path}}/share/java/connect_plugins,{{binary_base_path}}/share/filestream-connectors,/usr/share/java/connect_plugins"
+
         kafka_connect_connectors:
           - name: sample-connector-1
             config:
-              connector.class: "org.apache.kafka.connect.tools.VerifiableSourceConnector"
+              connector.class: "FileStreamSourceConnector"
               tasks.max: "1"
               file: "/etc/kafka/connect-distributed.properties"
               topic: "test_topic"
-              throughput: "1000"

--- a/molecule/broker-scale-up/molecule.yml
+++ b/molecule/broker-scale-up/molecule.yml
@@ -138,10 +138,14 @@ provisioner:
       kafka_connect:
         kafka_connect_ssl_enabled: false
         kafka_connect_ssl_mutual_auth_enabled: false
+        # To run the FileStream connector, you must add the filestream-connectors path in the plugin.path
+        kafka_connect_custom_properties:
+          plugin.path: "/usr/share/filestream-connectors,/usr/share/java/connect_plugins"
+
         kafka_connect_connectors:
           - name: sample-connector-1
             config:
-              connector.class: "org.apache.kafka.connect.tools.VerifiableSinkConnector"
+              connector.class: "FileStreamSinkConnector"
               tasks.max: "1"
               file: "/etc/kafka/connect-distributed.properties"
               topics: "test_topic"

--- a/molecule/connect-scale-up/molecule.yml
+++ b/molecule/connect-scale-up/molecule.yml
@@ -160,6 +160,9 @@ provisioner:
         ssl_enabled: true
         ssl_mutual_auth_enabled: true
         redhat_java_package_name: java-11-openjdk
+        # To run the FileStream connector, you must add the filestream-connectors path in the plugin.path
+        kafka_connect_custom_properties:
+          plugin.path: "/usr/share/filestream-connectors,/usr/share/java/connect_plugins"
       # connect clusters
       ssl:
         kafka_connect_group_id: connect-ssl
@@ -169,7 +172,7 @@ provisioner:
         kafka_connect_connectors:
           - name: sample-connector-3
             config:
-              connector.class: "org.apache.kafka.connect.tools.VerifiableSinkConnector"
+              connector.class: "FileStreamSinkConnector"
               tasks.max: "5"
               file: "/etc/kafka/connect-distributed.properties"
               topics: "test_topic"
@@ -183,7 +186,7 @@ provisioner:
         kafka_connect_connectors:
           - name: sample-connector-1
             config:
-              connector.class: "org.apache.kafka.connect.tools.VerifiableSinkConnector"
+              connector.class: "FileStreamSinkConnector"
               tasks.max: "5"
               file: "/etc/kafka/connect-distributed.properties"
               topics: "test_topic"
@@ -197,7 +200,7 @@ provisioner:
         kafka_connect_connectors:
           - name: sample-connector-2
             config:
-              connector.class: "org.apache.kafka.connect.tools.VerifiableSinkConnector"
+              connector.class: "FileStreamSinkConnector"
               tasks.max: "5"
               file: "/etc/kafka/connect-distributed.properties"
               topics: "test_topic"

--- a/molecule/kerberos-rhel/molecule.yml
+++ b/molecule/kerberos-rhel/molecule.yml
@@ -161,10 +161,14 @@ provisioner:
 
         kerberos_client_config_file_dest: /krb/krb5.conf
 
+        # To run the FileStream connector, you must add the filestream-connectors path in the plugin.path
+        kafka_connect_custom_properties:
+          plugin.path: "/usr/share/filestream-connectors,/usr/share/java/connect_plugins"
+
         kafka_connect_connectors:
           - name: sample-connector-1
             config:
-              connector.class: "org.apache.kafka.connect.tools.VerifiableSinkConnector"
+              connector.class: "FileStreamSinkConnector"
               tasks.max: "1"
               file: "/etc/kafka/connect-distributed.properties"
               topics: "test_topic"

--- a/molecule/kerberos-rhel/verify.yml
+++ b/molecule/kerberos-rhel/verify.yml
@@ -116,29 +116,26 @@
         add_new_connector:
           - name: test-connector-1
             config:
-              connector.class: "org.apache.kafka.connect.tools.VerifiableSourceConnector"
+              connector.class: "FileStreamSourceConnector"
               tasks.max: "1"
               file: "/etc/kafka/connect-distributed.properties"
               topic: "test_topic"
-              throughput: "1000"
 
         update_existing_connector:
           - name: test-connector-1
             config:
-              connector.class: "org.apache.kafka.connect.tools.VerifiableSourceConnector"
+              connector.class: "FileStreamSourceConnector"
               tasks.max: "5"
               file: "/etc/kafka/connect-distributed.properties"
               topic: "test_topic"
-              throughput: "1000"
 
         add_bad_request_connector:
           - name: test-connector-1
             config:
-              connector.class: "org.apache.kafka.connect.tools.VerifiableSourceConnector"
+              connector.class: "FileStreamSourceConnector"
               tasks.max: "5"
               file: "/etc/kafka/connect-distributed.properties"
               topic: "test_topic"
-              throughput: "1000"
           - name: test-connector-2
             config:
               connector.class: "org.apache.kafka.connect.mirror.MirrorHeartbeatConnector"
@@ -149,11 +146,10 @@
         add_non_existent_connector:
           - name: test-connector-1
             config:
-              connector.class: "org.apache.kafka.connect.tools.VerifiableSourceConnector"
+              connector.class: "FileStreamSourceConnector"
               tasks.max: "5"
               file: "/etc/kafka/connect-distributed.properties"
               topic: "test_topic"
-              throughput: "1000"
           - name: test-connector-2
             config:
               connector.class: "io.confluent.connect.jdbc.JdbcSinkConnector"
@@ -163,10 +159,9 @@
         delete_connector:
           - name: test-connector-2
             config:
-              connector.class: "org.apache.kafka.connect.tools.VerifiableSourceConnector"
+              connector.class: "FileStreamSourceConnector"
               tasks.max: "1"
               topic: "bar"
-              throughput: "1000"
 
     - import_role:
         name: confluent.test

--- a/molecule/ksql-scale-up/molecule.yml
+++ b/molecule/ksql-scale-up/molecule.yml
@@ -139,12 +139,15 @@ provisioner:
         redhat_java_package_name: java-1.8.0-openjdk # use java8 package
         ksql_custom_properties:
           ksql.heartbeat.enable: true
+        # To run the FileStream connector, you must add the filestream-connectors path in the plugin.path
+        kafka_connect_custom_properties:
+          plugin.path: "/usr/share/filestream-connectors,/usr/share/java/connect_plugins"
       kafka_connect:
         kafka_connect_group_id: connect-cluster1
         kafka_connect_connectors:
           - name: sample-connector-1
             config:
-              connector.class: "org.apache.kafka.connect.tools.VerifiableSinkConnector"
+              connector.class: "FileStreamSinkConnector"
               tasks.max: "1"
               file: "/etc/kafka/connect-distributed.properties"
               topics: "test_topic"

--- a/molecule/multi-ksql-connect-rhel/molecule.yml
+++ b/molecule/multi-ksql-connect-rhel/molecule.yml
@@ -161,6 +161,9 @@ provisioner:
         ssl_enabled: true
         ssl_mutual_auth_enabled: true
         kafka_connect_deploy_connector_timeout: 30
+        # To run the FileStream connector, you must add the filestream-connectors path in the plugin.path
+        kafka_connect_custom_properties:
+          plugin.path: "/usr/share/filestream-connectors,/usr/share/java/connect_plugins"
       # connect clusters
       ssl:
         kafka_connect_group_id: connect-ssl
@@ -169,11 +172,10 @@ provisioner:
         kafka_connect_connectors:
           - name: sample-connector-3
             config:
-              connector.class: "org.apache.kafka.connect.tools.VerifiableSourceConnector"
+              connector.class: "FileStreamSourceConnector"
               tasks.max: "5"
               file: "/etc/kafka/connect-distributed.properties"
               topic: "test_topic"
-              throughput: "1000"
               key.converter: "org.apache.kafka.connect.json.JsonConverter"
               value.converter: "org.apache.kafka.connect.json.JsonConverter"
       syslog:
@@ -184,7 +186,7 @@ provisioner:
         kafka_connect_connectors:
           - name: sample-connector-1
             config:
-              connector.class: "org.apache.kafka.connect.tools.VerifiableSinkConnector"
+              connector.class: "FileStreamSinkConnector"
               tasks.max: "1"
               file: "/etc/kafka/connect-distributed.properties"
               topics: "test_topic"
@@ -197,7 +199,7 @@ provisioner:
         kafka_connect_connectors:
           - name: sample-connector-2
             config:
-              connector.class: "org.apache.kafka.connect.tools.VerifiableSinkConnector"
+              connector.class: "FileStreamSinkConnector"
               tasks.max: "1"
               file: "/etc/kafka/connect-distributed.properties"
               topics: "test_topic"

--- a/molecule/multi-ksql-connect-rhel/molecule.yml
+++ b/molecule/multi-ksql-connect-rhel/molecule.yml
@@ -167,17 +167,6 @@ provisioner:
       # connect clusters
       ssl:
         kafka_connect_group_id: connect-ssl
-        kafka_connect_ssl_enabled: true
-        kafka_connect_ssl_mutual_auth_enabled: true
-        kafka_connect_connectors:
-          - name: sample-connector-3
-            config:
-              connector.class: "FileStreamSourceConnector"
-              tasks.max: "5"
-              file: "/etc/kafka/connect-distributed.properties"
-              topic: "test_topic"
-              key.converter: "org.apache.kafka.connect.json.JsonConverter"
-              value.converter: "org.apache.kafka.connect.json.JsonConverter"
       syslog:
         kafka_connect_group_id: connect-syslog
         # Create Connector without ssl

--- a/molecule/multi-ksql-connect-rhel/verify.yml
+++ b/molecule/multi-ksql-connect-rhel/verify.yml
@@ -115,8 +115,8 @@
     - name: Assert No Connectors Created
       assert:
         that:
-          - connectors.json[0] == "sample-connector-3"
-        fail_msg: "Connector not created"
+          - connectors.json|length == 0
+        fail_msg: "Connector should not be created"
         quiet: true
 
 - name: Verify - ksql

--- a/molecule/plain-rhel/molecule.yml
+++ b/molecule/plain-rhel/molecule.yml
@@ -139,10 +139,14 @@ provisioner:
         kafka_connect_plugins_remote:
           - "https://d1i4a15mxbxib1.cloudfront.net/api/plugins/confluentinc/kafka-connect-s3/versions/{{connect_s3_plugin_version}}/confluentinc-kafka-connect-s3-{{connect_s3_plugin_version}}.zip"
 
+        # To run the FileStream connector, you must add the filestream-connectors path in the plugin.path
+        kafka_connect_custom_properties:
+          plugin.path: "/usr/share/filestream-connectors,/usr/share/java/connect_plugins"
+
         kafka_connect_connectors:
           - name: sample-connector-1
             config:
-              connector.class: "org.apache.kafka.connect.tools.VerifiableSinkConnector"
+              connector.class: "FileStreamSinkConnector"
               tasks.max: "1"
               file: "/etc/kafka/connect-distributed.properties"
               topics: "test_topic"

--- a/molecule/plain-rhel/verify.yml
+++ b/molecule/plain-rhel/verify.yml
@@ -234,7 +234,7 @@
         add_new_connector:
           - name: test-connector-1
             config:
-              connector.class: "org.apache.kafka.connect.tools.VerifiableSinkConnector"
+              connector.class: "FileStreamSinkConnector"
               tasks.max: "1"
               file: "/etc/kafka/connect-distributed.properties"
               topics: "test_topic"
@@ -242,7 +242,7 @@
         update_existing_connector:
           - name: test-connector-1
             config:
-              connector.class: "org.apache.kafka.connect.tools.VerifiableSinkConnector"
+              connector.class: "FileStreamSinkConnector"
               tasks.max: "5"
               file: "/etc/kafka/connect-distributed.properties"
               topics: "test_topic"
@@ -250,7 +250,7 @@
         add_bad_request_connector:
           - name: test-connector-1
             config:
-              connector.class: "org.apache.kafka.connect.tools.VerifiableSinkConnector"
+              connector.class: "FileStreamSinkConnector"
               tasks.max: "5"
               file: "/etc/kafka/connect-distributed.properties"
               topics: "test_topic"
@@ -264,7 +264,7 @@
         add_non_existent_connector:
           - name: test-connector-1
             config:
-              connector.class: "org.apache.kafka.connect.tools.VerifiableSinkConnector"
+              connector.class: "FileStreamSinkConnector"
               tasks.max: "5"
               file: "/etc/kafka/connect-distributed.properties"
               topics: "test_topic"
@@ -277,7 +277,7 @@
         delete_connector:
           - name: test-connector-2
             config:
-              connector.class: "org.apache.kafka.connect.tools.VerifiableSinkConnector"
+              connector.class: "FileStreamSinkConnector"
               tasks.max: "1"
               topics: "bar"
 

--- a/molecule/rbac-mds-mtls-existing-keystore-truststore-ubuntu/molecule.yml
+++ b/molecule/rbac-mds-mtls-existing-keystore-truststore-ubuntu/molecule.yml
@@ -195,6 +195,10 @@ provisioner:
         rbac_component_additional_system_admins:
           - User:user1
 
+        # To run the FileStream connector, you must add the filestream-connectors path in the plugin.path
+        kafka_connect_custom_properties:
+          plugin.path: "/usr/share/filestream-connectors,/usr/share/java/connect_plugins"
+
       kafka_broker:
         ldap_config: |
           ldap.java.naming.factory.initial=com.sun.jndi.ldap.LdapCtxFactory
@@ -311,7 +315,7 @@ provisioner:
         kafka_connect_connectors:
           - name: sample-connector-1
             config:
-              connector.class: "org.apache.kafka.connect.tools.VerifiableSinkConnector"
+              connector.class: "FileStreamSinkConnector"
               tasks.max: "5"
               file: "/etc/kafka/connect-distributed.properties"
               topics: "test_topic"

--- a/molecule/rbac-mtls-rhel-fips/molecule.yml
+++ b/molecule/rbac-mtls-rhel-fips/molecule.yml
@@ -185,6 +185,10 @@ provisioner:
         kafka_controller_custom_properties:
           ssl.principal.mapping.rules: "RULE:.*O=(.*?),OU=TEST.*$$/$$1/"  #since we are providing mapping.rules to broker and have mTLS between broker and controller
 
+        # To run the FileStream connector, you must add the filestream-connectors path in the plugin.path
+        kafka_connect_custom_properties:
+          plugin.path: "/usr/share/filestream-connectors,/usr/share/java/connect_plugins"
+
       kafka_broker:
         kafka_broker_cluster_name: Test-Broker
         # Testing old way of passing ldap configs
@@ -215,7 +219,7 @@ provisioner:
         kafka_connect_connectors:
           - name: sample-connector-1
             config:
-              connector.class: "org.apache.kafka.connect.tools.VerifiableSinkConnector"
+              connector.class: "FileStreamSinkConnector"
               tasks.max: "1"
               file: "/etc/kafka/connect-distributed.properties"
               topics: "test_topic1"
@@ -223,11 +227,10 @@ provisioner:
               value.converter: "org.apache.kafka.connect.json.JsonConverter"
           - name: sample-connector-2
             config:
-              connector.class: "org.apache.kafka.connect.tools.VerifiableSourceConnector"
+              connector.class: "FileStreamSourceConnector"
               tasks.max: "1"
               file: "/etc/kafka/connect-distributed.properties"
               topic: "test_topic2"
-              throughput: "1000"
               key.converter: "org.apache.kafka.connect.json.JsonConverter"
               value.converter: "org.apache.kafka.connect.json.JsonConverter"
       ksql:

--- a/molecule/rbac-mtls-rhel-fips/verify.yml
+++ b/molecule/rbac-mtls-rhel-fips/verify.yml
@@ -230,7 +230,7 @@
         curl -k -X PUT https://localhost:8083/connectors/conn1/config \
           -H "Content-Type: application/json" -u mds:password \
           --cacert /var/ssl/private/ca.crt --key /var/ssl/private/kafka_connect.key --cert /var/ssl/private/kafka_connect.crt \
-          -d '{"connector.class": "org.apache.kafka.connect.tools.VerifiableSinkConnector",
+          -d '{"connector.class": "FileStreamSinkConnector",
           "tasks.max": "1",
           "topics": "${secret:conn1:topic}",
           "file": "/tmp/file-sink-test.txt",

--- a/molecule/rbac-plain-provided-debian9/molecule.yml
+++ b/molecule/rbac-plain-provided-debian9/molecule.yml
@@ -212,20 +212,23 @@ provisioner:
             ssl_enabed: true
             sasl_protocol: plain
 
+        # To run the FileStream connector, you must add the filestream-connectors path in the plugin.path
+        kafka_connect_custom_properties:
+          plugin.path: "/usr/share/filestream-connectors,/usr/share/java/connect_plugins"
+
         kafka_connect_connector_white_list: "test_topic1,test_topic2"
         kafka_connect_connectors:
           - name: sample-connector-1
             config:
-              connector.class: "org.apache.kafka.connect.tools.VerifiableSourceConnector"
+              connector.class: "FileStreamSourceConnector"
               tasks.max: "5"
               file: "/etc/kafka/connect-distributed.properties"
               topic: "test_topic1"
-              throughput: "1000"
               key.converter: "org.apache.kafka.connect.json.JsonConverter"
               value.converter: "org.apache.kafka.connect.json.JsonConverter"
           - name: sample-connector-2
             config:
-              connector.class: "org.apache.kafka.connect.tools.VerifiableSinkConnector"
+              connector.class: "FileStreamSinkConnector"
               tasks.max: "1"
               file: "/etc/kafka/connect-distributed.properties"
               topics: "test_topic2"

--- a/molecule/rbac-scram-custom-rhel-fips/molecule.yml
+++ b/molecule/rbac-scram-custom-rhel-fips/molecule.yml
@@ -180,7 +180,7 @@ provisioner:
     group_vars:
       all:
         scenario_name: rbac-scram-custom-rhel-fips
-        #fips_enabled: true
+        fips_enabled: true
         # Test additional scram user
         sasl_scram_users:
           client:

--- a/molecule/rbac-scram-custom-rhel-fips/molecule.yml
+++ b/molecule/rbac-scram-custom-rhel-fips/molecule.yml
@@ -180,7 +180,7 @@ provisioner:
     group_vars:
       all:
         scenario_name: rbac-scram-custom-rhel-fips
-        fips_enabled: true
+        #fips_enabled: true
         # Test additional scram user
         sasl_scram_users:
           client:
@@ -265,6 +265,8 @@ provisioner:
         kafka_connect_custom_rest_extension_classes:
           - io.confluent.connect.replicator.monitoring.ReplicatorMonitoringExtension
         kafka_connect_custom_java_args: "-Djavax.net.ssl.trustStore={{kafka_connect_truststore_path}} -Djavax.net.ssl.trustStorePassword={{kafka_connect_truststore_storepass}}"
+        kafka_connect_custom_properties:
+          plugin.path: "/usr/share/filestream-connectors,/usr/share/java/connect_plugins"
 
       cluster1:
         kafka_connect_group_id: connect-cluster1
@@ -272,7 +274,7 @@ provisioner:
         kafka_connect_connectors:
           - name: sample-connector-1
             config:
-              connector.class: "org.apache.kafka.connect.tools.VerifiableSinkConnector"
+              connector.class: "FileStreamSinkConnector"
               tasks.max: "5"
               file: "/etc/kafka/connect-distributed.properties"
               topics: "test_topic"
@@ -284,7 +286,7 @@ provisioner:
         kafka_connect_connectors:
           - name: sample-connector-2
             config:
-              connector.class: "org.apache.kafka.connect.tools.VerifiableSinkConnector"
+              connector.class: "FileStreamSinkConnector"
               tasks.max: "1"
               file: "/etc/kafka/connect-distributed.properties"
               topics: "test_topic"


### PR DESCRIPTION
# Description

Updating CP-Ansible tests to use FileStream Connectors since Verifiable Connector is no longer packaged with kafka.

Fixes # [ANSIENG-3235](https://confluentinc.atlassian.net/browse/ANSIENG-3235)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

https://jenkins.confluent.io/job/cp-ansible-on-demand/2507/ 
https://jenkins.confluent.io/job/cp-ansible-on-demand/2508/

# Checklist:

- [x] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[ANSIENG-3235]: https://confluentinc.atlassian.net/browse/ANSIENG-3235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ