### PR TITLE
[ANSIENG-4146] | fixing ubuntu flakiness of adding openjdk task by adding it in dockerfile

### DIFF
--- a/molecule/Dockerfile-ubuntu-archive.j2
+++ b/molecule/Dockerfile-ubuntu-archive.j2
@@ -1,5 +1,9 @@
 FROM {{ item.image }}
 
+# Add the OpenJDK repository to remove flakiness
+RUN add-apt-repository -y "ppa:openjdk-r/ppa" && \
+    apt-get update
+
 RUN mkdir -p /usr/share/man/man1 && \
     apt-get update -y && \
     apt-get install -y software-properties-common && \

--- a/molecule/Dockerfile-ubuntu-java11.j2
+++ b/molecule/Dockerfile-ubuntu-java11.j2
@@ -1,5 +1,9 @@
 FROM {{ item.image }}
 
+# Add the OpenJDK repository to remove flakiness
+RUN add-apt-repository -y "ppa:openjdk-r/ppa" && \
+    apt-get update
+
 RUN mkdir -p /usr/share/man/man1 && \
     apt-get update -y && \
     apt-get install -y openjdk-11-jdk wget gnupg

--- a/molecule/Dockerfile-ubuntu-java8.j2
+++ b/molecule/Dockerfile-ubuntu-java8.j2
@@ -1,5 +1,9 @@
 FROM {{ item.image }}
 
+# Add the OpenJDK repository to remove flakiness
+RUN add-apt-repository -y "ppa:openjdk-r/ppa" && \
+    apt-get update
+
 RUN mkdir -p /usr/share/man/man1 && \
     apt-get update -y && \
     apt-get install -y openjdk-8-jdk wget gnupg

--- a/molecule/Dockerfile-ubuntu.j2
+++ b/molecule/Dockerfile-ubuntu.j2
@@ -1,5 +1,9 @@
 FROM {{ item.image }}
 
+# Add the OpenJDK repository to remove flakiness
+RUN add-apt-repository -y "ppa:openjdk-r/ppa" && \
+    apt-get update
+
 RUN mkdir -p /usr/share/man/man1 && \
     apt-get update -y && \
     apt-get install -y software-properties-common && \

--- a/molecule/Dockerfile-ubuntu2004-archive.j2
+++ b/molecule/Dockerfile-ubuntu2004-archive.j2
@@ -1,5 +1,9 @@
 FROM {{ item.image }}
 
+# Add the OpenJDK repository to remove flakiness
+RUN add-apt-repository -y "ppa:openjdk-r/ppa" && \
+    apt-get update
+
 RUN mkdir -p /usr/share/man/man1 && \
     apt-get update -y && \
     apt-get install -y openjdk-17-jdk wget gnupg && \

--- a/molecule/Dockerfile-ubuntu2004-java11.j2
+++ b/molecule/Dockerfile-ubuntu2004-java11.j2
@@ -1,5 +1,9 @@
 FROM {{ item.image }}
 
+# Add the OpenJDK repository to remove flakiness
+RUN add-apt-repository -y "ppa:openjdk-r/ppa" && \
+    apt-get update
+
 RUN mkdir -p /usr/share/man/man1 && \
     apt-get update -y && \
     apt-get install -y openjdk-11-jdk wget gnupg && \


### PR DESCRIPTION
# Description

Fixing ubuntu flakiness of adding openjdk task by adding it in dockerfile

A bunch of ubuntu based scenarios fail in the task `Add open JDK repo`

```
- name: Add open JDK repo
  apt_repository:
    repo: "{{ubuntu_java_repository}}"
  #Throttle was introduced to help mitigate the APT Lock when deploying multiple components to the same node.
  throttle: 1
  register: apt_add_jdk_result
  until: apt_add_jdk_result is success
  retries: 5
  delay: 90
  when:
    - repository_configuration == 'confluent'
    - install_java|bool
```

To remove flakiness here we can add the openjdk  repo from dockerfile itself. The reason it is fine to do that is because even without it this above code works but just that it tests become flaky and might take 2-3 retries to setup. 
It also takes around 10 mins time for this task to run since it runs serially on all components.

Somehow when it is running on one component it is impacting others as well in case of molecule testing where each component is on a docker container inside same vm. Needs further analysis why this happens. 

It is quite likely increasing retries will also solve this issue.
Though this issue happens only in ubuntu 18 mainly which is pretty old, plus we have support for ubuntu20,22,24 as well. Also havent heard about this issue from customers in oncall so not worth it to spend too much effort in solving it from the roots rather just adding one line in dockerfile for tests seems sufficient.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

[tests](https://semaphore.ci.confluent.io/workflows/61ce158f-6aca-49e2-9473-f29c6d91ffc0?pipeline_id=63460c05-714a-42a0-ac7a-24323b95d6db)

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
