### PR TITLE
[ANSIENG-3880] | Fix centos7 Tests 

### DIFF
--- a/molecule/Dockerfile-rhel7-java11.j2
+++ b/molecule/Dockerfile-rhel7-java11.j2
@@ -1,5 +1,10 @@
 FROM {{ item.image }}
 
+# replace mirror.centos.org with vault.centos.org as centos7 is eol and this url does not work now.
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+RUN yum update -y
+
 RUN yum -y install java-11-openjdk \
       rsync \
       openssl \

--- a/molecule/Dockerfile-rhel7-java17.j2
+++ b/molecule/Dockerfile-rhel7-java17.j2
@@ -1,5 +1,10 @@
 FROM {{ item.image }}
 
+# replace mirror.centos.org with vault.centos.org as centos7 is eol and this url does not work now.
+RUN sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+RUN sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+RUN yum update -y
+
 # Download Java using wget
 
 RUN yum -y install wget curl


### PR DESCRIPTION
# Description

Centos 7 has reached EOL and thus our tests which used it are failing. To fix we need to move from mirror.centos.org to vault.centos.org in yum.repos.d files

Fixes # [(issue)](https://confluentinc.atlassian.net/browse/ANSIENG-3880)
## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

[zk](https://semaphore.ci.confluent.io/jobs/5ce7dc97-324c-435d-a9f4-3e1a8d33d287/summary)
[kraft](https://semaphore.ci.confluent.io/jobs/a9b664fe-9925-49af-9d48-93b0ce548c2e/summary)

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
