### PR TITLE
[ANSIENG-3474] | Fix Connect and Ksql Cluster Registry in colocated cluster

### DIFF
--- a/roles/kafka_connect/tasks/main.yml
+++ b/roles/kafka_connect/tasks/main.yml
@@ -298,6 +298,22 @@
       - kafka_connect
       - kafka_connect_parallel
       - kafka_connect_serial
+      - kafka_broker
+      - kafka_broker_parallel
+      - kafka_broker_serial
+      - zookeeper
+      - zookeeper_parallel
+      - zookeeper_serial
+      - kafka_rest
+      - kafka_rest_parallel
+      - kafka_rest_serial
+      - control_center
+      - control_center_parallel
+      - control_center_serial
+      - ksql
+      - ksql_parallel
+      - ksql_serial
+      - schema_registry
   set_fact:
     parent_kafka_connect_cluster_group: "{{ (group_names | difference(keywords))[0] | default('kafka_connect') }}"
     parent_kafka_connect_cluster_id: "{{ kafka_connect_final_properties['group.id'] }}"

--- a/roles/kafka_connect/tasks/register_cluster.yml
+++ b/roles/kafka_connect/tasks/register_cluster.yml
@@ -8,7 +8,7 @@
     copy_certs: false
 
 - name: Fetch Kafka Connect Cluster Groups
-  set_fact: active_kafka_connect_groups="{{ (((active_kafka_connect_groups | default([])) + hostvars[item].group_names) | difference('kafka_connect'+'kafka_connect_parallel'+'kafka_connect_serial')) | default(['kafka_connect'], true) }}"
+  set_fact: active_kafka_connect_groups="{{ (((active_kafka_connect_groups | default([])) + hostvars[item].group_names) | difference('kafka_connect'+'kafka_connect_parallel'+'kafka_connect_serial'+ 'kafka_broker'+ 'kafka_broker_parallel'+'kafka_broker_serial'+'ksql'+ 'ksql_parallel'+'ksql_serial'+'control_center'+'control_center_parallel'+'control_center_serial'+'schema_registry'+'zookeeper'+'zookeeper_parallel'+'zookeeper_serial'+'kafka_rest'+'kafka_rest_parallel'+'kafka_rest_serial')) | default(['kafka_connect'], true) }}"
   with_items: "{{ ansible_play_hosts }}"
 
 - name: Register Kafka Connect Cluster

--- a/roles/ksql/tasks/main.yml
+++ b/roles/ksql/tasks/main.yml
@@ -317,6 +317,22 @@
       - ksql
       - ksql_parallel
       - ksql_serial
+      - kafka_connect
+      - kafka_connect_parallel
+      - kafka_connect_serial
+      - kafka_broker
+      - kafka_broker_parallel
+      - kafka_broker_serial
+      - zookeeper
+      - zookeeper_parallel
+      - zookeeper_serial
+      - kafka_rest
+      - kafka_rest_parallel
+      - kafka_rest_serial
+      - control_center
+      - control_center_parallel
+      - control_center_serial
+      - schema_registry
   set_fact:
     parent_ksql_cluster_group: "{{ (group_names | difference(keywords))[0] | default('ksql') }}"
     parent_ksql_cluster_id: "{{ ksql_final_properties['ksql.service.id'] }}"

--- a/roles/ksql/tasks/register_cluster.yml
+++ b/roles/ksql/tasks/register_cluster.yml
@@ -8,7 +8,7 @@
     copy_certs: false
 
 - name: Fetch KSQL Cluster Groups
-  set_fact: active_ksql_groups="{{ (((active_ksql_groups | default([])) + hostvars[item].group_names) | difference('ksql'+'ksql_parallel'+'ksql_serial')) | default(['ksql'], true) }}"
+  set_fact: active_ksql_groups="{{ (((active_ksql_groups | default([])) + hostvars[item].group_names) | difference('ksql'+'ksql_parallel'+'ksql_serial'+'kafka_connect'+'kafka_connect_parallel'+'kafka_connect_serial'+ 'kafka_broker'+ 'kafka_broker_parallel'+'kafka_broker_serial'+'control_center'+'control_center_parallel'+'control_center_serial'+'schema_registry'+'zookeeper'+'zookeeper_parallel'+'zookeeper_serial'+'kafka_rest'+'kafka_rest_parallel'+'kafka_rest_serial')) | default(['ksql'], true) }}"
   with_items: "{{ ansible_play_hosts }}"
 
 - name: Register KSQL Cluster


### PR DESCRIPTION

# Description

Bug fix for registering Connect and Ksql clusters on colocated components

Fixes # [ANSIENG-3494](https://confluentinc.atlassian.net/browse/ANSIENG-3494)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

tested locally

# Checklist:

- [x] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[ANSIENG-3494]: https://confluentinc.atlassian.net/browse/ANSIENG-3494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ