### PR TITLE
[ANSIENG-4140] | Fix Issue in Health check of controllers due to fixes for KIP-919

### DIFF
--- a/roles/kafka_controller/tasks/health_check.yml
+++ b/roles/kafka_controller/tasks/health_check.yml
@@ -9,19 +9,50 @@
   ignore_errors: true
   changed_when: false
   check_mode: false
-  register: result1
+  register: greenfield
+
+- name: Choose bootstrap server vs controller
+  set_fact:
+    bootstrap_server_or_controller: >-
+      {% if greenfield.rc == 0 %}
+        '--bootstrap-controller'
+      {% elif greenfield.rc != 0 and confluent_server_enabled|bool %}
+        '--bootstrap-server'
+      {% endif %}
+
+- name: Add confluent.use.controller.listener config to Client Properties
+  lineinfile:
+    path: "{{ kafka_controller.client_config_file }}"
+    state: present
+    line: confluent.use.controller.listener=true
+  changed_when: false
+  check_mode: false
+  when:
+    - confluent_server_enabled|bool
+    - greenfield.rc != 0
+
+- name: Check Kafka Metadata Quorum
+  shell: |
+    {{ binary_base_path }}/bin/kafka-metadata-quorum {{bootstrap_server_or_controller}} {{inventory_hostname}}:{{kafka_controller_port}} \
+      --command-config {{kafka_controller.client_config_file}} describe --replication
+  environment:
+    KAFKA_OPTS: "-Xlog:all=error -XX:+IgnoreUnrecognizedVMOptions {% if kerberos_client_config_file_dest != '/etc/krb5.conf' %}-Djava.security.krb5.conf={{kerberos_client_config_file_dest}}{% endif %}"
+  ignore_errors: true
+  changed_when: false
+  check_mode: false
+  when: greenfield.rc == 0 or confluent_server_enabled|bool
 
 #Registers LEO of controllers only if Metadata Quorum passed in the above task
-- name: Register LogEndOffset using bootstrap controller
+- name: Register LogEndOffset
   shell: |
-    {{ binary_base_path }}/bin/kafka-metadata-quorum --bootstrap-controller {{inventory_hostname}}:{{kafka_controller_port}} \
+    {{ binary_base_path }}/bin/kafka-metadata-quorum {{bootstrap_server_or_controller}} {{inventory_hostname}}:{{kafka_controller_port}} \
       --command-config {{kafka_controller.client_config_file}} describe --replication |  grep -v Observer | awk '{print $2}'
   environment:
     KAFKA_OPTS: "-Xlog:all=error -XX:+IgnoreUnrecognizedVMOptions {% if kerberos_client_config_file_dest != '/etc/krb5.conf' %}-Djava.security.krb5.conf={{kerberos_client_config_file_dest}}{% endif %}"
   register: leo
   changed_when: false
   check_mode: false
-  when: result1.rc == 0
+  when: greenfield.rc == 0 or confluent_server_enabled|bool
 
 - name: Check LogEndOffset values
   assert:
@@ -33,46 +64,7 @@
   ignore_errors: false
   changed_when: false
   check_mode: false
-  when: result1.rc == 0
-
-- name: Add confluent.use.controller.listener config to Client Properties
-  lineinfile:
-    path: "{{ kafka_controller.client_config_file }}"
-    state: present
-    line: confluent.use.controller.listener=true
-  changed_when: false
-  check_mode: false
-  when:
-    - not kraft_migration|bool
-    - confluent_server_enabled|bool
-    - result1.rc == 1
-
-- name: Check Kafka Metadata Quorum using bootstrap server
-  shell: |
-    {{ binary_base_path }}/bin/kafka-metadata-quorum --bootstrap-server {{inventory_hostname}}:{{kafka_controller_port}} \
-      --command-config {{kafka_controller.client_config_file}} describe --replication
-  environment:
-    KAFKA_OPTS: "-Xlog:all=error -XX:+IgnoreUnrecognizedVMOptions {% if kerberos_client_config_file_dest != '/etc/krb5.conf' %}-Djava.security.krb5.conf={{kerberos_client_config_file_dest}}{% endif %}"
-  ignore_errors: false
-  changed_when: false
-  check_mode: false
-  when:
-    - confluent_server_enabled|bool
-    - result1.rc == 1
-
-- name: Register LogEndOffset using bootstrap server
-  shell: |
-    {{ binary_base_path }}/bin/kafka-metadata-quorum --bootstrap-server {{inventory_hostname}}:{{kafka_controller_port}} \
-      --command-config {{kafka_controller.client_config_file}} describe --replication |  grep -v Observer | awk '{print $2}'
-  environment:
-    KAFKA_OPTS: "-Xlog:all=error -XX:+IgnoreUnrecognizedVMOptions {% if kerberos_client_config_file_dest != '/etc/krb5.conf' %}-Djava.security.krb5.conf={{kerberos_client_config_file_dest}}{% endif %}"
-  register: leo
-  ignore_errors: false
-  changed_when: false
-  check_mode: false
-  when:
-    - confluent_server_enabled|bool
-    - result1.rc == 1
+  when: greenfield.rc == 0 or confluent_server_enabled|bool
 
 - name: Remove confluent.use.controller.listener config from Client Properties
   lineinfile:
@@ -84,18 +76,4 @@
   when:
     - not kraft_migration|bool
     - confluent_server_enabled|bool
-    - result1.rc == 1
-
-- name: Check LogEndOffset values
-  assert:
-    that:
-      - "{{ item|int > 0 and leo.stdout_lines[1:]|max|int - item|int < 1000 }}"
-    fail_msg: "UnreachableQuorumMember or Found at least one quorum voter with an offset {{ item }}, while the primary controller was at offset {{ leo.stdout_lines[1:]|max}}
-               The max allowed offset lag is 1000"
-  loop: "{{ leo.stdout_lines[1:] }}"
-  ignore_errors: false
-  changed_when: false
-  check_mode: false
-  when:
-    - confluent_server_enabled|bool
-    - result1.rc == 1
+    - greenfield.rc == 1

--- a/roles/kafka_controller/tasks/health_check.yml
+++ b/roles/kafka_controller/tasks/health_check.yml
@@ -11,18 +11,18 @@
   check_mode: false
   register: greenfield
 
-- name: Set hostnames and ports
+- name: Set Hostnames and Ports
   set_fact:
     broker_hostname_hc: "{{ hostvars[groups['kafka_broker'][0]] | confluent.platform.resolve_hostname }}"
     broker_port_hc: "{{kafka_broker_listeners[kafka_broker_inter_broker_listener_name]['port']}}"
     controller_hostname_hc: "{{inventory_hostname}}"
     controller_port_hc: "{{kafka_controller_port}}"
 
-- name: Set decider variables to pick broker or controller
+- name: Set Server/Controller Host and Port values
   set_fact:
     bootstrap_server_or_controller: "{% if greenfield.rc == 0 %}controller{% elif greenfield.rc != 0 and confluent_server_enabled|bool %}server{% endif %}"
-    broker_or_controller_hostname: "{% if greenfield.rc == 0 %}{{controller_hostname_hc}}{% elif greenfield.rc != 0 and confluent_server_enabled|bool %}{{broker_hostname_hc}}{% endif %}"
-    broker_or_controller_port: "{% if greenfield.rc == 0 %}{{controller_port_hc}}{% elif greenfield.rc != 0 and confluent_server_enabled|bool %}{{broker_port_hc}}{% endif %}"
+    server_hostname: "{% if greenfield.rc == 0 %}{{controller_hostname_hc}}{% elif greenfield.rc != 0 and confluent_server_enabled|bool %}{{broker_hostname_hc}}{% endif %}"
+    server_port: "{% if greenfield.rc == 0 %}{{controller_port_hc}}{% elif greenfield.rc != 0 and confluent_server_enabled|bool %}{{broker_port_hc}}{% endif %}"
 
 - name: Add confluent.use.controller.listener config to Client Properties
   lineinfile:
@@ -37,7 +37,7 @@
 
 - name: Check Kafka Metadata Quorum
   shell: |
-    {{ binary_base_path }}/bin/kafka-metadata-quorum --bootstrap-{{bootstrap_server_or_controller}} {{broker_or_controller_hostname}}:{{broker_or_controller_port}} \
+    {{ binary_base_path }}/bin/kafka-metadata-quorum --bootstrap-{{bootstrap_server_or_controller}} {{server_hostname}}:{{server_port}} \
       --command-config {{kafka_controller.client_config_file}} describe --replication
   environment:
     KAFKA_OPTS: "-Xlog:all=error -XX:+IgnoreUnrecognizedVMOptions {% if kerberos_client_config_file_dest != '/etc/krb5.conf' %}-Djava.security.krb5.conf={{kerberos_client_config_file_dest}}{% endif %}"
@@ -49,7 +49,7 @@
 #Registers LEO of controllers only if Metadata Quorum passed in the above task
 - name: Register LogEndOffset
   shell: |
-    {{ binary_base_path }}/bin/kafka-metadata-quorum --bootstrap-{{bootstrap_server_or_controller}} {{broker_or_controller_hostname}}:{{broker_or_controller_port}} \
+    {{ binary_base_path }}/bin/kafka-metadata-quorum --bootstrap-{{bootstrap_server_or_controller}} {{server_hostname}}:{{server_port}} \
       --command-config {{kafka_controller.client_config_file}} describe --replication |  grep -v Observer | awk '{print $2}'
   environment:
     KAFKA_OPTS: "-Xlog:all=error -XX:+IgnoreUnrecognizedVMOptions {% if kerberos_client_config_file_dest != '/etc/krb5.conf' %}-Djava.security.krb5.conf={{kerberos_client_config_file_dest}}{% endif %}"
@@ -80,4 +80,4 @@
   when:
     - not kraft_migration|bool
     - confluent_server_enabled|bool
-    - greenfield.rc == 1
+    - greenfield.rc != 0

--- a/roles/kafka_controller/tasks/health_check.yml
+++ b/roles/kafka_controller/tasks/health_check.yml
@@ -13,7 +13,13 @@
 
 - name: Choose bootstrap server vs controller
   set_fact:
+    broker_hostname_: "{{ hostvars[groups['kafka_broker'][0]]|confluent.platform.resolve_hostname }}"
+    broker_port_: "{{kafka_broker_listeners[kafka_broker_inter_broker_listener_name]['port']}}"
+    controller_hostname_: "{{inventory_hostname}}"
+    controller_port_: "{{kafka_controller_port}}"
     bootstrap_server_or_controller: "{% if greenfield.rc == 0 %}controller{% elif greenfield.rc != 0 and confluent_server_enabled|bool %}server{% endif %}"
+    broker_or_controller_hostname: "{% if greenfield.rc == 0 %}{{controller_hostname_}}{% elif greenfield.rc != 0 and confluent_server_enabled|bool %}{{broker_hostname_}}{% endif %}"
+    broker_or_controller_port: "{% if greenfield.rc == 0 %}{{controller_port_}}{% elif greenfield.rc != 0 and confluent_server_enabled|bool %}{{broker_port_}}{% endif %}"
 
 - name: Add confluent.use.controller.listener config to Client Properties
   lineinfile:
@@ -28,7 +34,7 @@
 
 - name: Check Kafka Metadata Quorum
   shell: |
-    {{ binary_base_path }}/bin/kafka-metadata-quorum --bootstrap-{{bootstrap_server_or_controller}} {{inventory_hostname}}:{{kafka_controller_port}} \
+    {{ binary_base_path }}/bin/kafka-metadata-quorum --bootstrap-{{bootstrap_server_or_controller}} {{broker_or_controller_hostname}}:{{broker_or_controller_port}} \
       --command-config {{kafka_controller.client_config_file}} describe --replication
   environment:
     KAFKA_OPTS: "-Xlog:all=error -XX:+IgnoreUnrecognizedVMOptions {% if kerberos_client_config_file_dest != '/etc/krb5.conf' %}-Djava.security.krb5.conf={{kerberos_client_config_file_dest}}{% endif %}"
@@ -40,7 +46,7 @@
 #Registers LEO of controllers only if Metadata Quorum passed in the above task
 - name: Register LogEndOffset
   shell: |
-    {{ binary_base_path }}/bin/kafka-metadata-quorum --bootstrap-{{bootstrap_server_or_controller}} {{inventory_hostname}}:{{kafka_controller_port}} \
+    {{ binary_base_path }}/bin/kafka-metadata-quorum --bootstrap-{{bootstrap_server_or_controller}} {{broker_or_controller_hostname}}:{{broker_or_controller_port}} \
       --command-config {{kafka_controller.client_config_file}} describe --replication |  grep -v Observer | awk '{print $2}'
   environment:
     KAFKA_OPTS: "-Xlog:all=error -XX:+IgnoreUnrecognizedVMOptions {% if kerberos_client_config_file_dest != '/etc/krb5.conf' %}-Djava.security.krb5.conf={{kerberos_client_config_file_dest}}{% endif %}"

--- a/roles/kafka_controller/tasks/health_check.yml
+++ b/roles/kafka_controller/tasks/health_check.yml
@@ -24,17 +24,6 @@
     server_hostname: "{% if greenfield.rc == 0 %}{{controller_hostname_hc}}{% elif greenfield.rc != 0 and confluent_server_enabled|bool %}{{broker_hostname_hc}}{% endif %}"
     server_port: "{% if greenfield.rc == 0 %}{{controller_port_hc}}{% elif greenfield.rc != 0 and confluent_server_enabled|bool %}{{broker_port_hc}}{% endif %}"
 
-- name: Add confluent.use.controller.listener config to Client Properties
-  lineinfile:
-    path: "{{ kafka_controller.client_config_file }}"
-    state: present
-    line: confluent.use.controller.listener=true
-  changed_when: false
-  check_mode: false
-  when:
-    - confluent_server_enabled|bool
-    - greenfield.rc != 0
-
 - name: Check Kafka Metadata Quorum
   shell: |
     {{ binary_base_path }}/bin/kafka-metadata-quorum --bootstrap-{{bootstrap_server_or_controller}} {{server_hostname}}:{{server_port}} \
@@ -69,15 +58,3 @@
   changed_when: false
   check_mode: false
   when: greenfield.rc == 0 or confluent_server_enabled|bool
-
-- name: Remove confluent.use.controller.listener config from Client Properties
-  lineinfile:
-    path: "{{ kafka_controller.client_config_file }}"
-    state: absent
-    line: confluent.use.controller.listener=true
-  changed_when: false
-  check_mode: false
-  when:
-    - not kraft_migration|bool
-    - confluent_server_enabled|bool
-    - greenfield.rc != 0

--- a/roles/kafka_controller/tasks/health_check.yml
+++ b/roles/kafka_controller/tasks/health_check.yml
@@ -11,15 +11,18 @@
   check_mode: false
   register: greenfield
 
-- name: Choose bootstrap server vs controller
+- name: Set hostnames and ports
   set_fact:
-    broker_hostname_: "{{ hostvars[groups['kafka_broker'][0]]|confluent.platform.resolve_hostname }}"
-    broker_port_: "{{kafka_broker_listeners[kafka_broker_inter_broker_listener_name]['port']}}"
-    controller_hostname_: "{{inventory_hostname}}"
-    controller_port_: "{{kafka_controller_port}}"
+    broker_hostname_hc: "{{ hostvars[groups['kafka_broker'][0]] | confluent.platform.resolve_hostname }}"
+    broker_port_hc: "{{kafka_broker_listeners[kafka_broker_inter_broker_listener_name]['port']}}"
+    controller_hostname_hc: "{{inventory_hostname}}"
+    controller_port_hc: "{{kafka_controller_port}}"
+
+- name: Set decider variables to pick broker or controller
+  set_fact:
     bootstrap_server_or_controller: "{% if greenfield.rc == 0 %}controller{% elif greenfield.rc != 0 and confluent_server_enabled|bool %}server{% endif %}"
-    broker_or_controller_hostname: "{% if greenfield.rc == 0 %}{{controller_hostname_}}{% elif greenfield.rc != 0 and confluent_server_enabled|bool %}{{broker_hostname_}}{% endif %}"
-    broker_or_controller_port: "{% if greenfield.rc == 0 %}{{controller_port_}}{% elif greenfield.rc != 0 and confluent_server_enabled|bool %}{{broker_port_}}{% endif %}"
+    broker_or_controller_hostname: "{% if greenfield.rc == 0 %}{{controller_hostname_hc}}{% elif greenfield.rc != 0 and confluent_server_enabled|bool %}{{broker_hostname_hc}}{% endif %}"
+    broker_or_controller_port: "{% if greenfield.rc == 0 %}{{controller_port_hc}}{% elif greenfield.rc != 0 and confluent_server_enabled|bool %}{{broker_port_hc}}{% endif %}"
 
 - name: Add confluent.use.controller.listener config to Client Properties
   lineinfile:

--- a/roles/kafka_controller/tasks/health_check.yml
+++ b/roles/kafka_controller/tasks/health_check.yml
@@ -15,9 +15,9 @@
   set_fact:
     bootstrap_server_or_controller: >-
       {% if greenfield.rc == 0 %}
-        '--bootstrap-controller'
+        --bootstrap-controller
       {% elif greenfield.rc != 0 and confluent_server_enabled|bool %}
-        '--bootstrap-server'
+        --bootstrap-server
       {% endif %}
 
 - name: Add confluent.use.controller.listener config to Client Properties
@@ -37,7 +37,7 @@
       --command-config {{kafka_controller.client_config_file}} describe --replication
   environment:
     KAFKA_OPTS: "-Xlog:all=error -XX:+IgnoreUnrecognizedVMOptions {% if kerberos_client_config_file_dest != '/etc/krb5.conf' %}-Djava.security.krb5.conf={{kerberos_client_config_file_dest}}{% endif %}"
-  ignore_errors: true
+  ignore_errors: false
   changed_when: false
   check_mode: false
   when: greenfield.rc == 0 or confluent_server_enabled|bool

--- a/roles/kafka_controller/tasks/health_check.yml
+++ b/roles/kafka_controller/tasks/health_check.yml
@@ -13,9 +13,7 @@
 
 - name: Choose bootstrap server vs controller
   set_fact:
-    bootstrap_server_or_controller: "{% if greenfield.rc == 0 %}--bootstrap-controller{% elif greenfield.rc != 0 and confluent_server_enabled|bool %}--bootstrap-server{% endif %}"
-
-
+    bootstrap_server_or_controller: "{% if greenfield.rc == 0 %}controller{% elif greenfield.rc != 0 and confluent_server_enabled|bool %}server{% endif %}"
 
 - name: Add confluent.use.controller.listener config to Client Properties
   lineinfile:
@@ -30,7 +28,7 @@
 
 - name: Check Kafka Metadata Quorum
   shell: |
-    {{ binary_base_path }}/bin/kafka-metadata-quorum {{bootstrap_server_or_controller}} {{inventory_hostname}}:{{kafka_controller_port}} \
+    {{ binary_base_path }}/bin/kafka-metadata-quorum --bootstrap-{{bootstrap_server_or_controller}} {{inventory_hostname}}:{{kafka_controller_port}} \
       --command-config {{kafka_controller.client_config_file}} describe --replication
   environment:
     KAFKA_OPTS: "-Xlog:all=error -XX:+IgnoreUnrecognizedVMOptions {% if kerberos_client_config_file_dest != '/etc/krb5.conf' %}-Djava.security.krb5.conf={{kerberos_client_config_file_dest}}{% endif %}"
@@ -42,7 +40,7 @@
 #Registers LEO of controllers only if Metadata Quorum passed in the above task
 - name: Register LogEndOffset
   shell: |
-    {{ binary_base_path }}/bin/kafka-metadata-quorum {{bootstrap_server_or_controller}} {{inventory_hostname}}:{{kafka_controller_port}} \
+    {{ binary_base_path }}/bin/kafka-metadata-quorum --bootstrap-{{bootstrap_server_or_controller}} {{inventory_hostname}}:{{kafka_controller_port}} \
       --command-config {{kafka_controller.client_config_file}} describe --replication |  grep -v Observer | awk '{print $2}'
   environment:
     KAFKA_OPTS: "-Xlog:all=error -XX:+IgnoreUnrecognizedVMOptions {% if kerberos_client_config_file_dest != '/etc/krb5.conf' %}-Djava.security.krb5.conf={{kerberos_client_config_file_dest}}{% endif %}"

--- a/roles/kafka_controller/tasks/health_check.yml
+++ b/roles/kafka_controller/tasks/health_check.yml
@@ -1,26 +1,27 @@
 ---
 # health check for kafka controller
-- name: Check Kafka Metadata Quorum
+- name: Check Kafka Metadata Quorum using bootstrap controller
   shell: |
     {{ binary_base_path }}/bin/kafka-metadata-quorum --bootstrap-controller {{inventory_hostname}}:{{kafka_controller_port}} \
       --command-config {{kafka_controller.client_config_file}} describe --replication
   environment:
     KAFKA_OPTS: "-Xlog:all=error -XX:+IgnoreUnrecognizedVMOptions {% if kerberos_client_config_file_dest != '/etc/krb5.conf' %}-Djava.security.krb5.conf={{kerberos_client_config_file_dest}}{% endif %}"
-  ignore_errors: false
+  ignore_errors: true
   changed_when: false
   check_mode: false
+  register: result1
 
 #Registers LEO of controllers only if Metadata Quorum passed in the above task
-- name: Register LogEndOffset
+- name: Register LogEndOffset using bootstrap controller
   shell: |
     {{ binary_base_path }}/bin/kafka-metadata-quorum --bootstrap-controller {{inventory_hostname}}:{{kafka_controller_port}} \
       --command-config {{kafka_controller.client_config_file}} describe --replication |  grep -v Observer | awk '{print $2}'
   environment:
     KAFKA_OPTS: "-Xlog:all=error -XX:+IgnoreUnrecognizedVMOptions {% if kerberos_client_config_file_dest != '/etc/krb5.conf' %}-Djava.security.krb5.conf={{kerberos_client_config_file_dest}}{% endif %}"
   register: leo
-  ignore_errors: false
   changed_when: false
   check_mode: false
+  when: result1.rc == 0
 
 - name: Check LogEndOffset values
   assert:
@@ -32,3 +33,69 @@
   ignore_errors: false
   changed_when: false
   check_mode: false
+  when: result1.rc == 0
+
+- name: Add confluent.use.controller.listener config to Client Properties
+  lineinfile:
+    path: "{{ kafka_controller.client_config_file }}"
+    state: present
+    line: confluent.use.controller.listener=true
+  changed_when: false
+  check_mode: false
+  when:
+    - not kraft_migration|bool
+    - confluent_server_enabled|bool
+    - result1.rc == 1
+
+- name: Check Kafka Metadata Quorum using bootstrap server
+  shell: |
+    {{ binary_base_path }}/bin/kafka-metadata-quorum --bootstrap-server {{inventory_hostname}}:{{kafka_controller_port}} \
+      --command-config {{kafka_controller.client_config_file}} describe --replication
+  environment:
+    KAFKA_OPTS: "-Xlog:all=error -XX:+IgnoreUnrecognizedVMOptions {% if kerberos_client_config_file_dest != '/etc/krb5.conf' %}-Djava.security.krb5.conf={{kerberos_client_config_file_dest}}{% endif %}"
+  ignore_errors: false
+  changed_when: false
+  check_mode: false
+  when:
+    - confluent_server_enabled|bool
+    - result1.rc == 1
+
+- name: Register LogEndOffset using bootstrap server
+  shell: |
+    {{ binary_base_path }}/bin/kafka-metadata-quorum --bootstrap-server {{inventory_hostname}}:{{kafka_controller_port}} \
+      --command-config {{kafka_controller.client_config_file}} describe --replication |  grep -v Observer | awk '{print $2}'
+  environment:
+    KAFKA_OPTS: "-Xlog:all=error -XX:+IgnoreUnrecognizedVMOptions {% if kerberos_client_config_file_dest != '/etc/krb5.conf' %}-Djava.security.krb5.conf={{kerberos_client_config_file_dest}}{% endif %}"
+  register: leo
+  ignore_errors: false
+  changed_when: false
+  check_mode: false
+  when:
+    - confluent_server_enabled|bool
+    - result1.rc == 1
+
+- name: Remove confluent.use.controller.listener config from Client Properties
+  lineinfile:
+    path: "{{ kafka_controller.client_config_file }}"
+    state: absent
+    line: confluent.use.controller.listener=true
+  changed_when: false
+  check_mode: false
+  when:
+    - not kraft_migration|bool
+    - confluent_server_enabled|bool
+    - result1.rc == 1
+
+- name: Check LogEndOffset values
+  assert:
+    that:
+      - "{{ item|int > 0 and leo.stdout_lines[1:]|max|int - item|int < 1000 }}"
+    fail_msg: "UnreachableQuorumMember or Found at least one quorum voter with an offset {{ item }}, while the primary controller was at offset {{ leo.stdout_lines[1:]|max}}
+               The max allowed offset lag is 1000"
+  loop: "{{ leo.stdout_lines[1:] }}"
+  ignore_errors: false
+  changed_when: false
+  check_mode: false
+  when:
+    - confluent_server_enabled|bool
+    - result1.rc == 1

--- a/roles/kafka_controller/tasks/health_check.yml
+++ b/roles/kafka_controller/tasks/health_check.yml
@@ -13,12 +13,9 @@
 
 - name: Choose bootstrap server vs controller
   set_fact:
-    bootstrap_server_or_controller: >-
-      {% if greenfield.rc == 0 %}
-        --bootstrap-controller
-      {% elif greenfield.rc != 0 and confluent_server_enabled|bool %}
-        --bootstrap-server
-      {% endif %}
+    bootstrap_server_or_controller: "{% if greenfield.rc == 0 %}--bootstrap-controller{% elif greenfield.rc != 0 and confluent_server_enabled|bool %}--bootstrap-server{% endif %}"
+
+
 
 - name: Add confluent.use.controller.listener config to Client Properties
   lineinfile:


### PR DESCRIPTION
 # Description

In CP 7.6 and older, CP-Ansible relies on the undocumented confluent.use.controller.listener configuration to communicate directly with KRaft controllers. This configuration was never intended to be used by external clients. In CP 7.7, this undocumented configuration was removed, as was the ability to communicate with KRaft controllers by putting a controller address in --bootstrap-server.

this caused issues during upgrade. We cannot directly move from --bootstrap-server to --bootstrap-controller as during rolling upgrade packages would be new but metadata version would be corresponding to older cp version and thus this will fail. Both need to be used in conjunction to address this.

Fixes # [(issue)](https://confluentinc.atlassian.net/browse/ANSIENG-4140)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

[semaphore-greenfield](https://semaphore.ci.confluent.io/workflows/fb2d7651-75ab-4f2d-8c84-ada442adf8e7?pipeline_id=280f5232-46e7-4d36-b126-63cbbf1b7def)
And also upgrade testing was done using ec2 instances

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
