### PR TITLE
[ANSIENG-3079] | modified direct communication with controller using bootstrap-controller

### DIFF
--- a/roles/kafka_controller/tasks/health_check.yml
+++ b/roles/kafka_controller/tasks/health_check.yml
@@ -2,7 +2,7 @@
 # health check for kafka controller
 - name: Check Kafka Metadata Quorum
   shell: |
-    {{ binary_base_path }}/bin/kafka-metadata-quorum --bootstrap-server {{inventory_hostname}}:{{kafka_controller_port}} \
+    {{ binary_base_path }}/bin/kafka-metadata-quorum --bootstrap-controller {{inventory_hostname}}:{{kafka_controller_port}} \
       --command-config {{kafka_controller.client_config_file}} describe --replication
   environment:
     KAFKA_OPTS: "-Xlog:all=error -XX:+IgnoreUnrecognizedVMOptions {% if kerberos_client_config_file_dest != '/etc/krb5.conf' %}-Djava.security.krb5.conf={{kerberos_client_config_file_dest}}{% endif %}"
@@ -13,7 +13,7 @@
 #Registers LEO of controllers only if Metadata Quorum passed in the above task
 - name: Register LogEndOffset
   shell: |
-    {{ binary_base_path }}/bin/kafka-metadata-quorum --bootstrap-server {{inventory_hostname}}:{{kafka_controller_port}} \
+    {{ binary_base_path }}/bin/kafka-metadata-quorum --bootstrap-controller {{inventory_hostname}}:{{kafka_controller_port}} \
       --command-config {{kafka_controller.client_config_file}} describe --replication |  grep -v Observer | awk '{print $2}'
   environment:
     KAFKA_OPTS: "-Xlog:all=error -XX:+IgnoreUnrecognizedVMOptions {% if kerberos_client_config_file_dest != '/etc/krb5.conf' %}-Djava.security.krb5.conf={{kerberos_client_config_file_dest}}{% endif %}"
@@ -32,12 +32,3 @@
   ignore_errors: false
   changed_when: false
   check_mode: false
-
-- name: Remove confluent.use.controller.listener config from Client Properties
-  lineinfile:
-    path: "{{ kafka_controller.client_config_file }}"
-    state: absent
-    line: confluent.use.controller.listener=true
-  changed_when: false
-  check_mode: false
-  when: not kraft_migration|bool

--- a/roles/kafka_controller/tasks/main.yml
+++ b/roles/kafka_controller/tasks/main.yml
@@ -425,7 +425,6 @@
 - name: Wait for Controller health checks to complete
   include_tasks: health_check.yml
   when:
-    - confluent_server_enabled|bool # metadata-quorum doesn't work on community kafka
     - kafka_controller_health_checks_enabled|bool
     - not ansible_check_mode
   tags: health_check

--- a/roles/kafka_controller/templates/client.properties.j2
+++ b/roles/kafka_controller/templates/client.properties.j2
@@ -4,4 +4,3 @@
 {% for key, value in kafka_controller_client_properties|dictsort%}
 {{key}}={{value}}
 {% endfor %}
-confluent.use.controller.listener=true


### PR DESCRIPTION
# Description
CP-Ansible relies on the undocumented confluent.use.controller.listener configuration to communicate directly with KRaft controllers. This configuration was never intended to be used by external clients. In CP 7.7, this undocumented configuration was removed, as was the ability to communicate with KRaft controllers by putting a controller address in --bootstrap-server instead use --bootstrap-controller when communicating directly with the controllers.


Fixes # [(issue)](https://confluentinc.atlassian.net/browse/ANSIENG-3079)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

[semaphore tests for community and enterprise](https://semaphore.ci.confluent.io/workflows/1bb04d63-63a5-4374-8fd0-55ee504b45ad)

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
