### PR TITLE
[ANSIENG-3627] | fix the raise error by using valueError instead of str

### DIFF
--- a/plugins/filter/filters.py
+++ b/plugins/filter/filters.py
@@ -377,9 +377,11 @@ class FilterModule(object):
         for rule_str in list_of_rules:
             tokens = rule_str.split('/')
             if len(tokens) < 2:
-                raise "Invalid rule format. Please ensure the rule has Mapping pattern and Mapping replacement.\n" \
-                      "For details, please refer to "\
-                      "https://cwiki.apache.org/confluence/display/KAFKA/KIP-371%3A+Add+a+configuration+to+build+custom+SSL+principal+name"
+                raise ValueError(
+                    "Invalid rule format. Please ensure the rule has Mapping pattern and Mapping replacement.\n"
+                    "For details, please refer to "
+                    "https://cwiki.apache.org/confluence/display/KAFKA/KIP-371%3A+Add+a+configuration+to+build+custom+SSL+principal+name"
+                )
 
             mapping_pattern = tokens[0]
             mapping_value = tokens[1]


### PR DESCRIPTION
# Description

In python when raising error instead of passing multiple strings it should be passed some object. So passing it the ValueError object to fix lint error in galaxy-importer

Fixes # [(ANSIENG-3627)](https://confluentinc.atlassian.net/browse/ANSIENG-3627)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
