### PR TITLE
Zookeeper to kraft migration would use metadata version to 3.7

### DIFF
--- a/molecule/rbac-mds-mtls-custom-rhel-fips/certificate-hosts
+++ b/molecule/rbac-mds-mtls-custom-rhel-fips/certificate-hosts
@@ -13,3 +13,5 @@ zookeeper:zookeeper1
 zookeeper:mds-zookeeper1
 kafka_controller:controller1
 kafka_controller:mds-controller1
+kafka_controller:controller1-mig
+kafka_controller:mds-controller1-mig

--- a/molecule/rbac-mds-mtls-custom-rhel-fips/prepare.yml
+++ b/molecule/rbac-mds-mtls-custom-rhel-fips/prepare.yml
@@ -9,5 +9,5 @@
   import_playbook: confluent.platform.all
 
 - name: Install Zookeeper Cluster
-  import_playbook: confluent.platform.all
+  import_playbook: ../multi_rbac_converge.yml
   when: lookup('env', 'MIGRATION')|default('false') == 'true'

--- a/molecule/rbac-mds-mtls-existing-keystore-truststore-ubuntu/molecule.yml
+++ b/molecule/rbac-mds-mtls-existing-keystore-truststore-ubuntu/molecule.yml
@@ -144,7 +144,7 @@ platforms:
       - name: confluent
   # Cluster 2 (Kraft) goups, groupnames will be changed during converge phase
   - name: controller1-mig
-    hostname: mds-controller1-mig.confluent
+    hostname: controller1-mig.confluent
     groups:
       - kafka_controller_migration
       - cluster2

--- a/roles/variables/vars/main.yml
+++ b/roles/variables/vars/main.yml
@@ -396,7 +396,7 @@ kafka_broker_properties:
       zookeeper.connection.timeout.ms: 18000
       zookeeper.metadata.migration.enable: "true"
       zookeeper.connect: "{{ groups['zookeeper'] | default(['localhost']) | confluent.platform.resolve_hostnames(hostvars) | join(':' + zookeeper_client_port|string + ',') }}:{{zookeeper_client_port}}{{zookeeper_chroot}}"
-      inter.broker.protocol.version: 3.6
+      inter.broker.protocol.version: 3.7
       confluent.cluster.link.metadata.topic.enable: "true"
   non_migration_mode:
     enabled: "{{ kraft_enabled|bool and not kraft_migration|bool }}"


### PR DESCRIPTION
# Description

- zookeeper to kraft migration would use metadata version to 3.7 instead of 3.6
- fixed minor issues in molecule scenarios for migration

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
