### PR TITLE
Fix doc for replicator variable ansieng 4561

### DIFF
--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -1,6 +1,0 @@
-# variables
-
-Below are the supported variables for the role variables
-
-***
-

--- a/VARIABLES.md
+++ b/VARIABLES.md
@@ -1,0 +1,6 @@
+# variables
+
+Below are the supported variables for the role variables
+
+***
+

--- a/docs/VARIABLES.md
+++ b/docs/VARIABLES.md
@@ -3324,6 +3324,14 @@ Default:  ""
 
 ***
 
+### kafka_connect_replicator_listener
+
+Kafka Connect Replicator Listener. Make sure it contains the keys: ssl_enabled, ssl_mutual_auth_enabled, sasl_protocol
+
+Default: 
+
+***
+
 ### kafka_connect_replicator_erp_host
 
 Variable to define the location of the Embedded Rest Proxy for configuring RBAC.
@@ -3516,6 +3524,14 @@ Default:  "{{  kafka_connect_replicator_keystore_storepass }}"
 
 ***
 
+### kafka_connect_replicator_consumer_listener
+
+Kafka Connect Replicator Consumer Listener. Make sure it contains the keys: ssl_enabled, ssl_mutual_auth_enabled, sasl_protocol
+
+Default: 
+
+***
+
 ### kafka_connect_replicator_consumer_erp_host
 
 Variable to define the location of the Embedded Rest Proxy for configuring RBAC.
@@ -3705,6 +3721,14 @@ Default:  "{{ kafka_connect_replicator_truststore_storepass}}"
 The password for the Kafka Connect Replicator Producer TLS keystore.  Defaults to match kafka_connect_replicator_keystore_storepass.
 
 Default:  "{{ kafka_connect_replicator_keystore_storepass }}"
+
+***
+
+### kafka_connect_replicator_producer_listener
+
+Kafka Connect Replicator Producer Listener. Make sure it contains the keys: ssl_enabled, ssl_mutual_auth_enabled, sasl_protocol
+
+Default: 
 
 ***
 
@@ -3905,6 +3929,14 @@ Default:  "{{ kafka_connect_replicator_truststore_storepass}}"
 The password for the Kafka Connect Replicator Monitoring Interceptor TLS keystore.  Defaults to match kafka_connect_replicator_keystore_storepass.
 
 Default:  "{{ kafka_connect_replicator_keystore_storepass }}"
+
+***
+
+### kafka_connect_replicator_monitoring_interceptor_listener
+
+Kafka Connect Replicator Monitoring Interceptor Listener. Make sure it contains the keys: ssl_enabled, ssl_mutual_auth_enabled, sasl_protocol
+
+Default: 
 
 ***
 

--- a/docs/VARIABLES.md
+++ b/docs/VARIABLES.md
@@ -3326,7 +3326,7 @@ Default:  ""
 
 ### kafka_connect_replicator_listener
 
-Kafka Connect Replicator Listener. Make sure it contains the keys: ssl_enabled, ssl_mutual_auth_enabled, sasl_protocol
+Listener Dictionary that describes Kafka Connect Replicator Listener. It contains the keys: ssl_enabled, ssl_mutual_auth_enabled, sasl_protocol
 
 Default: 
 
@@ -3526,7 +3526,7 @@ Default:  "{{  kafka_connect_replicator_keystore_storepass }}"
 
 ### kafka_connect_replicator_consumer_listener
 
-Kafka Connect Replicator Consumer Listener. Make sure it contains the keys: ssl_enabled, ssl_mutual_auth_enabled, sasl_protocol
+Listener Dictionary that describes Kafka Connect Replicator Consumer Listener. Make sure it contains the keys: ssl_enabled, ssl_mutual_auth_enabled, sasl_protocol
 
 Default: 
 
@@ -3726,7 +3726,7 @@ Default:  "{{ kafka_connect_replicator_keystore_storepass }}"
 
 ### kafka_connect_replicator_producer_listener
 
-Kafka Connect Replicator Producer Listener. Make sure it contains the keys: ssl_enabled, ssl_mutual_auth_enabled, sasl_protocol
+Listener Dictionary that describes Kafka Connect Replicator Producer Listener. It contains the keys: ssl_enabled, ssl_mutual_auth_enabled, sasl_protocol
 
 Default: 
 
@@ -3934,7 +3934,7 @@ Default:  "{{ kafka_connect_replicator_keystore_storepass }}"
 
 ### kafka_connect_replicator_monitoring_interceptor_listener
 
-Kafka Connect Replicator Monitoring Interceptor Listener. Make sure it contains the keys: ssl_enabled, ssl_mutual_auth_enabled, sasl_protocol
+Listener Dictionary that describes Kafka Connect Replicator Monitoring Interceptor Listener. It contains the keys: ssl_enabled, ssl_mutual_auth_enabled, sasl_protocol
 
 Default: 
 
@@ -5039,4 +5039,3 @@ Key Size used by keytool -genkeypair command when creating Keystores. Only used 
 Default:  2048
 
 ***
-

--- a/docs/VARIABLES.md
+++ b/docs/VARIABLES.md
@@ -3526,7 +3526,7 @@ Default:  "{{  kafka_connect_replicator_keystore_storepass }}"
 
 ### kafka_connect_replicator_consumer_listener
 
-Listener Dictionary that describes Kafka Connect Replicator Consumer Listener. Make sure it contains the keys: ssl_enabled, ssl_mutual_auth_enabled, sasl_protocol
+Listener Dictionary that describes Kafka Connect Replicator Consumer Listener. It contains the keys: ssl_enabled, ssl_mutual_auth_enabled, sasl_protocol
 
 Default: 
 

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -1780,6 +1780,11 @@ kafka_connect_replicator_kerberos_keytab_path: /etc/security/keytabs/kafka_conne
 kafka_connect_replicator_listener_name: kafka_connect_replicator_listener
 kafka_connect_replicator_group_id: replicator
 
+### Kafka Connect Replicator Listener. Make sure it contains the keys: ssl_enabled, ssl_mutual_auth_enabled, sasl_protocol
+kafka_connect_replicator_listener:
+  ssl_enabled:  "{{ssl_enabled}}"
+  ssl_mutual_auth_enabled: "{{ssl_mutual_auth_enabled}}"
+  sasl_protocol: "{{sasl_protocol}}"  
 ### Variable to define the location of the Embedded Rest Proxy for configuring RBAC.
 kafka_connect_replicator_erp_host: localhost:8090
 
@@ -1862,6 +1867,12 @@ kafka_connect_replicator_consumer_export_certs: kafka_connect_replicator_consume
 kafka_connect_replicator_consumer_keytab_path: /etc/security/keytabs/kafka_connect_replicator_consumer.keytab
 kafka_connect_replicator_consumer_kerberos_keytab_path: /etc/security/keytabs/kafka_connect_replicator_consumer.keytab
 
+### Kafka Connect Replicator Consumer Listener. Make sure it contains the keys: ssl_enabled, ssl_mutual_auth_enabled, sasl_protocol
+kafka_connect_replicator_consumer_listener:
+  ssl_enabled: "{{ssl_enabled}}"
+  ssl_mutual_auth_enabled: "{{ssl_mutual_auth_enabled}}"
+  sasl_protocol: "{{sasl_protocol}}"
+
 ### Variable to define the location of the Embedded Rest Proxy for configuring RBAC.
 kafka_connect_replicator_consumer_erp_host: localhost:8090
 
@@ -1943,6 +1954,12 @@ kafka_connect_replicator_producer_key_path: "{{ ssl_file_dir_final }}/kafka_conn
 kafka_connect_replicator_producer_export_certs: kafka_connect_replicator_producer_listener ['ssl_mutual_auth_enabled'] | default(ssl_mutual_auth_enabled) | bool
 kafka_connect_replicator_producer_keytab_path: /etc/security/keytabs/kafka_connect_replicator_producer.keytab
 kafka_connect_replicator_producer_kerberos_keytab_path: /etc/security/keytabs/kafka_connect_replicator_producer.keytab
+
+### Kafka Connect Replicator Producer Listener. Make sure it contains the keys: ssl_enabled, ssl_mutual_auth_enabled, sasl_protocol
+kafka_connect_replicator_producer_listener:
+  ssl_enabled: "{{ssl_enabled}}"
+  ssl_mutual_auth_enabled: "{{ssl_mutual_auth_enabled}}"
+  sasl_protocol: "{{sasl_protocol}}"
 
 ### Variable to define the location of the Embedded Rest Proxy for configuring RBAC. Defaults to kafka_connect_replicator_erp_host.
 kafka_connect_replicator_producer_erp_host: "{{ kafka_connect_replicator_erp_host }}"
@@ -2027,6 +2044,12 @@ kafka_connect_replicator_monitoring_interceptor_cert_path: "{{ ssl_file_dir_fina
 kafka_connect_replicator_monitoring_interceptor_key_path: "{{ ssl_file_dir_final }}/kafka_connect_replicator_monitoring_interceptor.key"
 kafka_connect_replicator_monitoring_interceptor_export_certs: kafka_connect_replicator_monitoring_interceptor_listener ['ssl_mutual_auth_enabled'] | default(ssl_mutual_auth_enabled) | bool
 kafka_connect_replicator_monitoring_interceptor_keytab_path: /etc/security/keytabs/kafka_connect_replicator_monitoring_interceptor.keytab
+
+### Kafka Connect Replicator Monitoring Interceptor Listener. Make sure it contains the keys: ssl_enabled, ssl_mutual_auth_enabled, sasl_protocol
+kafka_connect_replicator_monitoring_interceptor_listener:
+  ssl_enabled:  "{{ssl_enabled}}"
+  ssl_mutual_auth_enabled: "{{ssl_mutual_auth_enabled}}"
+  sasl_protocol: "{{sasl_protocol}}"
 
 ### Additional set of Kafka Connect Replicator extension classes.
 kafka_connect_replicator_custom_rest_extension_classes: []

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -1868,7 +1868,7 @@ kafka_connect_replicator_consumer_export_certs: kafka_connect_replicator_consume
 kafka_connect_replicator_consumer_keytab_path: /etc/security/keytabs/kafka_connect_replicator_consumer.keytab
 kafka_connect_replicator_consumer_kerberos_keytab_path: /etc/security/keytabs/kafka_connect_replicator_consumer.keytab
 
-### Listener Dictionary that describes Kafka Connect Replicator Consumer Listener. Make sure it contains the keys: ssl_enabled, ssl_mutual_auth_enabled, sasl_protocol
+### Listener Dictionary that describes Kafka Connect Replicator Consumer Listener. It contains the keys: ssl_enabled, ssl_mutual_auth_enabled, sasl_protocol
 kafka_connect_replicator_consumer_listener:
   ssl_enabled: "{{ssl_enabled}}"
   ssl_mutual_auth_enabled: "{{ssl_mutual_auth_enabled}}"

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -1780,7 +1780,7 @@ kafka_connect_replicator_kerberos_keytab_path: /etc/security/keytabs/kafka_conne
 kafka_connect_replicator_listener_name: kafka_connect_replicator_listener
 kafka_connect_replicator_group_id: replicator
 
-### Listener Dictionary that describes Kafka Connect Replicator Listener. Make sure it contains the keys: ssl_enabled, ssl_mutual_auth_enabled, sasl_protocol
+### Listener Dictionary that describes Kafka Connect Replicator Listener. It contains the keys: ssl_enabled, ssl_mutual_auth_enabled, sasl_protocol
 kafka_connect_replicator_listener:
   ssl_enabled:  "{{ssl_enabled}}"
   ssl_mutual_auth_enabled: "{{ssl_mutual_auth_enabled}}"
@@ -1956,7 +1956,7 @@ kafka_connect_replicator_producer_export_certs: kafka_connect_replicator_produce
 kafka_connect_replicator_producer_keytab_path: /etc/security/keytabs/kafka_connect_replicator_producer.keytab
 kafka_connect_replicator_producer_kerberos_keytab_path: /etc/security/keytabs/kafka_connect_replicator_producer.keytab
 
-### Listener Dictionary that describes Kafka Connect Replicator Producer Listener. Make sure it contains the keys: ssl_enabled, ssl_mutual_auth_enabled, sasl_protocol
+### Listener Dictionary that describes Kafka Connect Replicator Producer Listener. It contains the keys: ssl_enabled, ssl_mutual_auth_enabled, sasl_protocol
 kafka_connect_replicator_producer_listener:
   ssl_enabled: "{{ssl_enabled}}"
   ssl_mutual_auth_enabled: "{{ssl_mutual_auth_enabled}}"
@@ -2046,7 +2046,7 @@ kafka_connect_replicator_monitoring_interceptor_key_path: "{{ ssl_file_dir_final
 kafka_connect_replicator_monitoring_interceptor_export_certs: kafka_connect_replicator_monitoring_interceptor_listener ['ssl_mutual_auth_enabled'] | default(ssl_mutual_auth_enabled) | bool
 kafka_connect_replicator_monitoring_interceptor_keytab_path: /etc/security/keytabs/kafka_connect_replicator_monitoring_interceptor.keytab
 
-### Listener Dictionary that describes Kafka Connect Replicator Monitoring Interceptor Listener. Make sure it contains the keys: ssl_enabled, ssl_mutual_auth_enabled, sasl_protocol
+### Listener Dictionary that describes Kafka Connect Replicator Monitoring Interceptor Listener. It contains the keys: ssl_enabled, ssl_mutual_auth_enabled, sasl_protocol
 kafka_connect_replicator_monitoring_interceptor_listener:
   ssl_enabled:  "{{ssl_enabled}}"
   ssl_mutual_auth_enabled: "{{ssl_mutual_auth_enabled}}"

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -1780,11 +1780,12 @@ kafka_connect_replicator_kerberos_keytab_path: /etc/security/keytabs/kafka_conne
 kafka_connect_replicator_listener_name: kafka_connect_replicator_listener
 kafka_connect_replicator_group_id: replicator
 
-### Kafka Connect Replicator Listener. Make sure it contains the keys: ssl_enabled, ssl_mutual_auth_enabled, sasl_protocol
+### Listener Dictionary that describes Kafka Connect Replicator Listener. Make sure it contains the keys: ssl_enabled, ssl_mutual_auth_enabled, sasl_protocol
 kafka_connect_replicator_listener:
   ssl_enabled:  "{{ssl_enabled}}"
   ssl_mutual_auth_enabled: "{{ssl_mutual_auth_enabled}}"
   sasl_protocol: "{{sasl_protocol}}"  
+
 ### Variable to define the location of the Embedded Rest Proxy for configuring RBAC.
 kafka_connect_replicator_erp_host: localhost:8090
 
@@ -1867,7 +1868,7 @@ kafka_connect_replicator_consumer_export_certs: kafka_connect_replicator_consume
 kafka_connect_replicator_consumer_keytab_path: /etc/security/keytabs/kafka_connect_replicator_consumer.keytab
 kafka_connect_replicator_consumer_kerberos_keytab_path: /etc/security/keytabs/kafka_connect_replicator_consumer.keytab
 
-### Kafka Connect Replicator Consumer Listener. Make sure it contains the keys: ssl_enabled, ssl_mutual_auth_enabled, sasl_protocol
+### Listener Dictionary that describes Kafka Connect Replicator Consumer Listener. Make sure it contains the keys: ssl_enabled, ssl_mutual_auth_enabled, sasl_protocol
 kafka_connect_replicator_consumer_listener:
   ssl_enabled: "{{ssl_enabled}}"
   ssl_mutual_auth_enabled: "{{ssl_mutual_auth_enabled}}"
@@ -1955,7 +1956,7 @@ kafka_connect_replicator_producer_export_certs: kafka_connect_replicator_produce
 kafka_connect_replicator_producer_keytab_path: /etc/security/keytabs/kafka_connect_replicator_producer.keytab
 kafka_connect_replicator_producer_kerberos_keytab_path: /etc/security/keytabs/kafka_connect_replicator_producer.keytab
 
-### Kafka Connect Replicator Producer Listener. Make sure it contains the keys: ssl_enabled, ssl_mutual_auth_enabled, sasl_protocol
+### Listener Dictionary that describes Kafka Connect Replicator Producer Listener. Make sure it contains the keys: ssl_enabled, ssl_mutual_auth_enabled, sasl_protocol
 kafka_connect_replicator_producer_listener:
   ssl_enabled: "{{ssl_enabled}}"
   ssl_mutual_auth_enabled: "{{ssl_mutual_auth_enabled}}"
@@ -2045,7 +2046,7 @@ kafka_connect_replicator_monitoring_interceptor_key_path: "{{ ssl_file_dir_final
 kafka_connect_replicator_monitoring_interceptor_export_certs: kafka_connect_replicator_monitoring_interceptor_listener ['ssl_mutual_auth_enabled'] | default(ssl_mutual_auth_enabled) | bool
 kafka_connect_replicator_monitoring_interceptor_keytab_path: /etc/security/keytabs/kafka_connect_replicator_monitoring_interceptor.keytab
 
-### Kafka Connect Replicator Monitoring Interceptor Listener. Make sure it contains the keys: ssl_enabled, ssl_mutual_auth_enabled, sasl_protocol
+### Listener Dictionary that describes Kafka Connect Replicator Monitoring Interceptor Listener. Make sure it contains the keys: ssl_enabled, ssl_mutual_auth_enabled, sasl_protocol
 kafka_connect_replicator_monitoring_interceptor_listener:
   ssl_enabled:  "{{ssl_enabled}}"
   ssl_mutual_auth_enabled: "{{ssl_mutual_auth_enabled}}"


### PR DESCRIPTION
# Description

Thread [Message from Neeraj Upreti in #ansible-oncall](https://confluent.slack.com/archives/CMTBL483Y/p1738251439412289) 

There are 4 replicator variables which should be defined in the inventory file but they don't have any mention in the vars.md file as there is no comment above them to explain what they do.
add comments to explain their use

kafka_connect_replicator_listener
kafka_connect_replicator_consumer_listener
kafka_connect_replicator_producer_listener
kafka_connect_replicator_monitoring_interceptor_listener

Fixes # (issue)
doc update

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

# How Has This Been Tested?

no testing required.

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
