### PR TITLE
fix permission on right controller log dir when overwritten

### DIFF
--- a/roles/kafka_controller/tasks/main.yml
+++ b/roles/kafka_controller/tasks/main.yml
@@ -195,9 +195,9 @@
   tags:
     - configuration
 
-- name: Set Permissions on /var/lib/controller
+- name: Set Permissions on {{ kafka_controller_final_properties['log.dirs'] }}
   file:
-    path: /var/lib/controller/
+    path: "{{ kafka_controller_final_properties['log.dirs'] }}"
     owner: "{{kafka_controller_user}}"
     group: "{{kafka_controller_group}}"
     state: directory


### PR DESCRIPTION
# Description

Fixes #1879

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

set `kafka_controller: logs.dir:` entry to whatever but `/var/lib/controller`

# Checklist:

- [X] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [X] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
