### PR TITLE
[ANSIENG-3383] | Https in keycloak 

### DIFF
--- a/molecule/Dockerfile-oauth.j2
+++ b/molecule/Dockerfile-oauth.j2
@@ -1,8 +1,15 @@
 FROM registry.access.redhat.com/ubi9 AS ubi-micro-build
 RUN mkdir -p /mnt/rootfs
-RUN dnf install --installroot /mnt/rootfs python3 --releasever 9 --setopt install_weak_deps=false --nodocs -y && \
+RUN dnf install --installroot /mnt/rootfs python3 openssl --releasever 9 --setopt install_weak_deps=false --nodocs -y && \
     dnf --installroot /mnt/rootfs clean all && \
     rpm --root /mnt/rootfs -e --nodeps setup
+
+RUN openssl req -x509 -newkey rsa:4096 -keyout /mnt/rootfs/idp-key.pem -out /mnt/rootfs/idp-cert.pem -sha256 -days 3650 -nodes -subj "/C=XX/ST=KAR/L=BLR/O=Confluent/OU=CP/CN=oauth1"
+# the value of CN must be same as name in molecule.yml for https to work correctly
+
+# the key file doesnt have read permissions for group users by default but it is required
+RUN chmod 440 /mnt/rootfs/idp-key.pem
+RUN chmod 440 /mnt/rootfs/idp-cert.pem
 
 FROM {{ item.image }}
 COPY --from=ubi-micro-build /mnt/rootfs /

--- a/molecule/kafka-connect-replicator-mtls-scram-rhel/molecule.yml
+++ b/molecule/kafka-connect-replicator-mtls-scram-rhel/molecule.yml
@@ -30,9 +30,14 @@ platforms:
     env:
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
+      KC_HTTPS_CERTIFICATE_FILE: /idp-cert.pem
+      KC_HTTPS_CERTIFICATE_KEY_FILE: /idp-key.pem
+      KEYCLOAK_HTTP_PORT: "8080"
+      KEYCLOAK_HTTPS_PORT: "8443"
     dockerfile: ../Dockerfile-oauth.j2
     published_ports:
       - "8080:8080"
+      - "8443:8443"
     command: start-dev
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -257,7 +262,3 @@ provisioner:
         # kafka_connect_replicator_monitoring_interceptor_ssl_cert_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-ca1-signed.crt"
         # kafka_connect_replicator_monitoring_interceptor_ssl_key_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}-key.pem"
         # kafka_connect_replicator_monitoring_interceptor_ssl_key_password: keypass
-
-        kafka_connect_replicator_erp_host: http://mds-kafka-broker1:8090,http://mds-kafka-broker2:8090
-        kafka_connect_replicator_erp_oauth_user: superuser
-        kafka_connect_replicator_erp_oauth_password: my-secret

--- a/molecule/oauth-rbac-mds-kerberos-debian/molecule.yml
+++ b/molecule/oauth-rbac-mds-kerberos-debian/molecule.yml
@@ -18,9 +18,14 @@ platforms:
     env:
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
+      KC_HTTPS_CERTIFICATE_FILE: /idp-cert.pem
+      KC_HTTPS_CERTIFICATE_KEY_FILE: /idp-key.pem
+      KEYCLOAK_HTTP_PORT: "8080"
+      KEYCLOAK_HTTPS_PORT: "8443"
     dockerfile: ../Dockerfile-oauth.j2
     published_ports:
       - "8080:8080"
+      - "8443:8443"
     command: start-dev
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/molecule/oauth-rbac-plain-rhel8/molecule.yml
+++ b/molecule/oauth-rbac-plain-rhel8/molecule.yml
@@ -16,9 +16,14 @@ platforms:
     env:
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
+      KC_HTTPS_CERTIFICATE_FILE: /idp-cert.pem
+      KC_HTTPS_CERTIFICATE_KEY_FILE: /idp-key.pem
+      KEYCLOAK_HTTP_PORT: "8080"
+      KEYCLOAK_HTTPS_PORT: "8443"
     dockerfile: ../Dockerfile-oauth.j2
     published_ports:
       - "8080:8080"
+      - "8443:8443"
     command: start-dev
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/molecule/plain-rhel/molecule.yml
+++ b/molecule/plain-rhel/molecule.yml
@@ -17,15 +17,20 @@ platforms:
     env:
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
+      KC_HOSTNAME: localhost
+      KC_HTTPS_CERTIFICATE_FILE: /etc/ssl/idp-cert.pem
+      KC_HTTPS_CERTIFICATE_KEY_FILE: /etc/ssl/idp-key.pem
+      KEYCLOAK_HTTP_PORT: "8080"
+      KEYCLOAK_HTTPS_PORT: "8443"
     dockerfile: ../Dockerfile-oauth.j2
     published_ports:
       - "8080:8080"
+      - "8443:8443"
     command: start-dev
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
-    networks:
-      - name: confluent
+      - /home/ec2-user/keys/idp-cert.pem:/etc/ssl/idp-cert.pem:ro
+      - /home/ec2-user/keys/idp-key.pem:/etc/ssl/idp-key.pem:ro
   - name: ${KRAFT_CONTROLLER:-zookeeper}1
     hostname: ${KRAFT_CONTROLLER:-zookeeper}1.confluent
     groups:
@@ -139,24 +144,35 @@ provisioner:
     group_vars:
       all:
         sasl_protocol: plain
+
+        keycloak_oauth_server_port: 8443
+        keycloak_http_protocol: https
+
         oauth_enabled: true
         schema_registry_oauth_enabled: false # to test disabling OAuth on one component on a non rbac cluster
+
         oauth_client_id: superuser
         oauth_client_password: my-secret
+
         oauth_sub_claim: client_id
         oauth_groups_claim: groups
         oauth_token_uri: http://oauth1:8080/realms/cp-ansible-realm/protocol/openid-connect/token
         oauth_issuer_url: http://oauth1:8080/realms/cp-ansible-realm
         oauth_jwks_uri: http://oauth1:8080/realms/cp-ansible-realm/protocol/openid-connect/certs
         oauth_expected_audience: Confluent,account,https://my-company.com
+
         schema_registry_oauth_user: schema_registry
         schema_registry_oauth_password: my-secret
+
         kafka_rest_oauth_user: kafka_rest
         kafka_rest_oauth_password: my-secret
+
         kafka_connect_oauth_user: kafka_connect
         kafka_connect_oauth_password: my-secret
+
         control_center_oauth_user: control_center
         control_center_oauth_password: my-secret
+
         mask_secrets: false
 
         # kafka_broker_configure_control_plane_listener: true

--- a/molecule/plain-rhel/molecule.yml
+++ b/molecule/plain-rhel/molecule.yml
@@ -156,9 +156,9 @@ provisioner:
 
         oauth_sub_claim: client_id
         oauth_groups_claim: groups
-        oauth_token_uri: http://oauth1:8080/realms/cp-ansible-realm/protocol/openid-connect/token
-        oauth_issuer_url: http://oauth1:8080/realms/cp-ansible-realm
-        oauth_jwks_uri: http://oauth1:8080/realms/cp-ansible-realm/protocol/openid-connect/certs
+        oauth_token_uri: https://oauth1:8443/realms/cp-ansible-realm/protocol/openid-connect/token
+        oauth_issuer_url: https://oauth1:8443/realms/cp-ansible-realm
+        oauth_jwks_uri: https://oauth1:8443/realms/cp-ansible-realm/protocol/openid-connect/certs
         oauth_expected_audience: Confluent,account,https://my-company.com
 
         schema_registry_oauth_user: schema_registry

--- a/molecule/plain-rhel/molecule.yml
+++ b/molecule/plain-rhel/molecule.yml
@@ -17,9 +17,8 @@ platforms:
     env:
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
-      KC_HOSTNAME: localhost
-      KC_HTTPS_CERTIFICATE_FILE: /etc/ssl/idp-cert.pem
-      KC_HTTPS_CERTIFICATE_KEY_FILE: /etc/ssl/idp-key.pem
+      KC_HTTPS_CERTIFICATE_FILE: /idp-cert.pem
+      KC_HTTPS_CERTIFICATE_KEY_FILE: /idp-key.pem
       KEYCLOAK_HTTP_PORT: "8080"
       KEYCLOAK_HTTPS_PORT: "8443"
     dockerfile: ../Dockerfile-oauth.j2
@@ -29,8 +28,9 @@ platforms:
     command: start-dev
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
-      - /home/ec2-user/keys/idp-cert.pem:/etc/ssl/idp-cert.pem:ro
-      - /home/ec2-user/keys/idp-key.pem:/etc/ssl/idp-key.pem:ro
+    privileged: true
+    networks:
+      - name: confluent
   - name: ${KRAFT_CONTROLLER:-zookeeper}1
     hostname: ${KRAFT_CONTROLLER:-zookeeper}1.confluent
     groups:
@@ -145,9 +145,6 @@ provisioner:
       all:
         sasl_protocol: plain
 
-        keycloak_oauth_server_port: 8443
-        keycloak_http_protocol: https
-
         oauth_enabled: true
         schema_registry_oauth_enabled: false # to test disabling OAuth on one component on a non rbac cluster
 
@@ -156,9 +153,9 @@ provisioner:
 
         oauth_sub_claim: client_id
         oauth_groups_claim: groups
-        oauth_token_uri: https://oauth1:8443/realms/cp-ansible-realm/protocol/openid-connect/token
-        oauth_issuer_url: https://oauth1:8443/realms/cp-ansible-realm
-        oauth_jwks_uri: https://oauth1:8443/realms/cp-ansible-realm/protocol/openid-connect/certs
+        oauth_token_uri: http://oauth1:8080/realms/cp-ansible-realm/protocol/openid-connect/token
+        oauth_issuer_url: http://oauth1:8080/realms/cp-ansible-realm
+        oauth_jwks_uri: http://oauth1:8080/realms/cp-ansible-realm/protocol/openid-connect/certs
         oauth_expected_audience: Confluent,account,https://my-company.com
 
         schema_registry_oauth_user: schema_registry

--- a/molecule/rbac-kafka-connect-replicator-kerberos-mtls-custom-rhel/molecule.yml
+++ b/molecule/rbac-kafka-connect-replicator-kerberos-mtls-custom-rhel/molecule.yml
@@ -48,9 +48,14 @@ platforms:
     env:
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
+      KC_HTTPS_CERTIFICATE_FILE: /idp-cert.pem
+      KC_HTTPS_CERTIFICATE_KEY_FILE: /idp-key.pem
+      KEYCLOAK_HTTP_PORT: "8080"
+      KEYCLOAK_HTTPS_PORT: "8443"
     dockerfile: ../Dockerfile-oauth.j2
     published_ports:
       - "8080:8080"
+      - "8443:8443"
     command: start-dev
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/molecule/rbac-plain-provided-debian9/molecule.yml
+++ b/molecule/rbac-plain-provided-debian9/molecule.yml
@@ -32,9 +32,14 @@ platforms:
     env:
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
+      KC_HTTPS_CERTIFICATE_FILE: /idp-cert.pem
+      KC_HTTPS_CERTIFICATE_KEY_FILE: /idp-key.pem
+      KEYCLOAK_HTTP_PORT: "8080"
+      KEYCLOAK_HTTPS_PORT: "8443"
     dockerfile: ../Dockerfile-oauth.j2
     published_ports:
       - "8080:8080"
+      - "8443:8443"
     command: start-dev
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro


### PR DESCRIPTION
# Description

Enables https on keycloak server. Molecule scenarios can use it by defining the following variables
```
keycloak_oauth_server_port: 8443
keycloak_http_protocol: https
oauth_token_uri: https://oauth1:8443/realms/cp-ansible-realm/protocol/openid-connect/token
oauth_issuer_url: https://oauth1:8443/realms/cp-ansible-realm
oauth_jwks_uri: https://oauth1:8443/realms/cp-ansible-realm/protocol/openid-connect/certs
```

Fixes # [(ANSIENG-3383)](https://confluentinc.atlassian.net/browse/ANSIENG-3383)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
