### PR TITLE
[ANSIENG-3627] | renaming internal var with lowercase letters instead of uppercase

### DIFF
--- a/roles/kafka_controller/tasks/health_check.yml
+++ b/roles/kafka_controller/tasks/health_check.yml
@@ -17,7 +17,7 @@
       --command-config {{kafka_controller.client_config_file}} describe --replication |  grep -v Observer | awk '{print $2}'
   environment:
     KAFKA_OPTS: "-Xlog:all=error -XX:+IgnoreUnrecognizedVMOptions {% if kerberos_client_config_file_dest != '/etc/krb5.conf' %}-Djava.security.krb5.conf={{kerberos_client_config_file_dest}}{% endif %}"
-  register: LEO
+  register: leo
   ignore_errors: false
   changed_when: false
   check_mode: false
@@ -25,10 +25,10 @@
 - name: Check LogEndOffset values
   assert:
     that:
-      - "{{ item|int > 0 and LEO.stdout_lines[1:]|max|int - item|int < 1000 }}"
-    fail_msg: "UnreachableQuorumMember or Found at least one quorum voter with an offset {{ item }}, while the primary controller was at offset {{ LEO.stdout_lines[1:]|max}}
+      - "{{ item|int > 0 and leo.stdout_lines[1:]|max|int - item|int < 1000 }}"
+    fail_msg: "UnreachableQuorumMember or Found at least one quorum voter with an offset {{ item }}, while the primary controller was at offset {{ leo.stdout_lines[1:]|max}}
                The max allowed offset lag is 1000"
-  loop: "{{ LEO.stdout_lines[1:] }}"
+  loop: "{{ leo.stdout_lines[1:] }}"
   ignore_errors: false
   changed_when: false
   check_mode: false


### PR DESCRIPTION
# Description

renaming internal var with lowercase letters instead of uppercase. The variable names having uppercase letters cause warnings on running galaxy-importer

Fixes # [(issue)](https://confluentinc.atlassian.net/browse/ANSIENG-3627)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
