### PR TITLE
[ANSIENG-3627] | Is not of type Object Error from galaxy-importer

### DIFF
--- a/playbooks/validate_hosts.yml
+++ b/playbooks/validate_hosts.yml
@@ -64,12 +64,9 @@
       register: internet_access_check
       tags:
         - validate_internet_access
-      environment: "{
-        {% if 'http_proxy' in proxy_env or 'https_proxy' in proxy_env %}
-          'http_proxy': '{{ proxy_env.http_proxy if 'http_proxy' in proxy_env else proxy_env.https_proxy}}',
-          'https_proxy': '{{ proxy_env.https_proxy if 'https_proxy' in proxy_env else proxy_env.http_proxy }}'
-        {% endif %}
-      }"
+      environment:
+        http_proxy: "{{ proxy_env.http_proxy if 'http_proxy' in proxy_env else '' }}"
+        https_proxy: "{{ proxy_env.https_proxy if 'https_proxy' in proxy_env else '' }}"
 
     - name: Fail Provisioning because No Network Connectivity
       fail:

--- a/playbooks/validate_hosts.yml
+++ b/playbooks/validate_hosts.yml
@@ -65,8 +65,9 @@
       tags:
         - validate_internet_access
       environment:
-        http_proxy: "{{ proxy_env.http_proxy if 'http_proxy' in proxy_env else '' }}"
-        https_proxy: "{{ proxy_env.https_proxy if 'https_proxy' in proxy_env else '' }}"
+        http_proxy: "{% if 'http_proxy' in proxy_env %}{{proxy_env.http_proxy}}{% elif 'https_proxy' in proxy_env %}{{proxy_env.https_proxy}}{% endif %}"
+        https_proxy: "{% if 'https_proxy' in proxy_env %}{{proxy_env.https_proxy}}{% elif 'http_proxy' in proxy_env %}{{proxy_env.http_proxy}}{% endif %}"
+
 
     - name: Fail Provisioning because No Network Connectivity
       fail:


### PR DESCRIPTION
# Description

Galaxy Importer doesnt allow this format of using jinja in environment. So modified it

Fixes [ANSIENG-3627](https://confluentinc.atlassian.net/browse/ANSIENG-3627)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Manually tested validate_hosts playbook on molecule scenario

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[ANSIENG-3627]: https://confluentinc.atlassian.net/browse/ANSIENG-3627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ