### PR TITLE
[ANSIENG-4228] | fix molecule tests (#38)

### DIFF
--- a/molecule/archive-plain-rhel-fips/molecule.yml
+++ b/molecule/archive-plain-rhel-fips/molecule.yml
@@ -142,7 +142,7 @@ provisioner:
           - jcustenborder/kafka-connect-spooldir:2.0.43
 
         kafka_broker_custom_properties:
-          log.dirs: /tmp/logs1,/tmp/logs2
+          log.dirs: /tmp/logs1
 
         kafka_broker_custom_client_properties:
           abc: xyz

--- a/molecule/archive-plain-rhel-fips/verify.yml
+++ b/molecule/archive-plain-rhel-fips/verify.yml
@@ -44,7 +44,7 @@
       vars:
         file_path: /opt/confluent/custom-config/kafka-broker/server.properties
         property: log.dirs
-        expected_value: /tmp/logs1,/tmp/logs2
+        expected_value: /tmp/logs1
 
     - import_role:
         name: confluent.test

--- a/molecule/archive-scram-rhel/molecule.yml
+++ b/molecule/archive-scram-rhel/molecule.yml
@@ -106,3 +106,6 @@ provisioner:
         archive_owner: cp-custom
 
         mask_secrets: false
+
+        kafka_broker_custom_properties:
+          log.dirs: /tmp/logs1,/tmp/logs2

--- a/molecule/archive-scram-rhel/verify.yml
+++ b/molecule/archive-scram-rhel/verify.yml
@@ -46,6 +46,6 @@
         name: confluent.test
         tasks_from: check_property.yml
       vars:
-        file_path: /opt/confluent/custom-config/kafka-broker/server.properties
+        file_path: /opt/confluent/etc/kafka/server.properties
         property: log.dirs
         expected_value: /tmp/logs1,/tmp/logs2

--- a/molecule/archive-scram-rhel/verify.yml
+++ b/molecule/archive-scram-rhel/verify.yml
@@ -37,3 +37,15 @@
         file_path: /opt/confluent/etc/kafka/connect-distributed.properties
         property: plugin.path
         expected_value: "/opt/confluent/confluent-{{confluent_package_version}}/share/java/connect_plugins,/usr/share/java/connect_plugins"
+
+- name: Verify - kafka_broker
+  hosts: kafka_broker
+  gather_facts: false
+  tasks:
+    - import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: /opt/confluent/custom-config/kafka-broker/server.properties
+        property: log.dirs
+        expected_value: /tmp/logs1,/tmp/logs2


### PR DESCRIPTION
# Description
This PR fixes the molecule tests failing in 7.6.x because of following reasons:
archive-plain-rhel-fips: Get Topics with UnderReplicatedPartitions
rbac-mds-mtls-custom-rhel-fips: Retrieve SSL public key hash from private key on Local Host

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
https://semaphore.ci.confluent.io/workflows/da60affa-295e-42fe-be01-fbb3afc28fae?pipeline_id=4c04824c-8913-490a-a40f-86ce43559edf
https://semaphore.ci.confluent.io/workflows/48e4616d-ec1f-4b22-8d52-b73c4d0f5902?pipeline_id=b1e6b556-5a7a-453a-b7b8-95d0a45631f2

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
