### PR TITLE
fix(idempotency): make kafka-storage commands return correct changed_when status

### DIFF
--- a/roles/kafka_broker/tasks/get_meta_properties.yml
+++ b/roles/kafka_broker/tasks/get_meta_properties.yml
@@ -6,7 +6,8 @@
   register: uuid_broker
 
 - name: Format Storage Directory
-  shell: "{{ binary_base_path }}/bin/kafka-storage  format -t={{ clusterid }} -c {{ kafka_broker.config_file }} --ignore-formatted"
+  shell: "{{ binary_base_path }}/bin/kafka-storage format -t={{ clusterid }} -c {{ kafka_broker.config_file }} --ignore-formatted"
   register: format_meta
+  changed_when: format_meta.stdout_lines is not search('already formatted', multiline=true)
   vars:
     clusterid: "{{ (uuid_broker['content'] | b64decode).partition('cluster.id=')[2].partition('\n')[0] }}"

--- a/roles/kafka_controller/tasks/get_meta_properties.yml
+++ b/roles/kafka_controller/tasks/get_meta_properties.yml
@@ -3,12 +3,14 @@
   shell: "{{ binary_base_path }}/bin/kafka-storage info -c {{ kafka_controller.config_file }}"
   ignore_errors: true
   failed_when: false
+  changed_when: false
   register: formatted
 
 - name: Get ClusterId
   shell: "{{ binary_base_path }}/bin/kafka-storage random-uuid"
   environment:
     KAFKA_OPTS: "-Xlog:all=error -XX:+IgnoreUnrecognizedVMOptions"
+  changed_when: false
   register: uuid_key
   run_once: true
   when: not kraft_migration|bool


### PR DESCRIPTION
# Description

Before this PR, in KRaft mode, commands running `kafka-storage` had no explicit `changed_when`, so they would always report that they changed the system.

This PR sets `changed_when: false` for `kafka-storage info` and `kafka-storage random-uuid`, none of which changes anything on the hosts. It also sets `changed_when` for the `kafka-storage format` command, based on the output from the command.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested in our local provisioning pipeline.

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
