### PR TITLE
Update default Kafka Controller log dir documentation

### DIFF
--- a/docs/VARIABLES.md
+++ b/docs/VARIABLES.md
@@ -990,7 +990,7 @@ Default:  "{{kafka_controller_default_group}}"
 
 ### kafka_controller_log_dir
 
-Set this variable to customize the directory that the Kafka controller writes log files to. Default location is /var/log/kafka.
+Set this variable to customize the directory that the Kafka controller writes log files to. Default location is /var/log/controller.
 
 Default:  "{{kafka_controller_default_log_dir}}"
 

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -453,7 +453,7 @@ kafka_controller_user: "{{kafka_controller_default_user}}"
 ### Set this variable to customize the Linux Group that the Kafka controller Service user belongs to. Default group is confluent.
 kafka_controller_group: "{{kafka_controller_default_group}}"
 
-### Set this variable to customize the directory that the Kafka controller writes log files to. Default location is /var/log/kafka.
+### Set this variable to customize the directory that the Kafka controller writes log files to. Default location is /var/log/controller.
 kafka_controller_log_dir: "{{kafka_controller_default_log_dir}}"
 
 kafka_controller_packages:


### PR DESCRIPTION
# Description

PR to Update default Kafka Controller log dir documentation. The default location is /var/log/controller, whereas in the variables.md file, it was /var/log/kafka by mistake

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist:

- [x] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
