### PR TITLE
[ANSIENG-3880] | Fix centos7 Tests 

### DIFF
--- a/molecule/Dockerfile-rhel-base.j2
+++ b/molecule/Dockerfile-rhel-base.j2
@@ -1,5 +1,10 @@
 FROM {{ item.image }}
 
+# replace mirror.centos.org with vault.centos.org as centos7 is eol and this url does not work now.
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+RUN yum update -y
+
 RUN yum -y install java-11-openjdk \
       rsync \
       openssl

--- a/molecule/Dockerfile-rhel-java8.j2
+++ b/molecule/Dockerfile-rhel-java8.j2
@@ -1,5 +1,10 @@
 FROM {{ item.image }}
 
+# replace mirror.centos.org with vault.centos.org as centos7 is eol and this url does not work now.
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+RUN yum update -y
+
 RUN yum -y install java-8-openjdk \
       rsync \
       openssl \

--- a/molecule/Dockerfile-tar.j2
+++ b/molecule/Dockerfile-tar.j2
@@ -1,5 +1,10 @@
 FROM {{ item.image }}
 
+# replace mirror.centos.org with vault.centos.org as centos7 is eol and this url does not work now.
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+RUN yum update -y
+
 RUN yum -y install java-11-openjdk \
       rsync \
       openssl

--- a/molecule/Dockerfile.j2
+++ b/molecule/Dockerfile.j2
@@ -1,5 +1,10 @@
 FROM {{ item.image }}
 
+# replace mirror.centos.org with vault.centos.org as centos7 is eol and this url does not work now.
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+RUN yum update -y
+
 RUN yum -y install java-11-openjdk \
       rsync \
       openssl \

--- a/molecule/confluent-kafka-kerberos-customcerts-rhel/molecule.yml
+++ b/molecule/confluent-kafka-kerberos-customcerts-rhel/molecule.yml
@@ -24,7 +24,7 @@ platforms:
     groups:
       - zookeeper
     image: geerlingguy/docker-centos7-ansible
-    # dockerfile: ../Dockerfile.j2
+    dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -36,7 +36,7 @@ platforms:
     groups:
       - zookeeper
     image: geerlingguy/docker-centos7-ansible
-    # dockerfile: ../Dockerfile.j2
+    dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -48,7 +48,7 @@ platforms:
     groups:
       - zookeeper
     image: geerlingguy/docker-centos7-ansible
-    # dockerfile: ../Dockerfile.j2
+    dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -60,7 +60,7 @@ platforms:
     groups:
       - kafka_broker
     image: geerlingguy/docker-centos7-ansible
-    # dockerfile: ../Dockerfile.j2
+    dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -72,7 +72,7 @@ platforms:
     groups:
       - kafka_broker
     image: geerlingguy/docker-centos7-ansible
-    # dockerfile: ../Dockerfile.j2
+    dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -84,7 +84,7 @@ platforms:
     groups:
       - kafka_broker
     image: geerlingguy/docker-centos7-ansible
-    # dockerfile: ../Dockerfile.j2
+    dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -96,7 +96,7 @@ platforms:
     groups:
       - schema_registry
     image: geerlingguy/docker-centos7-ansible
-    # dockerfile: ../Dockerfile.j2
+    dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -108,7 +108,7 @@ platforms:
     groups:
       - kafka_rest
     image: geerlingguy/docker-centos7-ansible
-    # dockerfile: ../Dockerfile.j2
+    dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -120,7 +120,7 @@ platforms:
     groups:
       - kafka_connect
     image: geerlingguy/docker-centos7-ansible
-    # dockerfile: ../Dockerfile.j2
+    dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -132,7 +132,7 @@ platforms:
     groups:
       - ksql
     image: geerlingguy/docker-centos7-ansible
-    # dockerfile: ../Dockerfile.j2
+    dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -144,7 +144,7 @@ platforms:
     groups:
       - control_center
     image: geerlingguy/docker-centos7-ansible
-    # dockerfile: ../Dockerfile.j2
+    dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/molecule/cp-kafka-plain-rhel/molecule.yml
+++ b/molecule/cp-kafka-plain-rhel/molecule.yml
@@ -11,6 +11,7 @@ platforms:
       - kafka_broker
       - zookeeper
     image: geerlingguy/docker-centos7-ansible
+    dockerfile: ../Dockerfile-rhel-base.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -23,6 +24,7 @@ platforms:
       - kafka_broker
       - zookeeper
     image: geerlingguy/docker-centos7-ansible
+    dockerfile: ../Dockerfile-rhel-base.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -35,6 +37,7 @@ platforms:
       - kafka_broker
       - zookeeper
     image: geerlingguy/docker-centos7-ansible
+    dockerfile: ../Dockerfile-rhel-base.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -46,6 +49,7 @@ platforms:
     groups:
       - schema_registry
     image: geerlingguy/docker-centos7-ansible
+    dockerfile: ../Dockerfile-rhel-base.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -57,6 +61,7 @@ platforms:
     groups:
       - kafka_rest
     image: geerlingguy/docker-centos7-ansible
+    dockerfile: ../Dockerfile-rhel-base.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -68,6 +73,7 @@ platforms:
     groups:
       - kafka_connect
     image: geerlingguy/docker-centos7-ansible
+    dockerfile: ../Dockerfile-rhel-base.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -79,6 +85,7 @@ platforms:
     groups:
       - ksql
     image: geerlingguy/docker-centos7-ansible
+    dockerfile: ../Dockerfile-rhel-base.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -90,6 +97,7 @@ platforms:
     groups:
       - control_center
     image: geerlingguy/docker-centos7-ansible
+    dockerfile: ../Dockerfile-rhel-base.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/molecule/mtls-customcerts-rhel/molecule.yml
+++ b/molecule/mtls-customcerts-rhel/molecule.yml
@@ -10,6 +10,7 @@ platforms:
     groups:
       - zookeeper
     image: geerlingguy/docker-centos7-ansible
+    dockerfile: ../Dockerfile-rhel-base.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -21,6 +22,7 @@ platforms:
     groups:
       - kafka_broker
     image: geerlingguy/docker-centos7-ansible
+    dockerfile: ../Dockerfile-rhel-base.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -32,6 +34,7 @@ platforms:
     groups:
       - kafka_broker
     image: geerlingguy/docker-centos7-ansible
+    dockerfile: ../Dockerfile-rhel-base.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -43,6 +46,7 @@ platforms:
     groups:
       - kafka_broker
     image: geerlingguy/docker-centos7-ansible
+    dockerfile: ../Dockerfile-rhel-base.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -54,6 +58,7 @@ platforms:
     groups:
       - schema_registry
     image: geerlingguy/docker-centos7-ansible
+    dockerfile: ../Dockerfile-rhel-base.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -65,6 +70,7 @@ platforms:
     groups:
       - kafka_rest
     image: geerlingguy/docker-centos7-ansible
+    dockerfile: ../Dockerfile-rhel-base.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -76,6 +82,7 @@ platforms:
     groups:
       - kafka_connect
     image: geerlingguy/docker-centos7-ansible
+    dockerfile: ../Dockerfile-rhel-base.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -87,6 +94,7 @@ platforms:
     groups:
       - ksql
     image: geerlingguy/docker-centos7-ansible
+    dockerfile: ../Dockerfile-rhel-base.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -98,6 +106,7 @@ platforms:
     groups:
       - control_center
     image: geerlingguy/docker-centos7-ansible
+    dockerfile: ../Dockerfile-rhel-base.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/molecule/plaintext-rhel/molecule.yml
+++ b/molecule/plaintext-rhel/molecule.yml
@@ -24,6 +24,7 @@ platforms:
     groups:
       - zookeeper
     image: geerlingguy/docker-centos7-ansible
+    dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -35,6 +36,7 @@ platforms:
     groups:
       - zookeeper
     image: geerlingguy/docker-centos7-ansible
+    dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/molecule/rbac-scram-custom-rhel/molecule.yml
+++ b/molecule/rbac-scram-custom-rhel/molecule.yml
@@ -15,7 +15,7 @@ platforms:
     groups:
       - ldap_server
     image: geerlingguy/docker-centos7-ansible
-    # dockerfile: ../Dockerfile.j2
+    dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -27,7 +27,7 @@ platforms:
     groups:
       - zookeeper
     image: geerlingguy/docker-centos7-ansible
-    # dockerfile: ../Dockerfile.j2
+    dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -63,7 +63,7 @@ platforms:
     groups:
       - kafka_broker
     image: geerlingguy/docker-centos7-ansible
-    # dockerfile: ../Dockerfile.j2
+    dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -75,7 +75,7 @@ platforms:
     groups:
       - kafka_broker
     image: geerlingguy/docker-centos7-ansible
-    # dockerfile: ../Dockerfile.j2
+    dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -87,7 +87,7 @@ platforms:
     groups:
       - kafka_broker
     image: geerlingguy/docker-centos7-ansible
-    # dockerfile: ../Dockerfile.j2
+    dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -99,7 +99,7 @@ platforms:
     groups:
       - schema_registry
     image: geerlingguy/docker-centos7-ansible
-    # dockerfile: ../Dockerfile.j2
+    dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -111,7 +111,7 @@ platforms:
     groups:
       - kafka_rest
     image: geerlingguy/docker-centos7-ansible
-    # dockerfile: ../Dockerfile.j2
+    dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -123,7 +123,7 @@ platforms:
     groups:
       - kafka_connect
     image: geerlingguy/docker-centos7-ansible
-    # dockerfile: ../Dockerfile.j2
+    dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -135,7 +135,7 @@ platforms:
     groups:
       - ksql
     image: geerlingguy/docker-centos7-ansible
-    # dockerfile: ../Dockerfile.j2
+    dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -147,7 +147,7 @@ platforms:
     groups:
       - control_center
     image: geerlingguy/docker-centos7-ansible
-    # dockerfile: ../Dockerfile.j2
+    dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro


### PR DESCRIPTION
# Description

Centos 7 has reached EOL and thus our tests which used it are failing. To fix we need to move from mirror.centos.org to vault.centos.org in yum.repos.d files

Fixes # [(issue)](https://confluentinc.atlassian.net/browse/ANSIENG-3880)
## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

[semaphore](https://semaphore.ci.confluent.io/jobs/620cc221-c630-4748-ba21-0c8ba1b07797/summary)

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
