### PR TITLE
[ANSIENG-3860] | Add MDS truststore when sso idp cert provided

### DIFF
--- a/roles/variables/vars/main.yml
+++ b/roles/variables/vars/main.yml
@@ -606,6 +606,11 @@ kafka_broker_properties:
     enabled: "{{ rbac_enabled and not external_mds_enabled and sso_mode != 'none' and sso_groups_scope != 'none' }}"
     properties:
       confluent.oidc.idp.groups.claim.scope: "{{ sso_groups_scope }}"
+  rbac_mds_sso_ssl:
+    enabled: "{{ rbac_enabled and (not external_mds_enabled) and sso_mode != 'none' and sso_idp_cert_path != ''}}"
+    properties:
+      confluent.metadata.server.ssl.truststore.location: "{{kafka_broker_truststore_path}}"
+      confluent.metadata.server.ssl.truststore.password: "{{kafka_broker_truststore_storepass}}"
   rbac_external_mds:
     enabled: "{{rbac_enabled and external_mds_enabled}}"
     properties:


### PR DESCRIPTION
# Description

This PR is an extension of https://github.com/confluentinc/cp-ansible/pull/1686 to cover the case when SSO is enabled on non SSL cluster

Fixes # [ANSIENG-3860](https://confluentinc.atlassian.net/browse/ANSIENG-3860)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

tested locally

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[ANSIENG-3860]: https://confluentinc.atlassian.net/browse/ANSIENG-3860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ