### PR TITLE
[ANSIENG-2380] | onboard Debian12

### DIFF
--- a/roles/common/tasks/debian.yml
+++ b/roles/common/tasks/debian.yml
@@ -227,7 +227,7 @@
     - repository_configuration in ['custom', 'none']
   tags: package
 
-- name: Install Java - buster
+- name: Install Java - bookworm
   apt:
     name: "{{ debian_java_package_name }}"
     state: present

--- a/roles/common/tasks/debian.yml
+++ b/roles/common/tasks/debian.yml
@@ -227,6 +227,19 @@
     - repository_configuration in ['custom', 'none']
   tags: package
 
+- name: Install Java - buster
+  apt:
+    name: "{{ debian_java_package_name }}"
+    state: present
+  register: java_install_result
+  until: java_install_result is success
+  retries: 10
+  delay: 5
+  when:
+    - install_java|bool
+    - repository_configuration == 'confluent'
+    - ansible_distribution_release == "bookworm"
+
 - name: Install ca-certificates, openssl, unzip
   apt:
     name:

--- a/roles/common/tasks/debian.yml
+++ b/roles/common/tasks/debian.yml
@@ -253,14 +253,24 @@
     state: present
   become: true
   tags: package
+  when: ansible_distribution_release != "bookworm"
 
 - name: Upgrade pip
   ansible.builtin.pip:
     name: pip
     extra_args: --upgrade
   tags: package
+  when: ansible_distribution_release != "bookworm"
 
 - name: Install pip packages
   ansible.builtin.pip:
     name: "{{pip_packages}}"
   tags: package
+  when: ansible_distribution_release !=  "bookworm"
+
+- name: Install pip packages using apt # pep 668 for details
+  apt:
+    name: "python3-{{item}}"
+  tags: package
+  loop: "{{pip_packages}}"
+  when: ansible_distribution_release ==  "bookworm"


### PR DESCRIPTION
# Description

Due to pep 668 pip upgrade was not working for debian 12. So instead of using pip to install packages used the apt to install pip packages.

Fixes # [(ANSIENG-2380)](https://confluentinc.atlassian.net/browse/ANSIENG-2380)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested on ec2 instance with minimal inventory file

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
