### PR TITLE
Ansieng 4729

### DIFF
--- a/roles/control_center/defaults/main.yml
+++ b/roles/control_center/defaults/main.yml
@@ -21,7 +21,7 @@ control_center_java_args:
   - "{% if control_center_ssl_enabled|bool %}-Djdk.tls.ephemeralDHKeySize=2048{% endif %}"
   - "{% if control_center_authentication_type == 'basic' %}-Djava.security.auth.login.config={{control_center.jaas_file}}{% endif %}"
   - "{% if kerberos_client_config_file_dest != '/etc/krb5.conf' %}-Djava.security.krb5.conf={{kerberos_client_config_file_dest}}{% endif %}"
-
+  - "-Dorg.apache.kafka.sasl.oauthbearer.allowed.urls=*"
 ### Custom Java Args to add to the Control Center Process
 control_center_custom_java_args: ""
 

--- a/roles/kafka_broker/defaults/main.yml
+++ b/roles/kafka_broker/defaults/main.yml
@@ -25,6 +25,7 @@ kafka_broker_java_args:
   - "{% if kafka_broker_jmxexporter_enabled|bool %}-javaagent:{{jmxexporter_jar_path}}={{kafka_broker_jmxexporter_port}}:{{kafka_broker_jmxexporter_config_path}}{% endif %}"
   - "{% if zookeeper_client_authentication_type == 'kerberos' and zookeeper_kerberos_primary != 'zookeeper' %}-Dzookeeper.sasl.client.username={{zookeeper_kerberos_primary}}{% endif %}"
   - "{% if kerberos_client_config_file_dest != '/etc/krb5.conf' %}-Djava.security.krb5.conf={{kerberos_client_config_file_dest}}{% endif %}"
+  - "-Dorg.apache.kafka.sasl.oauthbearer.allowed.urls=*"
 
 # Strip primary from the zookeeper principal on first zk host. Adds defaults for if there is not even a zookeeper group
 zookeeper_kerberos_primary: "{{ (hostvars[ groups['zookeeper'][0] | default('zookeeper') ] | default({})) ['zookeeper_kerberos_principal'] | default('zookeeper/host@EXAMPLE>COM') | regex_replace('/.*') }}"

--- a/roles/kafka_connect/defaults/main.yml
+++ b/roles/kafka_connect/defaults/main.yml
@@ -23,6 +23,7 @@ kafka_connect_java_args:
   - "{% if kafka_connect_jmxexporter_enabled|bool %}-javaagent:{{jmxexporter_jar_path}}={{kafka_connect_jmxexporter_port}}:{{kafka_connect_jmxexporter_config_path}}{% endif %}"
   - "{% if kafka_connect_authentication_type == 'basic' %}-Djava.security.auth.login.config={{kafka_connect.jaas_file}}{% endif %}"
   - "{% if kerberos_client_config_file_dest != '/etc/krb5.conf' %}-Djava.security.krb5.conf={{kerberos_client_config_file_dest}}{% endif %}"
+  - "-Dorg.apache.kafka.sasl.oauthbearer.allowed.urls=*"
 
 ### Custom Java Args to add to the Connect Process
 kafka_connect_custom_java_args: ""

--- a/roles/kafka_connect_replicator/defaults/main.yml
+++ b/roles/kafka_connect_replicator/defaults/main.yml
@@ -11,6 +11,7 @@ kafka_connect_replicator_java_args:
   - "{% if kafka_connect_replicator_ssl_mutual_auth_enabled| bool %}-Djdk.tls.ephemeralDHKeySize=2048{% endif %}"
   - "{% if kafka_connect_replicator_jolokia_enabled|bool %}-javaagent:{{kafka_connect_replicator_jolokia_jar_path}}=config={{kafka_connect_replicator_jolokia_config}}{% endif %}"
   - "{% if kerberos_client_config_file_dest != '/etc/krb5.conf' %}-Djava.security.krb5.conf={{kerberos_client_config_file_dest}}{% endif %}"
+  - "-Dorg.apache.kafka.sasl.oauthbearer.allowed.urls=*"
 
 ### Custom Java Args to add to the Kafka Connect Replicator Process
 kafka_connect_replicator_custom_java_args: ""

--- a/roles/kafka_controller/defaults/main.yml
+++ b/roles/kafka_controller/defaults/main.yml
@@ -24,6 +24,7 @@ kafka_controller_java_args:
   - "{% if kafka_controller_jmxexporter_enabled|bool %}-javaagent:{{jmxexporter_jar_path}}={{kafka_controller_jmxexporter_port}}:{{kafka_controller_jmxexporter_config_path}}{% endif %}"
   - "{% if kraft_migration|bool and zookeeper_client_authentication_type == 'kerberos' and zookeeper_kerberos_primary != 'zookeeper' %}-Dzookeeper.sasl.client.username={{zookeeper_kerberos_primary}}{% endif %}"
   - "{% if kerberos_client_config_file_dest != '/etc/krb5.conf' %}-Djava.security.krb5.conf={{kerberos_client_config_file_dest}}{% endif %}"
+  - "-Dorg.apache.kafka.sasl.oauthbearer.allowed.urls=*"
 
 # Strip primary from the zookeeper principal on first zk host. Adds defaults for if there is not even a zookeeper group
 zookeeper_kerberos_primary: "{{ (hostvars[ groups['zookeeper'][0] | default('zookeeper') ] | default({})) ['zookeeper_kerberos_principal'] | default('zookeeper/host@EXAMPLE>COM') | regex_replace('/.*') }}"

--- a/roles/kafka_rest/defaults/main.yml
+++ b/roles/kafka_rest/defaults/main.yml
@@ -23,6 +23,7 @@ kafka_rest_java_args:
   - "{% if kafka_rest_jmxexporter_enabled|bool %}-javaagent:{{jmxexporter_jar_path}}={{kafka_rest_jmxexporter_port}}:{{kafka_rest_jmxexporter_config_path}}{% endif %}"
   - "{% if kafka_rest_authentication_type == 'basic' %}-Djava.security.auth.login.config={{kafka_rest.jaas_file}}{% endif %}"
   - "{% if kerberos_client_config_file_dest != '/etc/krb5.conf' %}-Djava.security.krb5.conf={{kerberos_client_config_file_dest}}{% endif %}"
+  - "-Dorg.apache.kafka.sasl.oauthbearer.allowed.urls=*"
 
 ### Custom Java Args to add to the Rest Proxy Process
 kafka_rest_custom_java_args: ""

--- a/roles/ksql/defaults/main.yml
+++ b/roles/ksql/defaults/main.yml
@@ -23,6 +23,7 @@ ksql_java_args:
   - "{% if ksql_jmxexporter_enabled|bool %}-javaagent:{{jmxexporter_jar_path}}={{ksql_jmxexporter_port}}:{{ksql_jmxexporter_config_path}}{% endif %}"
   - "{% if ksql_authentication_type == 'basic' %}-Djava.security.auth.login.config={{ksql.jaas_file}}{% endif %}"
   - "{% if kerberos_client_config_file_dest != '/etc/krb5.conf' %}-Djava.security.krb5.conf={{kerberos_client_config_file_dest}}{% endif %}"
+  - "-Dorg.apache.kafka.sasl.oauthbearer.allowed.urls=*"
 
 ### Custom Java Args to add to the ksqlDB Process
 ksql_custom_java_args: ""

--- a/roles/schema_registry/defaults/main.yml
+++ b/roles/schema_registry/defaults/main.yml
@@ -23,6 +23,7 @@ schema_registry_java_args:
   - "{% if schema_registry_jmxexporter_enabled|bool %}-javaagent:{{jmxexporter_jar_path}}={{schema_registry_jmxexporter_port}}:{{schema_registry_jmxexporter_config_path}}{% endif %}"
   - "{% if schema_registry_authentication_type == 'basic' %}-Djava.security.auth.login.config={{schema_registry.jaas_file}}{% endif %}"
   - "{% if kerberos_client_config_file_dest != '/etc/krb5.conf' %}-Djava.security.krb5.conf={{kerberos_client_config_file_dest}}{% endif %}"
+  - "-Dorg.apache.kafka.sasl.oauthbearer.allowed.urls=*"
 
 ### Custom Java Args to add to the Schema Registry Process
 schema_registry_custom_java_args: ""


### PR DESCRIPTION
# Description

After changes in ce-kafka, all endpoints used to configure OAuth need to be explicitly added in a system property by the name (https://github.com/confluentinc/ce-kafka/pull/19023 )

org.apache.kafka.sasl.oauthbearer.allowed.urls, this change needs to be done in all of the component run/startup scripts or nodes on which they are brought up.

This can be done in either of the 2 ways :- 

Explicitly setting the urls as a list in the above config.


org.apache.kafka.sasl.oauthbearer.allowed.urls=<idp_jwks_url>,<idp_token_url>

Allowing all endpoints :- 
org.apache.kafka.sasl.oauthbearer.allowed.urls=*


currently allowing all urls
will be visiting this change back.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
