### PR TITLE
[ANSIENG-3627] | renamed jenkinsfile in sanity ignores files

### DIFF
--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -1,4 +1,4 @@
-Jenkinsfile shebang!skip
+Jenkinsfile.disabled shebang!skip
 plugins/modules/kafka_connectors.py pylint:ansible-format-automatic-specification
 plugins/modules/kafka_connectors.py validate-modules:missing-gplv3-license
 molecule/certs-create.sh shebang

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -1,4 +1,4 @@
-Jenkinsfile shebang!skip
+Jenkinsfile.disabled shebang!skip
 plugins/modules/kafka_connectors.py pylint:ansible-format-automatic-specification
 plugins/modules/kafka_connectors.py validate-modules:missing-gplv3-license
 molecule/certs-create.sh shebang

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -1,4 +1,4 @@
-Jenkinsfile shebang
+Jenkinsfile.disabled shebang
 plugins/modules/kafka_connectors.py pylint:ansible-format-automatic-specification
 plugins/modules/kafka_connectors.py validate-modules:missing-gplv3-license
 molecule/certs-create.sh shebang

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -1,4 +1,4 @@
-Jenkinsfile shebang
+Jenkinsfile.disabled shebang
 plugins/modules/kafka_connectors.py pylint:ansible-format-automatic-specification
 plugins/modules/kafka_connectors.py validate-modules:missing-gplv3-license
 molecule/certs-create.sh shebang

--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -1,4 +1,4 @@
-Jenkinsfile shebang
+Jenkinsfile.disabled shebang
 plugins/modules/kafka_connectors.py validate-modules:missing-gplv3-license
 molecule/certs-create.sh shebang
 molecule/certs-create.sh shellcheck!skip

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -1,4 +1,4 @@
-Jenkinsfile shebang
+Jenkinsfile.disabled shebang
 plugins/modules/kafka_connectors.py validate-modules:missing-gplv3-license
 molecule/certs-create.sh shebang
 molecule/certs-create.sh shellcheck!skip

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -1,4 +1,4 @@
-Jenkinsfile shebang!skip
+Jenkinsfile.disabled shebang!skip
 plugins/modules/kafka_connectors.py pylint:ansible-format-automatic-specification
 plugins/modules/kafka_connectors.py validate-modules:missing-gplv3-license
 molecule/certs-create.sh shebang


### PR DESCRIPTION
# Description

Since jenkinsfile is renamed all the references to it in code should also be renamed.

Fixes # [(issue)](https://confluentinc.atlassian.net/browse/ANSIENG-3627)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
