### PR TITLE
feat: new variable to control Kafka URP topics retries

### DIFF
--- a/docs/VARIABLES.md
+++ b/docs/VARIABLES.md
@@ -5694,6 +5694,14 @@ Default:  20
 
 ***
 
+### kafka_broker_health_check_urp_topics_retries
+
+Number of retries while waiting for no URP topics during Kafka Health Checks.
+
+Default:  15
+
+***
+
 ### kafka_broker_jmxexporter_startup_delay
 
 Time in seconds to wait before JMX exporter starts serving metrics. Any requests within the delay period will result in an empty metrics set.

--- a/roles/kafka_broker/defaults/main.yml
+++ b/roles/kafka_broker/defaults/main.yml
@@ -65,6 +65,9 @@ kafka_broker_sysctl_file: /usr/lib/sysctl.d/sysctl.conf
 ### Time in seconds to wait before starting Kafka Health Checks.
 kafka_broker_health_check_delay: 20
 
+### Number of retries while waiting for no URP topics during Kafka Health Checks.
+kafka_broker_health_check_urp_topics_retries: 15
+
 kafka_broker_secrets_protection_file: "{{ ssl_file_dir_final }}/kafka-broker-security.properties"
 
 kafka_broker_client_secrets_protection_file: "{{ ssl_file_dir_final }}/kafka-broker-client-security.properties"

--- a/roles/kafka_broker/tasks/health_check.yml
+++ b/roles/kafka_broker/tasks/health_check.yml
@@ -8,7 +8,7 @@
   register: urp_topics
   # stdout_lines will have topics with URPs and stderr has WARN and ERROR level logs
   until: urp_topics.stdout_lines|length == 0 and 'ERROR' not in urp_topics.stderr
-  retries: 15
+  retries: "{{ kafka_broker_health_check_urp_topics_retries }}"
   delay: 5
   ignore_errors: true
   changed_when: false
@@ -25,7 +25,7 @@
   register: urp_topics_secrets_protection
   # stdout_lines will have topics with URPs and stderr has WARN and ERROR level logs
   until: urp_topics_secrets_protection.stdout_lines|length == 0 and 'ERROR' not in urp_topics_secrets_protection.stderr
-  retries: 15
+  retries: "{{ kafka_broker_health_check_urp_topics_retries }}"
   delay: 5
   ignore_errors: true
   changed_when: false


### PR DESCRIPTION
# Description

This PR makes it possible to configure the number of retries while waiting for URP topics to stabilize during Kafka health checks.

We are using the health checks tasks when OS-patching our clusters. For some major patches that require a node reboot, a restarted broker needs more time to catch up on replicating partitions. With the current settings, this fails the play, which also wastes a lot of resources on fetching log files for troubleshooting (not required). We think the number of retries while waiting for URP topics to stabilize should be configurable - as it will depend on the cluster load.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
