### PR TITLE
Add IDP to truststore in C3 SSO

### DIFF
--- a/plugins/filter/filters.py
+++ b/plugins/filter/filters.py
@@ -165,7 +165,7 @@ class FilterModule(object):
                             plain_jaas_config, keytab_path,
                             kerberos_principal, kerberos_primary,
                             scram_user, scram_password, scram256_user,
-                            scram256_password, oauth_pem_path):
+                            scram256_password, oauth_pem_path, rbac_enabled, kraft_listener):
         # For kafka broker properties: Takes listeners dictionary and outputs all properties based on the listeners' settings
         # Other inputs help fill out the properties
         final_dict = {}
@@ -220,6 +220,10 @@ class FilterModule(object):
                     'io.confluent.kafka.server.plugins.auth.token.TokenBearerServerLoginCallbackHandler'
                 final_dict['listener.name.' + listener_name + '.oauthbearer.sasl.jaas.config'] =\
                     'org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required publicKeyPath=\"' + oauth_pem_path + '\";'
+                final_dict['listener.name.' + listener_name + '.principal.builder.class'] =\
+                    'io.confluent.kafka.security.authenticator.OAuthKafkaPrincipalBuilder'
+            
+            if kraft_listener and rbac_enabled:
                 final_dict['listener.name.' + listener_name + '.principal.builder.class'] =\
                     'io.confluent.kafka.security.authenticator.OAuthKafkaPrincipalBuilder'
 

--- a/roles/common/tasks/idp_certs.yml
+++ b/roles/common/tasks/idp_certs.yml
@@ -1,0 +1,67 @@
+---
+- name: Register if Truststore Exists
+  stat:
+    path: "{{truststore_path}}"
+  register: truststore
+
+- name: Create SSL Certificate Directory
+  file:
+    path: /var/ssl/private
+    state: directory
+    mode: '755'
+  tags:
+    - privileged
+    - filesystem
+  when: not truststore.stat.exists|bool
+
+- name: Copy IDP Cert to Node
+  copy:
+    src: "{{idp_cert_path}}"
+    dest: "{{idp_cert_dest}}"
+  diff: "{{ not mask_sensitive_diff|bool }}"
+
+- name: Check if Cert already imported
+  shell: |
+    keytool -list -keystore {{truststore_path}} \
+    -storetype pkcs12 -alias {{alias}} -storepass {{truststore_storepass}}
+  ignore_errors: true
+  register: cert_imported
+  no_log: "{{mask_secrets|bool}}"
+
+- name: Import IdP certificate to Truststore
+  shell: |
+    keytool -noprompt -keystore {{truststore_path}} \
+      -storetype pkcs12 \
+      -alias {{alias}} \
+      -import -file {{idp_cert_dest}} \
+      -storepass {{truststore_storepass}}
+  when:
+    - cert_imported.rc == 1
+  no_log: "{{mask_secrets|bool}}"
+
+- name: Check if Cert already imported
+  shell: |
+    keytool -list -keystore {{bcfks_truststore_path}} \
+    -storetype BCFKS -alias {{alias}} \
+    -storepass {{truststore_storepass}} \
+    -providerclass org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider \
+    -providerpath {{ (binary_base_path, 'share/java/kafka/bc-fips-*.jar') | path_join }}
+  ignore_errors: true
+  register: cert_imported
+  when:
+    - create_bouncy_castle_keystore|bool
+  no_log: "{{mask_secrets|bool}}"
+
+- name: Import IdP certificate to BCFKS Truststore
+  shell: |
+    keytool -noprompt -keystore {{bcfks_truststore_path}} \
+      -storetype BCFKS \
+      -alias {{alias}} \
+      -import -file {{idp_cert_dest}} \
+      -storepass {{truststore_storepass}} \
+      -providerclass org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider \
+      -providerpath {{ (binary_base_path, 'share/java/kafka/bc-fips-*.jar') | path_join }}
+  when:
+    - create_bouncy_castle_keystore|bool
+    - cert_imported.rc == 1
+  no_log: "{{mask_secrets|bool}}"

--- a/roles/kafka_broker/tasks/main.yml
+++ b/roles/kafka_broker/tasks/main.yml
@@ -147,6 +147,23 @@
 - include_tasks: rbac.yml
   when: rbac_enabled|bool
 
+- name: Import IDP certificate to MDS Truststore for C3 SSO
+  include_role:
+    name: common
+    tasks_from: idp_certs.yml
+  vars:
+    idp_cert_path: "{{ sso_idp_cert_path }}"
+    idp_cert_dest: "sso_idp_cert.pem"
+    alias: "sso_cert"
+    truststore_storepass: "{{kafka_broker_truststore_storepass}}"
+    truststore_path: "{{kafka_broker_pkcs12_truststore_path}}"
+    bcfks_truststore_path: "{{kafka_broker_bcfks_truststore_path}}"
+    create_bouncy_castle_keystore: "{{fips_enabled}}"
+  when:
+    - sso_mode != 'none'
+    - sso_idp_cert_path != ""
+    - not external_mds_enabled|bool
+
 - name: Configure Kerberos
   include_role:
     name: kerberos

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -1443,6 +1443,9 @@ sso_groups_scope: none
 ### Configures whether offline_access scope would be requested in the authorization URI, Set this to false if offline tokens are not allowed for the user or client in IdP
 sso_refresh_token: true
 
+### SSL certificate (full path of file on control node) of IDP Domain for SSO in C3/cli. Optional, needed when IDP server has TLS enabled with custom certificate
+sso_idp_cert_path: ""
+
 ### LDAP User which will be granted super user permissions to create role bindings in the MDS
 mds_super_user: mds
 

--- a/roles/variables/vars/main.yml
+++ b/roles/variables/vars/main.yml
@@ -232,7 +232,7 @@ kafka_controller_properties:
     properties: "{{ kafka_controller_listeners | confluent.platform.listener_properties(kafka_controller_ssl_enabled, fips_enabled, kafka_controller_ssl_mutual_auth_enabled, kafka_controller_sasl_protocol,
                     kafka_controller_truststore_path, kafka_controller_truststore_storepass, kafka_controller_keystore_path, kafka_controller_keystore_storepass, kafka_controller_keystore_keypass,
                     plain_jaas_config, kafka_controller_keytab_path, kafka_controller_kerberos_principal|default('kafka'), kerberos_kafka_controller_primary,
-                    sasl_scram_users_final.admin.principal, sasl_scram_users_final.admin.password, sasl_scram256_users_final.admin.principal, sasl_scram256_users_final.admin.password, rbac_enabled_public_pem_path ) }}"
+                    sasl_scram_users_final.admin.principal, sasl_scram_users_final.admin.password, sasl_scram256_users_final.admin.principal, sasl_scram256_users_final.admin.password, rbac_enabled_public_pem_path, rbac_enabled, true) }}"
   metrics_reporter:
     enabled: "{{ kafka_controller_metrics_reporter_enabled|bool }}"
     properties:
@@ -377,7 +377,7 @@ kafka_broker_properties:
     properties: "{{ kafka_controller_listeners | confluent.platform.listener_properties(kafka_controller_ssl_enabled, fips_enabled, kafka_controller_ssl_mutual_auth_enabled, kafka_controller_sasl_protocol,
                     kafka_broker_truststore_path, kafka_broker_truststore_storepass, kafka_broker_keystore_path, kafka_broker_keystore_storepass, kafka_broker_keystore_keypass,
                     plain_jaas_config, kafka_broker_keytab_path, kafka_broker_kerberos_principal|default('kafka'), kerberos_kafka_broker_primary,
-                    sasl_scram_users_final.admin.principal, sasl_scram_users_final.admin.password, sasl_scram256_users_final.admin.principal, sasl_scram256_users_final.admin.password, rbac_enabled_public_pem_path ) }}"
+                    sasl_scram_users_final.admin.principal, sasl_scram_users_final.admin.password, sasl_scram256_users_final.admin.principal, sasl_scram256_users_final.admin.password, rbac_enabled_public_pem_path, rbac_enabled, false) }}"
   broker_id:
     enabled: "{{ inventory_hostname in groups.kafka_broker }}"
     properties:
@@ -523,6 +523,11 @@ kafka_broker_properties:
     enabled: "{{ rbac_enabled and not external_mds_enabled and sso_mode != 'none' and sso_groups_scope != 'none' }}"
     properties:
       confluent.oidc.idp.groups.claim.scope: "{{ sso_groups_scope }}"
+  rbac_mds_sso_ssl:
+    enabled: "{{ rbac_enabled and (not external_mds_enabled) and sso_mode != 'none' and sso_idp_cert_path != ''}}"
+    properties:
+      confluent.metadata.server.ssl.truststore.location: "{{kafka_broker_truststore_path}}"
+      confluent.metadata.server.ssl.truststore.password: "{{kafka_broker_truststore_storepass}}"
   rbac_external_mds:
     enabled: "{{rbac_enabled and external_mds_enabled}}"
     properties:
@@ -595,7 +600,7 @@ kafka_broker_properties:
     properties: "{{ kafka_broker_listeners | confluent.platform.listener_properties(ssl_enabled, fips_enabled, ssl_mutual_auth_enabled, sasl_protocol,
                     kafka_broker_truststore_path, kafka_broker_truststore_storepass, kafka_broker_keystore_path, kafka_broker_keystore_storepass, kafka_broker_keystore_keypass,
                     plain_jaas_config, kafka_broker_keytab_path, kafka_broker_kerberos_principal|default('kafka'), kerberos_kafka_broker_primary,
-                    sasl_scram_users_final.admin.principal, sasl_scram_users_final.admin.password, sasl_scram256_users_final.admin.principal, sasl_scram256_users_final.admin.password, rbac_enabled_public_pem_path ) }}"
+                    sasl_scram_users_final.admin.principal, sasl_scram_users_final.admin.password, sasl_scram256_users_final.admin.principal, sasl_scram256_users_final.admin.password, rbac_enabled_public_pem_path, rbac_enabled, false) }}"
   controlplane_listener:
     enabled: "{{ kafka_broker_configure_control_plane_listener|bool and kafka_broker_configure_multiple_listeners|bool and not kraft_enabled|bool}}"
     properties:


### PR DESCRIPTION
# Description

Add IDP to truststore in C3 SSO in 7.5.x patch, same changes would be needed in 7.6.x 

Fixes # [ANSIENG-3860](https://confluentinc.atlassian.net/browse/ANSIENG-3860)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

tested locally, it will be better tested when we create local keycloak idp server in 7.5 as well, similar to 7.7

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[ANSIENG-3860]: https://confluentinc.atlassian.net/browse/ANSIENG-3860?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ