### PR TITLE
[ANSIENG-4200] | fixing race condition by skipping the task for runni…

### DIFF
--- a/roles/kafka_broker/tasks/main.yml
+++ b/roles/kafka_broker/tasks/main.yml
@@ -191,6 +191,12 @@
   tags:
     - filesystem
 
+- name: Check Green/Brownfield setup
+  set_fact:
+    is_brownfield_setup: "{{ broker_service_state == 'running' }}"
+  vars:
+    broker_service_state: "{{ ansible_facts.services[kafka_broker_service_name + '.service'].state | default('unknown') }}"
+
 - name: Set Permissions on Data Dir files  # noqa no-free-form
   # Have to use command + chown instead of the Ansible file module here as it seems
   # like the file module can't handle files modified/deleted while running. This task
@@ -198,6 +204,7 @@
   command: chown -R {{ kafka_broker_user }}:{{ kafka_broker_group }} {{ item }}
   changed_when: false
   with_items: "{{ kafka_broker_final_properties['log.dirs'].split(',') }}"
+  when: not is_brownfield_setup # Skips this task during upgrades as the user/group is already set in the initial setup run. This will avoid the race condition caused by sudden deletion of .tmp files in data dir.
   tags:
     - filesystem
 


### PR DESCRIPTION
# Description 
This task tries to change owner and group of files which exist inside data dir.

All those files are created by kafka user in zookeeper setups.

2 files meta.properties and bootstrap.checkpoint are created by ansible_user which is typically root and different from kafka_broker_user.

Running this task for greenfield fresh setup would change the owner/grp of the above files to kafka_broker_user,kafka_broker_group which is correct behaviour.

But changing the user and owner using this ansible task while cluster upgrades doesnt do anything.

When I tried to change owner and group of data dir and kafka server process in a running cluster using kafka_broker_user & kafka_broker_group it wasnt able to start the cluster and also messed up logs. log files owner didnt change it simply changed the owner of directory which contains log files and thus no new logs were getting written unless manually i change the owner, groups of log files. So it seems even for changing user, group this task isn't helping.

Solution

We can check if kraft/kafka service is running or not.
If running we should skip the task causing race condition and it will have no impact
If not running then we should not skip and run this task. But here it wont be getting trapped in race condition as there wont be any .tmp files coming and going while it runs.

Fixes # [(issue)](https://confluentinc.atlassian.net/browse/ANSIENG-4200)

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
