### PR TITLE
[ANSIENG-4252] | Get Authorization token using certs

### DIFF
--- a/roles/common/tasks/get_authorization_token.yml
+++ b/roles/common/tasks/get_authorization_token.yml
@@ -7,6 +7,9 @@
     idp_body: "{{ idp_body + [['scope', oauth_groups_scope ]]}}"
   when: oauth|bool and oauth_groups_scope != 'none'
 
+- set_fact:
+    send_client_cert: "{{ ssl_client_authentication in ['required', 'requested'] }}"
+
 - name: Get Authorization Token from Identity Provider
   uri:
     url: "{{ oauth_token_uri }}"
@@ -17,6 +20,8 @@
     url_username: "{{ oauth_user }}"
     url_password: "{{ oauth_password }}"
     force_basic_auth: true
+    client_cert: "{{ client_cert if send_client_cert|bool else omit }}"
+    client_key: "{{ client_key if send_client_cert|bool else omit }}"
     headers:
       Content-Type: application/x-www-form-urlencoded
     body_format: form-urlencoded
@@ -38,6 +43,8 @@
     status_code: 200
     url_username: "{{ldap_user}}"
     url_password: "{{ldap_password}}"
+    client_cert: "{{ client_cert if send_client_cert|bool else omit }}"
+    client_key: "{{ client_key if send_client_cert|bool else omit }}"
     force_basic_auth: true
   register: auth_token_mds
   until: auth_token_mds.status == 200
@@ -46,9 +53,35 @@
   no_log: "{{mask_secrets|bool}}"
   when:
     - cluster_id_source | default('erp') == 'erp'
-    - not oauth|bool
+    - auth_mode == 'ldap'
+
+- name: Get Authorization Token from MDS using mTLS certs
+  uri:
+    url: "{{mds_bootstrap_server_urls.split(',')[0]}}/security/1.0/authenticate"
+    method: GET
+    validate_certs: false
+    return_content: true
+    status_code: 200
+    force_basic_auth: false
+    client_cert: "{{ client_cert if send_client_cert|bool else omit }}"
+    client_key: "{{ client_key if send_client_cert|bool else omit }}"
+  register: auth_token_mds_mtls
+  until: auth_token_mds_mtls.status == 200
+  retries: 10
+  delay: 5
+  no_log: "{{mask_secrets|bool}}"
+  when:
+    - cluster_id_source | default('erp') == 'erp'
+    - auth_mode == 'mtls'
 
 - name: Get Authorization Token
   set_fact:
-    authorization_token: "{{ (auth_token_mds.content | from_json).auth_token if not oauth else (auth_token_oauth.content | from_json).access_token }}"
+    authorization_token: >-
+      {%- if oauth|bool -%}
+        {{ (auth_token_oauth.content | from_json).access_token }}
+      {%- elif auth_mode == 'ldap' -%}
+        {{ (auth_token_mds.content | from_json).auth_token }}
+      {%- elif auth_mode == 'mtls' -%}
+        {{ (auth_token_mds_mtls.content | from_json).auth_token }}
+      {%- endif -%}
   no_log: "{{mask_secrets|bool}}"

--- a/roles/common/tasks/rbac_setup.yml
+++ b/roles/common/tasks/rbac_setup.yml
@@ -7,6 +7,8 @@
     oauth_password: "{{ oauth_superuser_client_password }}"
     ldap_user: "{{ mds_super_user }}"
     ldap_password: "{{ mds_super_user_password }}"
+    client_cert: "{{ kafka_broker_cert_path }}"
+    client_key: "{{ kafka_broker_key_path }}"
 
 - name: Get Kafka Cluster ID from Embedded Rest Proxy
   uri:

--- a/roles/kafka_broker/tasks/health_check.yml
+++ b/roles/kafka_broker/tasks/health_check.yml
@@ -34,6 +34,9 @@
     - kafka_broker_client_secrets_protection_enabled|bool
     - rbac_enabled|bool or confluent_cli_version is version('3.0.0', '>=')
 
+- set_fact:
+    send_client_cert: "{{ ssl_client_authentication in ['required', 'requested'] }}"
+
 - name: Get Authorization Token for Super User
   import_role:
     name: common
@@ -44,6 +47,8 @@
     oauth_password: "{{ oauth_superuser_client_password }}"
     ldap_user: "{{ mds_super_user }}"
     ldap_password: "{{ mds_super_user_password }}"
+    client_cert: "{{ kafka_broker_cert_path }}"
+    client_key: "{{ kafka_broker_key_path }}"
   when: rbac_enabled or oauth_enabled
 
 - name: Wait for Metadata Service to start
@@ -55,6 +60,8 @@
     headers:
       Content-Type: application/json
       Authorization: "Bearer {{ authorization_token }}"
+    client_cert: "{{ kafka_broker_cert_path if send_client_cert|bool else omit }}"
+    client_key: "{{ kafka_broker_key_path if send_client_cert|bool else omit }}"
   register: mds_result
   until: mds_result.status == 200
   retries: "{{ mds_retries }}"
@@ -75,6 +82,8 @@
     headers:
       Content-Type: application/json
       Authorization: "Bearer {{ authorization_token }}"
+    client_cert: "{{ kafka_broker_cert_path if send_client_cert|bool else omit }}"
+    client_key: "{{ kafka_broker_key_path if send_client_cert|bool else omit }}"
   register: erp_result
   until: erp_result.status == 200
   retries: "{{ mds_retries }}"


### PR DESCRIPTION
# Description

Earlier Get Authorization token used LDAP credentials or OAuth clientId,secret to get an authorization token.
Now we may have cases like using mTLS certs to get the token or OAuth creds + Certs or LDAP creds + certs to get the token. Thus modified the logic of getting the authorization token

Fixes # [(issue)](https://confluentinc.atlassian.net/browse/ANSIENG-4252)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
