### PR TITLE
Remove verify control plane listener from oauth-plain-rhel test

### DIFF
--- a/molecule/oauth-plain-rhel/verify.yml
+++ b/molecule/oauth-plain-rhel/verify.yml
@@ -96,16 +96,6 @@
       failed_when: "'Custom Kafka description' not in systemctl_status.stdout_lines[0]"
       changed_when: false
 
-    - name: Check Control Plane Listener Property
-      import_role:
-        name: confluent.test
-        tasks_from: check_property.yml
-      vars:
-        file_path: /etc/kafka/server.properties
-        property: listener.name.controller.sasl.enabled.mechanisms
-        expected_value: PLAIN
-      when: not kraft_mode|bool
-
     - import_role:
         name: confluent.test
         tasks_from: check_property.yml


### PR DESCRIPTION
# Description

Remove verify control plane listener from oauth-plain-rhel test where `kafka_broker_configure_control_plane_listener: true` was removed from molecule.yml earlier.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Failing test without this change https://semaphore.ci.confluent.io/workflows/cc1207c9-a379-4157-bb7c-93b3a5d0f24c/summary?report_id=1f827083-0472-3472-86b2-93e695256a2a&pipeline_id=c7dfa17b-83e8-47f2-892d-6bcdfe3a33ea

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
