### PR TITLE
[ANSIENG-3627] | added sanity test ignores for discovery in ansible 9

### DIFF
--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -26,4 +26,3 @@ discovery/service/schema_registry.py pep8!skip
 discovery/service/zookeeper.py pep8!skip
 discovery/system/system.py pep8!skip
 discovery/service/service.py pep8!skip
-

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -25,3 +25,7 @@ discovery/service/schema_registry.py pep8!skip
 discovery/service/zookeeper.py pep8!skip
 discovery/system/system.py pep8!skip
 discovery/service/service.py pep8!skip
+discovery/manager/manager.py compile-3.12!skip
+discovery/service/control_center.py compile-3.12!skip
+discovery/service/service.py compile-3.12!skip
+discovery/system/system.py compile-3.12!skip


### PR DESCRIPTION
# Description

Added few discovery files in sanity tests ignores for ansible 9.

Fixes # [(issue)](https://confluentinc.atlassian.net/browse/ANSIENG-3627)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
