### PR TITLE
[ANSIENG-4314] | Adding check sub property role for testing comma seperated list of values

### DIFF
--- a/molecule/archive-scram-rhel/verify.yml
+++ b/molecule/archive-scram-rhel/verify.yml
@@ -31,11 +31,13 @@
         name: variables
     - import_role:
         name: confluent.test
-        tasks_from: check_property.yml
+        tasks_from: check_subproperty.yml
       vars:
         file_path: /opt/confluent/etc/controller/server.properties
         property: sasl.enabled.mechanisms
-        expected_value: SCRAM-SHA-256,PLAIN
+        expected_values:
+          - SCRAM-SHA-256
+          - PLAIN
     - import_role:
         name: confluent.test
         tasks_from: check_property.yml

--- a/molecule/kerberos-rhel/verify.yml
+++ b/molecule/kerberos-rhel/verify.yml
@@ -18,11 +18,13 @@
         expected_value: "{{ kafka_controller_quorum_voters }}"
     - import_role:
         name: confluent.test
-        tasks_from: check_property.yml
+        tasks_from: check_subproperty.yml
       vars:
         file_path: /etc/controller/server.properties
         property: sasl.enabled.mechanisms
-        expected_value: GSSAPI,PLAIN
+        expected_values:
+          - GSSAPI
+          - PLAIN
     - import_role:
         name: confluent.test
         tasks_from: check_property.yml
@@ -37,11 +39,13 @@
   tasks:
     - import_role:
         name: confluent.test
-        tasks_from: check_property.yml
+        tasks_from: check_subproperty.yml
       vars:
         file_path: /etc/kafka/server.properties
         property: sasl.enabled.mechanisms
-        expected_value: GSSAPI,PLAIN
+        expected_values:
+          - GSSAPI
+          - PLAIN
 
     - import_role:
         name: confluent.test

--- a/molecule/rbac-scram-custom-rhel-fips/verify.yml
+++ b/molecule/rbac-scram-custom-rhel-fips/verify.yml
@@ -16,11 +16,14 @@
         name: variables
     - import_role:
         name: confluent.test
-        tasks_from: check_property.yml
+        tasks_from: check_subproperty.yml
       vars:
         file_path: /etc/controller/server.properties
         property: sasl.enabled.mechanisms
-        expected_value: OAUTHBEARER,SCRAM-SHA-512,PLAIN
+        expected_values:
+          - OAUTHBEARER
+          - SCRAM-SHA-512
+          - PLAIN
     - import_role:
         name: confluent.test
         tasks_from: check_property.yml

--- a/molecule/scram-rhel/verify.yml
+++ b/molecule/scram-rhel/verify.yml
@@ -64,11 +64,11 @@
 
     - import_role:
         name: confluent.test
-        tasks_from: check_property.yml
+        tasks_from: check_subproperty.yml
       vars:
         file_path: /etc/kafka/server.properties
         property: sasl.enabled.mechanisms
-        expected_value:
+        expected_values:
           - SCRAM-SHA-512
           - SCRAM-SHA-256
       when: not kraft_mode|bool

--- a/molecule/scram-rhel/verify.yml
+++ b/molecule/scram-rhel/verify.yml
@@ -8,11 +8,14 @@
         name: variables
     - import_role:
         name: confluent.test
-        tasks_from: check_property.yml
+        tasks_from: check_subproperty.yml
       vars:
         file_path: /etc/controller/server.properties
         property: sasl.enabled.mechanisms
-        expected_value: SCRAM-SHA-512,SCRAM-SHA-256,GSSAPI
+        expected_values:
+          - SCRAM-SHA-512
+          - SCRAM-SHA-256
+          - GSSAPI
     - import_role:
         name: confluent.test
         tasks_from: check_property.yml
@@ -30,11 +33,13 @@
 
     - import_role:
         name: confluent.test
-        tasks_from: check_property.yml
+        tasks_from: check_subproperty.yml
       vars:
         file_path: /etc/kafka/server.properties
         property: listener.name.internal.sasl.enabled.mechanisms
-        expected_value: SCRAM-SHA-512,SCRAM-SHA-256
+        expected_values:
+          - SCRAM-SHA-512
+          - SCRAM-SHA-256
 
     - import_role:
         name: confluent.test
@@ -47,11 +52,14 @@
 
     - import_role:
         name: confluent.test
-        tasks_from: check_property.yml
+        tasks_from: check_subproperty.yml
       vars:
         file_path: /etc/kafka/server.properties
         property: sasl.enabled.mechanisms
-        expected_value: SCRAM-SHA-512,SCRAM-SHA-256,GSSAPI
+        expected_values:
+          - SCRAM-SHA-512
+          - SCRAM-SHA-256
+          - GSSAPI
       when: kraft_mode|bool
 
     - import_role:
@@ -60,17 +68,21 @@
       vars:
         file_path: /etc/kafka/server.properties
         property: sasl.enabled.mechanisms
-        expected_value: SCRAM-SHA-512,SCRAM-SHA-256
+        expected_value:
+          - SCRAM-SHA-512
+          - SCRAM-SHA-256
       when: not kraft_mode|bool
 
     - name: Check Control Plane Listener Property
       import_role:
         name: confluent.test
-        tasks_from: check_property.yml
+        tasks_from: check_subproperty.yml
       vars:
         file_path: /etc/kafka/server.properties
         property: listener.name.controller.sasl.enabled.mechanisms
-        expected_value: SCRAM-SHA-512,SCRAM-SHA-256
+        expected_values:
+          - SCRAM-SHA-512
+          - SCRAM-SHA-256
       when: not kraft_mode|bool
 
     - name: Check Control Plane Listener Property

--- a/test_roles/confluent.test/tasks/check_subproperty.yml
+++ b/test_roles/confluent.test/tasks/check_subproperty.yml
@@ -16,10 +16,18 @@
   set_fact:
     values: "{{ value_string.split(',') }}"
 
-- name: Check if all expected values are present
+- name: Sort actual values and expected values lists
+  set_fact:
+    values_sorted: "{{ values | sort }}"
+    expected_values_sorted: "{{ expected_values | sort }}"
+
+- name: Compare lists
   assert:
     that:
-      - "item in values"
-    fail_msg: "Value '{{ item }}' not found for the key '{{ property }}'"
-    success_msg: "Value '{{ item }}' found for the key '{{ property }}'"
-  loop: "{{ expected_values }}"
+      - values_sorted == expected_values_sorted
+    fail_msg: >-
+      Lists do not match for property '{{ property }}'
+      Expected: {{ expected_values_sorted }}
+      Actual: {{ values_sorted }}
+      Missing items: {{ expected_values_sorted | difference(values_sorted) }}
+      Extra items: {{ values_sorted | difference(expected_values_sorted) }}

--- a/test_roles/confluent.test/tasks/check_subproperty.yml
+++ b/test_roles/confluent.test/tasks/check_subproperty.yml
@@ -1,0 +1,25 @@
+---
+- name: Read the properties file
+  slurp:
+    src: "{{file_path}}"
+  register: file_content_raw
+
+- name: Decode content
+  set_fact:
+    file_content: "{{ file_content_raw['content'] | b64decode }}"
+
+- name: Extract value for specific property
+  set_fact:
+    value_string: "{{ file_content | regex_search(property + '=([^\n]*)', '\\1') | first }}"
+
+- name: Make a list of values for our property
+  set_fact:
+    values: "{{ value_string.split(',') }}"
+
+- name: Check if all expected values are present
+  assert:
+    that:
+      - "item in values"
+    fail_msg: "Value '{{ item }}' not found for the key '{{ property }}'"
+    success_msg: "Value '{{ item }}' found for the key '{{ property }}'"
+  loop: "{{ expected_values }}"

--- a/test_roles/confluent.test/tasks/check_subproperty.yml
+++ b/test_roles/confluent.test/tasks/check_subproperty.yml
@@ -10,7 +10,8 @@
 
 - name: Extract value for specific property
   set_fact:
-    value_string: "{{ file_content | regex_search(property + '=([^\n]*)', '\\1') | first }}"
+    # [\\n|^] matches either newline or start of the file. This ensures we are not matching property with some prefix i.e when searching for sasl.enabled.mechnisms, we don't want to match controller.listener.sasl.enabled.mechanisms
+    value_string: "{{ file_content | regex_search('[\\n|^]' + property + '=([^\n]*)', '\\1') | first }}"
 
 - name: Make a list of values for our property
   set_fact:


### PR DESCRIPTION
# Description

In a couple of test cases we had a check to confirm the value of `sasl.enabled.mechanisms` is set to `GSSAPI,PLAIN` but it could also have been set to `PLAIN,GSSAPI`. so instead of doing a string matching of values we can parse the value and split by comma and make a list. Then compare items of list to ensure all the mechanisms which should be present are actually present.

This will help remove flakiness as at times this property would be set to  `GSSAPI,PLAIN` and at other times it would be `PLAIN,GSSAPI` both of which are same from cp point of view.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Semaphore link - [add here]

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
