### PR TITLE
[ANSIENG-3780] | permission issue for log directory fix

### DIFF
--- a/roles/kafka_broker/tasks/main.yml
+++ b/roles/kafka_broker/tasks/main.yml
@@ -181,27 +181,6 @@
     - privileged
     - filesystem
 
-- name: Set Permissions on Data Dirs
-  file:
-    path: "{{item}}"
-    owner: "{{kafka_broker_user}}"
-    group: "{{kafka_broker_group}}"
-    state: directory
-    mode: '750'
-  with_items: "{{ kafka_broker_final_properties['log.dirs'].split(',') }}"
-  tags:
-    - filesystem
-
-- name: Set Permissions on Data Dir files  # noqa no-free-form
-  # Have to use command + chown instead of the Ansible file module here as it seems
-  # like the file module can't handle files modified/deleted while running. This task
-  # can fail on a very active cluster. See https://github.com/confluentinc/cp-ansible/pull/903 for details.
-  command: chown -R {{ kafka_broker_user }}:{{ kafka_broker_group }} {{ item }}
-  changed_when: false
-  with_items: "{{ kafka_broker_final_properties['log.dirs'].split(',') }}"
-  tags:
-    - filesystem
-
 - name: Create Kafka Broker Config directory
   file:
     path: "{{ kafka_broker.config_file | dirname }}"
@@ -261,6 +240,27 @@
   tags:
     - filesystem
     - log
+
+- name: Set Permissions on Data Dirs
+  file:
+    path: "{{item}}"
+    owner: "{{kafka_broker_user}}"
+    group: "{{kafka_broker_group}}"
+    state: directory
+    mode: '750'
+  with_items: "{{ kafka_broker_final_properties['log.dirs'].split(',') }}"
+  tags:
+    - filesystem
+
+- name: Set Permissions on Data Dir files  # noqa no-free-form
+  # Have to use command + chown instead of the Ansible file module here as it seems
+  # like the file module can't handle files modified/deleted while running. This task
+  # can fail on a very active cluster. See https://github.com/confluentinc/cp-ansible/pull/903 for details.
+  command: chown -R {{ kafka_broker_user }}:{{ kafka_broker_group }} {{ item }}
+  changed_when: false
+  with_items: "{{ kafka_broker_final_properties['log.dirs'].split(',') }}"
+  tags:
+    - filesystem
 
 - name: Update Kafka log4j Config for Log Cleanup
   include_role:

--- a/roles/kafka_controller/tasks/main.yml
+++ b/roles/kafka_controller/tasks/main.yml
@@ -178,26 +178,6 @@
     - privileged
     - filesystem
 
-- name: Set Permissions on Data Dirs
-  file:
-    path: "{{kafka_controller_final_properties['log.dirs']}}"
-    owner: "{{kafka_controller_user}}"
-    group: "{{kafka_controller_group}}"
-    state: directory
-    mode: '750'
-  tags:
-    - filesystem
-    - privileged
-
-- name: Set Permissions on Data Dir files  # noqa no-free-form
-  # Have to use command + chown instead of the Ansible file module here as it seems
-  # like the file module can't handle files modified/deleted while running. This task
-  # can fail on a very active cluster. See https://github.com/confluentinc/cp-ansible/pull/903 for details.
-  command: chown -R {{ kafka_controller_user }}:{{ kafka_controller_group }} {{ kafka_controller_final_properties['log.dirs'] }}
-  changed_when: false
-  tags:
-    - filesystem
-
 - name: Create Kafka Controller Config directory
   file:
     path: "{{ kafka_controller.config_file | dirname }}"
@@ -249,6 +229,26 @@
     - filesystem
     - log
     - privileged
+
+- name: Set Permissions on Data Dirs
+  file:
+    path: "{{kafka_controller_final_properties['log.dirs']}}"
+    owner: "{{kafka_controller_user}}"
+    group: "{{kafka_controller_group}}"
+    state: directory
+    mode: '750'
+  tags:
+    - filesystem
+    - privileged
+
+- name: Set Permissions on Data Dir files  # noqa no-free-form
+  # Have to use command + chown instead of the Ansible file module here as it seems
+  # like the file module can't handle files modified/deleted while running. This task
+  # can fail on a very active cluster. See https://github.com/confluentinc/cp-ansible/pull/903 for details.
+  command: chown -R {{ kafka_controller_user }}:{{ kafka_controller_group }} {{ kafka_controller_final_properties['log.dirs'] }}
+  changed_when: false
+  tags:
+    - filesystem
 
 - name: Update Kafka log4j Config for Log Cleanup
   include_role:


### PR DESCRIPTION
# Description
This PR fixes the permission issue of directory file which was caused of permission change task running before storage command.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
https://semaphore.ci.confluent.io/workflows/bf823595-d3a5-49ce-be22-a54f80b881cf?pipeline_id=214a07d1-3995-41fe-adef-65eab0aa36c1

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
