### PR TITLE
KSQL as OAuth client

### DIFF
--- a/molecule/oauth-rbac-mds-kerberos-debian/molecule.yml
+++ b/molecule/oauth-rbac-mds-kerberos-debian/molecule.yml
@@ -181,20 +181,20 @@ platforms:
     privileged: true
     networks:
       - name: confluent
-  # - name: ksql1
-  #   hostname: ksql1.confluent
-  #   groups:
-  #     - ksql2
-  #     - ksql2_migration
-  #     - cluster2
-  #   image: geerlingguy/docker-debian10-ansible
-  #   dockerfile: ../Dockerfile-debian10.j2
-  #   command: ""
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:ro
-  #   privileged: true
-  #   networks:
-  #     - name: confluent
+  - name: ksql1
+    hostname: ksql1.confluent
+    groups:
+      - ksql2
+      - ksql2_migration
+      - cluster2
+    image: geerlingguy/docker-debian10-ansible
+    dockerfile: ../Dockerfile-debian10.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    networks:
+      - name: confluent
   - name: control-center1
     hostname: control-center1.confluent
     groups:
@@ -211,33 +211,33 @@ platforms:
       - "9021:9021"
     networks:
       - name: confluent
-  # # Cluster 2 (Kraft) goups, groupnames will be changed during converge phase
-  # - name: mds-controller1-mig
-  #   hostname: mds-controller1-mig.confluent
-  #   groups:
-  #     - kafka_controller_migration
-  #     - mds
-  #   image: geerlingguy/docker-debian10-ansible
-  #   dockerfile: ../Dockerfile-debian10.j2
-  #   command: ""
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:ro
-  #   privileged: true
-  #   networks:
-  #     - name: confluent
-  # - name: controller1-mig
-  #   hostname: controller1-mig.confluent
-  #   groups:
-  #     - kafka_controller2_migration
-  #     - cluster2
-  #   image: geerlingguy/docker-debian10-ansible
-  #   dockerfile: ../Dockerfile-debian10.j2
-  #   command: ""
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:ro
-  #   privileged: true
-  #   networks:
-  #     - name: confluent
+  # Cluster 2 (Kraft) goups, groupnames will be changed during converge phase
+  - name: mds-controller1-mig
+    hostname: mds-controller1-mig.confluent
+    groups:
+      - kafka_controller_migration
+      - mds
+    image: geerlingguy/docker-debian10-ansible
+    dockerfile: ../Dockerfile-debian10.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    networks:
+      - name: confluent
+  - name: controller1-mig
+    hostname: controller1-mig.confluent
+    groups:
+      - kafka_controller2_migration
+      - cluster2
+    image: geerlingguy/docker-debian10-ansible
+    dockerfile: ../Dockerfile-debian10.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    networks:
+      - name: confluent
 provisioner:
   playbooks:
     converge: ${MIGRATION_CONVERGE_RBAC:-../multi_rbac_converge.yml}
@@ -260,8 +260,6 @@ provisioner:
           realm: realm.example.com
           kdc_hostname: mds-kerberos1
           admin_hostname: mds-kerberos1
-
-        kafka_connect_secret_registry_enabled: false
 
         zookeeper_kerberos_principal: "zookeeper/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
         zookeeper_kerberos_keytab_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs/zookeeper-{{inventory_hostname}}.keytab"
@@ -295,7 +293,21 @@ provisioner:
         control_center_oauth_user: control_center
         control_center_oauth_password: my-secret
         control_center_oauth_principal: control_center_sub
-        mask_secrets: false
+        ksql_oauth_user: ksql
+        ksql_oauth_password: my-secret
+        ksql_oauth_principal: ksql_sub
+
+        sso_mode: oidc
+        sso_groups_claim: groups
+        sso_sub_claim: sub
+        sso_issuer_url: https://dev-59009577.okta.com/oauth2/aus96p2og3u7Cpwu65d7
+        sso_jwks_uri: https://dev-59009577.okta.com/oauth2/aus96p2og3u7Cpwu65d7/v1/keys
+        sso_authorize_uri: https://dev-59009577.okta.com/oauth2/aus96p2og3u7Cpwu65d7/v1/authorize
+        sso_token_uri: https://dev-59009577.okta.com/oauth2/aus96p2og3u7Cpwu65d7/v1/token
+        sso_device_authorization_uri: https://dev-59009577.okta.com/oauth2/aus96p2og3u7Cpwu65d7/v1/device/authorize
+        sso_cli: true
+        sso_client_id: ${OKTA_CLIENT:-user}
+        sso_client_password: ${OKTA_PASSWORD:-pass}
       mds:
         kafka_broker_cluster_name: mds
 

--- a/molecule/oauth-rbac-plain-rhel8/molecule.yml
+++ b/molecule/oauth-rbac-plain-rhel8/molecule.yml
@@ -1,8 +1,8 @@
 ---
 ### Installs Confluent Platform Cluster on Oracle Linux 8.
 ### RBAC enabled.
-### MTLS enabled.
-### Kafka Broker Customer Listener.
+### Kafka Broker Custom Listener.
+### OAuth using keycloak idp on all cp components
 ### SSO authentication using OIDC in Control center using Okta IdP
 
 driver:
@@ -171,42 +171,42 @@ platforms:
     networks:
       - name: confluent
     # Cluster 2 (Kraft) goups, groupnames will be changed during converge phase
-  # - name: controller1-mig
-  #   hostname: controller1-mig.confluent
-  #   groups:
-  #     - kafka_controller_migration
-  #   image: oraclelinux:8-slim
-  #   dockerfile: ../Dockerfile-rhel-java8.j2
-  #   command: ""
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:ro
-  #   privileged: true
-  #   networks:
-  #     - name: confluent
-  # - name: controller2-mig
-  #   hostname: controller2-mig.confluent
-  #   groups:
-  #     - kafka_controller_migration
-  #   image: oraclelinux:8-slim
-  #   dockerfile: ../Dockerfile-rhel-java8.j2
-  #   command: ""
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:ro
-  #   privileged: true
-  #   networks:
-  #     - name: confluent
-  # - name: controller3-mig
-  #   hostname: controller3-mig.confluent
-  #   groups:
-  #     - kafka_controller_migration
-  #   image: oraclelinux:8-slim
-  #   dockerfile: ../Dockerfile-rhel-java8.j2
-  #   command: ""
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:ro
-  #   privileged: true
-  #   networks:
-  #     - name: confluent
+  - name: controller1-mig
+    hostname: controller1-mig.confluent
+    groups:
+      - kafka_controller_migration
+    image: oraclelinux:8-slim
+    dockerfile: ../Dockerfile-rhel-java8.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    networks:
+      - name: confluent
+  - name: controller2-mig
+    hostname: controller2-mig.confluent
+    groups:
+      - kafka_controller_migration
+    image: oraclelinux:8-slim
+    dockerfile: ../Dockerfile-rhel-java8.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    networks:
+      - name: confluent
+  - name: controller3-mig
+    hostname: controller3-mig.confluent
+    groups:
+      - kafka_controller_migration
+    image: oraclelinux:8-slim
+    dockerfile: ../Dockerfile-rhel-java8.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    networks:
+      - name: confluent
 provisioner:
   playbooks:
     converge: ${MIGRATION_CONVERGE:-../collections_converge.yml}
@@ -216,6 +216,8 @@ provisioner:
         sasl_protocol: plain
         kafka_broker_cluster_name: kafka-cluster
         schema_registry_cluster_name: Test-Schema
+        kafka_connect_cluster_name: Test-Connect
+        ksql_cluster_name: Test-Ksql
         rbac_enabled: true
         rbac_component_additional_system_admins:
           - user1
@@ -225,8 +227,6 @@ provisioner:
             name: CLIENT
             port: 9093
 
-        #kafka_connect_secret_registry_enabled: false
-        ksql_monitoring_interceptors_enabled: false
         oauth_enabled: true
         oauth_client_id: superuser
         oauth_client_password: my-secret
@@ -242,11 +242,16 @@ provisioner:
         kafka_rest_oauth_password: my-secret
         kafka_connect_oauth_user: kafka_connect
         kafka_connect_oauth_password: my-secret
+        ksql_oauth_user: ksql
+        ksql_oauth_password: my-secret
         control_center_oauth_user: control_center
         control_center_oauth_password: my-secret
+
+        # SSO in C3 vars
         sso_mode: oidc
         sso_groups_claim: groups
         sso_sub_claim: sub
+        sso_groups_scope: groups
         sso_issuer_url: https://dev-59009577.okta.com/oauth2/aus96p2og3u7Cpwu65d7
         sso_jwks_uri: https://dev-59009577.okta.com/oauth2/aus96p2og3u7Cpwu65d7/v1/keys
         sso_authorize_uri: https://dev-59009577.okta.com/oauth2/aus96p2og3u7Cpwu65d7/v1/authorize
@@ -255,10 +260,3 @@ provisioner:
         sso_cli: true
         sso_client_id: ${OKTA_CLIENT:-user}
         sso_client_password: ${OKTA_PASSWORD:-pass}
-        secrets_protection_enabled: false
-        mask_secrets: false
-        #ksql_authentication_type: basic
-
-        kafka_connect_cluster_name: Test-Connect
-        ksql_ldap_user: ksql
-        ksql_ldap_password: my-secret

--- a/molecule/oauth-rbac-plain-rhel8/molecule.yml
+++ b/molecule/oauth-rbac-plain-rhel8/molecule.yml
@@ -142,19 +142,19 @@ platforms:
     privileged: true
     networks:
       - name: confluent
-  # - name: ksql1
-  #   hostname: ksql1.confluent
-  #   groups:
-  #     - ksql
-  #     - ksql_migration
-  #   image: oraclelinux:8-slim
-  #   dockerfile: ../Dockerfile-rhel-java8.j2
-  #   command: ""
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:ro
-  #   privileged: true
-  #   networks:
-  #     - name: confluent
+  - name: ksql1
+    hostname: ksql1.confluent
+    groups:
+      - ksql
+      - ksql_migration
+    image: oraclelinux:8-slim
+    dockerfile: ../Dockerfile-rhel-java8.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    networks:
+      - name: confluent
   - name: control-center1
     hostname: control-center1.confluent
     groups:
@@ -225,8 +225,8 @@ provisioner:
             name: CLIENT
             port: 9093
 
-        kafka_connect_secret_registry_enabled: false
-
+        #kafka_connect_secret_registry_enabled: false
+        ksql_monitoring_interceptors_enabled: false
         oauth_enabled: true
         oauth_client_id: superuser
         oauth_client_password: my-secret
@@ -255,7 +255,10 @@ provisioner:
         sso_cli: true
         sso_client_id: ${OKTA_CLIENT:-user}
         sso_client_password: ${OKTA_PASSWORD:-pass}
-        secrets_protection_enabled: true
+        secrets_protection_enabled: false
         mask_secrets: false
+        #ksql_authentication_type: basic
 
         kafka_connect_cluster_name: Test-Connect
+        ksql_ldap_user: ksql
+        ksql_ldap_password: my-secret

--- a/molecule/plain-rhel/molecule.yml
+++ b/molecule/plain-rhel/molecule.yml
@@ -91,19 +91,19 @@ platforms:
     privileged: true
     networks:
       - name: confluent
-  # - name: ksql1
-  #   hostname: ksql1.confluent
-  #   groups:
-  #     - ksql
-  #     - ksql_migration
-  #   image: redhat/ubi9-minimal
-  #   dockerfile: ../Dockerfile-rhel-java17.j2
-  #   command: ""
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:ro
-  #   privileged: true
-  #   networks:
-  #     - name: confluent
+  - name: ksql1
+    hostname: ksql1.confluent
+    groups:
+      - ksql
+      - ksql_migration
+    image: redhat/ubi9-minimal
+    dockerfile: ../Dockerfile-rhel-java17.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    networks:
+      - name: confluent
   - name: control-center1
     hostname: control-center1.confluent
     groups:
@@ -119,19 +119,19 @@ platforms:
       - "9021:9021"
     networks:
       - name: confluent
-  #   # Cluster 2 (Kraft) goups, groupnames will be changed during converge phase
-  # - name: controller1-mig
-  #   hostname: controller1-mig.confluent
-  #   groups:
-  #     - kafka_controller_migration
-  #   image: redhat/ubi9-minimal
-  #   dockerfile: ../Dockerfile-rhel-java17.j2
-  #   command: ""
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:ro
-  #   privileged: true
-  #   networks:
-  #     - name: confluent
+    # Cluster 2 (Kraft) goups, groupnames will be changed during converge phase
+  - name: controller1-mig
+    hostname: controller1-mig.confluent
+    groups:
+      - kafka_controller_migration
+    image: redhat/ubi9-minimal
+    dockerfile: ../Dockerfile-rhel-java17.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    networks:
+      - name: confluent
 provisioner:
   playbooks:
     converge: ${MIGRATION_CONVERGE:-../collections_converge.yml}
@@ -157,7 +157,8 @@ provisioner:
         kafka_connect_oauth_password: my-secret
         control_center_oauth_user: control_center
         control_center_oauth_password: my-secret
-        mask_secrets: false
+        ksql_oauth_user: ksql
+        ksql_oauth_password: my-secret
 
         # kafka_broker_configure_control_plane_listener: true
         # kafka_rest_oauth_enabled: false

--- a/molecule/rbac-plain-provided-debian9/molecule.yml
+++ b/molecule/rbac-plain-provided-debian9/molecule.yml
@@ -54,32 +54,32 @@ platforms:
     privileged: true
     networks:
       - name: confluent
-  # - name: ${KRAFT_CONTROLLER:-zookeeper}2
-  #   hostname: ${KRAFT_CONTROLLER:-zookeeper}2.confluent
-  #   groups:
-  #     - ${CONTROLLER_HOSTGROUP:-zookeeper}
-  #     - ${CONTROLLER_HOSTGROUP:-zookeeper}_migration
-  #   image: geerlingguy/docker-debian9-ansible
-  #   dockerfile: ../Dockerfile-debian.j2
-  #   command: ""
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:ro
-  #   privileged: true
-  #   networks:
-  #     - name: confluent
-  # - name: ${KRAFT_CONTROLLER:-zookeeper}3
-  #   hostname: ${KRAFT_CONTROLLER:-zookeeper}3.confluent
-  #   groups:
-  #     - ${CONTROLLER_HOSTGROUP:-zookeeper}
-  #     - ${CONTROLLER_HOSTGROUP:-zookeeper}_migration
-  #   image: geerlingguy/docker-debian9-ansible
-  #   dockerfile: ../Dockerfile-debian.j2
-  #   command: ""
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:ro
-  #   privileged: true
-  #   networks:
-  #     - name: confluent
+  - name: ${KRAFT_CONTROLLER:-zookeeper}2
+    hostname: ${KRAFT_CONTROLLER:-zookeeper}2.confluent
+    groups:
+      - ${CONTROLLER_HOSTGROUP:-zookeeper}
+      - ${CONTROLLER_HOSTGROUP:-zookeeper}_migration
+    image: geerlingguy/docker-debian9-ansible
+    dockerfile: ../Dockerfile-debian.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    networks:
+      - name: confluent
+  - name: ${KRAFT_CONTROLLER:-zookeeper}3
+    hostname: ${KRAFT_CONTROLLER:-zookeeper}3.confluent
+    groups:
+      - ${CONTROLLER_HOSTGROUP:-zookeeper}
+      - ${CONTROLLER_HOSTGROUP:-zookeeper}_migration
+    image: geerlingguy/docker-debian9-ansible
+    dockerfile: ../Dockerfile-debian.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    networks:
+      - name: confluent
   - name: kafka-broker1
     hostname: kafka-broker1.confluent
     groups:
@@ -93,32 +93,32 @@ platforms:
     privileged: true
     networks:
       - name: confluent
-  # - name: kafka-broker2
-  #   hostname: kafka-broker2.confluent
-  #   groups:
-  #     - kafka_broker
-  #     - kafka_broker_migration
-  #   image: geerlingguy/docker-debian9-ansible
-  #   dockerfile: ../Dockerfile-debian.j2
-  #   command: ""
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:ro
-  #   privileged: true
-  #   networks:
-  #     - name: confluent
-  # - name: kafka-broker3
-  #   hostname: kafka-broker3.confluent
-  #   groups:
-  #     - kafka_broker
-  #     - kafka_broker_migration
-  #   image: geerlingguy/docker-debian9-ansible
-  #   dockerfile: ../Dockerfile-debian.j2
-  #   command: ""
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:ro
-  #   privileged: true
-  #   networks:
-  #     - name: confluent
+  - name: kafka-broker2
+    hostname: kafka-broker2.confluent
+    groups:
+      - kafka_broker
+      - kafka_broker_migration
+    image: geerlingguy/docker-debian9-ansible
+    dockerfile: ../Dockerfile-debian.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    networks:
+      - name: confluent
+  - name: kafka-broker3
+    hostname: kafka-broker3.confluent
+    groups:
+      - kafka_broker
+      - kafka_broker_migration
+    image: geerlingguy/docker-debian9-ansible
+    dockerfile: ../Dockerfile-debian.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    networks:
+      - name: confluent
   - name: schema-registry1
     hostname: schema-registry1.confluent
     groups:
@@ -158,34 +158,34 @@ platforms:
     privileged: true
     networks:
       - name: confluent
-  # - name: ksql1
-  #   hostname: ksql1.confluent
-  #   groups:
-  #     - ksql
-  #     - ksql_migration
-  #   image: geerlingguy/docker-debian9-ansible
-  #   dockerfile: ../Dockerfile-debian.j2
-  #   command: ""
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:ro
-  #   privileged: true
-  #   networks:
-  #     - name: confluent
-  # Testing metrics reporter logic when c3 not in inventory
-  # - name: control-center1
-  #   hostname: control-center1.confluent
-  #   groups:
-  #     - control_center
-  #   image: geerlingguy/docker-debian9-ansible
-  #   dockerfile: ../Dockerfile-debian.j2
-  #   command: ""
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:ro
-  #   privileged: true
-  #   published_ports:
-  #     - "9021:9021"
-  #   networks:
-  #     - name: confluent
+  - name: ksql1
+    hostname: ksql1.confluent
+    groups:
+      - ksql
+      - ksql_migration
+    image: geerlingguy/docker-debian9-ansible
+    dockerfile: ../Dockerfile-debian.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    networks:
+      - name: confluent
+  #Testing metrics reporter logic when c3 not in inventory
+  - name: control-center1
+    hostname: control-center1.confluent
+    groups:
+      - control_center
+    image: geerlingguy/docker-debian9-ansible
+    dockerfile: ../Dockerfile-debian.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    published_ports:
+      - "9021:9021"
+    networks:
+      - name: confluent
   # Cluster 2 (Kraft) goups, groupnames will be changed during converge phase
   - name: controller1-mig
     hostname: controller1-mig.confluent
@@ -209,23 +209,20 @@ provisioner:
 
         sasl_protocol: plain
 
-        # ssl_enabled: true
+        ssl_enabled: true
 
-        # ssl_provided_keystore_and_truststore: true
-        # ssl_keystore_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}.keystore.jks"
-        # ssl_keystore_key_password: keystorepass
-        # ssl_keystore_store_password: keystorepass
-        # ssl_truststore_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/truststore.jks"
-        # ssl_truststore_password: truststorepass
-        # ssl_truststore_ca_cert_alias: CARoot
-
-        kafka_connect_secret_registry_enabled: false
+        ssl_provided_keystore_and_truststore: true
+        ssl_keystore_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}.keystore.jks"
+        ssl_keystore_key_password: keystorepass
+        ssl_keystore_store_password: keystorepass
+        ssl_truststore_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/truststore.jks"
+        ssl_truststore_password: truststorepass
+        ssl_truststore_ca_cert_alias: CARoot
 
         oauth_enabled: true
-        schema_registry_oauth_enabled: false
+        schema_registry_oauth_enabled: false # to test SR without OAuth after upgrade
         kafka_rest_oauth_enabled: true
         kafka_connect_oauth_enabled: true
-        mask_secrets: false
         ldap_with_oauth_enabled: true
         oauth_client_id: superuser
         oauth_client_password: my-secret
@@ -241,7 +238,24 @@ provisioner:
         kafka_rest_oauth_password: my-secret
         kafka_connect_oauth_user: kafka_connect
         kafka_connect_oauth_password: my-secret
+        ksql_oauth_user: ksql
+        ksql_oauth_password: my-secret
+        control_center_oauth_user: control_center
+        control_center_oauth_password: my-secret
 
+        sso_mode: oidc
+        sso_groups_claim: groups
+        sso_sub_claim: sub
+        sso_groups_scope: groups
+        sso_issuer_url: https://dev-59009577.okta.com/oauth2/aus96p2og3u7Cpwu65d7
+        sso_jwks_uri: https://dev-59009577.okta.com/oauth2/aus96p2og3u7Cpwu65d7/v1/keys
+        sso_authorize_uri: https://dev-59009577.okta.com/oauth2/aus96p2og3u7Cpwu65d7/v1/authorize
+        sso_token_uri: https://dev-59009577.okta.com/oauth2/aus96p2og3u7Cpwu65d7/v1/token
+        sso_device_authorization_uri: https://dev-59009577.okta.com/oauth2/aus96p2og3u7Cpwu65d7/v1/device/authorize
+        sso_cli: true
+        sso_client_id: ${OKTA_CLIENT:-user}
+        sso_client_password: ${OKTA_PASSWORD:-pass}
+        sso_idp_pem_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/oktacertfile.pem"
         rbac_enabled: true
         custom_java_path: /opt/jdk17 # Use custom Java 17
 

--- a/molecule/rbac-plain-provided-debian9/prepare.yml
+++ b/molecule/rbac-plain-provided-debian9/prepare.yml
@@ -11,3 +11,8 @@
 - name: Install Zookeeper Cluster
   import_playbook: confluent.platform.all
   when: lookup('env', 'MIGRATION')|default('false') == 'true'
+
+- name: Download Okta IDP cert  # temporary, till we are using OKTA IDP
+  hosts: localhost
+  tasks:
+    - shell: openssl s_client -showcerts -connect dev-59009577.okta.com:443 </dev/null 2>/dev/null|openssl x509 -outform PEM > oktacertfile.pem

--- a/plugins/filter/filters.py
+++ b/plugins/filter/filters.py
@@ -333,7 +333,7 @@ class FilterModule(object):
 
     def c3_connect_properties(self, connect_group_list, groups, hostvars, ssl_enabled, http_protocol, port, default_connect_group_id,
                               truststore_path, truststore_storepass, keystore_path, keystore_storepass, keystore_keypass,
-                              oauth_enabled, rbac_enabled, oauth_user, oauth_password):
+                              oauth_enabled, rbac_enabled, oauth_user, oauth_password, oauth_groups_scope):
         # For c3's connect properties, inputs a list of ansible groups of connect hosts, as well as their ssl settings
         # Outputs a properties dictionary with properties necessary to connect to each connect group
         # Other inputs help fill out the properties
@@ -364,6 +364,9 @@ class FilterModule(object):
                 if delegate_host.get('kafka_connect_oauth_enabled', oauth_enabled) and not rbac_enabled:
                     final_dict['confluent.controlcenter.connect.' + group_id + '.oauthbearer.login.client.id'] = oauth_user
                     final_dict['confluent.controlcenter.connect.' + group_id + '.oauthbearer.login.client.secret'] = oauth_password
+
+                if delegate_host.get('kafka_connect_oauth_enabled', oauth_enabled) and not rbac_enabled and oauth_groups_scope != 'none':
+                    final_dict['confluent.controlcenter.connect.' + group_id + '.oauthbearer.login.oauth.scope'] = oauth_groups_scope
 
         return final_dict
 

--- a/roles/ksql/tasks/main.yml
+++ b/roles/ksql/tasks/main.yml
@@ -161,9 +161,19 @@
   tags:
     - configuration
 
-- name: Configure RBAC
+- name: Configure RBAC for OAuth User
   include_tasks: rbac.yml
-  when: rbac_enabled|bool
+  vars:
+    ksqldb_user: "{{ksql_oauth_principal}}"
+  when: rbac_enabled|bool and oauth_enabled
+
+- name: Configure RBAC for LDAP User
+  include_tasks: rbac.yml
+  vars:
+    ksqldb_user: "{{ksql_ldap_user}}"
+  when:
+    - rbac_enabled|bool
+    - ((not oauth_enabled) or ( oauth_enabled and ldap_with_oauth_enabled ))
 
 - name: Create Ksql Config directory
   file:

--- a/roles/ksql/tasks/rbac.yml
+++ b/roles/ksql/tasks/rbac.yml
@@ -16,11 +16,9 @@
     url: "{{mds_bootstrap_server_urls.split(',')[0]}}/security/1.0/principals/{% if 'User' not in item and 'Group' not in item %}User:{% endif %}{{item}}/roles/SystemAdmin"
     method: POST
     validate_certs: false
-    force_basic_auth: true
-    url_username: "{{mds_super_user}}"
-    url_password: "{{mds_super_user_password}}"
     headers:
       Content-Type: application/json
+      Authorization: "Bearer {{ authorization_token }}"
     body_format: json
     body: >
       {
@@ -42,11 +40,9 @@
     url: "{{mds_bootstrap_server_urls.split(',')[0]}}/security/1.0/principals/User:{{ksql_ldap_user}}/roles/ResourceOwner/bindings"
     method: POST
     validate_certs: false
-    force_basic_auth: true
-    url_username: "{{mds_super_user}}"
-    url_password: "{{mds_super_user_password}}"
     headers:
       Content-Type: application/json
+      Authorization: "Bearer {{ authorization_token }}"
     body_format: json
     body: >
       {
@@ -73,11 +69,9 @@
     url: "{{mds_bootstrap_server_urls.split(',')[0]}}/security/1.0/principals/User:{{ksql_ldap_user}}/roles/ResourceOwner/bindings"
     method: POST
     validate_certs: false
-    force_basic_auth: true
-    url_username: "{{mds_super_user}}"
-    url_password: "{{mds_super_user_password}}"
     headers:
       Content-Type: application/json
+      Authorization: "Bearer {{ authorization_token }}"
     body_format: json
     body: >
       {
@@ -111,11 +105,9 @@
     url: "{{mds_bootstrap_server_urls.split(',')[0]}}/security/1.0/principals/User:{{ksql_ldap_user}}/roles/DeveloperWrite/bindings"
     method: POST
     validate_certs: false
-    force_basic_auth: true
-    url_username: "{{mds_super_user}}"
-    url_password: "{{mds_super_user_password}}"
     headers:
       Content-Type: application/json
+      Authorization: "Bearer {{ authorization_token }}"
     body_format: json
     body: >
       {
@@ -142,11 +134,9 @@
     url: "{{mds_bootstrap_server_urls.split(',')[0]}}/security/1.0/principals/User:{{ksql_ldap_user}}/roles/ResourceOwner/bindings"
     method: POST
     validate_certs: false
-    force_basic_auth: true
-    url_username: "{{mds_super_user}}"
-    url_password: "{{mds_super_user_password}}"
     headers:
       Content-Type: application/json
+      Authorization: "Bearer {{ authorization_token }}"
     body_format: json
     body: >
       {
@@ -174,11 +164,9 @@
     url: "{{mds_bootstrap_server_urls.split(',')[0]}}/security/1.0/principals/User:{{ksql_ldap_user}}/roles/DeveloperWrite/bindings"
     method: POST
     validate_certs: false
-    force_basic_auth: true
-    url_username: "{{mds_super_user}}"
-    url_password: "{{mds_super_user_password}}"
     headers:
       Content-Type: application/json
+      Authorization: "Bearer {{ authorization_token }}"
     body_format: json
     body: >
       {
@@ -205,11 +193,9 @@
     url: "{{mds_bootstrap_server_urls.split(',')[0]}}/security/1.0/principals/User:{{item}}/roles/ResourceOwner/bindings"
     method: POST
     validate_certs: false
-    force_basic_auth: true
-    url_username: "{{mds_super_user}}"
-    url_password: "{{mds_super_user_password}}"
     headers:
       Content-Type: application/json
+      Authorization: "Bearer {{ authorization_token }}"
     body_format: json
     body: >
       {

--- a/roles/ksql/tasks/rbac.yml
+++ b/roles/ksql/tasks/rbac.yml
@@ -37,7 +37,7 @@
 
 - name: Grant ResourceOwner of KSQL Cluster on KSQL User
   uri:
-    url: "{{mds_bootstrap_server_urls.split(',')[0]}}/security/1.0/principals/User:{{ksql_ldap_user}}/roles/ResourceOwner/bindings"
+    url: "{{mds_bootstrap_server_urls.split(',')[0]}}/security/1.0/principals/User:{{ksqldb_user}}/roles/ResourceOwner/bindings"
     method: POST
     validate_certs: false
     headers:
@@ -66,7 +66,7 @@
 
 - name: Grant ksql user the ResourceOwner role with four resourcePatterns
   uri:
-    url: "{{mds_bootstrap_server_urls.split(',')[0]}}/security/1.0/principals/User:{{ksql_ldap_user}}/roles/ResourceOwner/bindings"
+    url: "{{mds_bootstrap_server_urls.split(',')[0]}}/security/1.0/principals/User:{{ksqldb_user}}/roles/ResourceOwner/bindings"
     method: POST
     validate_certs: false
     headers:
@@ -102,7 +102,7 @@
 
 - name: Grant ksql user the DeveloperWrite role on resourceType TransactionalId
   uri:
-    url: "{{mds_bootstrap_server_urls.split(',')[0]}}/security/1.0/principals/User:{{ksql_ldap_user}}/roles/DeveloperWrite/bindings"
+    url: "{{mds_bootstrap_server_urls.split(',')[0]}}/security/1.0/principals/User:{{ksqldb_user}}/roles/DeveloperWrite/bindings"
     method: POST
     validate_certs: false
     headers:
@@ -131,7 +131,7 @@
 
 - name: Grant ksql user the ResourceOwner role on resourceType Subject in Schema Registry Cluster
   uri:
-    url: "{{mds_bootstrap_server_urls.split(',')[0]}}/security/1.0/principals/User:{{ksql_ldap_user}}/roles/ResourceOwner/bindings"
+    url: "{{mds_bootstrap_server_urls.split(',')[0]}}/security/1.0/principals/User:{{ksqldb_user}}/roles/ResourceOwner/bindings"
     method: POST
     validate_certs: false
     headers:
@@ -161,7 +161,7 @@
 
 - name: Grant ksql user the DeveloperWrite role on Monitoring Interceptor Topic
   uri:
-    url: "{{mds_bootstrap_server_urls.split(',')[0]}}/security/1.0/principals/User:{{ksql_ldap_user}}/roles/DeveloperWrite/bindings"
+    url: "{{mds_bootstrap_server_urls.split(',')[0]}}/security/1.0/principals/User:{{ksqldb_user}}/roles/DeveloperWrite/bindings"
     method: POST
     validate_certs: false
     headers:
@@ -218,6 +218,6 @@
   retries: "{{ mds_retries }}"
   delay: 5
   loop:
-    - "{{ksql_ldap_user}}"
+    - "{{ksqldb_user}}"
     - "{{ksql_log4j_principal}}"
   when: ksql_log_streaming_enabled | bool and not ansible_check_mode

--- a/roles/ksql/tasks/register_cluster.yml
+++ b/roles/ksql/tasks/register_cluster.yml
@@ -22,11 +22,9 @@
     url: "{{mds_bootstrap_server_urls.split(',')[0]}}/security/1.0/registry/clusters"
     method: POST
     validate_certs: false
-    force_basic_auth: true
-    url_username: "{{mds_super_user}}"
-    url_password: "{{mds_super_user_password}}"
     headers:
       Content-Type: application/json
+      Authorization: "Bearer {{ authorization_token }}"
     body_format: json
     body: >
       [

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -1577,6 +1577,15 @@ ksql_ldap_user: ksql
 ### Password to ksql_ldap_user LDAP User
 ksql_ldap_password: password
 
+### OAuth User for ksql to authenticate as
+ksql_oauth_user: ksql
+
+### Password to ksql_oauth_user
+ksql_oauth_password: password
+
+### Service principal for Ksql client in Idp server. Defaults to Ksql client
+ksql_oauth_principal: "{{ ksql_oauth_user }}"
+
 ### LDAP User for Rest Proxy to authenticate as
 kafka_rest_ldap_user: kafka-rest
 

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -1898,10 +1898,10 @@ kafka_connect_health_check_user: "{{ kafka_connect_basic_users.admin.principal }
 kafka_connect_health_check_password: "{{ kafka_connect_basic_users.admin.password }}"
 
 ### User for authenticated ksqlDB Health Check. Set if using customized security like Basic Auth.
-ksql_health_check_user: "{{ ksql_ldap_user if (rbac_enabled|bool and not oauth_enabled) else ksql_basic_users.admin.principal }}"
+ksql_health_check_user: "{{ ksql_ldap_user if (rbac_enabled|bool and ((not oauth_enabled) or ldap_with_oauth_enabled)) else ksql_basic_users.admin.principal }}"
 
 ### Password for authenticated ksqlDB Health Check. Set if using customized security like Basic Auth.
-ksql_health_check_password: "{{ ksql_ldap_password if (rbac_enabled|bool and not oauth_enabled) else ksql_basic_users.admin.password }}"
+ksql_health_check_password: "{{ ksql_ldap_password if (rbac_enabled|bool and ((not oauth_enabled) or ldap_with_oauth_enabled)) else ksql_basic_users.admin.password }}"
 
 ### User for authenticated Rest Proxy Health Check. Set if using customized security like Basic Auth.
 kafka_rest_health_check_user: "{{ kafka_rest_basic_users.admin.principal }}"

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -1889,10 +1889,10 @@ kafka_connect_health_check_user: "{{ kafka_connect_basic_users.admin.principal }
 kafka_connect_health_check_password: "{{ kafka_connect_basic_users.admin.password }}"
 
 ### User for authenticated ksqlDB Health Check. Set if using customized security like Basic Auth.
-ksql_health_check_user: "{{ ksql_ldap_user if rbac_enabled|bool else ksql_basic_users.admin.principal }}"
+ksql_health_check_user: "{{ ksql_ldap_user if (rbac_enabled|bool and not oauth_enabled) else ksql_basic_users.admin.principal }}"
 
 ### Password for authenticated ksqlDB Health Check. Set if using customized security like Basic Auth.
-ksql_health_check_password: "{{ ksql_ldap_password if rbac_enabled|bool else ksql_basic_users.admin.password }}"
+ksql_health_check_password: "{{ ksql_ldap_password if (rbac_enabled|bool and not oauth_enabled) else ksql_basic_users.admin.password }}"
 
 ### User for authenticated Rest Proxy Health Check. Set if using customized security like Basic Auth.
 kafka_rest_health_check_user: "{{ kafka_rest_basic_users.admin.principal }}"

--- a/roles/variables/vars/main.yml
+++ b/roles/variables/vars/main.yml
@@ -1310,7 +1310,6 @@ ksql_properties:
     properties:
       public.key.path: "{{rbac_enabled_public_pem_path}}"
       confluent.metadata.bootstrap.server.urls: "{{mds_bootstrap_server_urls}}"
-      confluent.metadata.http.auth.credentials.provider: OAUTHBEARER
   rbac_ldap:
     enabled: "{{rbac_enabled and ((not oauth_enabled) or ldap_with_oauth_enabled)}}"
     properties:
@@ -1325,6 +1324,7 @@ ksql_properties:
       confluent.metadata.oauthbearer.login.client.secret: "{{ksql_oauth_password}}"
       confluent.metadata.oauthbearer.token.endpoint.url: "{{ oauth_token_uri }}"
       confluent.metadata.oauthbearer.login.credentials.source: OAUTHBEARER
+      confluent.metadata.http.auth.credentials.provider: OAUTHBEARER
   rbac_oauth_scope:
     enabled: "{{ rbac_enabled and oauth_enabled and (not ldap_with_oauth_enabled) and oauth_groups_scope!='none'}}"
     properties:

--- a/roles/variables/vars/main.yml
+++ b/roles/variables/vars/main.yml
@@ -507,14 +507,14 @@ kafka_broker_properties:
       confluent.basic.auth.credentials.source: USER_INFO
       confluent.basic.auth.user.info: "{{schema_registry_ldap_user | default('sr') }}:{{schema_registry_ldap_password | default('pass')}}"
   sr_oauth:
-    enabled: "{{ kafka_broker_schema_validation_enabled and 'schema_registry' in groups and rbac_enabled and schema_registry_oauth_enabled }}"
+    enabled: "{{ kafka_broker_schema_validation_enabled and 'schema_registry' in groups and schema_registry_oauth_enabled }}"
     properties:
       confluent.bearer.auth.credentials.source: OAUTHBEARER
       confluent.bearer.auth.issuer.endpoint.url: "{{ oauth_token_uri }}"
       confluent.bearer.auth.client.id: "{{ schema_registry_oauth_user }}"
       confluent.bearer.auth.client.secret: "{{ schema_registry_oauth_password }}"
   sr_oauth_scope:
-    enabled: "{{ kafka_broker_schema_validation_enabled and 'schema_registry' in groups and rbac_enabled and schema_registry_oauth_enabled and oauth_groups_scope!='none'}}"
+    enabled: "{{ kafka_broker_schema_validation_enabled and 'schema_registry' in groups and schema_registry_oauth_enabled and oauth_groups_scope!='none'}}"
     properties:
       confluent.bearer.auth.scope: "{{ oauth_groups_scope }}"
   sr_basic:
@@ -671,6 +671,10 @@ kafka_broker_properties:
       kafka.rest.confluent.metadata.oauthbearer.login.client.id: "{{kafka_broker_oauth_user}}"
       kafka.rest.confluent.metadata.oauthbearer.login.client.secret: "{{kafka_broker_oauth_password}}"
       kafka.rest.confluent.metadata.oauthbearer.token.endpoint.url: "{{ oauth_token_uri }}"
+  embedded_rest_proxy_rbac_oauth_scope:
+    enabled: "{{ kafka_broker_rest_proxy_enabled and rbac_enabled and oauth_enabled and oauth_groups_scope!='none'}}"
+    properties:
+      kafka.rest.confluent.metadata.oauthbearer.login.oauth.scope: "{{ oauth_groups_scope }}"
   embedded_rest_proxy_oauth:
     enabled: "{{ kafka_broker_rest_proxy_enabled and oauth_enabled }}"
     properties:
@@ -874,10 +878,10 @@ schema_registry_properties:
       oauthbearer.jwks.endpoint.url: "{{oauth_jwks_uri}}"
       oauthbearer.sub.claim.name: "{{ oauth_sub_claim }}"
       oauthbearer.expected.issuer: "{{ oauth_issuer_url }}"
-  sr_oauth_scope:
-    enabled: "{{schema_registry_oauth_enabled and oauth_groups_scope!='none' }}"
+  sr_oauth_claim:
+    enabled: "{{schema_registry_oauth_enabled and oauth_groups_claim!='none' }}"
     properties:
-      oauthbearer.groups.claim.name: "{{ oauth_groups_scope }}"
+      oauthbearer.groups.claim.name: "{{ oauth_groups_claim }}"
   sr_oauth_audience:
     enabled: "{{schema_registry_oauth_enabled and oauth_expected_audience!='none' }}"
     properties:
@@ -1092,10 +1096,10 @@ kafka_connect_properties:
       oauthbearer.jwks.endpoint.url: "{{oauth_jwks_uri}}"
       oauthbearer.sub.claim.name: "{{ oauth_sub_claim }}"
       oauthbearer.expected.issuer: "{{ oauth_issuer_url }}"
-  kafka_connect_oauth_scope:
-    enabled: "{{kafka_connect_oauth_enabled and oauth_groups_scope!='none' }}"
+  kafka_connect_oauth_claim:
+    enabled: "{{kafka_connect_oauth_enabled and oauth_groups_claim!='none' }}"
     properties:
-      oauthbearer.groups.claim.name: "{{ oauth_groups_scope }}"
+      oauthbearer.groups.claim.name: "{{ oauth_groups_claim }}"
   kafka_connect_oauth_audience:
     enabled: "{{kafka_connect_oauth_enabled and oauth_expected_audience!='none' }}"
     properties:
@@ -1240,20 +1244,20 @@ ksql_properties:
       sasl.jaas.config: |-
         com.sun.security.auth.module.Krb5LoginModule required useKeyTab=true storeKey=true keyTab="{{ksql_keytab_path}}" principal="{{ksql_kerberos_principal | default('ksql')}}";
   kafka_sasl_ldap:
-    enabled: "{{ kafka_broker_listeners[ksql_kafka_listener_name]['sasl_protocol'] | default(sasl_protocol) | confluent.platform.normalize_sasl_protocol == 'OAUTHBEARER' and (not oauth_enabled or ldap_with_oauth_enabled) }}"
+    enabled: "{{ kafka_broker_listeners[ksql_kafka_listener_name]['sasl_protocol'] | default(sasl_protocol) | confluent.platform.normalize_sasl_protocol == 'OAUTHBEARER' and ((not oauth_enabled) or ldap_with_oauth_enabled) }}"
     properties:
       sasl.mechanism: OAUTHBEARER
       sasl.login.callback.handler.class: io.confluent.kafka.clients.plugins.auth.token.TokenUserLoginCallbackHandler
       sasl.jaas.config: |-
         org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required username="{{ksql_ldap_user | default('ksql')}}" password="{{ksql_ldap_password | default('pass')}}" metadataServerUrls="{{mds_bootstrap_server_urls}}";
   kafka_sasl_oauth:
-    enabled: "{{ kafka_broker_listeners[ksql_kafka_listener_name]['sasl_protocol'] | default(sasl_protocol) | confluent.platform.normalize_sasl_protocol == 'OAUTHBEARER' and (oauth_enabled and not ldap_with_oauth_enabled)}}"
+    enabled: "{{ kafka_broker_listeners[ksql_kafka_listener_name]['sasl_protocol'] | default(sasl_protocol) | confluent.platform.normalize_sasl_protocol == 'OAUTHBEARER' and (oauth_enabled and (not ldap_with_oauth_enabled))}}"
     properties:
       sasl.mechanism: OAUTHBEARER
       sasl.login.callback.handler.class: org.apache.kafka.common.security.oauthbearer.secured.OAuthBearerLoginCallbackHandler
       sasl.oauthbearer.token.endpoint.url: "{{oauth_token_uri}}"
       sasl.jaas.config: |-
-        org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required clientId="{{ksql_oauth_user}}" clientSecret="{{ksql_oauth_password}}" {% if oauth_groups_scope!='none' %}scope="{{oauth_groups_scope}}{% endif %}";
+        org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required clientId="{{ksql_oauth_user}}" clientSecret="{{ksql_oauth_password}}" {% if oauth_groups_scope!='none' %}scope="{{oauth_groups_scope}}"{% endif %};
   sr:
     enabled: "{{ 'schema_registry' in groups }}"
     properties:
@@ -1272,19 +1276,19 @@ ksql_properties:
       ksql.schema.registry.basic.auth.credentials.source: USER_INFO
       ksql.schema.registry.basic.auth.user.info: "{{schema_registry_basic_users_final.admin.principal}}:{{schema_registry_basic_users_final.admin.password}}"
   sr_rbac:
-    enabled: "{{ 'schema_registry' in groups and rbac_enabled|bool and (not oauth_enabled or ldap_with_oauth_enabled)}}"
+    enabled: "{{ 'schema_registry' in groups and rbac_enabled|bool and ((not schema_registry_oauth_enabled) or ldap_with_oauth_enabled)}}"
     properties:
       ksql.schema.registry.basic.auth.credentials.source: USER_INFO
       ksql.schema.registry.basic.auth.user.info: "{{ ksql_ldap_user | default('ksql') }}:{{ ksql_ldap_password | default('pass') }}"
-  sr_rbac_oauth:
-    enabled: "{{ 'schema_registry' in groups and rbac_enabled|bool and (oauth_enabled and not ldap_with_oauth_enabled)}}"
+  sr_oauth:
+    enabled: "{{ 'schema_registry' in groups and schema_registry_oauth_enabled and (not ldap_with_oauth_enabled)}}"
     properties:
       ksql.schema.registry.bearer.auth.credentials.source: OAUTHBEARER
       ksql.schema.registry.bearer.auth.client.id: "{{ksql_oauth_user}}"
       ksql.schema.registry.bearer.auth.client.secret: "{{ksql_oauth_password}}"
       ksql.schema.registry.bearer.auth.issuer.endpoint.url: "{{oauth_token_uri}}"
-  sr_rbac_oauth_scope:
-    enabled: "{{ 'schema_registry' in groups and rbac_enabled|bool and (oauth_enabled and not ldap_with_oauth_enabled) and oauth_groups_scope!='none'}}"
+  sr_oauth_scope:
+    enabled: "{{ 'schema_registry' in groups and schema_registry_oauth_enabled and (not ldap_with_oauth_enabled) and oauth_groups_scope!='none'}}"
     properties:
       ksql.schema.registry.bearer.auth.scope: "{{oauth_groups_scope}}"
   monitoring_interceptor:
@@ -1300,7 +1304,7 @@ ksql_properties:
                             'confluent.monitoring.interceptor.', ksql_truststore_path, ksql_truststore_storepass, public_certificates_enabled, ksql_keystore_path, ksql_keystore_storepass, ksql_keystore_keypass,
                             false, sasl_plain_users_final.ksql.principal, sasl_plain_users_final.ksql.password, sasl_scram_users_final.ksql.principal, sasl_scram_users_final.ksql.password, sasl_scram256_users_final.ksql.principal, sasl_scram256_users_final.ksql.password,
                             kerberos_kafka_broker_primary, ksql_keytab_path, ksql_kerberos_principal|default('ksql'),
-                            false, ksql_ldap_user, ksql_ldap_password, mds_bootstrap_server_urls, oauth_enabled and not ldap_with_oauth_enabled,ksql_oauth_user, ksql_oauth_password, oauth_groups_scope, oauth_token_uri) }}"
+                            false, ksql_ldap_user, ksql_ldap_password, mds_bootstrap_server_urls, oauth_enabled and (not ldap_with_oauth_enabled),ksql_oauth_user, ksql_oauth_password, oauth_groups_scope, oauth_token_uri) }}"
   rbac:
     enabled: "{{rbac_enabled}}"
     properties:
@@ -1308,21 +1312,21 @@ ksql_properties:
       confluent.metadata.bootstrap.server.urls: "{{mds_bootstrap_server_urls}}"
       confluent.metadata.http.auth.credentials.provider: OAUTHBEARER
   rbac_ldap:
-    enabled: "{{rbac_enabled and (not oauth_enabled or ldap_with_oauth_enabled)}}"
+    enabled: "{{rbac_enabled and ((not oauth_enabled) or ldap_with_oauth_enabled)}}"
     properties:
       ksql.security.extension.class: io.confluent.ksql.security.KsqlConfluentSecurityExtension
       ksql.authentication.plugin.class: io.confluent.ksql.security.VertxBearerOrBasicAuthenticationPlugin
       confluent.metadata.basic.auth.user.info: "{{ ksql_ldap_user | default('ksql') }}:{{ ksql_ldap_password | default('pass') }}"
       confluent.metadata.http.auth.credentials.provider: BASIC
   rbac_oauth:
-    enabled: "{{ rbac_enabled and (oauth_enabled and not ldap_with_oauth_enabled) }}"
+    enabled: "{{ rbac_enabled and oauth_enabled and (not ldap_with_oauth_enabled) }}"
     properties:
       confluent.metadata.oauthbearer.login.client.id: "{{ksql_oauth_user}}"
       confluent.metadata.oauthbearer.login.client.secret: "{{ksql_oauth_password}}"
       confluent.metadata.oauthbearer.token.endpoint.url: "{{ oauth_token_uri }}"
       confluent.metadata.oauthbearer.login.credentials.source: OAUTHBEARER
   rbac_oauth_scope:
-    enabled: "{{ rbac_enabled and (oauth_enabled and not ldap_with_oauth_enabled) and oauth_groups_scope!='none'}}"
+    enabled: "{{ rbac_enabled and oauth_enabled and (not ldap_with_oauth_enabled) and oauth_groups_scope!='none'}}"
     properties:
       confluent.metadata.oauthbearer.login.oauth.scope: "{{ oauth_groups_scope }}"
   rbac_external_client:
@@ -1496,10 +1500,10 @@ kafka_rest_properties:
       oauthbearer.jwks.endpoint.url: "{{oauth_jwks_uri}}"
       oauthbearer.sub.claim.name: "{{ oauth_sub_claim }}"
       oauthbearer.expected.issuer: "{{ oauth_issuer_url }}"
-  kafka_rest_oauth_scope:
-    enabled: "{{kafka_rest_oauth_enabled and oauth_groups_scope!='none' }}"
+  kafka_rest_oauth_claim:
+    enabled: "{{kafka_rest_oauth_enabled and oauth_groups_claim!='none' }}"
     properties:
-      oauthbearer.groups.claim.name: "{{ oauth_groups_scope }}"
+      oauthbearer.groups.claim.name: "{{ oauth_groups_claim }}"
   kafka_rest_oauth_audience:
     enabled: "{{kafka_rest_oauth_enabled and oauth_expected_audience!='none' }}"
     properties:
@@ -1631,12 +1635,16 @@ control_center_properties:
       confluent.controlcenter.schema.registry.bearer.auth.credentials.source: OAUTHBEARER
       confluent.controlcenter.schema.registry.oauthbearer.login.client.id: "{{ control_center_oauth_user }}"
       confluent.controlcenter.schema.registry.oauthbearer.login.client.secret: "{{ control_center_oauth_password }}"
+  sr_oauth_scope:
+    enabled: "{{ ('schema_registry' in groups and schema_registry_oauth_enabled|bool) and (not rbac_enabled|bool) and oauth_groups_scope!='none' }}"
+    properties:
+      confluent.controlcenter.schema.registry.oauthbearer.login.oauth.scope: "{{ oauth_groups_scope }}"
   connect:
     enabled: "{{ kafka_connect_cluster_ansible_group_names | default(omit) | length > 0 }}"
     properties: "{{ kafka_connect_cluster_ansible_group_names | confluent.platform.c3_connect_properties(groups, hostvars, kafka_connect_ssl_enabled,
         kafka_connect_http_protocol, kafka_connect_rest_port, kafka_connect_group_id, control_center_truststore_path, control_center_truststore_storepass,
         control_center_keystore_path, control_center_keystore_storepass, control_center_keystore_keypass, kafka_connect_oauth_enabled, rbac_enabled,
-        control_center_oauth_user, control_center_oauth_password) }}"
+        control_center_oauth_user, control_center_oauth_password, oauth_groups_scope) }}"
   ksql:
     enabled: "{{ ksql_cluster_ansible_group_names | default(omit) | length > 0 }}"
     properties: "{{ ksql_cluster_ansible_group_names | confluent.platform.c3_ksql_properties(groups, hostvars, ksql_ssl_enabled,
@@ -1662,6 +1670,10 @@ control_center_properties:
     properties:
       confluent.metadata.oauthbearer.login.client.id: "{{ control_center_oauth_user }}"
       confluent.metadata.oauthbearer.login.client.secret: "{{ control_center_oauth_password }}"
+  rbac_oauth_scope:
+    enabled: "{{rbac_enabled and oauth_enabled and oauth_groups_scope != 'none'}}"
+    properties:
+      confluent.metadata.oauthbearer.login.oauth.scope: "{{ oauth_groups_scope }}"
   rbac_external_client:
     enabled: "{{rbac_enabled and external_mds_enabled and mds_tls_enabled }}"
     properties:

--- a/roles/variables/vars/main.yml
+++ b/roles/variables/vars/main.yml
@@ -1235,13 +1235,21 @@ ksql_properties:
       sasl.kerberos.service.name: "{{kerberos_kafka_broker_primary}}"
       sasl.jaas.config: |-
         com.sun.security.auth.module.Krb5LoginModule required useKeyTab=true storeKey=true keyTab="{{ksql_keytab_path}}" principal="{{ksql_kerberos_principal | default('ksql')}}";
+  # kafka_sasl_oauth:
+  #   enabled: "{{ kafka_broker_listeners[ksql_kafka_listener_name]['sasl_protocol'] | default(sasl_protocol) | confluent.platform.normalize_sasl_protocol == 'OAUTHBEARER' }}"
+  #   properties:
+  #     sasl.mechanism: OAUTHBEARER
+  #     sasl.login.callback.handler.class: io.confluent.kafka.clients.plugins.auth.token.TokenUserLoginCallbackHandler
+  #     sasl.jaas.config: |-
+  #       org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required username="{{ksql_ldap_user | default('ksql')}}" password="{{ksql_ldap_password | default('pass')}}" metadataServerUrls="{{mds_bootstrap_server_urls}}";
   kafka_sasl_oauth:
     enabled: "{{ kafka_broker_listeners[ksql_kafka_listener_name]['sasl_protocol'] | default(sasl_protocol) | confluent.platform.normalize_sasl_protocol == 'OAUTHBEARER' }}"
     properties:
       sasl.mechanism: OAUTHBEARER
-      sasl.login.callback.handler.class: io.confluent.kafka.clients.plugins.auth.token.TokenUserLoginCallbackHandler
+      sasl.login.callback.handler.class: org.apache.kafka.common.security.oauthbearer.secured.OAuthBearerLoginCallbackHandler
+      sasl.oauthbearer.token.endpoint.url: http://oauth1:8080/realms/cp-ansible-realm/protocol/openid-connect/token
       sasl.jaas.config: |-
-        org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required username="{{ksql_ldap_user | default('ksql')}}" password="{{ksql_ldap_password | default('pass')}}" metadataServerUrls="{{mds_bootstrap_server_urls}}";
+        org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required clientId="ksql" clientSecret="my-secret";
   sr:
     enabled: "{{ 'schema_registry' in groups }}"
     properties:
@@ -1264,6 +1272,15 @@ ksql_properties:
     properties:
       ksql.schema.registry.basic.auth.credentials.source: USER_INFO
       ksql.schema.registry.basic.auth.user.info: "{{ ksql_ldap_user | default('ksql') }}:{{ ksql_ldap_password | default('pass') }}"
+  sr_rbac:
+    enabled: "{{ 'schema_registry' in groups and rbac_enabled|bool }}"
+    properties:
+      ksql.schema.registry.bearer.auth.credentials.source: OAUTHBEARER
+      ksql.schema.registry.bearer.auth.client.id: "ksql"
+      ksql.schema.registry.bearer.auth.client.secret: "my-secret"
+      ksql.schema.registry.bearer.auth.issuer.endpoint.url: http://oauth1:8080/realms/cp-ansible-realm/protocol/openid-connect/token
+      # ksql.schema.registry.basic.auth.credentials.source: USER_INFO
+      # ksql.schema.registry.basic.auth.user.info: "{{ ksql_ldap_user | default('ksql') }}:{{ ksql_ldap_password | default('pass') }}"
   monitoring_interceptor:
     enabled: "{{ ksql_monitoring_interceptors_enabled|bool }}"
     properties:
@@ -1285,8 +1302,13 @@ ksql_properties:
       ksql.authentication.plugin.class: io.confluent.ksql.security.VertxBearerOrBasicAuthenticationPlugin
       public.key.path: "{{rbac_enabled_public_pem_path}}"
       confluent.metadata.bootstrap.server.urls: "{{mds_bootstrap_server_urls}}"
-      confluent.metadata.basic.auth.user.info: "{{ ksql_ldap_user | default('ksql') }}:{{ ksql_ldap_password | default('pass') }}"
-      confluent.metadata.http.auth.credentials.provider: BASIC
+      #confluent.metadata.basic.auth.user.info: "{{ ksql_ldap_user | default('ksql') }}:{{ ksql_ldap_password | default('pass') }}"
+      #confluent.metadata.http.auth.credentials.provider: BASIC
+      confluent.metadata.http.auth.credentials.provider: OAUTHBEARER
+      confluent.metadata.oauthbearer.login.client.id: "ksql"
+      confluent.metadata.oauthbearer.login.client.secret: "my-secret"
+      confluent.metadata.oauthbearer.token.endpoint.url: "{{ oauth_token_uri }}"
+      confluent.metadata.oauthbearer.login.credentials.source: OAUTHBEARER
   rbac_external_client:
     enabled: "{{rbac_enabled and external_mds_enabled and mds_tls_enabled }}"
     properties:

--- a/roles/variables/vars/main.yml
+++ b/roles/variables/vars/main.yml
@@ -513,6 +513,10 @@ kafka_broker_properties:
       confluent.bearer.auth.issuer.endpoint.url: "{{ oauth_token_uri }}"
       confluent.bearer.auth.client.id: "{{ schema_registry_oauth_user }}"
       confluent.bearer.auth.client.secret: "{{ schema_registry_oauth_password }}"
+  sr_oauth_scope:
+    enabled: "{{ kafka_broker_schema_validation_enabled and 'schema_registry' in groups and rbac_enabled and schema_registry_oauth_enabled and oauth_groups_scope!='none'}}"
+    properties:
+      confluent.bearer.auth.scope: "{{ oauth_groups_scope }}"
   sr_basic:
     # Should not turn on basic auth if rbac is enabled
     enabled: "{{ kafka_broker_schema_validation_enabled and 'schema_registry' in groups and schema_registry_authentication_type == 'basic'}}"
@@ -1235,21 +1239,21 @@ ksql_properties:
       sasl.kerberos.service.name: "{{kerberos_kafka_broker_primary}}"
       sasl.jaas.config: |-
         com.sun.security.auth.module.Krb5LoginModule required useKeyTab=true storeKey=true keyTab="{{ksql_keytab_path}}" principal="{{ksql_kerberos_principal | default('ksql')}}";
-  # kafka_sasl_oauth:
-  #   enabled: "{{ kafka_broker_listeners[ksql_kafka_listener_name]['sasl_protocol'] | default(sasl_protocol) | confluent.platform.normalize_sasl_protocol == 'OAUTHBEARER' }}"
-  #   properties:
-  #     sasl.mechanism: OAUTHBEARER
-  #     sasl.login.callback.handler.class: io.confluent.kafka.clients.plugins.auth.token.TokenUserLoginCallbackHandler
-  #     sasl.jaas.config: |-
-  #       org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required username="{{ksql_ldap_user | default('ksql')}}" password="{{ksql_ldap_password | default('pass')}}" metadataServerUrls="{{mds_bootstrap_server_urls}}";
+  kafka_sasl_ldap:
+    enabled: "{{ kafka_broker_listeners[ksql_kafka_listener_name]['sasl_protocol'] | default(sasl_protocol) | confluent.platform.normalize_sasl_protocol == 'OAUTHBEARER' and (not oauth_enabled or ldap_with_oauth_enabled) }}"
+    properties:
+      sasl.mechanism: OAUTHBEARER
+      sasl.login.callback.handler.class: io.confluent.kafka.clients.plugins.auth.token.TokenUserLoginCallbackHandler
+      sasl.jaas.config: |-
+        org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required username="{{ksql_ldap_user | default('ksql')}}" password="{{ksql_ldap_password | default('pass')}}" metadataServerUrls="{{mds_bootstrap_server_urls}}";
   kafka_sasl_oauth:
-    enabled: "{{ kafka_broker_listeners[ksql_kafka_listener_name]['sasl_protocol'] | default(sasl_protocol) | confluent.platform.normalize_sasl_protocol == 'OAUTHBEARER' }}"
+    enabled: "{{ kafka_broker_listeners[ksql_kafka_listener_name]['sasl_protocol'] | default(sasl_protocol) | confluent.platform.normalize_sasl_protocol == 'OAUTHBEARER' and (oauth_enabled and not ldap_with_oauth_enabled)}}"
     properties:
       sasl.mechanism: OAUTHBEARER
       sasl.login.callback.handler.class: org.apache.kafka.common.security.oauthbearer.secured.OAuthBearerLoginCallbackHandler
-      sasl.oauthbearer.token.endpoint.url: http://oauth1:8080/realms/cp-ansible-realm/protocol/openid-connect/token
+      sasl.oauthbearer.token.endpoint.url: "{{oauth_token_uri}}"
       sasl.jaas.config: |-
-        org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required clientId="ksql" clientSecret="my-secret";
+        org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required clientId="{{ksql_oauth_user}}" clientSecret="{{ksql_oauth_password}}" {% if oauth_groups_scope!='none' %}scope="{{oauth_groups_scope}}{% endif %}";
   sr:
     enabled: "{{ 'schema_registry' in groups }}"
     properties:
@@ -1268,19 +1272,21 @@ ksql_properties:
       ksql.schema.registry.basic.auth.credentials.source: USER_INFO
       ksql.schema.registry.basic.auth.user.info: "{{schema_registry_basic_users_final.admin.principal}}:{{schema_registry_basic_users_final.admin.password}}"
   sr_rbac:
-    enabled: "{{ 'schema_registry' in groups and rbac_enabled|bool }}"
+    enabled: "{{ 'schema_registry' in groups and rbac_enabled|bool and (not oauth_enabled or ldap_with_oauth_enabled)}}"
     properties:
       ksql.schema.registry.basic.auth.credentials.source: USER_INFO
       ksql.schema.registry.basic.auth.user.info: "{{ ksql_ldap_user | default('ksql') }}:{{ ksql_ldap_password | default('pass') }}"
-  sr_rbac:
-    enabled: "{{ 'schema_registry' in groups and rbac_enabled|bool }}"
+  sr_rbac_oauth:
+    enabled: "{{ 'schema_registry' in groups and rbac_enabled|bool and (oauth_enabled and not ldap_with_oauth_enabled)}}"
     properties:
       ksql.schema.registry.bearer.auth.credentials.source: OAUTHBEARER
-      ksql.schema.registry.bearer.auth.client.id: "ksql"
-      ksql.schema.registry.bearer.auth.client.secret: "my-secret"
-      ksql.schema.registry.bearer.auth.issuer.endpoint.url: http://oauth1:8080/realms/cp-ansible-realm/protocol/openid-connect/token
-      # ksql.schema.registry.basic.auth.credentials.source: USER_INFO
-      # ksql.schema.registry.basic.auth.user.info: "{{ ksql_ldap_user | default('ksql') }}:{{ ksql_ldap_password | default('pass') }}"
+      ksql.schema.registry.bearer.auth.client.id: "{{ksql_oauth_user}}"
+      ksql.schema.registry.bearer.auth.client.secret: "{{ksql_oauth_password}}"
+      ksql.schema.registry.bearer.auth.issuer.endpoint.url: "{{oauth_token_uri}}"
+  sr_rbac_oauth_scope:
+    enabled: "{{ 'schema_registry' in groups and rbac_enabled|bool and (oauth_enabled and not ldap_with_oauth_enabled) and oauth_groups_scope!='none'}}"
+    properties:
+      ksql.schema.registry.bearer.auth.scope: "{{oauth_groups_scope}}"
   monitoring_interceptor:
     enabled: "{{ ksql_monitoring_interceptors_enabled|bool }}"
     properties:
@@ -1294,21 +1300,31 @@ ksql_properties:
                             'confluent.monitoring.interceptor.', ksql_truststore_path, ksql_truststore_storepass, public_certificates_enabled, ksql_keystore_path, ksql_keystore_storepass, ksql_keystore_keypass,
                             false, sasl_plain_users_final.ksql.principal, sasl_plain_users_final.ksql.password, sasl_scram_users_final.ksql.principal, sasl_scram_users_final.ksql.password, sasl_scram256_users_final.ksql.principal, sasl_scram256_users_final.ksql.password,
                             kerberos_kafka_broker_primary, ksql_keytab_path, ksql_kerberos_principal|default('ksql'),
-                            false, ksql_ldap_user, ksql_ldap_password, mds_bootstrap_server_urls, false,'', '', '', '') }}"
+                            false, ksql_ldap_user, ksql_ldap_password, mds_bootstrap_server_urls, oauth_enabled and not ldap_with_oauth_enabled,ksql_oauth_user, ksql_oauth_password, oauth_groups_scope, oauth_token_uri) }}"
   rbac:
     enabled: "{{rbac_enabled}}"
     properties:
-      ksql.security.extension.class: io.confluent.ksql.security.KsqlConfluentSecurityExtension
-      ksql.authentication.plugin.class: io.confluent.ksql.security.VertxBearerOrBasicAuthenticationPlugin
       public.key.path: "{{rbac_enabled_public_pem_path}}"
       confluent.metadata.bootstrap.server.urls: "{{mds_bootstrap_server_urls}}"
-      #confluent.metadata.basic.auth.user.info: "{{ ksql_ldap_user | default('ksql') }}:{{ ksql_ldap_password | default('pass') }}"
-      #confluent.metadata.http.auth.credentials.provider: BASIC
       confluent.metadata.http.auth.credentials.provider: OAUTHBEARER
-      confluent.metadata.oauthbearer.login.client.id: "ksql"
-      confluent.metadata.oauthbearer.login.client.secret: "my-secret"
+  rbac_ldap:
+    enabled: "{{rbac_enabled and (not oauth_enabled or ldap_with_oauth_enabled)}}"
+    properties:
+      ksql.security.extension.class: io.confluent.ksql.security.KsqlConfluentSecurityExtension
+      ksql.authentication.plugin.class: io.confluent.ksql.security.VertxBearerOrBasicAuthenticationPlugin
+      confluent.metadata.basic.auth.user.info: "{{ ksql_ldap_user | default('ksql') }}:{{ ksql_ldap_password | default('pass') }}"
+      confluent.metadata.http.auth.credentials.provider: BASIC
+  rbac_oauth:
+    enabled: "{{ rbac_enabled and (oauth_enabled and not ldap_with_oauth_enabled) }}"
+    properties:
+      confluent.metadata.oauthbearer.login.client.id: "{{ksql_oauth_user}}"
+      confluent.metadata.oauthbearer.login.client.secret: "{{ksql_oauth_password}}"
       confluent.metadata.oauthbearer.token.endpoint.url: "{{ oauth_token_uri }}"
       confluent.metadata.oauthbearer.login.credentials.source: OAUTHBEARER
+  rbac_oauth_scope:
+    enabled: "{{ rbac_enabled and (oauth_enabled and not ldap_with_oauth_enabled) and oauth_groups_scope!='none'}}"
+    properties:
+      confluent.metadata.oauthbearer.login.oauth.scope: "{{ oauth_groups_scope }}"
   rbac_external_client:
     enabled: "{{rbac_enabled and external_mds_enabled and mds_tls_enabled }}"
     properties:

--- a/test_roles/confluent.test.oauth/defaults/main.yml
+++ b/test_roles/confluent.test.oauth/defaults/main.yml
@@ -19,3 +19,4 @@ keycloak_clients:
   - control_center
   - kafka_broker
   - kafka_controller
+  - ksql


### PR DESCRIPTION
# Description

This PR adds ksql as OAuth client support. In ldap+oauth setup, ksql will act as ldap client. In oauth only setup, ksql will act as oauth client. However, ksql will not have authn/authz as server.
Along with this some fixes are added for oauth_groups_scope clients.

Fixes # [ANSIENG-3839](https://confluentinc.atlassian.net/browse/ANSIENG-3839)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

tested locally on OAuth setup

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[ANSIENG-3839]: https://confluentinc.atlassian.net/browse/ANSIENG-3839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ