### PR TITLE
[ANSIENG-4238] | remove py 3.8 from ci checks as it is eol

### DIFF
--- a/.semaphore/build_collection.sh
+++ b/.semaphore/build_collection.sh
@@ -4,7 +4,7 @@ set -ex
 
 cd $PATH_TO_CPA
 
-pyenv local $PYTHON_VERSION 3.9 3.8 3.9 3.10 3.11 3.12 # This creates .python-version file which lists all these versions.
+pyenv local $PYTHON_VERSION 3.9 3.10 3.11 3.12 # This creates .python-version file which lists all these versions.
 # 1st version in list will be 3.9 and also become the default version of python
 pip install wheel
 pip install pylint


### PR DESCRIPTION
# Description

Ci checks assume python 3.8 and onwards are pre installed. This used to be the case earlier but since python 3.8 went EOL semaphore nodes dont come preinstalled with it.

Fixes # ([issue](https://confluentinc.atlassian.net/browse/ANSIENG-4328))

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
