### PR TITLE
Adding a single property to copy files to components all_components_copy_files

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,5 @@ If you would like to contribute to the CP-Ansible project, please refer to the [
 ## License
 
 [Apache 2.0](docs/LICENSE.md)
+
+newline

--- a/README.md
+++ b/README.md
@@ -35,5 +35,3 @@ If you would like to contribute to the CP-Ansible project, please refer to the [
 ## License
 
 [Apache 2.0](docs/LICENSE.md)
-
-newline

--- a/docs/VARIABLES.md
+++ b/docs/VARIABLES.md
@@ -188,6 +188,12 @@ Default:  0
 
 ***
 
+### all_components_copy_files
+
+Use to copy files from control node to all components hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '750') and file_mode (default: '640') to set directory and file permissions.
+
+Default:  []
+
 ### kerberos_configure
 
 Boolean to configure Kerberos krb5.conf file, must also set kerberos.realm, kerberos.kdc_hostname, kerberos.admin_hostname, where kerberos is a dictionary. Optional variables: kerberos.kdc_port (default: 88), kerberos.admin_port (default: 749)

--- a/docs/hosts_example.yml
+++ b/docs/hosts_example.yml
@@ -279,6 +279,10 @@ all:
     # ksql_custom_properties:
     #   key: val
 
+  #   ## To copy files to all components hosts, set this list below
+  #   all_components_copy_files:
+  #     - source_path: /path/to/file.txt
+  #       destination_path: /tmp/file.txt
 zookeeper:
   ## To set variables on all zookeeper hosts, use the vars block here
   # vars:

--- a/roles/control_center/tasks/main.yml
+++ b/roles/control_center/tasks/main.yml
@@ -163,6 +163,18 @@
   tags:
     - configuration
 
+- name: Copy Custom Files From All Components List
+  include_role:
+    name: common
+    tasks_from: copy_files.yml
+  vars:
+    copy_files: "{{all_components_copy_files}}"
+    user: "{{control_center_user}}"
+    group: "{{control_center_group}}"
+  when: all_components_copy_files | length > 0
+  tags:
+    - configuration
+
 - name: Configure RBAC for OAuth User
   include_tasks: rbac.yml
   vars:

--- a/roles/kafka_broker/tasks/main.yml
+++ b/roles/kafka_broker/tasks/main.yml
@@ -170,6 +170,18 @@
   tags:
     - configuration
 
+- name: Copy Custom Files From All Components List
+  include_role:
+    name: common
+    tasks_from: copy_files.yml
+  vars:
+    copy_files: "{{all_components_copy_files}}"
+    user: "{{kafka_broker_user}}"
+    group: "{{kafka_broker_group}}"
+  when: all_components_copy_files | length > 0
+  tags:
+    - configuration
+
 - name: Set Permissions on /var/lib/kafka
   file:
     path: /var/lib/kafka/

--- a/roles/kafka_connect/tasks/main.yml
+++ b/roles/kafka_connect/tasks/main.yml
@@ -155,6 +155,18 @@
   tags:
     - configuration
 
+- name: Copy Custom Files From All Components List
+  include_role:
+    name: common
+    tasks_from: copy_files.yml
+  vars:
+    copy_files: "{{all_components_copy_files}}"
+    user: "{{kafka_connect_user}}"
+    group: "{{kafka_connect_group}}"
+  when: all_components_copy_files | length > 0
+  tags:
+    - configuration
+
 - name: Configure RBAC for OAuth User
   include_tasks: rbac.yml
   vars:

--- a/roles/kafka_connect_replicator/tasks/main.yml
+++ b/roles/kafka_connect_replicator/tasks/main.yml
@@ -240,6 +240,18 @@
   tags:
     - configuration
 
+- name: Copy Custom Files From All Components List
+  include_role:
+    name: common
+    tasks_from: copy_files.yml
+  vars:
+    copy_files: "{{all_components_copy_files}}"
+    user: "{{kafka_connect_replicator_user}}"
+    group: "{{kafka_connect_replicator_group}}"
+  when: all_components_copy_files | length > 0
+  tags:
+    - configuration
+
 - name: Register Cluster
   include_tasks: register_cluster.yml
   when: kafka_connect_replicator_cluster_name|length > 0 and rbac_enabled|bool

--- a/roles/kafka_controller/tasks/main.yml
+++ b/roles/kafka_controller/tasks/main.yml
@@ -161,6 +161,18 @@
   tags:
     - configuration
 
+- name: Copy Custom Files From All Components List
+  include_role:
+    name: common
+    tasks_from: copy_files.yml
+  vars:
+    copy_files: "{{all_components_copy_files}}"
+    user: "{{kafka_controller_user}}"
+    group: "{{kafka_controller_group}}"
+  when: all_components_copy_files | length > 0
+  tags:
+    - configuration
+
 - name: Set Permissions on /var/lib/controller
   file:
     path: /var/lib/controller/

--- a/roles/kafka_rest/tasks/main.yml
+++ b/roles/kafka_rest/tasks/main.yml
@@ -142,6 +142,18 @@
   tags:
     - configuration
 
+- name: Copy Custom Files From All Components List
+  include_role:
+    name: common
+    tasks_from: copy_files.yml
+  vars:
+    copy_files: "{{all_components_copy_files}}"
+    user: "{{kafka_rest_user}}"
+    group: "{{kafka_rest_group}}"
+  when: all_components_copy_files | length > 0
+  tags:
+    - configuration
+
 - name: Configure RBAC for OAuth User
   include_tasks: rbac.yml
   vars:

--- a/roles/ksql/tasks/main.yml
+++ b/roles/ksql/tasks/main.yml
@@ -161,6 +161,18 @@
   tags:
     - configuration
 
+- name: Copy Custom Files From All Components List
+  include_role:
+    name: common
+    tasks_from: copy_files.yml
+  vars:
+    copy_files: "{{all_components_copy_files}}"
+    user: "{{ksql_user}}"
+    group: "{{ksql_group}}"
+  when: all_components_copy_files | length > 0
+  tags:
+    - configuration
+
 - name: Configure RBAC
   include_tasks: rbac.yml
   when: rbac_enabled|bool

--- a/roles/schema_registry/tasks/main.yml
+++ b/roles/schema_registry/tasks/main.yml
@@ -142,6 +142,18 @@
   tags:
     - configuration
 
+- name: Copy Custom Files From All Components List
+  include_role:
+    name: common
+    tasks_from: copy_files.yml
+  vars:
+    copy_files: "{{all_components_copy_files}}"
+    user: "{{schema_registry_user}}"
+    group: "{{schema_registry_group}}"
+  when: all_components_copy_files | length > 0
+  tags:
+    - configuration
+
 - name: Configure RBAC for OAuth User
   include_tasks: rbac.yml
   vars:

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -79,6 +79,9 @@ logredactor_rule_url: ""
 ### If present, it's used to specify a time in ms for how often the file system or URL of the policy rules will be checked for changes. Default is 0 and it means that the policy rules will be checked only at startup. Can be specified as logredactor_policy_refresh_interval: 7000
 logredactor_policy_refresh_interval: 0
 
+### Use to copy files from control node to all components hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '750') and file_mode (default: '640') to set directory and file permissions.
+all_components_copy_files: []
+
 ### Boolean to configure Kerberos krb5.conf file, must also set kerberos.realm, kerberos.kdc_hostname, kerberos.admin_hostname, where kerberos is a dictionary. Optional variables: kerberos.kdc_port (default: 88), kerberos.admin_port (default: 749)
 kerberos_configure: true
 

--- a/roles/zookeeper/tasks/main.yml
+++ b/roles/zookeeper/tasks/main.yml
@@ -138,6 +138,18 @@
   tags:
     - configuration
 
+- name: Copy Custom Files From All Components List
+  include_role:
+    name: common
+    tasks_from: copy_files.yml
+  vars:
+    copy_files: "{{all_components_copy_files}}"
+    user: "{{zookeeper_user}}"
+    group: "{{zookeeper_group}}"
+  when: all_components_copy_files | length > 0
+  tags:
+    - configuration
+
 - name: Set Zookeeper Data Dir Ownership
   file:
     path: "{{zookeeper_final_properties.dataDir}}"


### PR DESCRIPTION
# Description

At times it could be useful to copy a file to all managed nodes, today you will need to include an entry for each of the components making the inventory file too long for no reason. 

Adding all_components_copy_files will copy the list of files to all managed nodes



## Type of change

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Validated against a AWS installed cluster.

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
