### PR TITLE
[scram-rhel] | fixing space before and after = sign in properties file

### DIFF
--- a/test_roles/confluent.test/tasks/check_subproperty.yml
+++ b/test_roles/confluent.test/tasks/check_subproperty.yml
@@ -11,7 +11,7 @@
 - name: Extract value for specific property
   set_fact:
     # [\\n|^] matches either newline or start of the file. This ensures we are not matching property with some prefix i.e when searching for sasl.enabled.mechnisms, we don't want to match controller.listener.sasl.enabled.mechanisms
-    value_string: "{{ file_content | regex_search('[\\n|^]' + property + '=([^\n]*)', '\\1') | first }}"
+    value_string: "{{ file_content | regex_search('[\\n|^]' + property + ' *= *([^\n]*)', '\\1') | first }}"
 
 - name: Make a list of values for our property
   set_fact:


### PR DESCRIPTION
# Description

properties file can be of the format `key=val` or `key = val` or even something like `key= val`. So artibitrary number of space before and after = should be handled in regex when capturing the list of property values.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

[sem](https://semaphore.ci.confluent.io/workflows/218901b5-3f3f-415d-b3d6-3f953c59ea90/summary)

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
