### PR TITLE
[ANSIENG-4213] | Copy IDP Cert to /tmp instead of ~/ for 7.6

### DIFF
--- a/roles/kafka_broker/tasks/main.yml
+++ b/roles/kafka_broker/tasks/main.yml
@@ -153,7 +153,7 @@
     tasks_from: idp_certs.yml
   vars:
     idp_cert_path: "{{ sso_idp_cert_path }}"
-    idp_cert_dest: "sso_idp_cert.pem"
+    idp_cert_dest: /tmp/sso_idp_cert.pem
     alias: "sso_cert"
     truststore_storepass: "{{kafka_broker_truststore_storepass}}"
     truststore_path: "{{kafka_broker_pkcs12_truststore_path}}"


### PR DESCRIPTION
# Description

In Copy IDP Cert to Node task the idp_cert_path variable comes from sso_idp_cert_path which is user facing variable. But the idp_cert_dest is hardcoded to sso_idp_cert.pem which means it goes to the home directory of target machine. Now in certain cases ansible-playbook’s user might not have permissions to write files to home directory where this task will fail with the error Destination . not writable.

To fix we move the target file to /tmp directory which is a directory where all users have write permissions.

Fixes # ([issue](https://confluentinc.atlassian.net/browse/ANSIENG-4213))

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

[semaphore](https://semaphore.ci.confluent.io/workflows/9dadb691-93e9-4e05-a379-13219bec6759?pipeline_id=9d3cdcb8-3579-4504-8d0c-9dda43153e1c)

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
