### PR TITLE
[ANSIENG-4681] | Replace deprecated parameter for mtls in hosts_example.yml

### DIFF
--- a/docs/hosts_example.yml
+++ b/docs/hosts_example.yml
@@ -51,7 +51,7 @@ all:
     ## By default, data will NOT be encrypted. To turn on TLS encryption, uncomment this line
     # ssl_enabled: true
     ## By default, the components will be configured with One-Way TLS, to turn on TLS mutual auth, uncomment this line:
-    # ssl_mutual_auth_enabled: true
+    # ssl_client_authentication: true
     ## By default, the certs for this configuration will be self signed, to deploy custom certificates there are two options.
     ## Option 1: Custom Certs
     ## You will need to provide the path to the Certificate Authority Cert used to sign each hosts' certs
@@ -86,14 +86,14 @@ all:
     ## Zookeeper's TLS settings are inherited from the ssl_enabled settings.
     ## If you have ssl_enabled, but want zookeeper without TLS, uncomment these lines
     # zookeeper_ssl_enabled: false
-    # zookeeper_ssl_mutual_auth_enabled: false
+    # zookeeper_ssl_client_authentication: false
 
     #### Kafka Controller TLS Configuration ####
     ## Controller can also have TLS Encryption and mTLS Authentication
     ## Controller's TLS settings are inherited from the ssl_enabled settings.
     ## If you have ssl_enabled, but want controller without TLS, uncomment these lines
     # kafka_controller_ssl_enabled: false
-    # kafka_controller_ssl_mutual_auth_enabled: false
+    # kafka_controller_ssl_client_authentication: false
 
     #### Certificate Regeneration ####
     ## When using self signed certificates, each playbook run will regenerate the CA, to turn this off, uncomment this line:
@@ -157,20 +157,20 @@ all:
     #     name: BROKER
     #     port: 9091
     #     ssl_enabled: false
-    #     ssl_mutual_auth_enabled: false
+    #     ssl_client_authentication: false
     #     sasl_protocol: none
     #   internal:
     #     name: INTERNAL
     #     port: 9092
     #     ssl_enabled: true
-    #     ssl_mutual_auth_enabled: false
+    #     ssl_client_authentication: false
     #     sasl_protocol: scram
     ## You can even add additional listeners, make sure name and port are unique
     #   client_listener:
     #     name: CLIENT
     #     port: 9093
     #     ssl_enabled: true
-    #     ssl_mutual_auth_enabled: true
+    #     ssl_client_authentication: true
     #     sasl_protocol: scram
 
     #### Creating Connectors ####
@@ -202,7 +202,7 @@ all:
     ## Note: Confluent components will be configured to connect to the "internal" listener automatically
     ## DO NOT UPDATE the internal listener
     ## Note: It is recommended to create an additional listener for external clients, but the interbroker listener would also work
-    ## Note: An authentication mode must be selected on all listeners, for example (ssl_enabled=false and ssl_mutual_auth_enabled=false) or sasl_protocol=none is not supported.
+    ## Note: An authentication mode must be selected on all listeners, for example (ssl_enabled=false and ssl_client_authentication=false) or sasl_protocol=none is not supported.
     # rbac_enabled: true
     ##
     ## LDAP Users
@@ -243,7 +243,7 @@ all:
     ## Configure the security settings to match the same listener as defined in the mds_broker_bootstrap_servers
     # mds_broker_listener:
     #   ssl_enabled: true <set to false if remote MDS does not use TLS>
-    #   ssl_mutual_auth_enabled: true <set to false if remote MDS doe not use MTLS>
+    #   ssl_client_authentication: true <set to false if remote MDS doe not use MTLS>
     #   sasl_protocol: none <set protocol for remote MDS, options are: kerberos, sasl_plain, sasl_scram>
     ##
     # kafka_controller_ldap_user: <Your Kafka Controller username in LDAP, works only when rbac_enabled is true>

--- a/docs/hosts_example.yml
+++ b/docs/hosts_example.yml
@@ -51,7 +51,7 @@ all:
     ## By default, data will NOT be encrypted. To turn on TLS encryption, uncomment this line
     # ssl_enabled: true
     ## By default, the components will be configured with One-Way TLS, to turn on TLS mutual auth, uncomment this line:
-    # ssl_client_authentication: true
+    # ssl_client_authentication: required
     ## By default, the certs for this configuration will be self signed, to deploy custom certificates there are two options.
     ## Option 1: Custom Certs
     ## You will need to provide the path to the Certificate Authority Cert used to sign each hosts' certs
@@ -86,14 +86,14 @@ all:
     ## Zookeeper's TLS settings are inherited from the ssl_enabled settings.
     ## If you have ssl_enabled, but want zookeeper without TLS, uncomment these lines
     # zookeeper_ssl_enabled: false
-    # zookeeper_ssl_client_authentication: false
+    # zookeeper_ssl_client_authentication: none
 
     #### Kafka Controller TLS Configuration ####
     ## Controller can also have TLS Encryption and mTLS Authentication
     ## Controller's TLS settings are inherited from the ssl_enabled settings.
     ## If you have ssl_enabled, but want controller without TLS, uncomment these lines
     # kafka_controller_ssl_enabled: false
-    # kafka_controller_ssl_client_authentication: false
+    # kafka_controller_ssl_client_authentication: none
 
     #### Certificate Regeneration ####
     ## When using self signed certificates, each playbook run will regenerate the CA, to turn this off, uncomment this line:
@@ -157,20 +157,20 @@ all:
     #     name: BROKER
     #     port: 9091
     #     ssl_enabled: false
-    #     ssl_client_authentication: false
+    #     ssl_client_authentication: none
     #     sasl_protocol: none
     #   internal:
     #     name: INTERNAL
     #     port: 9092
     #     ssl_enabled: true
-    #     ssl_client_authentication: false
+    #     ssl_client_authentication: none
     #     sasl_protocol: scram
     ## You can even add additional listeners, make sure name and port are unique
     #   client_listener:
     #     name: CLIENT
     #     port: 9093
     #     ssl_enabled: true
-    #     ssl_client_authentication: true
+    #     ssl_client_authentication: required
     #     sasl_protocol: scram
 
     #### Creating Connectors ####
@@ -202,7 +202,7 @@ all:
     ## Note: Confluent components will be configured to connect to the "internal" listener automatically
     ## DO NOT UPDATE the internal listener
     ## Note: It is recommended to create an additional listener for external clients, but the interbroker listener would also work
-    ## Note: An authentication mode must be selected on all listeners, for example (ssl_enabled=false and ssl_client_authentication=false) or sasl_protocol=none is not supported.
+    ## Note: An authentication mode must be selected on all listeners, for example (ssl_enabled=false and ssl_client_authentication=none) or sasl_protocol=none is not supported.
     # rbac_enabled: true
     ##
     ## LDAP Users
@@ -243,7 +243,7 @@ all:
     ## Configure the security settings to match the same listener as defined in the mds_broker_bootstrap_servers
     # mds_broker_listener:
     #   ssl_enabled: true <set to false if remote MDS does not use TLS>
-    #   ssl_client_authentication: true <set to false if remote MDS does not use MTLS>
+    #   ssl_client_authentication: true <set to none if remote MDS does not use MTLS>
     #   sasl_protocol: none <set protocol for remote MDS, options are: kerberos, sasl_plain, sasl_scram>
     ##
     # kafka_controller_ldap_user: <Your Kafka Controller username in LDAP, works only when rbac_enabled is true>

--- a/docs/hosts_example.yml
+++ b/docs/hosts_example.yml
@@ -202,7 +202,7 @@ all:
     ## Note: Confluent components will be configured to connect to the "internal" listener automatically
     ## DO NOT UPDATE the internal listener
     ## Note: It is recommended to create an additional listener for external clients, but the interbroker listener would also work
-    ## Note: An authentication mode must be selected on all listeners, for example (ssl_enabled=false and ssl_client_authentication=none) or sasl_protocol=none is not supported.
+    ## Note: An authentication mode must be selected on all listeners, for example a listener without mTLS and sasl protocol, i.e., both being none simultaneously (ssl_client_authentication=none and sasl_protocol=none) is not supported.
     # rbac_enabled: true
     ##
     ## LDAP Users

--- a/docs/hosts_example.yml
+++ b/docs/hosts_example.yml
@@ -243,7 +243,7 @@ all:
     ## Configure the security settings to match the same listener as defined in the mds_broker_bootstrap_servers
     # mds_broker_listener:
     #   ssl_enabled: true <set to false if remote MDS does not use TLS>
-    #   ssl_client_authentication: true <set to none if remote MDS does not use MTLS>
+    #   ssl_client_authentication: required <set to none if remote MDS does not use MTLS>
     #   sasl_protocol: none <set protocol for remote MDS, options are: kerberos, sasl_plain, sasl_scram>
     ##
     # kafka_controller_ldap_user: <Your Kafka Controller username in LDAP, works only when rbac_enabled is true>

--- a/docs/hosts_example.yml
+++ b/docs/hosts_example.yml
@@ -243,7 +243,7 @@ all:
     ## Configure the security settings to match the same listener as defined in the mds_broker_bootstrap_servers
     # mds_broker_listener:
     #   ssl_enabled: true <set to false if remote MDS does not use TLS>
-    #   ssl_client_authentication: true <set to false if remote MDS doe not use MTLS>
+    #   ssl_client_authentication: true <set to false if remote MDS does not use MTLS>
     #   sasl_protocol: none <set protocol for remote MDS, options are: kerberos, sasl_plain, sasl_scram>
     ##
     # kafka_controller_ldap_user: <Your Kafka Controller username in LDAP, works only when rbac_enabled is true>


### PR DESCRIPTION


# Description

Replace ssl_mutual_auth_enabled by ssl_client_authentication in hosts_example.yml as ssl_mutual-auth_enabled is deprecated. This is already correctly reflected in VARIABLES.md and the filters.py. However, in the hosts_example.yml it is still reflecting the incorrect configuration in various places.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
