### PR TITLE
making connector default to ldap in brownfield OAuth unless specified

### DIFF
--- a/molecule/oauth-rbac-kafka-connect-replicator-kerberos-mtls-custom-rhel/molecule.yml
+++ b/molecule/oauth-rbac-kafka-connect-replicator-kerberos-mtls-custom-rhel/molecule.yml
@@ -358,6 +358,8 @@ provisioner:
         kafka_connect_replicator_consumer_custom_properties:
           client.id: consumer-test
 
+        kafka_connect_replicator_erp_admin_user: mds
+        kafka_connect_replicator_erp_admin_password: password
         kafka_connect_replicator_consumer_rbac_enabled: true
         kafka_connect_replicator_consumer_erp_tls_enabled: false
         kafka_connect_replicator_consumer_erp_host: http://mds-kafka-broker1:8090,http://mds-kafka-broker2:8090

--- a/molecule/oauth-rbac-plain-provided-debian12/molecule.yml
+++ b/molecule/oauth-rbac-plain-provided-debian12/molecule.yml
@@ -283,6 +283,11 @@ provisioner:
               topics: "test_topic2"
               key.converter: "org.apache.kafka.connect.json.JsonConverter"
               value.converter: "org.apache.kafka.connect.json.JsonConverter"
+              consumer.override.security.protocol: SASL_SSL
+              consumer.override.sasl.mechanism: OAUTHBEARER
+              consumer.override.sasl.jaas.config: "org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required username=\"kafka_connect\" password=\"password\" metadataServerUrls=\"https://kafka-broker1:8090,https://kafka-broker2:8090,https://kafka-broker3:8090\";"
+              principal.service.name: "kafka_connect"
+              principal.service.password: "password"
 
         mds_super_user: mds
         mds_super_user_password: password

--- a/roles/variables/vars/main.yml
+++ b/roles/variables/vars/main.yml
@@ -1076,14 +1076,14 @@ kafka_connect_properties:
                             'producer.', kafka_connect_truststore_path, kafka_connect_truststore_storepass, public_certificates_enabled, kafka_connect_keystore_path, kafka_connect_keystore_storepass, kafka_connect_keystore_keypass,
                             false, sasl_plain_users_final.kafka_connect.principal, sasl_plain_users_final.kafka_connect.password, sasl_scram_users_final.kafka_connect.principal, sasl_scram_users_final.kafka_connect.password, sasl_scram256_users_final.kafka_connect.principal, sasl_scram256_users_final.kafka_connect.password,
                             kerberos_kafka_broker_primary, kafka_connect_keytab_path, kafka_connect_kerberos_principal|default('kafka'),
-                            false, kafka_connect_ldap_user, kafka_connect_ldap_password, mds_bootstrap_server_urls, oauth_enabled, kafka_connect_oauth_user, kafka_connect_oauth_password, oauth_groups_scope, oauth_token_uri, idp_self_signed) }}"
+                            false, kafka_connect_ldap_user, kafka_connect_ldap_password, mds_bootstrap_server_urls, oauth_enabled and not ldap_with_oauth_enabled, kafka_connect_oauth_user, kafka_connect_oauth_password, oauth_groups_scope, oauth_token_uri, idp_self_signed) }}"
   consumer:
     enabled: true
     properties: "{{ kafka_broker_listeners[kafka_connect_consumer_kafka_listener_name] | confluent.platform.client_properties(ssl_enabled, False, ssl_mutual_auth_enabled, sasl_protocol,
                             'consumer.', kafka_connect_truststore_path, kafka_connect_truststore_storepass, public_certificates_enabled, kafka_connect_keystore_path, kafka_connect_keystore_storepass, kafka_connect_keystore_keypass,
                             false, sasl_plain_users_final.kafka_connect.principal, sasl_plain_users_final.kafka_connect.password, sasl_scram_users_final.kafka_connect.principal, sasl_scram_users_final.kafka_connect.password, sasl_scram256_users_final.kafka_connect.principal, sasl_scram256_users_final.kafka_connect.password,
                             kerberos_kafka_broker_primary, kafka_connect_keytab_path, kafka_connect_kerberos_principal|default('kafka'),
-                            false, kafka_connect_ldap_user, kafka_connect_ldap_password, mds_bootstrap_server_urls, oauth_enabled, kafka_connect_oauth_user, kafka_connect_oauth_password, oauth_groups_scope, oauth_token_uri, idp_self_signed) }}"
+                            false, kafka_connect_ldap_user, kafka_connect_ldap_password, mds_bootstrap_server_urls, oauth_enabled and not ldap_with_oauth_enabled, kafka_connect_oauth_user, kafka_connect_oauth_password, oauth_groups_scope, oauth_token_uri, idp_self_signed) }}"
   monitoring_interceptor:
     enabled: "{{ kafka_connect_monitoring_interceptors_enabled|bool }}"
     properties:


### PR DESCRIPTION

# Description

The aim of this PR is For OAuth brownfield setup, the connectors present in ldap cluster should remain on ldap configs to avoid downtime. 

Fixes #[ ANSIENG-4168](https://confluentinc.atlassian.net/browse/ANSIENG-4168)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

tested on oauth-rbac-plain-provided-debian12, more testing going on

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
