### PR TITLE
[ANSIENG-3489] | removed jinja from when in add redactor in logger

### DIFF
--- a/roles/common/tasks/configure_logredactor.yml
+++ b/roles/common/tasks/configure_logredactor.yml
@@ -13,7 +13,7 @@
     path: "{{log4j_file}}"
     regexp: '{{ item.logger_name }}=(.*)'
     replace: '{{ item.logger_name }}=\1, {{ redactor_name }}'
-  when: not ( output | regex_search("{{ redactor_name }}") )
+  when: not ( output | regex_search(redactor_name) )
 
 - name: Check if the redactor has been configured
   ansible.builtin.shell: grep "log4j.appender.{{ redactor_name }}=io.confluent.log4j.redactor.RedactorAppender" {{ log4j_file }}


### PR DESCRIPTION
# Description

Removed jinja from when statements in add redactor in logger task.
Already fixed in 7.4.x and onwards. Missed to merge this one in 7.2.x & 7.3.x

Fixes # [(ANSIENG-3489)](https://confluentinc.atlassian.net/browse/ANSIENG-3489)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
