### PR TITLE
[ANSIENG-3696] | Fix kafka-storage command for cluster id starting with hyphen

### DIFF
--- a/roles/kafka_broker/tasks/get_meta_properties.yml
+++ b/roles/kafka_broker/tasks/get_meta_properties.yml
@@ -6,7 +6,7 @@
   register: uuid_broker
 
 - name: Format Storage Directory
-  shell: "{{ binary_base_path }}/bin/kafka-storage  format -t {{ clusterid }} -c {{ kafka_broker.config_file }} --ignore-formatted"
+  shell: "{{ binary_base_path }}/bin/kafka-storage  format -t={{ clusterid }} -c {{ kafka_broker.config_file }} --ignore-formatted"
   register: format_meta
   vars:
     clusterid: "{{ (uuid_broker['content'] | b64decode).partition('cluster.id=')[2].partition('\n')[0] }}"

--- a/roles/kafka_controller/tasks/get_meta_properties.yml
+++ b/roles/kafka_controller/tasks/get_meta_properties.yml
@@ -7,7 +7,7 @@
   run_once: true
 
 - name: Format Data Directory
-  shell: "{{ binary_base_path }}/bin/kafka-storage  format -t {{ clusterid }} -c {{ kafka_controller.config_file }}  --ignore-formatted"
+  shell: "{{ binary_base_path }}/bin/kafka-storage  format -t={{ clusterid }} -c {{ kafka_controller.config_file }}  --ignore-formatted"
   register: format_meta
   vars:
     clusterid: "{{ uuid_key.stdout }}"


### PR DESCRIPTION

# Description

This PR aims to fix bug raised in https://github.com/confluentinc/cp-ansible/issues/1587

Fixes # [ANSIENG-3696](https://confluentinc.atlassian.net/browse/ANSIENG-3696)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

tested locally 

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules


[ANSIENG-3696]: https://confluentinc.atlassian.net/browse/ANSIENG-3696?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ