### PR TITLE
Remove jinja from when and that ANSIENG-3489

### DIFF
--- a/molecule/broker-scale-up/verify.yml
+++ b/molecule/broker-scale-up/verify.yml
@@ -91,11 +91,11 @@
     - name: Verify broker4 and broker5 not in the output
       assert:
         that:
-          - "1 in {{ quorum_output.stdout }}"
-          - "2 in {{ quorum_output.stdout }}"
-          - "3 in {{ quorum_output.stdout }}"
-          - "4 in {{ quorum_output.stdout }}"
-          - "5 in {{ quorum_output.stdout }}"
+          - "'1' in quorum_output.stdout"
+          - "'2' in quorum_output.stdout"
+          - "'3' in quorum_output.stdout"
+          - "'4' in quorum_output.stdout"
+          - "'5' in quorum_output.stdout"
       when: kraft_mode|bool
 
 - name: Verify - control_center

--- a/molecule/rbac-mtls-rhel-fips/verify.yml
+++ b/molecule/rbac-mtls-rhel-fips/verify.yml
@@ -369,28 +369,28 @@
     - name: Assert Broker Cluster ID as expected
       assert:
         that:
-          - broker_name == "{{cluster_name_query_json[0]['clusterName']}}"
+          - broker_name == cluster_name_query_json[0].clusterName
         fail_msg: "Broker ID set to {{cluster_name_query_json[0]['clusterName']}} not {{broker_name}}"
         quiet: true
 
     - name: Assert Kafka Connect Cluster ID as expected
       assert:
         that:
-          - connect_name == "{{cluster_name_query_json[1]['clusterName']}}"
+          - connect_name == cluster_name_query_json[1].clusterName
         fail_msg: "Connect Cluster ID set to {{cluster_name_query_json[1]['clusterName']}} not {{connect_name}}"
         quiet: true
 
     - name: Assert KSQL Cluster ID as expected
       assert:
         that:
-          - ksql_name == "{{cluster_name_query_json[2]['clusterName']}}"
+          - ksql_name == cluster_name_query_json[2].clusterName
         fail_msg: "KSQL Cluster ID set to {{cluster_name_query_json[2]['clusterName']}} not {{ksql_name}}"
         quiet: true
 
     - name: Assert Schema Registry Cluster ID as expected
       assert:
         that:
-          - schema_registry_name == "{{cluster_name_query_json[3]['clusterName']}}"
+          - schema_registry_name == cluster_name_query_json[3].clusterName
         fail_msg: "Schema Registry Cluster ID set to {{cluster_name_query_json[3]['clusterName']}} not {{schema_registry_name}}"
         quiet: true
 

--- a/roles/common/tasks/configure_logredactor.yml
+++ b/roles/common/tasks/configure_logredactor.yml
@@ -13,7 +13,7 @@
     path: "{{log4j_file}}"
     regexp: '{{ item.logger_name }}=(.*)'
     replace: '{{ item.logger_name }}=\1, {{ redactor_name }}'
-  when: not ( output | regex_search("{{ redactor_name }}") )
+  when: not ( output | regex_search(redactor_name) )
 
 - name: Check if the redactor has been configured
   ansible.builtin.shell: grep "log4j.appender.{{ redactor_name }}=io.confluent.log4j.redactor.RedactorAppender" {{ log4j_file }}


### PR DESCRIPTION
# Description

Modifed verify files to remove jinja usage in when and that statements as it causes error for ansible version 7

Fixes # [(issue)](https://confluentinc.atlassian.net/browse/ANSIENG-3489)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

ansible version 4.10.0 [Jenkins-2611](https://jenkins.confluent.io/job/cp-ansible-on-demand/2611/)
ansible version 5.5.0 [Jenkins-2610](https://jenkins.confluent.io/job/cp-ansible-on-demand/2610/)
ansible version 6.4.0 [Jenkins-2609](https://jenkins.confluent.io/job/cp-ansible-on-demand/2609/)
ansible version 7.1.0 [Jenkins-2608](https://jenkins.confluent.io/job/cp-ansible-on-demand/2608/)
# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
