### PR TITLE
Adding explicit owner and group using file module

### DIFF
--- a/roles/common/tasks/confluent_cli.yml
+++ b/roles/common/tasks/confluent_cli.yml
@@ -31,6 +31,15 @@
     creates: "{{confluent_cli_base_path}}/{{confluent_cli_binary}}/{{confluent_cli_binary}}"
   when: confluent_cli_custom_download_url is not defined
 
+- name: Set Group and Owner for Confluent CLI archive
+  file:
+    path: "{{ confluent_cli_base_path }}"
+    group: "{{ omit if archive_group == '' else archive_group }}"
+    owner: "{{ omit if archive_owner == '' else archive_owner }}"
+    mode: '755'
+    recurse: true
+  when: confluent_cli_custom_download_url is not defined
+
 - name: Download Confluent CLI - Custom URL
   get_url:
     url: "{{ confluent_cli_custom_download_url }}"

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -59,6 +59,15 @@
     creates: "{{binary_base_path}}"
   when: installation_method == "archive"
 
+- name: Set Group and Owner for Confluent Platform archive
+  file:
+    path: "{{archive_destination_path}}"
+    group: "{{ omit if archive_group == '' else archive_group }}"
+    owner: "{{ omit if archive_owner == '' else archive_owner }}"
+    mode: '755'
+    recurse: true
+  when: installation_method == "archive"
+
 - name: Create Jolokia directory
   file:
     path: "{{ jolokia_jar_path | dirname }}"


### PR DESCRIPTION
# Description

Adding explicit owner and group using file module after unarchive as unarchive is not able to set owners correctly

Fixes # [(issue)](https://confluentinc.atlassian.net/browse/ANSIENG-4181)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

[semaphore](https://semaphore.ci.confluent.io/jobs/201c8a90-2206-41d0-9a64-59560e6882b9)

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
