### PR TITLE
[ANSIENG-4200] | adding a variable which skips running the task which changes user, group of files inside data dirs

### DIFF
--- a/roles/kafka_broker/defaults/main.yml
+++ b/roles/kafka_broker/defaults/main.yml
@@ -70,3 +70,6 @@ kafka_broker_jmxexporter_startup_delay: 60
 
 ### Whether to cache bean name expressions to rule computation (match and mismatch). Not recommended for rules matching on bean value, as only the value from the first scrape will be cached and re-used. This can increase performance when collecting a lot of mbeans.
 kafka_broker_jmxexporter_bean_name_expressions_cache: false
+
+### This variable if set to true then during upgrades all the files inside data dirs's owner, group will change to kafka_broker_user:kafka_broker_group. The files inside data dirs where anyways owned by kafka_broker_user:kafka_broker_group so this will not have any impact unless you change kafka_broker_user or kafka_broker_group.
+change_user_group_kafka_data_dir_files: false

--- a/roles/kafka_broker/tasks/main.yml
+++ b/roles/kafka_broker/tasks/main.yml
@@ -198,6 +198,7 @@
   command: chown -R {{ kafka_broker_user }}:{{ kafka_broker_group }} {{ item }}
   changed_when: false
   with_items: "{{ kafka_broker_final_properties['log.dirs'].split(',') }}"
+  when: change_user_group_kafka_data_dir_files|bool
   tags:
     - filesystem
 


### PR DESCRIPTION
# Description

This task `Set Permissions on Data Dir files` tries to change owner and group of files which exist inside data dir. All those files are created by kafka process' user. So changing the user and owner using this ansible task while cluster upgrades makes no sense. Removing this task for majority users would be fine. 

When I tried to change owner and group of data dir and kafka server process in a running cluster using kafka_broker_user & kafka_broker_group it wasnt able to start the cluster and also messed up logs. log files owner didnt change it simply changed the owner of directory which contains log files and thus no new logs were getting written unless manually i change the owner, groups of log files. So it seems even for changing user, group this task isn't helping. Thus it should be removed completely in theory.

I cant think of any possible reason why this might be in use but still if there is some strange use case exists where customer relies on this task to do anything it might cause issue to them if we remove this task. Thus if we add a variable update_user_grp_on_kafka_data_files: false and make this task not run by default. But if someone wants to run it they can simply set this variable to true and it will stop skipping this task. 



Fixes # [(issue)](https://confluentinc.atlassian.net/browse/ANSIENG-4200)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

[Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration](https://semaphore.ci.confluent.io/workflows/b2c389fa-22b8-47be-a68e-84175717d3a4/summary?report_id=63a7566e-bb24-3b6d-a18c-7af5cdce63f5)
[zk->kraft mig](https://semaphore.ci.confluent.io/workflows/124878a4-5761-413e-bf6b-0a505dfca13a?pipeline_id=d47d6177-513d-4895-aae2-adfc1aec46ec)

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
