### PR TITLE
Use confluent-hub api to download connect-plugins

### DIFF
--- a/molecule/plain-rhel/molecule.yml
+++ b/molecule/plain-rhel/molecule.yml
@@ -115,7 +115,7 @@ provisioner:
           - "/tmp/local_plugins/confluentinc-kafka-connect-gcp-functions-1.1.9.zip"
           - "/tmp/local_plugins/confluentinc-kafka-connect-azure-data-lake-gen2-storage-1.6.15.zip"
         kafka_connect_plugins_remote:
-          - "https://d1i4a15mxbxib1.cloudfront.net/api/plugins/confluentinc/kafka-connect-s3/versions/{{connect_s3_plugin_version}}/confluentinc-kafka-connect-s3-{{connect_s3_plugin_version}}.zip"
+          - "https://api.hub,confluent.io/api/plugins/confluentinc/kafka-connect-s3/versions/{{connect_s3_plugin_version}}/confluentinc-kafka-connect-s3-{{connect_s3_plugin_version}}.zip"
 
         kafka_connect_connectors:
           - name: sample-connector-1

--- a/molecule/plain-rhel/molecule.yml
+++ b/molecule/plain-rhel/molecule.yml
@@ -115,7 +115,7 @@ provisioner:
           - "/tmp/local_plugins/confluentinc-kafka-connect-gcp-functions-1.1.9.zip"
           - "/tmp/local_plugins/confluentinc-kafka-connect-azure-data-lake-gen2-storage-1.6.15.zip"
         kafka_connect_plugins_remote:
-          - "https://api.hub,confluent.io/api/plugins/confluentinc/kafka-connect-s3/versions/{{connect_s3_plugin_version}}/confluentinc-kafka-connect-s3-{{connect_s3_plugin_version}}.zip"
+          - "https://api.hub.confluent.io/api/plugins/confluentinc/kafka-connect-s3/versions/{{connect_s3_plugin_version}}/confluentinc-kafka-connect-s3-{{connect_s3_plugin_version}}.zip"
 
         kafka_connect_connectors:
           - name: sample-connector-1

--- a/molecule/plain-rhel/prepare.yml
+++ b/molecule/plain-rhel/prepare.yml
@@ -14,5 +14,5 @@
         url: "{{ item }}"
         dest: /tmp/local_plugins/
       with_items:
-        - "https://d1i4a15mxbxib1.cloudfront.net/api/plugins/confluentinc/kafka-connect-gcp-functions/versions/1.1.9/confluentinc-kafka-connect-gcp-functions-1.1.9.zip"
-        - "https://d1i4a15mxbxib1.cloudfront.net/api/plugins/confluentinc/kafka-connect-azure-data-lake-gen2-storage/versions/1.6.15/confluentinc-kafka-connect-azure-data-lake-gen2-storage-1.6.15.zip"
+        - "https://api.hub.confluent.io/api/plugins/confluentinc/kafka-connect-gcp-functions/versions/1.1.9/confluentinc-kafka-connect-gcp-functions-1.1.9.zip"
+        - "https://api.hub.confluent.io/api/plugins/confluentinc/kafka-connect-azure-data-lake-gen2-storage/versions/1.6.15/confluentinc-kafka-connect-azure-data-lake-gen2-storage-1.6.15.zip"


### PR DESCRIPTION
# Description
Currently the CDN URL is used to get connector plugins, updating and using confluent-hub api. CDN `d1i4a15mxbxib1` is being deprecated as part of cc-root-1 migration - https://confluentinc.atlassian.net/browse/CC-22768

confluent-hub api should be used to download connector plugins which redirects to the updated EBS and CDN

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Test job: https://jenkins.confluent.io/job/cp-ansible-on-demand/2650/console

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
