### PR TITLE
[ANSIENG-4331] | add kafka_broker_client_secrets_protection_enabled

### DIFF
--- a/molecule/archive-scram-rhel/molecule.yml
+++ b/molecule/archive-scram-rhel/molecule.yml
@@ -122,6 +122,7 @@ provisioner:
         sasl_protocol: scram256
 
         installation_method: archive
+        secrets_protection_enabled: true
 
         archive_group: custom
         archive_owner: cp-custom

--- a/roles/kafka_broker/tasks/main.yml
+++ b/roles/kafka_broker/tasks/main.yml
@@ -572,6 +572,24 @@
   when:
     - "'SCRAM-SHA-512' in kafka_sasl_enabled_mechanisms"
     - kraft_enabled|bool
+    - not ( kafka_broker_client_secrets_protection_enabled|bool )
+  no_log: "{{ mask_secrets|bool }}"
+
+- name: Create SCRAM Users with KRaft and Secrets Protection enabled
+  shell: |
+    {{ binary_base_path }}/bin/kafka-configs \
+      --bootstrap-server {{ hostvars[inventory_hostname]|confluent.platform.resolve_hostname }}:{{kafka_broker_listeners[kafka_broker_inter_broker_listener_name]['port']}} \
+      --command-config {{ kafka_broker.client_config_file }} \
+      --alter --add-config 'SCRAM-SHA-512=[password={{ item.value['password'] }}]' \
+      --entity-type users --entity-name {{ item.value['principal'] }}
+  environment:
+    CONFLUENT_SECURITY_MASTER_KEY: "{{ secrets_protection_masterkey }}"
+  loop: "{{ sasl_scram_users_final|dict2items }}"
+  run_once: true
+  when:
+    - "'SCRAM-SHA-512' in kafka_sasl_enabled_mechanisms"
+    - kraft_enabled|bool
+    - kafka_broker_client_secrets_protection_enabled|bool
   no_log: "{{ mask_secrets|bool }}"
 
 - name: Create SCRAM 256 Users with KRaft
@@ -586,6 +604,24 @@
   when:
     - "'SCRAM-SHA-256' in kafka_sasl_enabled_mechanisms"
     - kraft_enabled|bool
+    - not ( kafka_broker_client_secrets_protection_enabled|bool )
+  no_log: "{{ mask_secrets|bool }}"
+
+- name: Create SCRAM 256 Users with KRaft and Secrets Protection enabled
+  shell: |
+    {{ binary_base_path }}/bin/kafka-configs \
+      --bootstrap-server {{ hostvars[inventory_hostname]|confluent.platform.resolve_hostname }}:{{kafka_broker_listeners[kafka_broker_inter_broker_listener_name]['port']}} \
+      --command-config {{ kafka_broker.client_config_file }} \
+      --alter --add-config 'SCRAM-SHA-256=[password={{ item.value['password'] }}]' \
+      --entity-type users --entity-name {{ item.value['principal'] }}
+  environment:
+    CONFLUENT_SECURITY_MASTER_KEY: "{{ secrets_protection_masterkey }}"
+  loop: "{{ sasl_scram256_users_final|dict2items }}"
+  run_once: true
+  when:
+    - "'SCRAM-SHA-256' in kafka_sasl_enabled_mechanisms"
+    - kraft_enabled|bool
+    - kafka_broker_client_secrets_protection_enabled|bool
   no_log: "{{ mask_secrets|bool }}"
 
 - name: Register Cluster


### PR DESCRIPTION
# Description

This PR add SCRAM support in case kafka_broker_client_secrets_protection_enabled is set to true i.e. secrets are encrypted.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
[Job Link](https://semaphore.ci.confluent.io/workflows/0afe15df-b7f2-4be7-89cc-e0682722ac5e?pipeline_id=9c47b0a4-2f32-41f1-91eb-15c2f7498dd5)

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
