### PR TITLE
Fix pep8 issues, add 2.15 and 2.16 sanity ignore

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,6 +1,7 @@
 ---
 exclude_paths:
   - hosts_example.yml
+  - molecule
 skip_list:
   - risky-shell-pipe
   - command-instead-of-shell

--- a/plugins/modules/kafka_connectors.py
+++ b/plugins/modules/kafka_connectors.py
@@ -94,7 +94,8 @@ TIMEOUT_WAITING_FOR_TASK_STATUS = 30  # seconds
 
 def get_current_connectors(connect_url, timeout, username, password, client_cert, client_key):
     try:
-        res = open_url(connect_url, validate_certs=False, timeout=timeout, url_username=username, url_password=password, client_cert=client_cert, client_key=client_key)
+        res = open_url(connect_url, validate_certs=False, timeout=timeout, url_username=username,
+                       url_password=password, client_cert=client_cert, client_key=client_key)
         return json.loads(res.read())
     except urllib_error.HTTPError as e:
         if e.code != 404:
@@ -104,7 +105,8 @@ def get_current_connectors(connect_url, timeout, username, password, client_cert
 
 def remove_connector(connect_url, name, timeout, username, password, client_cert, client_key):
     url = "{}/{}".format(connect_url, name)
-    r = open_url(method='DELETE', url=url, validate_certs=False, timeout=timeout, url_username=username, url_password=password, client_cert=client_cert, client_key=client_key)
+    r = open_url(method='DELETE', url=url, validate_certs=False, timeout=timeout, url_username=username,
+                 url_password=password, client_cert=client_cert, client_key=client_key)
     return r.getcode() == 200
 
 
@@ -113,7 +115,8 @@ def create_new_connector(connect_url, name, config, timeout, username, password,
     data = json.dumps({'name': name, 'config': config})
     headers = {'Content-Type': 'application/json'}
     try:
-        r = open_url(method='POST', url=connect_url, data=data, headers=headers, validate_certs=False, timeout=timeout, url_username=username, url_password=password, client_cert=client_cert, client_key=client_key)
+        r = open_url(method='POST', url=connect_url, data=data, headers=headers, validate_certs=False,
+                     timeout=timeout, url_username=username, url_password=password, client_cert=client_cert, client_key=client_key)
     except urllib_error.HTTPError as e:
         message = "error while adding new connector configuration ({})".format(e)
         return False, False, message
@@ -144,7 +147,8 @@ def get_connector_status(connect_url, connector_name, timeout, username, passwor
     time.sleep(WAIT_TIME_BEFORE_GET_STATUS)
     status_url = "{}/{}/status".format(connect_url, connector_name)
 
-    res = open_url(status_url, validate_certs=False, timeout=timeout, url_username=username, url_password=password, client_cert=client_cert, client_key=client_key)
+    res = open_url(status_url, validate_certs=False, timeout=timeout, url_username=username,
+                   url_password=password, client_cert=client_cert, client_key=client_key)
     current_status = json.loads(res.read())
 
     connector_status = current_status['connector']['state']
@@ -161,7 +165,8 @@ def get_connector_status(connect_url, connector_name, timeout, username, passwor
         if time_waited > TIMEOUT_WAITING_FOR_TASK_STATUS:
             return False, "timeout getting task status"
 
-        res = open_url(status_url, validate_certs=False, timeout=timeout, url_username=username, url_password=password, client_cert=client_cert, client_key=client_key)
+        res = open_url(status_url, validate_certs=False, timeout=timeout, url_username=username,
+                       url_password=password, client_cert=client_cert, client_key=client_key)
         current_status = json.loads(res.read())
         nb_tasks = len(current_status['tasks'])
 
@@ -198,7 +203,8 @@ def update_existing_connector(connect_url, name, config, timeout, username, pass
     headers = {'Content-Type': 'application/json'}
     r = None
     try:
-        r = open_url(method='PUT', url=url, data=data, headers=headers, validate_certs=False, timeout=timeout, url_username=username, url_password=password, client_cert=client_cert, client_key=client_key)
+        r = open_url(method='PUT', url=url, data=data, headers=headers, validate_certs=False,
+                     timeout=timeout, url_username=username, url_password=password, client_cert=client_cert, client_key=client_key)
     except urllib_error.HTTPError as e:
         message = "error while updating configuration ({})".format(e)
         success = False
@@ -213,7 +219,8 @@ def update_existing_connector(connect_url, name, config, timeout, username, pass
     message = "connector configuration updated"
     success = True
     try:
-        r = open_url(method='POST', url=restart_url, validate_certs=False, timeout=timeout, url_username=username, url_password=password, client_cert=client_cert, client_key=client_key)
+        r = open_url(method='POST', url=restart_url, validate_certs=False, timeout=timeout, url_username=username,
+                     url_password=password, client_cert=client_cert, client_key=client_key)
     except urllib_error.HTTPError:
         pass
     finally:
@@ -271,12 +278,15 @@ def run_module():
     output_messages = []
     added_updated_messages = []
     try:
-        current_connector_names = get_current_connectors(connect_url=module.params['connect_url'], timeout=module.params['timeout'],username=module.params['username'],password=module.params['password'],client_cert=module.params['client_cert'],client_key=module.params['client_key'])
+        current_connector_names = get_current_connectors(connect_url=module.params['connect_url'], timeout=module.params['timeout'],
+                                                         username=module.params['username'], password=module.params['password'],
+                                                         client_cert=module.params['client_cert'], client_key=module.params['client_key'])
         active_connector_names = (c['name'] for c in module.params['active_connectors'])
         deleted_connector_names = set(current_connector_names) - set(active_connector_names)
 
         for to_delete in deleted_connector_names:
-            remove_connector(connect_url=module.params['connect_url'], name=to_delete, timeout=module.params['timeout'],username=module.params['username'],password=module.params['password'],client_cert=module.params['client_cert'],client_key=module.params['client_key'])
+            remove_connector(connect_url=module.params['connect_url'], name=to_delete, timeout=module.params['timeout'], username=module.params['username'],
+                             password=module.params['password'], client_cert=module.params['client_cert'], client_key=module.params['client_key'])
 
         if deleted_connector_names:
             output_messages.append("Connectors removed: {}.".format(', '.join(deleted_connector_names)))

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -1,9 +1,6 @@
 Jenkinsfile shebang!skip
 plugins/modules/kafka_connectors.py pylint:ansible-format-automatic-specification
 plugins/modules/kafka_connectors.py validate-modules:missing-gplv3-license
-plugins/modules/kafka_connectors.py validate-modules:no-log-needed
-plugins/modules/kafka_connectors.py ansible-doc!skip
-plugins/modules/kafka_connectors.py pep8!skip
 molecule/certs-create.sh shebang
 molecule/certs-create.sh shellcheck!skip
 molecule/mtls-custombundle-rhel7-fips/create_ca_bundle.sh shebang

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -1,9 +1,6 @@
 Jenkinsfile shebang!skip
 plugins/modules/kafka_connectors.py pylint:ansible-format-automatic-specification
 plugins/modules/kafka_connectors.py validate-modules:missing-gplv3-license
-plugins/modules/kafka_connectors.py validate-modules:no-log-needed
-plugins/modules/kafka_connectors.py ansible-doc!skip
-plugins/modules/kafka_connectors.py pep8!skip
 molecule/certs-create.sh shebang
 molecule/certs-create.sh shellcheck!skip
 molecule/mtls-custombundle-rhel7-fips/create_ca_bundle.sh shebang

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -1,9 +1,6 @@
 Jenkinsfile shebang
 plugins/modules/kafka_connectors.py pylint:ansible-format-automatic-specification
 plugins/modules/kafka_connectors.py validate-modules:missing-gplv3-license
-plugins/modules/kafka_connectors.py validate-modules:no-log-needed
-plugins/modules/kafka_connectors.py ansible-doc!skip
-plugins/modules/kafka_connectors.py pep8!skip
 molecule/certs-create.sh shebang
 molecule/certs-create.sh shellcheck!skip
 molecule/mtls-custombundle-rhel7-fips/create_ca_bundle.sh shebang

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -1,11 +1,8 @@
 Jenkinsfile shebang
 plugins/modules/kafka_connectors.py pylint:ansible-format-automatic-specification
 plugins/modules/kafka_connectors.py validate-modules:missing-gplv3-license
-<<<<<<< HEAD
 plugins/modules/kafka_connectors.py validate-modules:no-log-needed
 plugins/modules/kafka_connectors.py ansible-doc!skip
-=======
->>>>>>> parent of 41620d6b (Fix sanity tests for 7.6.x (#1557))
 molecule/certs-create.sh shebang
 molecule/certs-create.sh shellcheck!skip
 molecule/mtls-custombundle-rhel7-fips/create_ca_bundle.sh shebang

--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -1,11 +1,8 @@
 Jenkinsfile shebang
 plugins/modules/kafka_connectors.py pylint:ansible-format-automatic-specification
 plugins/modules/kafka_connectors.py validate-modules:missing-gplv3-license
-<<<<<<< HEAD
 plugins/modules/kafka_connectors.py validate-modules:no-log-needed
 plugins/modules/kafka_connectors.py ansible-doc!skip
-=======
->>>>>>> parent of 41620d6b (Fix sanity tests for 7.6.x (#1557))
 molecule/certs-create.sh shebang
 molecule/certs-create.sh shellcheck!skip
 molecule/mtls-custombundle-rhel7-fips/create_ca_bundle.sh shebang

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -1,11 +1,7 @@
 Jenkinsfile shebang
-plugins/modules/kafka_connectors.py pylint:ansible-format-automatic-specification
 plugins/modules/kafka_connectors.py validate-modules:missing-gplv3-license
-<<<<<<< HEAD
 plugins/modules/kafka_connectors.py validate-modules:no-log-needed
 plugins/modules/kafka_connectors.py ansible-doc!skip
-=======
->>>>>>> parent of 41620d6b (Fix sanity tests for 7.6.x (#1557))
 molecule/certs-create.sh shebang
 molecule/certs-create.sh shellcheck!skip
 molecule/mtls-custombundle-rhel7-fips/create_ca_bundle.sh shebang


### PR DESCRIPTION
# Description

Updated spacing and corrected ansible-test sanity pep8 line-too-long errors in plugins/modules/kafka_connectors.py.
Added tests/sanity/ignore-2.15.txt and tests/sanity/ignore-2.16.txt to ensure ignores are up-to-date for versions tested against. Added an ignore to .ansible-lint for the molecule directory.

Included 2.14 changes from #1557 


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Ran `ansible-test sanity --docker default` in venv for 2.15 and 2.16 to confirm pep8 and other logging is clean.


# Checklist:

- [x] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


Regards, 
Ansible PE