### PR TITLE
[ANSIENG-4583] | Remove confluent cli download dependency for cli SSO

### DIFF
--- a/molecule/oauth-rbac-plain-rhel8/verify.yml
+++ b/molecule/oauth-rbac-plain-rhel8/verify.yml
@@ -26,6 +26,21 @@
         property: listener.name.internal.sasl.enabled.mechanisms
         expected_value: OAUTHBEARER
 
+    - name: Read the kafka properties
+      slurp:
+        src: /etc/kafka/server.properties
+      register: file_content
+
+    - name: Check if property exists
+      set_fact:
+        property_exists: "{{ file_content.content | b64decode | split('\n') | select('match','^confluent.oidc.idp.device.authorization.endpoint.uri=') | list | length > 0  }}"
+
+    - name: Assert that the property exists
+      assert:
+        that:
+          - property_exists == true
+        msg: "Property 'confluent.oidc.idp.device.authorization.endpoint.uri=' was not found in the file."     
+
 - name: Verify Client Packages
   hosts: zookeeper kafka_controller kafka_broker schema_registry kafka_rest kafka_connect ksql control_center
   gather_facts: false

--- a/roles/variables/vars/main.yml
+++ b/roles/variables/vars/main.yml
@@ -636,7 +636,7 @@ kafka_broker_properties:
       confluent.metadata.ssl.truststore.location: "{{kafka_broker_truststore_path}}"
       confluent.metadata.ssl.truststore.password: "{{kafka_broker_truststore_storepass}}"
   rbac_cli_sso:
-    enabled: "{{confluent_cli_download_enabled and sso_cli}}"
+    enabled: "{{sso_cli}}"
     properties:
       confluent.oidc.idp.device.authorization.endpoint.uri: "{{ sso_device_authorization_uri }}"
   rbac_oauth_ssl:


### PR DESCRIPTION
# Description

Ansible should not restrict adding cli sso config based on the cli installation method. It is possible that cli was installed manually and cp-ansible is used to enable SSO in it.

Fixes # [ANSIENG-4583](https://confluentinc.atlassian.net/browse/ANSIENG-4583)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

tested locally. Also added a task in verify to validate that the config is getting added now

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules


[ANSIENG-4583]: https://confluentinc.atlassian.net/browse/ANSIENG-4583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ