### PR TITLE
[ANSIENG-4727] | updating internal token listener to be created whenv…

### DIFF
--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -592,7 +592,7 @@ kafka_broker_default_listeners: "{
     'ssl_client_authentication': '{% if ccloud_kafka_enabled|bool %}none{% else %}{{ssl_client_authentication|string|lower}}{% endif %}',
     'principal_mapping_rules': {{principal_mapping_rules}},
     'sasl_protocol': '{% if auth_mode in [\"ldap\", \"ldap_with_oauth\", \"oauth\"] %}OAUTH{% elif ccloud_kafka_enabled|bool %}PLAIN{% else %}{{sasl_protocol}}{% endif %}'
-  }{% if auth_mode == 'mtls' %},
+  }{% if mds_ssl_client_authentication in [\"required\", \"requested\"] %},
   'internal_token': {
     'name': 'INTERNAL_TOKEN',
     'port': 9088,

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -595,7 +595,7 @@ kafka_broker_default_listeners: "{
   }{% if mds_ssl_client_authentication in [\"required\", \"requested\"] %},
   'internal_token': {
     'name': 'INTERNAL_TOKEN',
-    'port': 9088,
+    'port': {{internal_token_port}},
     'ssl_enabled': true,
     'ssl_mutual_auth_enabled': true,
     'ssl_client_authentication': '{{ssl_client_authentication|string|lower}}',
@@ -1503,6 +1503,9 @@ rbac_enabled: false
 
 ### Port to expose MDS Server API on
 mds_port: 8090
+
+### Internal Token listener Port
+internal_token_port: 9088
 
 # Deprecated
 mds_ssl_enabled: "{{ssl_enabled}}"


### PR DESCRIPTION
# Description

Internal token listener was created so rest proxy can have some sasl_ssl based listener in case internal listener was based on SSL security protocol. Thus the condition to create it was `auth_mode == mtls` but for brownfield migration we need that listener before removing the ldap oauth configs and thus we should not wait until `auth_mode == mtls` but rather create this internal token listener when mds has mtls`

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

[semaphore job](https://semaphore.ci.confluent.io/workflows/f530e87b-ddee-4b27-892e-c69b3ca0e236?pipeline_id=b0c3bdaf-bd2b-45b7-a72d-ed2763ecf1d6)

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
