### PR TITLE
[ANSIENG-3489] | removed jinja from when in provided keystore truststore

### DIFF
--- a/roles/ssl/tasks/provided_keystore_and_truststore.yml
+++ b/roles/ssl/tasks/provided_keystore_and_truststore.yml
@@ -32,14 +32,14 @@
     msg:  >-
       "Ensure that the keystore has valid permissions. The unix file permission of the keystore should be set to atleast read (>=400) with the
         name of the owner being '{{ user }}' and the group being '{{ group }}'."
-  when: ( st_keystore.stat.mode|int < 400 ) or ( st_keystore.stat.pw_name != '{{user}}' ) or ( st_keystore.stat.gr_name != '{{group}}' )
+  when: ( st_keystore.stat.mode|int < 400 ) or ( st_keystore.stat.pw_name != user ) or ( st_keystore.stat.gr_name != group )
 
 - name: Validate truststore permissions
   debug:
     msg:  >-
       "Ensure that the truststore has valid permissions. The unix file permission of the truststore should be set to atleast read (>=400) with the
         name of the owner being '{{ user }}' and the group being '{{ group }}'."
-  when: ( st_truststore.stat.mode|int < 400 ) or ( st_truststore.stat.pw_name != '{{user}}' ) or ( st_truststore.stat.gr_name != '{{group}}' )
+  when: ( st_truststore.stat.mode|int < 400 ) or ( st_truststore.stat.pw_name != user ) or ( st_truststore.stat.gr_name != group )
 
 - name: Export Certs from Keystore and Truststore
   include_tasks: export_certs_from_keystore_and_truststore.yml


### PR DESCRIPTION
# Description

There should not be any jinja2 in when statements. Thus removing it

Fixes # [(ANSIENG-3489)](https://confluentinc.atlassian.net/browse/ANSIENG-3489)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Added debug statements to check values which are getting used [semaphore-run](https://semaphore.ci.confluent.io/jobs/08583afb-de35-4244-9cf1-f27eeb06ca1f)

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
