### PR TITLE
[Do-not-review][ANSIENG-4255] | Adding first class support for file based mds user store 

### DIFF
--- a/molecule/mini-setup-ext-mds-mtls/molecule.yml
+++ b/molecule/mini-setup-ext-mds-mtls/molecule.yml
@@ -173,7 +173,7 @@ provisioner:
         mask_secrets: false
 
         rbac_enabled: true
-        auth_mode: mtls
+        auth_mode: file
 
         kafka_broker_custom_listeners:
           external_listener:

--- a/molecule/mini-setup-ext-mds-mtls/molecule.yml
+++ b/molecule/mini-setup-ext-mds-mtls/molecule.yml
@@ -216,9 +216,13 @@ provisioner:
 
       mds:
         kafka_broker_cluster_name: 'mds'
-        kafka_broker_custom_properties:
-          confluent.metadata.server.user.store: FILE
-          confluent.metadata.server.user.store.file.path: /tmp/credentials
+        confluent_metadata_server_user_store_file_src: /tmp/credentials
+        confluent_metadata_server_user_store_file_dest_path: /etc/kafka
+        confluent_metadata_server_user_store_file_remote_src: true # credentials file already on target node
+
+        # kafka_broker_custom_properties:
+        #   confluent.metadata.server.user.store: FILE
+        #   confluent.metadata.server.user.store.file.path: /tmp/credentials
 
       cluster2:
         kafka_broker_cluster_name: 'second-cluster'

--- a/molecule/mini-setup-ext-mds-mtls/molecule.yml
+++ b/molecule/mini-setup-ext-mds-mtls/molecule.yml
@@ -173,7 +173,8 @@ provisioner:
         mask_secrets: false
 
         rbac_enabled: true
-        auth_mode: file
+        auth_mode: mtls
+        mds_user_store_file_enabled: true
 
         kafka_broker_custom_listeners:
           external_listener:

--- a/molecule/mini-setup-ext-mds-mtls/molecule.yml
+++ b/molecule/mini-setup-ext-mds-mtls/molecule.yml
@@ -174,7 +174,7 @@ provisioner:
 
         rbac_enabled: true
         auth_mode: mtls
-        mds_user_store_file_enabled: true
+        mds_file_based_user_store_enabled: true
 
         kafka_broker_custom_listeners:
           external_listener:
@@ -217,9 +217,9 @@ provisioner:
 
       mds:
         kafka_broker_cluster_name: 'mds'
-        confluent_metadata_server_user_store_file_src: /tmp/credentials
-        confluent_metadata_server_user_store_file_dest_path: /etc/kafka/credentials
-        confluent_metadata_server_user_store_file_remote_src: true # credentials file already on target node
+        mds_file_based_user_store_src_path: /tmp/credentials
+        mds_file_based_user_store_dest_path: /etc/kafka/credentials
+        mds_file_based_user_store_remote_src: true # credentials file already on target node
 
       cluster2:
         kafka_broker_cluster_name: 'second-cluster'

--- a/molecule/mini-setup-ext-mds-mtls/molecule.yml
+++ b/molecule/mini-setup-ext-mds-mtls/molecule.yml
@@ -220,10 +220,6 @@ provisioner:
         confluent_metadata_server_user_store_file_dest_path: /etc/kafka
         confluent_metadata_server_user_store_file_remote_src: true # credentials file already on target node
 
-        # kafka_broker_custom_properties:
-        #   confluent.metadata.server.user.store: FILE
-        #   confluent.metadata.server.user.store.file.path: /tmp/credentials
-
       cluster2:
         kafka_broker_cluster_name: 'second-cluster'
         external_mds_enabled: true

--- a/molecule/mini-setup-ext-mds-mtls/molecule.yml
+++ b/molecule/mini-setup-ext-mds-mtls/molecule.yml
@@ -218,7 +218,7 @@ provisioner:
       mds:
         kafka_broker_cluster_name: 'mds'
         confluent_metadata_server_user_store_file_src: /tmp/credentials
-        confluent_metadata_server_user_store_file_dest_path: /etc/kafka
+        confluent_metadata_server_user_store_file_dest_path: /etc/kafka/credentials
         confluent_metadata_server_user_store_file_remote_src: true # credentials file already on target node
 
       cluster2:

--- a/molecule/mini-setup-ext-mds-mtls/molecule.yml
+++ b/molecule/mini-setup-ext-mds-mtls/molecule.yml
@@ -175,6 +175,9 @@ provisioner:
         rbac_enabled: true
         auth_mode: mtls
         mds_file_based_user_store_enabled: true
+        mds_file_based_user_store_src_path: /tmp/credentials
+        mds_file_based_user_store_dest_path: /etc/kafka/credentials
+        mds_file_based_user_store_remote_src: true # credentials file already on target node
 
         kafka_broker_custom_listeners:
           external_listener:
@@ -217,9 +220,6 @@ provisioner:
 
       mds:
         kafka_broker_cluster_name: 'mds'
-        mds_file_based_user_store_src_path: /tmp/credentials
-        mds_file_based_user_store_dest_path: /etc/kafka/credentials
-        mds_file_based_user_store_remote_src: true # credentials file already on target node
 
       cluster2:
         kafka_broker_cluster_name: 'second-cluster'

--- a/molecule/mini-setup-mtls/molecule.yml
+++ b/molecule/mini-setup-mtls/molecule.yml
@@ -214,7 +214,7 @@ provisioner:
           - "DEFAULT"
 
         confluent_metadata_server_user_store_file_src: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/credentials"
-        confluent_metadata_server_user_store_file_dest_path: /etc/kafka
+        confluent_metadata_server_user_store_file_dest_path: /etc/kafka/credentials
         confluent_metadata_server_user_store_file_remote_src: false # credentials file on ansible control node
 
         kafka_connect_custom_properties:

--- a/molecule/mini-setup-mtls/molecule.yml
+++ b/molecule/mini-setup-mtls/molecule.yml
@@ -200,7 +200,7 @@ provisioner:
         mds_ssl_client_authentication: required
 
         rbac_enabled: true
-        auth_mode: mtls
+        auth_mode: file
 
         impersonation_super_users:
           - 'kafka_broker'

--- a/molecule/mini-setup-mtls/molecule.yml
+++ b/molecule/mini-setup-mtls/molecule.yml
@@ -200,7 +200,8 @@ provisioner:
         mds_ssl_client_authentication: required
 
         rbac_enabled: true
-        auth_mode: file
+        auth_mode: mtls
+        mds_user_store_file_enabled: true
 
         impersonation_super_users:
           - 'kafka_broker'

--- a/molecule/mini-setup-mtls/molecule.yml
+++ b/molecule/mini-setup-mtls/molecule.yml
@@ -201,7 +201,7 @@ provisioner:
 
         rbac_enabled: true
         auth_mode: mtls
-        mds_user_store_file_enabled: true
+        mds_file_based_user_store_enabled: true
 
         impersonation_super_users:
           - 'kafka_broker'
@@ -213,9 +213,9 @@ provisioner:
           - "RULE:.*CN=([a-zA-Z0-9.-_]*).*$$/$$1/"
           - "DEFAULT"
 
-        confluent_metadata_server_user_store_file_src: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/credentials"
-        confluent_metadata_server_user_store_file_dest_path: /etc/kafka/credentials
-        confluent_metadata_server_user_store_file_remote_src: false # credentials file on ansible control node
+        mds_file_based_user_store_src_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/credentials"
+        mds_file_based_user_store_dest_path: /etc/kafka/credentials
+        mds_file_based_user_store_remote_src: false # credentials file on ansible control node
 
         kafka_connect_custom_properties:
           plugin.path: "/usr/share/filestream-connectors,/usr/share/java/connect_plugins"

--- a/molecule/mini-setup-mtls/molecule.yml
+++ b/molecule/mini-setup-mtls/molecule.yml
@@ -212,9 +212,13 @@ provisioner:
           - "RULE:.*CN=([a-zA-Z0-9.-_]*).*$$/$$1/"
           - "DEFAULT"
 
-        kafka_broker_custom_properties:
-          confluent.metadata.server.user.store: FILE
-          confluent.metadata.server.user.store.file.path: /tmp/credentials
+        confluent_metadata_server_user_store_file_src: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/credentials"
+        confluent_metadata_server_user_store_file_dest_path: /etc/kafka
+        confluent_metadata_server_user_store_file_remote_src: false # credentials file on ansible control node
+
+        # kafka_broker_custom_properties:
+        #   confluent.metadata.server.user.store: FILE
+        #   confluent.metadata.server.user.store.file.path: /tmp/credentials
 
         kafka_connect_custom_properties:
           plugin.path: "/usr/share/filestream-connectors,/usr/share/java/connect_plugins"

--- a/molecule/mini-setup-mtls/molecule.yml
+++ b/molecule/mini-setup-mtls/molecule.yml
@@ -216,10 +216,6 @@ provisioner:
         confluent_metadata_server_user_store_file_dest_path: /etc/kafka
         confluent_metadata_server_user_store_file_remote_src: false # credentials file on ansible control node
 
-        # kafka_broker_custom_properties:
-        #   confluent.metadata.server.user.store: FILE
-        #   confluent.metadata.server.user.store.file.path: /tmp/credentials
-
         kafka_connect_custom_properties:
           plugin.path: "/usr/share/filestream-connectors,/usr/share/java/connect_plugins"
 

--- a/molecule/mini-setup-mtls/prepare.yml
+++ b/molecule/mini-setup-mtls/prepare.yml
@@ -1,11 +1,11 @@
 ---
-- name: File Based login in C3/CLI configs via override
-  hosts: kafka_broker
-  tasks:
-    - name: Copy Credentials file to MDS
-      copy:
-        src: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/credentials"
-        dest: "/tmp/credentials"
+# - name: File Based login in C3/CLI configs via override
+#   hosts: kafka_broker
+#   tasks:
+#     - name: Copy Credentials file to MDS
+#       copy:
+#         src: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/credentials"
+#         dest: "/tmp/credentials"
 - name: Install Zookeeper Cluster
   import_playbook: confluent.platform.all
   when: lookup('env', 'MIGRATION')|default('false') == 'true'

--- a/molecule/mini-setup-mtls/prepare.yml
+++ b/molecule/mini-setup-mtls/prepare.yml
@@ -1,11 +1,4 @@
 ---
-# - name: File Based login in C3/CLI configs via override
-#   hosts: kafka_broker
-#   tasks:
-#     - name: Copy Credentials file to MDS
-#       copy:
-#         src: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/credentials"
-#         dest: "/tmp/credentials"
 - name: Install Zookeeper Cluster
   import_playbook: confluent.platform.all
   when: lookup('env', 'MIGRATION')|default('false') == 'true'

--- a/roles/common/tasks/config_validations.yml
+++ b/roles/common/tasks/config_validations.yml
@@ -161,14 +161,14 @@
 
 - assert:
     that:
-      - auth_mode in ['ldap', 'ldap_with_oauth', 'oauth', 'mtls', 'file', 'none']
-    fail_msg: "auth_mode must be one of 'ldap', 'ldap_with_oauth', 'oauth', 'mtls', 'file', 'none'"
+      - auth_mode in ['ldap', 'ldap_with_oauth', 'oauth', 'mtls', 'none']
+    fail_msg: "auth_mode must be one of 'ldap', 'ldap_with_oauth', 'oauth', 'mtls', 'none'"
   tags: validate
 
 - assert:
     that:
-      - auth_mode in ['ldap', 'ldap_with_oauth', 'oauth', 'mtls', 'file']
-    fail_msg: "When RBAC is enabled, auth_mode must be one of 'ldap', 'ldap_with_oauth', 'oauth', 'mtls', 'file'"
+      - auth_mode in ['ldap', 'ldap_with_oauth', 'oauth', 'mtls']
+    fail_msg: "When RBAC is enabled, auth_mode must be one of 'ldap', 'ldap_with_oauth', 'oauth', 'mtls'"
   when:
     - rbac_enabled|bool
   tags: validate
@@ -186,7 +186,7 @@
       - rbac_enabled|bool
     fail_msg: "When auth mode is ldap or mtls or file, RBAC also must be enabled"
   when:
-    - auth_mode == 'ldap' or auth_mode == 'ldap_with_oauth' or auth_mode == 'mtls' or auth_mode == 'file'
+    - auth_mode == 'ldap' or auth_mode == 'ldap_with_oauth' or auth_mode == 'mtls'
   tags: validate
 
 - assert:
@@ -194,7 +194,7 @@
       - mds_ssl_client_authentication != 'none'
     fail_msg: "When auth mode is mtls or file mds must have ssl client authentication is set to required or requested"
   when:
-    - auth_mode == 'mtls' or auth_mode == 'file'
+    - auth_mode == 'mtls'
   tags: validate
 
 - assert:

--- a/roles/common/tasks/config_validations.yml
+++ b/roles/common/tasks/config_validations.yml
@@ -184,15 +184,32 @@
 - assert:
     that:
       - rbac_enabled|bool
-    fail_msg: "When auth mode is ldap or mtls or file, RBAC also must be enabled"
+    fail_msg: "When auth mode is ldap or mtls, RBAC also must be enabled"
   when:
     - auth_mode == 'ldap' or auth_mode == 'ldap_with_oauth' or auth_mode == 'mtls'
   tags: validate
 
 - assert:
     that:
+      - rbac_enabled|bool
+    fail_msg: "When we have file based user store enabled we must have MDS and thus RBAC also must be enabled"
+  when:
+    - mds_file_based_user_store_enabled|bool
+  tags: validate
+
+- assert:
+    that:
+      - mds_file_based_user_store_src_path != ''
+      - mds_file_based_user_store_dest_path != ''
+    fail_msg: "When mds_file_based_user_store_enabled is true we must also define  mds_file_based_user_store_src_path and mds_file_based_user_store_dest_path"
+  when:
+    - mds_file_based_user_store_enabled|bool
+  tags: validate
+
+- assert:
+    that:
       - mds_ssl_client_authentication != 'none'
-    fail_msg: "When auth mode is mtls or file mds must have ssl client authentication is set to required or requested"
+    fail_msg: "When auth mode is mtls, mds must have ssl client authentication is set to required or requested"
   when:
     - auth_mode == 'mtls'
   tags: validate

--- a/roles/common/tasks/config_validations.yml
+++ b/roles/common/tasks/config_validations.yml
@@ -161,14 +161,14 @@
 
 - assert:
     that:
-      - auth_mode in ['ldap', 'ldap_with_oauth', 'oauth', 'mtls', 'none']
-    fail_msg: "auth_mode must be one of 'ldap', 'ldap_with_oauth', 'oauth', 'none'"
+      - auth_mode in ['ldap', 'ldap_with_oauth', 'oauth', 'mtls', 'file' 'none']
+    fail_msg: "auth_mode must be one of 'ldap', 'ldap_with_oauth', 'oauth', 'mtls', 'file', 'none'"
   tags: validate
 
 - assert:
     that:
-      - auth_mode in ['ldap', 'ldap_with_oauth', 'oauth', 'mtls']
-    fail_msg: "When RBAC is enabled, auth_mode must be one of 'ldap', 'ldap_with_oauth', 'oauth'"
+      - auth_mode in ['ldap', 'ldap_with_oauth', 'oauth', 'mtls', 'file']
+    fail_msg: "When RBAC is enabled, auth_mode must be one of 'ldap', 'ldap_with_oauth', 'oauth', 'mtls', 'file'"
   when:
     - rbac_enabled|bool
   tags: validate
@@ -184,17 +184,17 @@
 - assert:
     that:
       - rbac_enabled|bool
-    fail_msg: "When auth mode is ldap or mtls, RBAC also must be enabled"
+    fail_msg: "When auth mode is ldap or mtls or file, RBAC also must be enabled"
   when:
-    - auth_mode == 'ldap' or auth_mode == 'ldap_with_oauth' or auth_mode == 'mtls'
+    - auth_mode == 'ldap' or auth_mode == 'ldap_with_oauth' or auth_mode == 'mtls' or auth_mode == 'file'
   tags: validate
 
 - assert:
     that:
       - mds_ssl_client_authentication != 'none'
-    fail_msg: "When auth mode is mtls mds must have ssl client authentication is set to required or requested"
+    fail_msg: "When auth mode is mtls or file mds must have ssl client authentication is set to required or requested"
   when:
-    - auth_mode == 'mtls'
+    - auth_mode == 'mtls' or auth_mode == 'file'
   tags: validate
 
 - assert:

--- a/roles/common/tasks/config_validations.yml
+++ b/roles/common/tasks/config_validations.yml
@@ -161,7 +161,7 @@
 
 - assert:
     that:
-      - auth_mode in ['ldap', 'ldap_with_oauth', 'oauth', 'mtls', 'file' 'none']
+      - auth_mode in ['ldap', 'ldap_with_oauth', 'oauth', 'mtls', 'file', 'none']
     fail_msg: "auth_mode must be one of 'ldap', 'ldap_with_oauth', 'oauth', 'mtls', 'file', 'none'"
   tags: validate
 

--- a/roles/kafka_broker/tasks/rbac.yml
+++ b/roles/kafka_broker/tasks/rbac.yml
@@ -184,7 +184,7 @@
 
 - name: Create MDS User Store File Directory
   file:
-    path: "{{ confluent_metadata_server_user_store_file_dest_path }}"
+    path: "{{ confluent_metadata_server_user_store_file_dest_path | dirname }}"
     state: directory
     owner: "{{ kafka_broker_user }}"
     group: "{{ kafka_broker_group }}"

--- a/roles/kafka_broker/tasks/rbac.yml
+++ b/roles/kafka_broker/tasks/rbac.yml
@@ -184,13 +184,13 @@
 
 - name: Create MDS User Store File Directory
   file:
-    path: "{{ confluent_metadata_server_user_store_file_dest_path | dirname }}"
+    path: "{{ mds_file_based_user_store_dest_path | dirname }}"
     state: directory
     owner: "{{ kafka_broker_user }}"
     group: "{{ kafka_broker_group }}"
     mode: '750'
   when:
-    - mds_user_store_file_enabled|bool
+    - mds_file_based_user_store_enabled|bool
     - not external_mds_enabled|bool
   tags:
     - privileged
@@ -198,11 +198,11 @@
 
 - name: Copy MDS User Store File to MDS
   copy:
-    src: "{{ confluent_metadata_server_user_store_file_src }}"
-    dest: "{{ confluent_metadata_server_user_store_file_dest_path }}"
-    remote_src: "{{ confluent_metadata_server_user_store_file_remote_src|bool}}"
+    src: "{{ mds_file_based_user_store_src_path }}"
+    dest: "{{ mds_file_based_user_store_dest_path }}"
+    remote_src: "{{ mds_file_based_user_store_remote_src|bool}}"
   when:
-    - mds_user_store_file_enabled|bool
+    - mds_file_based_user_store_enabled|bool
     - not external_mds_enabled|bool
   tags:
     - configuration

--- a/roles/kafka_broker/tasks/rbac.yml
+++ b/roles/kafka_broker/tasks/rbac.yml
@@ -189,6 +189,8 @@
     owner: "{{ kafka_broker_user }}"
     group: "{{ kafka_broker_group }}"
     mode: '750'
+  when:
+    - mds_user_store_file_enabled|bool
   tags:
     - privileged
     - filesystem
@@ -199,6 +201,6 @@
     dest: "{{ confluent_metadata_server_user_store_file_dest_path }}"
     remote_src: "{{ confluent_metadata_server_user_store_file_remote_src|bool}}"
   when:
-    - auth_mode == 'file'
+    - mds_user_store_file_enabled|bool
   tags:
     - configuration

--- a/roles/kafka_broker/tasks/rbac.yml
+++ b/roles/kafka_broker/tasks/rbac.yml
@@ -191,6 +191,7 @@
     mode: '750'
   when:
     - mds_user_store_file_enabled|bool
+    - not external_mds_enabled|bool
   tags:
     - privileged
     - filesystem
@@ -202,5 +203,6 @@
     remote_src: "{{ confluent_metadata_server_user_store_file_remote_src|bool}}"
   when:
     - mds_user_store_file_enabled|bool
+    - not external_mds_enabled|bool
   tags:
     - configuration

--- a/roles/kafka_broker/tasks/rbac.yml
+++ b/roles/kafka_broker/tasks/rbac.yml
@@ -180,3 +180,25 @@
     - broker_private_pem_file.stat.exists|bool
     - not ( ssl_provided_keystore_and_truststore_remote_src|bool )
   diff: "{{ not mask_sensitive_diff|bool }}"
+
+
+- name: Create MDS User Store File Directory
+  file:
+    path: "{{ confluent_metadata_server_user_store_file_dest_path }}"
+    state: directory
+    owner: "{{ kafka_broker_user }}"
+    group: "{{ kafka_broker_group }}"
+    mode: '750'
+  tags:
+    - privileged
+    - filesystem
+
+- name: Copy MDS User Store File to MDS
+  copy:
+    src: "{{ confluent_metadata_server_user_store_file_src }}"
+    dest: "{{ confluent_metadata_server_user_store_file_dest_path }}"
+    remote_src: "{{ confluent_metadata_server_user_store_file_remote_src|bool}}"
+  when:
+    - auth_mode == 'file'
+  tags:
+    - configuration

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -1559,7 +1559,16 @@ sso_cli: false
 ### Device Authorization endpoint of Idp, Required to enable SSO in cli.
 sso_device_authorization_uri: none
 
-### Authorization mode on all cp components. Possible values are ldap, oauth, ldap_with_oauth and none. Set this to oauth for OAuth cluster and ldap_with_oauth for cluster with both ldap and oauth support. When set to oauth or ldap_with_oauth, you must set oauth_jwks_uri, oauth_token_uri, oauth_issuer_url, oauth_superuser_client_id, oauth_superuser_client_password.
+### Path to the file containing the user store for MDS. This must be definde when auth_mode is set to file.
+confluent_metadata_server_user_store_file_src: ""
+
+### Boolean to indicate if the user store file is present on the control node or remote host. If false, the file will be copied from the control node to the target host.
+confluent_metadata_server_user_store_file_remote_src: false
+
+### Path to the destination file on the target host.
+confluent_metadata_server_user_store_file_dest_path: /tmp/credentials
+
+### Authorization mode on all cp components. Possible values are ldap, oauth, ldap_with_oauth, mtls, file and none. Set this to oauth for OAuth cluster and ldap_with_oauth for cluster with both ldap and oauth support. When set to oauth or ldap_with_oauth, you must set oauth_jwks_uri, oauth_token_uri, oauth_issuer_url, oauth_superuser_client_id, oauth_superuser_client_password.
 auth_mode: "{% if rbac_enabled|bool %}ldap{% else %}none{% endif %}"
 
 ### Client id used to authorize and request token from IdP via cp components. This is the super user for all MDS api calls

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -1559,16 +1559,19 @@ sso_cli: false
 ### Device Authorization endpoint of Idp, Required to enable SSO in cli.
 sso_device_authorization_uri: none
 
-### Path to the file containing the user store for MDS. This must be definde when auth_mode is set to file.
-confluent_metadata_server_user_store_file_src: ""
+### Boolean to enable file based user store on MDS. Can be helpful in case of no SSO in Control Center. When setting this true we must also define mds_file_based_user_store_src_path and mds_file_based_user_store_dest_path.
+mds_file_based_user_store_enabled: false
 
-### Boolean to indicate if the user store file is present on the control node or remote host. If false, the file will be copied from the control node to the target host.
-confluent_metadata_server_user_store_file_remote_src: false
+### Path to the file containing the user store for MDS. This must be defined when mds_file_based_user_store_enabled is true. The file must have the format where each entry is newline seperated and in each entry we have username and password separated by a colon. For example: admin: admin-secret
+mds_file_based_user_store_src_path: ""
 
-### Path to the destination file on the target host.
-confluent_metadata_server_user_store_file_dest_path: /tmp/credentials
+### Boolean to indicate if the user store file is present on the control node or remote host. If false, the file will be copied from the control node to the target host. If true it will be moved from src to dst path on the target host.
+mds_file_based_user_store_remote_src: false
 
-### Authorization mode on all cp components. Possible values are ldap, oauth, ldap_with_oauth, mtls, file and none. Set this to oauth for OAuth cluster and ldap_with_oauth for cluster with both ldap and oauth support. When set to oauth or ldap_with_oauth, you must set oauth_jwks_uri, oauth_token_uri, oauth_issuer_url, oauth_superuser_client_id, oauth_superuser_client_password.
+### Path of the destination file on the target host i.e MDS server. Should be a file path and not a directory.
+mds_file_based_user_store_dest_path: ""
+
+### Authorization mode on all cp components. Possible values are ldap, oauth, ldap_with_oauth, mtls and none. Set this to oauth for OAuth cluster and ldap_with_oauth for cluster with both ldap and oauth support. When set to oauth or ldap_with_oauth, you must set oauth_jwks_uri, oauth_token_uri, oauth_issuer_url, oauth_superuser_client_id, oauth_superuser_client_password.
 auth_mode: "{% if rbac_enabled|bool %}ldap{% else %}none{% endif %}"
 
 ### Client id used to authorize and request token from IdP via cp components. This is the super user for all MDS api calls

--- a/roles/variables/vars/main.yml
+++ b/roles/variables/vars/main.yml
@@ -624,6 +624,11 @@ kafka_broker_properties:
     enabled: "{{ rbac_enabled and not external_mds_enabled and mds_ssl_enabled|bool and auth_mode == 'mtls' }}"
     properties:
       confluent.metadata.server.user.store: NONE
+  rbac_mds_file_store:
+    enabled: "{{ rbac_enabled and not external_mds_enabled and auth_mode == 'file' }}"
+    properties:
+      confluent.metadata.server.user.store: FILE
+      confluent.metadata.server.user.store.file.path: "{{ confluent_metadata_server_user_store_file_dest_path }}"
   rbac_mds_client_authentication:
     enabled: "{{ rbac_enabled and not external_mds_enabled and mds_ssl_enabled|bool and mds_ssl_client_authentication != 'none' }}"
     properties:

--- a/roles/variables/vars/main.yml
+++ b/roles/variables/vars/main.yml
@@ -621,11 +621,11 @@ kafka_broker_properties:
     properties:
       confluent.metadata.server.auth.ssl.principal.mapping.rules: "{{ principal_mapping_rules | join(',') }}"
   rbac_mds_mtls_only:
-    enabled: "{{ rbac_enabled and not external_mds_enabled and mds_ssl_enabled|bool and auth_mode == 'mtls' }}"
+    enabled: "{{ rbac_enabled and not external_mds_enabled and mds_ssl_enabled|bool and auth_mode == 'mtls' and not mds_user_store_file_enabled }}"
     properties:
       confluent.metadata.server.user.store: NONE
   rbac_mds_file_store:
-    enabled: "{{ rbac_enabled and not external_mds_enabled and auth_mode == 'file' }}"
+    enabled: "{{ rbac_enabled and not external_mds_enabled and mds_user_store_file_enabled }}"
     properties:
       confluent.metadata.server.user.store: FILE
       confluent.metadata.server.user.store.file.path: "{{ confluent_metadata_server_user_store_file_dest_path }}"

--- a/roles/variables/vars/main.yml
+++ b/roles/variables/vars/main.yml
@@ -621,14 +621,14 @@ kafka_broker_properties:
     properties:
       confluent.metadata.server.auth.ssl.principal.mapping.rules: "{{ principal_mapping_rules | join(',') }}"
   rbac_mds_mtls_only:
-    enabled: "{{ rbac_enabled and not external_mds_enabled and mds_ssl_enabled|bool and auth_mode == 'mtls' and not mds_user_store_file_enabled }}"
+    enabled: "{{ rbac_enabled and not external_mds_enabled and mds_ssl_enabled|bool and auth_mode == 'mtls' and not mds_file_based_user_store_enabled|bool }}"
     properties:
       confluent.metadata.server.user.store: NONE
   rbac_mds_file_store:
-    enabled: "{{ rbac_enabled and not external_mds_enabled and mds_user_store_file_enabled }}"
+    enabled: "{{ rbac_enabled and not external_mds_enabled and mds_file_based_user_store_enabled|bool }}"
     properties:
       confluent.metadata.server.user.store: FILE
-      confluent.metadata.server.user.store.file.path: "{{ confluent_metadata_server_user_store_file_dest_path }}"
+      confluent.metadata.server.user.store.file.path: "{{ mds_file_based_user_store_dest_path }}"
   rbac_mds_client_authentication:
     enabled: "{{ rbac_enabled and not external_mds_enabled and mds_ssl_enabled|bool and mds_ssl_client_authentication != 'none' }}"
     properties:


### PR DESCRIPTION
# Description

To use file based mds user store earlier kafka broker custom properties needed to be used and the credentials file needed to be present on all brokers where mds was running.
Adding this first class support allows user to define these variables `confluent_metadata_server_user_store_file_src, confluent_metadata_server_user_store_file_dest_path,  confluent_metadata_server_user_store_file_remote_src` and it would either send the credentials from ansible control node to broker or from one path to another in broker based on `confluent_metadata_server_user_store_file_remote_src`'s value.

Fixes # [(issue)](https://confluentinc.atlassian.net/browse/ANSIENG-4255)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

[semaphore](https://semaphore.ci.confluent.io/workflows/277c1323-c7ad-4eb7-b630-4e7d80c5c695?pipeline_id=866a94a0-bc77-49f3-88f9-5cebe692a5bc)

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
