### PR TITLE
Set kafka_broker.key permissions (removes when) Fixes #1590

### DIFF
--- a/roles/ssl/tasks/main.yml
+++ b/roles/ssl/tasks/main.yml
@@ -44,7 +44,6 @@
     - "{{ca_cert_path}}"
     - "{{cert_path}}"
     - "{{key_path}}"
-  when: export_certs|bool
 
 - name: Set BCFKS Truststore and Keystore File Permissions
   file:


### PR DESCRIPTION
This patch is related to issue #1590, see that for further discussion.

Permissions on the /var/ssl/private/kafka_broker.key file are publicly readable.  Upon further investigation it looks to be conditional, dependent on
`ssl_provided_keystore_and_truststore_remote_src`, and if that is set to false, the keystore is protected.

It seems like in any case you'd want it to be protected.

This looks like in 7.5.3 it is related to the
setting ssl_mutual_auth_enabled and in 7.6.1 the
ssl_provided_keystore_and_trustore_remote_src setting. The block in question is, in 7.6.1-post:

- name: Set Truststore and Keystore File Permissions file: path: "{{item}}" owner: "{{user}}" group: "{{group}}" mode: '640' loop: - "{{keystore_path}}" - "{{truststore_path}}" when: not ( ssl_provided_keystore_and_truststore_remote_src|bool )

In reading the git history (and checking back in 6.2.15-post where the 640 permission was last changed from int to string), I'm under the impression that the "when" condition was blanket applied to the tasks in this role, when it probably shouldn't have been applied to this permission setting. In 7.5.3, this when condition was when: export_certs|bool where export_certs: "{{ssl_mutual_auth_enabled}}"

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
