### PR TITLE
Add Rhel 9 in supported OS list

### DIFF
--- a/playbooks/validate_hosts.yml
+++ b/playbooks/validate_hosts.yml
@@ -21,7 +21,7 @@
           Rhel Version: {{ansible_distribution_major_version}} not in supported versions: {{redhat_supported_versions}}.
           To skip host validations, set validate_hosts to false.
       vars:
-        redhat_supported_versions: ['7', '8']
+        redhat_supported_versions: ['7', '8', '9']
       when: ansible_os_family == "RedHat"
       tags:
         - validate_os_version


### PR DESCRIPTION
# Description

validate_hosts playbook did not have rhel 9 in supported OS list, even though RHEL9 is supported starting CP-Ansible 7.4.x

Fixes # [ANSIENG-3148](https://confluentinc.atlassian.net/browse/ANSIENG-3148)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[ANSIENG-3148]: https://confluentinc.atlassian.net/browse/ANSIENG-3148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ