### PR TITLE
[ANSIENG-3465] | fixing check_connector to allow unauthenticated connectors as well

### DIFF
--- a/test_roles/confluent.test/tasks/check_connector.yml
+++ b/test_roles/confluent.test/tasks/check_connector.yml
@@ -3,7 +3,7 @@
   confluent.platform.kafka_connectors:
     connect_url: "{{ connect_url_input }}"
     active_connectors: "{{ active_connectors_input }}"
-    token: "{{ authorization_token }}"
+    token: "{% if rbac_enabled or kafka_connect_oauth_enabled %}{{ authorization_token }}{% else %}{{none}}{% endif %}"
     timeout: 20
   ignore_errors: true
   register: json_output


### PR DESCRIPTION
# Description

- Fixing check_connector file used during verify in molecule to allow unauthenticated connectors as well
- Fixes kerberos-rhel and archive-plain-rhel-fips verify

Fixes # (issue)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
