### PR TITLE
[ANSIENG-4213] |  Copy IDP Cert to /tmp instead of ~/ for 7.7

### DIFF
--- a/molecule/oauth-plain-rhel/verify.yml
+++ b/molecule/oauth-plain-rhel/verify.yml
@@ -87,15 +87,6 @@
         tasks_from: check_property.yml
       vars:
         file_path: /etc/kafka/server.properties
-        property: control.plane.listener.name
-        expected_value: CONTROLLER
-      when: not kraft_mode|bool
-
-    - import_role:
-        name: confluent.test
-        tasks_from: check_property.yml
-      vars:
-        file_path: /etc/kafka/server.properties
         property: transaction.state.log.min.isr
         expected_value: "2"
 

--- a/molecule/scram-rhel/verify.yml
+++ b/molecule/scram-rhel/verify.yml
@@ -5,6 +5,9 @@
   hosts: kafka_broker
   gather_facts: false
   tasks:
+    - set_fact:
+      kraft_mode: "{{ ('kafka_controller' in groups.keys() and groups['kafka_controller'] | length > 0) }}"
+
     - import_role:
         name: confluent.test
         tasks_from: check_property.yml

--- a/molecule/scram-rhel/verify.yml
+++ b/molecule/scram-rhel/verify.yml
@@ -13,6 +13,15 @@
         property: listener.name.internal.sasl.enabled.mechanisms
         expected_value: SCRAM-SHA-512
 
+    - import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: /etc/kafka/server.properties
+        property: control.plane.listener.name
+        expected_value: CONTROLLER
+      when: not kraft_mode|bool
+
 - name: Verify - schema_registry
   hosts: schema_registry
   gather_facts: false

--- a/molecule/scram-rhel/verify.yml
+++ b/molecule/scram-rhel/verify.yml
@@ -6,7 +6,7 @@
   gather_facts: false
   tasks:
     - set_fact:
-      kraft_mode: "{{ ('kafka_controller' in groups.keys() and groups['kafka_controller'] | length > 0) }}"
+        kraft_mode: "{{ ('kafka_controller' in groups.keys() and groups['kafka_controller'] | length > 0) }}"
 
     - import_role:
         name: confluent.test

--- a/roles/control_center/tasks/main.yml
+++ b/roles/control_center/tasks/main.yml
@@ -183,7 +183,7 @@
     tasks_from: idp_certs.yml
   vars:
     idp_cert_path: "{{ oauth_idp_cert_path }}"
-    idp_cert_dest: "oauth_idp_cert.pem"
+    idp_cert_dest: /tmp/oauth_idp_cert.pem
     alias: "oauth_cert"
     truststore_storepass: "{{control_center_truststore_storepass}}"
     truststore_path: "{{control_center_truststore_path}}"

--- a/roles/kafka_broker/tasks/main.yml
+++ b/roles/kafka_broker/tasks/main.yml
@@ -153,7 +153,7 @@
     tasks_from: idp_certs.yml
   vars:
     idp_cert_path: "{{ oauth_idp_cert_path }}"
-    idp_cert_dest: "oauth_idp_cert.pem"
+    idp_cert_dest: /tmp/oauth_idp_cert.pem
     alias: "oauth_cert"
     truststore_storepass: "{{kafka_broker_truststore_storepass}}"
     truststore_path: "{{kafka_broker_pkcs12_truststore_path}}"
@@ -169,7 +169,7 @@
     tasks_from: idp_certs.yml
   vars:
     idp_cert_path: "{{ sso_idp_cert_path }}"
-    idp_cert_dest: "sso_idp_cert.pem"
+    idp_cert_dest: /tmp/sso_idp_cert.pem
     alias: "sso_cert"
     truststore_storepass: "{{kafka_broker_truststore_storepass}}"
     truststore_path: "{{kafka_broker_pkcs12_truststore_path}}"

--- a/roles/kafka_connect/tasks/main.yml
+++ b/roles/kafka_connect/tasks/main.yml
@@ -175,7 +175,7 @@
     tasks_from: idp_certs.yml
   vars:
     idp_cert_path: "{{ oauth_idp_cert_path }}"
-    idp_cert_dest: "oauth_idp_cert.pem"
+    idp_cert_dest: /tmp/oauth_idp_cert.pem
     alias: "oauth_cert"
     truststore_storepass: "{{kafka_connect_truststore_storepass}}"
     truststore_path: "{{kafka_connect_truststore_path}}"

--- a/roles/kafka_connect_replicator/tasks/main.yml
+++ b/roles/kafka_connect_replicator/tasks/main.yml
@@ -314,7 +314,7 @@
     tasks_from: idp_certs.yml
   vars:
     idp_cert_path: "{{ oauth_idp_cert_path }}"
-    idp_cert_dest: "oauth_idp_cert.pem"
+    idp_cert_dest: /tmp/oauth_idp_cert.pem
     alias: "oauth_cert"
     truststore_storepass: "{{kafka_connect_replicator_truststore_storepass}}"
     truststore_path: "{{kafka_connect_replicator_truststore_path}}"

--- a/roles/kafka_controller/tasks/main.yml
+++ b/roles/kafka_controller/tasks/main.yml
@@ -149,7 +149,7 @@
     tasks_from: idp_certs.yml
   vars:
     idp_cert_path: "{{ oauth_idp_cert_path }}"
-    idp_cert_dest: "oauth_idp_cert.pem"
+    idp_cert_dest: /tmp/oauth_idp_cert.pem
     alias: "oauth_cert"
     truststore_storepass: "{{kafka_controller_truststore_storepass}}"
     truststore_path: "{{kafka_controller_pkcs12_truststore_path}}"

--- a/roles/kafka_rest/tasks/main.yml
+++ b/roles/kafka_rest/tasks/main.yml
@@ -162,7 +162,7 @@
     tasks_from: idp_certs.yml
   vars:
     idp_cert_path: "{{ oauth_idp_cert_path }}"
-    idp_cert_dest: "oauth_idp_cert.pem"
+    idp_cert_dest: /tmp/oauth_idp_cert.pem
     alias: "oauth_cert"
     truststore_storepass: "{{kafka_rest_truststore_storepass}}"
     truststore_path: "{{kafka_rest_truststore_path}}"

--- a/roles/ksql/tasks/main.yml
+++ b/roles/ksql/tasks/main.yml
@@ -181,7 +181,7 @@
     tasks_from: idp_certs.yml
   vars:
     idp_cert_path: "{{ oauth_idp_cert_path }}"
-    idp_cert_dest: "oauth_idp_cert.pem"
+    idp_cert_dest: /tmp/oauth_idp_cert.pem
     alias: "oauth_cert"
     truststore_storepass: "{{ksql_truststore_storepass}}"
     truststore_path: "{{ksql_truststore_path}}"

--- a/roles/schema_registry/tasks/main.yml
+++ b/roles/schema_registry/tasks/main.yml
@@ -162,7 +162,7 @@
     tasks_from: idp_certs.yml
   vars:
     idp_cert_path: "{{ oauth_idp_cert_path }}"
-    idp_cert_dest: "oauth_idp_cert.pem"
+    idp_cert_dest: /tmp/oauth_idp_cert.pem
     alias: "oauth_cert"
     truststore_storepass: "{{schema_registry_truststore_storepass}}"
     truststore_path: "{{schema_registry_truststore_path}}"


### PR DESCRIPTION
# Description

In Copy IDP Cert to Node task the idp_cert_path variable comes from oauth_idp_cert_path which is user facing variable. But the idp_cert_dest is hardcoded to oauth_idp_cert.pem which means it goes to the home directory of target machine. Now in certain cases ansible-playbook’s user might not have permissions to write files to home directory where this task will fail with the error Destination . not writable.

- To fix we move the target file to /tmp directory which is a directory where all users have write permissions.
- Also moved the control plane listener property check in the verify from oauth-plain-rhel to scram-rhel as the corresponding `kafka_broker_configure_control_plane_listener: true` was also earlier moved to scram-rhel scenario.


Fixes # [(issue)](https://confluentinc.atlassian.net/browse/ANSIENG-4213)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

[kraft](https://semaphore.ci.confluent.io/workflows/e605965f-e6a0-4b8f-8428-b44b30c7c36a?pipeline_id=ca910ce6-610d-4851-84db-16246573c58f)
[zookeeper](https://semaphore.ci.confluent.io/workflows/b269f6da-466f-4ae7-a2c6-e7fc5bf69a4b?pipeline_id=2c45d3b6-3b85-4a07-a6b0-bc91c70b7df6)
[scram-rhel](https://semaphore.ci.confluent.io/workflows/a59e0c52-24e0-43c3-9a3b-d18b3bca6cc4?pipeline_id=1f0d20b2-5528-40a4-a64a-b0b8b158b9f0)


# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
