### PR TITLE
[ANSIENG-3712] | moving from ftp.debian.org to archive.debian.org as debian10 reached eol

### DIFF
--- a/roles/common/tasks/debian.yml
+++ b/roles/common/tasks/debian.yml
@@ -121,7 +121,7 @@
 - name: Add buster-backports Repo
   lineinfile:
     path: /etc/apt/sources.list
-    line: deb [check-valid-until=no] http://ftp.debian.org/debian buster-backports main
+    line: deb [check-valid-until=no] http://archive.debian.org/debian buster-backports main
     regexp: '.*buster-backports.*'
   notify:
     - debian apt-get update


### PR DESCRIPTION
# Description

Debian 10 has reached EOL and thus ftp.debian.org no longer works and we need to use archive.debian.org in etc/apt/source.list

Fixes # [(issue)](https://confluentinc.atlassian.net/browse/ANSIENG-3712)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
