### PR TITLE
Fix: Kraft Controllers raft-metrics expose (Fixes Issue:1899)

### DIFF
--- a/roles/kafka_controller/templates/kafka.yml.j2
+++ b/roles/kafka_controller/templates/kafka.yml.j2
@@ -17,7 +17,7 @@ excludeObjectNames:
   # "kafka.admin.client:type=*, id=*"
   - "kafka.admin.client:*"
   - "kafka.server:type=*,cipher=*,protocol=*,listener=*,networkProcessor=*"
-  - "kafka.server:type=*"
+  #- "kafka.server:type=*"
 rules:
   # This is by far the biggest contributor to the number of sheer metrics being produced.
   # Always keep it on the top for the case of probability when so many metrics will hit the first condition and exit.
@@ -189,3 +189,30 @@ rules:
     cache: {{ kafka_controller_jmxexporter_bean_name_expressions_cache | lower }}
     labels:
       "$3": "$4"
+  # KRaft overall related metrics
+  # distinguish between always increasing COUNTER (total and max) and variable GAUGE (all others) metrics
+  - pattern: "kafka.server<type=raft-metrics><>(.+-total|.+-max):"
+    name: kafka_server_raftmetrics_$1
+    type: COUNTER
+    cache: {{ kafka_controller_jmxexporter_bean_name_expressions_cache | lower }}
+  - pattern: "kafka.server<type=raft-metrics><>(current-state): (.+)"
+    name: kafka_server_raftmetrics_$1
+    value: 1
+    type: UNTYPED
+    cache: {{ kafka_controller_jmxexporter_bean_name_expressions_cache | lower }}
+    labels:
+      $1: "$2"
+  - pattern: "kafka.server<type=raft-metrics><>(.+):"
+    name: kafka_server_raftmetrics_$1
+    type: GAUGE
+    cache: {{ kafka_controller_jmxexporter_bean_name_expressions_cache | lower }}
+  # KRaft "low level" channels related metrics
+  # distinguish between always increasing COUNTER (total and max) and variable GAUGE (all others) metrics
+  - pattern: "kafka.server<type=raft-channel-metrics><>(.+-total|.+-max):"
+    name: kafka_server_raftchannelmetrics_$1
+    type: COUNTER
+    cache: {{ kafka_controller_jmxexporter_bean_name_expressions_cache | lower }}
+  - pattern: "kafka.server<type=raft-channel-metrics><>(.+):"
+    name: kafka_server_raftchannelmetrics_$1
+    type: GAUGE
+    cache: {{ kafka_controller_jmxexporter_bean_name_expressions_cache | lower }}


### PR DESCRIPTION
# Description

Kraft controller raft-metrics won't be exposed via JMX exporter by default. Since they are valuable metrics we should add it to the related [ansible template](https://github.com/confluentinc/cp-ansible/blob/v7.7.2/roles/kafka_controller/templates/kafka.yml.j2#L20).

Fixes # (1899)

## Type of change

- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

I've tested on my local environment. Raft metrics has been exposed without issues.

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
