### PR TITLE
Updated line 16 certificate_authority tag description in docs/TAGS.md

### DIFF
--- a/discovery/service/kafka_broker.py
+++ b/discovery/service/kafka_broker.py
@@ -326,7 +326,7 @@ class KafkaServicePropertyBaseBuilder(AbstractPropertyBuilder):
                 "port": port
             }
 
-            non_standard_protocol = {'GSSAPI':'kerberos', 'SCRAM-SHA-512':'scram', 'SCRAM-SHA-256':'scram256', 'PLAIN':'plain', 'OAUTHBEARER':'oauth'}
+            non_standard_protocol = {'GSSAPI': 'kerberos', 'SCRAM-SHA-512': 'scram', 'SCRAM-SHA-256': 'scram256', 'PLAIN': 'plain', 'OAUTHBEARER': 'oauth'}
 
             ssl_enabled = service_prop.get(key2)
             if ssl_enabled is not None:

--- a/docs/TAGS.md
+++ b/docs/TAGS.md
@@ -15,7 +15,7 @@ Description: To make a task/play run always regardless of the tag specified. It'
 
 ### Tag - certificate_authority
 
-Description: To generate the certificate authority (CA) if TLS encryption is enabled and using self-signed certificates.
+Description: To generate the certificate authority (CA) if TLS encryption is enabled and using self-signed certificates.Additionally, a key pair for the MDS token, a private key and a public certificate, will be generated.
 
 ***
 


### PR DESCRIPTION
# Description

updated line 16 certificate_authority tag description .

Description: To generate the certificate authority (CA) if TLS encryption is enabled and using self-signed certificates.Additionally, a key pair for the MDS token, a private key and a public certificate, will be generated.

Fixes # (issue)
https://github.com/confluentinc/cp-ansible/issues/1560
## Type of change

edited description for docs/tags.md certificate_authority


# How Has This Been Tested?

https://confluentinc.atlassian.net/browse/DOCS-28059
https://docs.confluent.io/ansible/7.8/ansible-install.html