### PR TITLE
[ANSIENG-3880] | Fix centos7 Tests 

### DIFF
--- a/molecule/Dockerfile-rhel-java11.j2
+++ b/molecule/Dockerfile-rhel-java11.j2
@@ -1,5 +1,10 @@
 FROM {{ item.image }}
 
+# replace mirror.centos.org with vault.centos.org as centos7 is eol and this url does not work now.
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+RUN yum update -y
+
 RUN yum -y install java-11-openjdk \
       rsync \
       openssl \

--- a/molecule/Dockerfile-rhel7-java17.j2
+++ b/molecule/Dockerfile-rhel7-java17.j2
@@ -1,5 +1,10 @@
 FROM {{ item.image }}
 
+# replace mirror.centos.org with vault.centos.org as centos7 is eol and this url does not work now.
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+RUN yum update -y
+
 # Download Java using wget
 
 RUN yum -y install wget curl

--- a/molecule/Dockerfile.j2
+++ b/molecule/Dockerfile.j2
@@ -1,5 +1,10 @@
 FROM {{ item.image }}
 
+# replace mirror.centos.org with vault.centos.org as centos7 is eol and this url does not work now.
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+RUN yum update -y
+
 RUN yum -y install java-11-openjdk \
       rsync \
       openssl \

--- a/molecule/kerberos-rhel/molecule.yml
+++ b/molecule/kerberos-rhel/molecule.yml
@@ -22,7 +22,7 @@ platforms:
     groups:
       - ${CONTROLLER_HOSTGROUP:-zookeeper}
     image: geerlingguy/docker-centos7-ansible
-    dockerfile: ../Dockerfile-rhel-java17.j2
+    dockerfile: ../Dockerfile-rhel7-java17.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -34,7 +34,7 @@ platforms:
     groups:
       - kafka_broker
     image: geerlingguy/docker-centos7-ansible
-    dockerfile: ../Dockerfile-rhel-java17.j2
+    dockerfile: ../Dockerfile-rhel7-java17.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -46,7 +46,7 @@ platforms:
     groups:
       - kafka_broker
     image: geerlingguy/docker-centos7-ansible
-    dockerfile: ../Dockerfile-rhel-java17.j2
+    dockerfile: ../Dockerfile-rhel7-java17.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -58,7 +58,7 @@ platforms:
     groups:
       - kafka_broker
     image: geerlingguy/docker-centos7-ansible
-    dockerfile: ../Dockerfile-rhel-java17.j2
+    dockerfile: ../Dockerfile-rhel7-java17.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -70,7 +70,7 @@ platforms:
     groups:
       - schema_registry
     image: geerlingguy/docker-centos7-ansible
-    dockerfile: ../Dockerfile-rhel-java17.j2
+    dockerfile: ../Dockerfile-rhel7-java17.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -82,7 +82,7 @@ platforms:
     groups:
       - kafka_rest
     image: geerlingguy/docker-centos7-ansible
-    dockerfile: ../Dockerfile-rhel-java17.j2
+    dockerfile: ../Dockerfile-rhel7-java17.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -94,7 +94,7 @@ platforms:
     groups:
       - kafka_connect
     image: geerlingguy/docker-centos7-ansible
-    dockerfile: ../Dockerfile-rhel-java17.j2
+    dockerfile: ../Dockerfile-rhel7-java17.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -106,7 +106,7 @@ platforms:
     groups:
       - ksql
     image: geerlingguy/docker-centos7-ansible
-    dockerfile: ../Dockerfile-rhel-java17.j2
+    dockerfile: ../Dockerfile-rhel7-java17.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
@@ -118,7 +118,7 @@ platforms:
     groups:
       - control_center
     image: geerlingguy/docker-centos7-ansible
-    dockerfile: ../Dockerfile-rhel-java17.j2
+    dockerfile: ../Dockerfile-rhel7-java17.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/molecule/rbac-mtls-rhel8/molecule.yml
+++ b/molecule/rbac-mtls-rhel8/molecule.yml
@@ -12,7 +12,7 @@ platforms:
     groups:
       - ldap_server
     image: geerlingguy/docker-centos7-ansible
-    dockerfile: ../Dockerfile-rhel-java17.j2
+    dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/molecule/rbac-scram-custom-rhel/molecule.yml
+++ b/molecule/rbac-scram-custom-rhel/molecule.yml
@@ -15,7 +15,7 @@ platforms:
     groups:
       - ldap_server
     image: geerlingguy/docker-centos7-ansible
-    # dockerfile: ../Dockerfile.j2
+    dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/molecule/rbac-scram-custom-rhel/molecule.yml
+++ b/molecule/rbac-scram-custom-rhel/molecule.yml
@@ -15,7 +15,7 @@ platforms:
     groups:
       - ldap_server
     image: geerlingguy/docker-centos7-ansible
-    # dockerfile: ../Dockerfile-rhel-java17.j2
+    # dockerfile: ../Dockerfile.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro


### PR DESCRIPTION
# Description

Centos 7 has reached EOL and thus our tests which used it are failing. To fix we need to move from mirror.centos.org to vault.centos.org in yum.repos.d files

Fixes # [(issue)](https://confluentinc.atlassian.net/browse/ANSIENG-3880)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

[zk](https://semaphore.ci.confluent.io/jobs/47c1cce8-acec-4aa1-a7a6-42088248c86d/summary)
[kraft](https://semaphore.ci.confluent.io/jobs/199f7df0-feea-4d50-b044-54f71855c114/summary)

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
