### PR TITLE
remove c3 package as dependency from other components package list

### DIFF
--- a/molecule/Dockerfile-debian-java8.j2
+++ b/molecule/Dockerfile-debian-java8.j2
@@ -52,6 +52,4 @@ RUN apt-get install --yes \
      confluent-ksqldb \
      confluent-schema-registry \
      confluent-security \
-     confluent-control-center-fe \
-     confluent-control-center \
      confluent-schema-registry-plugins

--- a/molecule/Dockerfile-debian10.j2
+++ b/molecule/Dockerfile-debian10.j2
@@ -45,6 +45,4 @@ RUN apt-get install --yes \
      confluent-ksqldb \
      confluent-schema-registry \
      confluent-security \
-     confluent-control-center-fe \
-     confluent-control-center \
      confluent-schema-registry-plugins

--- a/molecule/Dockerfile-ubuntu-java11.j2
+++ b/molecule/Dockerfile-ubuntu-java11.j2
@@ -32,6 +32,4 @@ RUN apt-get install --yes \
       confluent-ksqldb \
       confluent-schema-registry \
       confluent-security \
-      confluent-control-center-fe \
-      confluent-control-center \
       confluent-schema-registry-plugins

--- a/molecule/Dockerfile-ubuntu-java8.j2
+++ b/molecule/Dockerfile-ubuntu-java8.j2
@@ -31,6 +31,4 @@ RUN apt-get install --yes \
       confluent-ksqldb \
       confluent-schema-registry \
       confluent-security \
-      confluent-control-center-fe \
-      confluent-control-center \
       confluent-schema-registry-plugins

--- a/molecule/Dockerfile-ubuntu.j2
+++ b/molecule/Dockerfile-ubuntu.j2
@@ -33,6 +33,4 @@ RUN apt-get install --yes \
       confluent-ksqldb \
       confluent-schema-registry \
       confluent-security \
-      confluent-control-center-fe \
-      confluent-control-center \
       confluent-schema-registry-plugins

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -915,8 +915,6 @@ kafka_rest_packages:
   - "{{ kafka_broker_main_package }}"
   - confluent-security
   - confluent-rebalancer
-  - confluent-control-center-fe
-  - confluent-control-center
 
 kafka_rest_truststore_path: "{% if ssl_provided_keystore_and_truststore_remote_src %}{{ssl_truststore_filepath}}{% else %}{{ ssl_file_dir_final }}/kafka_rest.truststore.jks{% endif %}"
 kafka_rest_keystore_path: "{% if ssl_provided_keystore_and_truststore_remote_src %}{{ssl_keystore_filepath}}{% else %}{{ ssl_file_dir_final }}/kafka_rest.keystore.jks{% endif %}"
@@ -1034,8 +1032,6 @@ kafka_connect_packages:
   - confluent-kafka-connect-replicator
   - confluent-security
   - confluent-rebalancer
-  - confluent-control-center-fe
-  - confluent-control-center
   - confluent-schema-registry
 
 kafka_connect_truststore_path: "{% if ssl_provided_keystore_and_truststore_remote_src %}{{ssl_truststore_filepath}}{% else %}{{ ssl_file_dir_final }}/{{ kafka_connect_service_name + '.truststore.jks' if kafka_connect_service_name != kafka_connect_default_service_name else 'kafka_connect.truststore.jks'}}{% endif %}"
@@ -1180,8 +1176,6 @@ ksql_packages:
   - "{{ ksql_main_package }}"
   - confluent-security
   - confluent-rebalancer
-  - confluent-control-center-fe
-  - confluent-control-center
 
 ksql_truststore_path: "{% if ssl_provided_keystore_and_truststore_remote_src %}{{ssl_truststore_filepath}}{% else %}{{ ssl_file_dir_final }}/ksql.truststore.jks{% endif %}"
 ksql_keystore_path: "{% if ssl_provided_keystore_and_truststore_remote_src %}{{ssl_keystore_filepath}}{% else %}{{ ssl_file_dir_final }}/ksql.keystore.jks{% endif %}"
@@ -2246,8 +2240,6 @@ kafka_connect_replicator_packages:
   - confluent-kafka-connect-replicator
   - confluent-security
   - confluent-rebalancer
-  - confluent-control-center-fe
-  - confluent-control-center
   - confluent-schema-registry
 
 ### The password for the Kafka Connect Replicator TLS truststore.


### PR DESCRIPTION
# Description

C3 is independent release from 8.0 and thus it will not be pacakged with cp. So when we install it via current configuration for cp repos via yum/apt it fails. 
Thus decoupling it from other components by removing it from package list of other components.


Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
