### PR TITLE
[ANSIENG-3229] | removed cd to fix dockerfile for ubi9-min

### DIFF
--- a/molecule/Dockerfile-rhel9-java11.j2
+++ b/molecule/Dockerfile-rhel9-java11.j2
@@ -3,9 +3,9 @@ LABEL maintainer="CP Ansible"
 ENV container docker
 
 RUN microdnf -y --nodocs install yum
-RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == \
-systemd-tmpfiles-setup.service ] || rm -f $i; done); \
-rm -f /lib/systemd/system/multi-user.target.wants/*;\
+# RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == \
+# systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+RUN rm -f /lib/systemd/system/multi-user.target.wants/*;\
 rm -f /etc/systemd/system/*.wants/*;\
 rm -f /lib/systemd/system/local-fs.target.wants/*; \
 rm -f /lib/systemd/system/sockets.target.wants/*udev*; \

--- a/molecule/Dockerfile-rhel9-java17.j2
+++ b/molecule/Dockerfile-rhel9-java17.j2
@@ -3,9 +3,9 @@ LABEL maintainer="CP Ansible"
 ENV container docker
 
 RUN microdnf -y --nodocs install yum
-RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == \
-systemd-tmpfiles-setup.service ] || rm -f $i; done); \
-rm -f /lib/systemd/system/multi-user.target.wants/*;\
+# RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == \
+# systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+RUN rm -f /lib/systemd/system/multi-user.target.wants/*;\
 rm -f /etc/systemd/system/*.wants/*;\
 rm -f /lib/systemd/system/local-fs.target.wants/*; \
 rm -f /lib/systemd/system/sockets.target.wants/*udev*; \

--- a/molecule/Dockerfile-rhel9-java8.j2
+++ b/molecule/Dockerfile-rhel9-java8.j2
@@ -3,9 +3,9 @@ LABEL maintainer="CP Ansible"
 ENV container docker
 
 RUN microdnf -y --nodocs install yum
-RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == \
-systemd-tmpfiles-setup.service ] || rm -f $i; done); \
-rm -f /lib/systemd/system/multi-user.target.wants/*;\
+# RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == \
+# systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+RUN rm -f /lib/systemd/system/multi-user.target.wants/*;\
 rm -f /etc/systemd/system/*.wants/*;\
 rm -f /lib/systemd/system/local-fs.target.wants/*; \
 rm -f /lib/systemd/system/sockets.target.wants/*udev*; \

--- a/molecule/Dockerfile-rhel9-tar.j2
+++ b/molecule/Dockerfile-rhel9-tar.j2
@@ -3,9 +3,9 @@ LABEL maintainer="CP Ansible"
 ENV container docker
 
 RUN microdnf -y --nodocs install yum
-RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == \
-systemd-tmpfiles-setup.service ] || rm -f $i; done); \
-rm -f /lib/systemd/system/multi-user.target.wants/*;\
+# RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == \
+# systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+RUN rm -f /lib/systemd/system/multi-user.target.wants/*;\
 rm -f /etc/systemd/system/*.wants/*;\
 rm -f /lib/systemd/system/local-fs.target.wants/*; \
 rm -f /lib/systemd/system/sockets.target.wants/*udev*; \


### PR DESCRIPTION
# Description

Molecule scenarios having ubi9-minimal image were failing due to a cd command in dockerfile. Modified the dockerfile by removing the line.

Fixes # [ANSIENG-3229](https://confluentinc.atlassian.net/browse/ANSIENG-3229)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Test scenarios based on ubi9 -> [jenkins](https://jenkins.confluent.io/job/cp-ansible-on-demand/2459/testReport/)

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[ANSIENG-3229]: https://confluentinc.atlassian.net/browse/ANSIENG-3229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ