### PR TITLE
fix: support check mode for new host with Java installed

### DIFF
--- a/roles/common/tasks/debian.yml
+++ b/roles/common/tasks/debian.yml
@@ -252,12 +252,13 @@
 - name: Get Java Version
   shell: java -version
   register: version_output
-  check_mode: false
   changed_when: false
 
 - name: Print Java Version
   debug:
     msg: "Current Java Version is: {{version_output.stderr_lines[0]}}"
+  # Conditional to support check mode
+  when: version_output is defined
 
 - name: Install pip
   apt:

--- a/roles/common/tasks/redhat.yml
+++ b/roles/common/tasks/redhat.yml
@@ -84,12 +84,13 @@
 - name: Get Java Version
   shell: java -version
   register: version_output
-  check_mode: false
   changed_when: false
 
 - name: Print Java Version
   debug:
     msg: "Current Java Version is: {{version_output.stderr_lines[0]}}"
+  # Conditional to support check mode
+  when: version_output is defined
 
 - name: Install pip
   yum:

--- a/roles/common/tasks/ubuntu.yml
+++ b/roles/common/tasks/ubuntu.yml
@@ -140,12 +140,13 @@
 - name: Get Java Version
   shell: java -version
   register: version_output
-  check_mode: false
   changed_when: false
 
 - name: Print Java Version
   debug:
     msg: "Current Java Version is: {{version_output.stderr_lines[0]}}"
+  # Conditional to support check mode
+  when: version_output is defined
 
 - name: Install pip
   apt:


### PR DESCRIPTION
# Description

This is a better fix to the issue described in https://github.com/confluentinc/cp-ansible/pull/1228.

We always run our pipelines in check mode before applying any changes. Now we got some new servers without Java installed, and they now fail in check mode:

````
fatal: [REDACTED]: FAILED! => changed=false 
  cmd: java -version
  delta: '0:00:00.003744'
  end: '2024-09-20 12:36:51.082189'
  msg: non-zero return code
  rc: 127
  start: '2024-09-20 12:36:51.078445'
  stderr: '/bin/sh: line 1: java: command not found'
  stderr_lines: <omitted>
  stdout: ''
  stdout_lines: <omitted>
````

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
