### PR TITLE
[ANSIENG-3858] | stoping delegation for secrets protection kraft mtls…

### DIFF
--- a/molecule/rbac-mtls-rhel/molecule.yml
+++ b/molecule/rbac-mtls-rhel/molecule.yml
@@ -140,10 +140,7 @@ provisioner:
         scenario_name: rbac-mtls-rhel
 
         rbac_super_users:
-          - User:C=US,ST=Ca,L=PaloAlto,O=CONFLUENT,OU=TEST,CN=kafka_broker
-          - User:C=US,ST=Ca,L=PaloAlto,O=CONFLUENT,OU=TEST,CN=kafka_controller
-          - User:CN=kafka_controller,OU=QE IT,O=CONFLUENT,L=PaloAlto,ST=Ca,C=US
-          - User:CN=kafka_broker,OU=QE IT,O=CONFLUENT,L=PaloAlto,ST=Ca,C=US
+          - User:CONFLUENT
 
         redhat_java_package_name: java-11-openjdk
         ssl_enabled: true

--- a/roles/kafka_broker/tasks/main.yml
+++ b/roles/kafka_broker/tasks/main.yml
@@ -509,7 +509,8 @@
   when:
     - kafka_controller_secrets_protection_enabled|bool or kafka_controller_client_secrets_protection_enabled|bool
     - rbac_enabled|bool
-    - kafka_controller_ssl_mutual_auth_enabled|bool or ( not external_mds_enabled|bool and confluent_cli_version is version('3.0.0', '<'))
+    - (kafka_controller_ssl_mutual_auth_enabled|bool and rbac_super_users | length == 0)
+      or ( not external_mds_enabled|bool and confluent_cli_version is version('3.0.0', '<'))
     - kraft_enabled|bool
   run_once: true
 


### PR DESCRIPTION
# Description

Secrets protection needed delegation from broker to controller to encrypt secrets in case when broker had updated controller super users (when doing mtls rbac cluster setup).
But now with coming of `rbac_super_users` variable whenever it is defined the first delegation to controller to update its super.users is not happening. Thus the second delegation to encrypt secrets is also not needed.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

[semaphore](https://semaphore.ci.confluent.io/workflows/7a3dcd7a-49a3-44a3-bda4-6ffbfa90197e?pipeline_id=f0a37dd9-c52a-460d-b289-7a34f1ae55ee)

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
