### PR TITLE
[ANSIENG-4742] | Fix c3 kafka listener

### DIFF
--- a/molecule/mini-setup-ext-mds-mtls/credentials
+++ b/molecule/mini-setup-ext-mds-mtls/credentials
@@ -1,2 +1,3 @@
+c3user: c3password
 user1: password1
 user2: password2

--- a/molecule/mini-setup-ext-mds-mtls/molecule.yml
+++ b/molecule/mini-setup-ext-mds-mtls/molecule.yml
@@ -191,10 +191,6 @@ provisioner:
         mds_file_based_user_store_dest_path: /etc/kafka/credentials
         mds_file_based_user_store_remote_src: true # credentials file already on target node
 
-        # The following username, password pair must be present in the credentials file
-        mds_file_based_control_center_user: c3user
-        mds_file_based_control_center_password: c3password
-
         create_mds_certs: false
         token_services_public_pem_file: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/public.pem"
         token_services_private_pem_file: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/tokenKeypair.pem"

--- a/molecule/mini-setup-ext-mds-mtls/molecule.yml
+++ b/molecule/mini-setup-ext-mds-mtls/molecule.yml
@@ -186,6 +186,15 @@ provisioner:
         ssl_client_authentication: required
         mds_ssl_client_authentication: required
 
+        mds_file_based_user_store_enabled: true
+        mds_file_based_user_store_src_path: /tmp/credentials
+        mds_file_based_user_store_dest_path: /etc/kafka/credentials
+        mds_file_based_user_store_remote_src: true # credentials file already on target node
+
+        # The following username, password pair must be present in the credentials file
+        mds_file_based_control_center_user: c3user
+        mds_file_based_control_center_password: c3password
+
         create_mds_certs: false
         token_services_public_pem_file: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/public.pem"
         token_services_private_pem_file: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/tokenKeypair.pem"
@@ -216,9 +225,6 @@ provisioner:
 
       mds:
         kafka_broker_cluster_name: 'mds'
-        kafka_broker_custom_properties:
-          confluent.metadata.server.user.store: FILE
-          confluent.metadata.server.user.store.file.path: /tmp/credentials
 
       cluster2:
         kafka_broker_cluster_name: 'second-cluster'

--- a/molecule/mini-setup-mtls/credentials
+++ b/molecule/mini-setup-mtls/credentials
@@ -1,2 +1,0 @@
-user1: password1
-user2: password2

--- a/molecule/mini-setup-mtls/molecule.yml
+++ b/molecule/mini-setup-mtls/molecule.yml
@@ -212,10 +212,6 @@ provisioner:
           - "RULE:.*CN=([a-zA-Z0-9.-_]*).*$$/$$1/"
           - "DEFAULT"
 
-        # kafka_broker_custom_properties:
-        #   confluent.metadata.server.user.store: FILE
-        #   confluent.metadata.server.user.store.file.path: /tmp/credentials
-
         sso_mode: oidc
         sso_groups_claim: groups
         sso_sub_claim: sub

--- a/molecule/mini-setup-mtls/molecule.yml
+++ b/molecule/mini-setup-mtls/molecule.yml
@@ -212,9 +212,23 @@ provisioner:
           - "RULE:.*CN=([a-zA-Z0-9.-_]*).*$$/$$1/"
           - "DEFAULT"
 
-        kafka_broker_custom_properties:
-          confluent.metadata.server.user.store: FILE
-          confluent.metadata.server.user.store.file.path: /tmp/credentials
+        # kafka_broker_custom_properties:
+        #   confluent.metadata.server.user.store: FILE
+        #   confluent.metadata.server.user.store.file.path: /tmp/credentials
+
+        sso_mode: oidc
+        sso_groups_claim: groups
+        sso_sub_claim: sub
+        sso_groups_scope: groups
+        sso_issuer_url: https://dev-59009577.okta.com/oauth2/aus96p2og3u7Cpwu65d7
+        sso_jwks_uri: https://dev-59009577.okta.com/oauth2/aus96p2og3u7Cpwu65d7/v1/keys
+        sso_authorize_uri: https://dev-59009577.okta.com/oauth2/aus96p2og3u7Cpwu65d7/v1/authorize
+        sso_token_uri: https://dev-59009577.okta.com/oauth2/aus96p2og3u7Cpwu65d7/v1/token
+        sso_device_authorization_uri: https://dev-59009577.okta.com/oauth2/aus96p2og3u7Cpwu65d7/v1/device/authorize
+        sso_cli: true
+        sso_client_id: ${OKTA_CLIENT:-user}
+        sso_client_password: ${OKTA_PASSWORD:-password}
+        sso_idp_cert_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/ssocertfile.pem"
 
         kafka_connect_custom_properties:
           plugin.path: "/usr/share/filestream-connectors,/usr/share/java/connect_plugins"

--- a/molecule/mini-setup-mtls/prepare.yml
+++ b/molecule/mini-setup-mtls/prepare.yml
@@ -1,12 +1,4 @@
 ---
-- name: File Based login in C3/CLI configs via override
-  hosts: kafka_broker
-  tasks:
-    - name: Copy Credentials file to MDS
-      copy:
-        src: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/credentials"
-        dest: "/tmp/credentials"
-
 - name: Download SSO IDP cert  # temporary, till we are using OKTA IDP
   hosts: localhost
   tasks:

--- a/molecule/mini-setup-mtls/prepare.yml
+++ b/molecule/mini-setup-mtls/prepare.yml
@@ -6,6 +6,12 @@
       copy:
         src: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/credentials"
         dest: "/tmp/credentials"
+
+- name: Download SSO IDP cert  # temporary, till we are using OKTA IDP
+  hosts: localhost
+  tasks:
+    - shell: openssl s_client -showcerts -connect dev-59009577.okta.com:443 </dev/null 2>/dev/null|openssl x509 -outform PEM > ssocertfile.pem
+
 - name: Install Zookeeper Cluster
   import_playbook: confluent.platform.all
   when: lookup('env', 'MIGRATION')|default('false') == 'true'

--- a/plugins/filter/filters.py
+++ b/plugins/filter/filters.py
@@ -349,7 +349,8 @@ class FilterModule(object):
             # Not adding this config always when normalize_sasl_protocols[0] == 'OAUTHBEARER'
             # This is because it is not getting added for ERP currently due to omit_oauth_configs currently.
             final_dict[config_prefix + 'sasl.mechanism'] = 'OAUTHBEARER'
-            final_dict[config_prefix + 'sasl.jaas.config'] = 'org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required metadataServerUrls=\"' + mds_bootstrap_server_urls + '\";'
+            final_dict[config_prefix + 'sasl.jaas.config'] = 'org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule \
+                required metadataServerUrls=\"' + mds_bootstrap_server_urls + '\";'
 
         if not omit_oauth_configs:
             if normalize_sasl_protocols[0] == 'OAUTHBEARER' and not oauth_enabled:

--- a/plugins/filter/filters.py
+++ b/plugins/filter/filters.py
@@ -345,6 +345,11 @@ class FilterModule(object):
             final_dict[config_prefix + 'sasl.jaas.config'] = 'com.sun.security.auth.module.Krb5LoginModule required useKeyTab=true storeKey=true keyTab=\"' +\
                 keytab_path + '\" principal=\"' + kerberos_principal + '\";'
 
+        if listener_dict.get('name','').lower() == 'internal_token': # other oauth configs should be omitted
+            # Not adding this config always when normalize_sasl_protocols[0] == 'OAUTHBEARER',
+            # This is because it is not getting added for ERP currently due to omit_oauth_configs currently.
+            final_dict[config_prefix + 'sasl.mechanism'] = 'OAUTHBEARER'
+
         if not omit_oauth_configs:
             if normalize_sasl_protocols[0] == 'OAUTHBEARER' and not oauth_enabled:
                 final_dict[config_prefix + 'sasl.mechanism'] = 'OAUTHBEARER'

--- a/plugins/filter/filters.py
+++ b/plugins/filter/filters.py
@@ -345,10 +345,11 @@ class FilterModule(object):
             final_dict[config_prefix + 'sasl.jaas.config'] = 'com.sun.security.auth.module.Krb5LoginModule required useKeyTab=true storeKey=true keyTab=\"' +\
                 keytab_path + '\" principal=\"' + kerberos_principal + '\";'
 
-        if listener_dict.get('name','').lower() == 'internal_token': # other oauth configs should be omitted
-            # Not adding this config always when normalize_sasl_protocols[0] == 'OAUTHBEARER',
+        if listener_dict.get('name', '').lower() == 'internal_token':  # other oauth configs should be omitted
+            # Not adding this config always when normalize_sasl_protocols[0] == 'OAUTHBEARER'
             # This is because it is not getting added for ERP currently due to omit_oauth_configs currently.
             final_dict[config_prefix + 'sasl.mechanism'] = 'OAUTHBEARER'
+            final_dict[config_prefix + 'sasl.jaas.config'] = 'org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required metadataServerUrls=\"' + mds_bootstrap_server_urls + '\";'
 
         if not omit_oauth_configs:
             if normalize_sasl_protocols[0] == 'OAUTHBEARER' and not oauth_enabled:

--- a/roles/common/tasks/config_validations.yml
+++ b/roles/common/tasks/config_validations.yml
@@ -162,13 +162,13 @@
 - assert:
     that:
       - auth_mode in ['ldap', 'ldap_with_oauth', 'oauth', 'mtls', 'none']
-    fail_msg: "auth_mode must be one of 'ldap', 'ldap_with_oauth', 'oauth', 'none'"
+    fail_msg: "auth_mode must be one of 'ldap', 'ldap_with_oauth', 'oauth', 'mtls', 'none'"
   tags: validate
 
 - assert:
     that:
       - auth_mode in ['ldap', 'ldap_with_oauth', 'oauth', 'mtls']
-    fail_msg: "When RBAC is enabled, auth_mode must be one of 'ldap', 'ldap_with_oauth', 'oauth'"
+    fail_msg: "When RBAC is enabled, auth_mode must be one of 'ldap', 'ldap_with_oauth', 'oauth', 'mtls'"
   when:
     - rbac_enabled|bool
   tags: validate
@@ -191,8 +191,25 @@
 
 - assert:
     that:
+      - rbac_enabled|bool
+    fail_msg: "When we have file based user store enabled we must have MDS and thus RBAC also must be enabled"
+  when:
+    - mds_file_based_user_store_enabled|bool
+  tags: validate
+
+- assert:
+    that:
+      - mds_file_based_user_store_src_path != ''
+      - mds_file_based_user_store_dest_path != ''
+    fail_msg: "When mds_file_based_user_store_enabled is true we must also define  mds_file_based_user_store_src_path and mds_file_based_user_store_dest_path"
+  when:
+    - mds_file_based_user_store_enabled|bool
+  tags: validate
+
+- assert:
+    that:
       - mds_ssl_client_authentication != 'none'
-    fail_msg: "When auth mode is mtls mds must have ssl client authentication is set to required or requested"
+    fail_msg: "When auth mode is mtls, mds must have ssl client authentication is set to required or requested"
   when:
     - auth_mode == 'mtls'
   tags: validate

--- a/roles/control_center/tasks/main.yml
+++ b/roles/control_center/tasks/main.yml
@@ -209,6 +209,15 @@
     - rbac_enabled|bool
     - mds_ssl_client_authentication != 'none'
 
+- name: Configure RBAC for file based User
+  include_tasks: rbac.yml
+  vars:
+    c3_user: "{{ mds_file_based_control_center_user }}"
+  when:
+    - rbac_enabled|bool
+    - mds_ssl_client_authentication != 'none'
+    - mds_file_based_user_store_enabled|bool # Todo: Check if above task needs to be skipped in file based case or not
+
 - name: Import IDP certificate to Truststore for OAuth
   include_role:
     name: common

--- a/roles/control_center/tasks/main.yml
+++ b/roles/control_center/tasks/main.yml
@@ -209,15 +209,6 @@
     - rbac_enabled|bool
     - mds_ssl_client_authentication != 'none'
 
-- name: Configure RBAC for file based User
-  include_tasks: rbac.yml
-  vars:
-    c3_user: "{{ mds_file_based_control_center_user }}"
-  when:
-    - rbac_enabled|bool
-    - mds_ssl_client_authentication != 'none'
-    - mds_file_based_user_store_enabled|bool # Todo: Check if above task needs to be skipped in file based case or not
-
 - name: Import IDP certificate to Truststore for OAuth
   include_role:
     name: common

--- a/roles/kafka_broker/tasks/rbac.yml
+++ b/roles/kafka_broker/tasks/rbac.yml
@@ -180,3 +180,30 @@
     - broker_private_pem_file.stat.exists|bool
     - not ( ssl_provided_keystore_and_truststore_remote_src|bool )
   diff: "{{ not mask_sensitive_diff|bool }}"
+
+- name: Create MDS User Store File Directory
+  file:
+    path: "{{ mds_file_based_user_store_dest_path | dirname }}"
+    state: directory
+    owner: "{{ kafka_broker_user }}"
+    group: "{{ kafka_broker_group }}"
+    mode: '750'
+  when:
+    - mds_file_based_user_store_enabled|bool
+    - not external_mds_enabled|bool
+  tags:
+    - privileged
+    - filesystem
+    - file_user_store
+
+- name: Copy MDS User Store File to MDS
+  copy:
+    src: "{{ mds_file_based_user_store_src_path }}"
+    dest: "{{ mds_file_based_user_store_dest_path }}"
+    remote_src: "{{ mds_file_based_user_store_remote_src|bool }}"
+  when:
+    - mds_file_based_user_store_enabled|bool
+    - not external_mds_enabled|bool
+  tags:
+    - configuration
+    - file_user_store

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -822,6 +822,8 @@ schema_registry_cert_path: "{{ ssl_file_dir_final }}/schema_registry.crt"
 schema_registry_key_path: "{{ ssl_file_dir_final }}/schema_registry.key"
 schema_registry_export_certs: "{{ True if schema_registry_authentication_type == 'mtls' else False }}"
 schema_registry_keytab_path: /etc/security/keytabs/schema_registry.keytab
+
+### Name of listener used by Schema Registry to talk to Kafka
 schema_registry_kafka_listener_name: internal
 
 ### Boolean to enable Jolokia Agent installation and configuration on schema registry
@@ -928,6 +930,8 @@ kafka_rest_cert_path: "{{ ssl_file_dir_final }}/kafka_rest.crt"
 kafka_rest_key_path: "{{ ssl_file_dir_final }}/kafka_rest.key"
 kafka_rest_export_certs: "{{ True if kafka_rest_authentication_type == 'mtls' else False }}"
 kafka_rest_keytab_path: /etc/security/keytabs/kafka_rest.keytab
+
+### Name of listener used by Kafka Rest to talk to Kafka
 kafka_rest_kafka_listener_name: >-
   {%- if rbac_enabled|bool and auth_mode=='mtls' -%}
     internal_token
@@ -1048,6 +1052,8 @@ kafka_connect_cert_path: "{{ ssl_file_dir_final }}/{{ kafka_connect_service_name
 kafka_connect_key_path: "{{ ssl_file_dir_final }}/{{ kafka_connect_service_name + '.key' if kafka_connect_service_name != kafka_connect_default_service_name else 'kafka_connect.key'}}"
 kafka_connect_export_certs: "{{ True if kafka_connect_authentication_type == 'mtls' else False }}"
 kafka_connect_keytab_path: /etc/security/keytabs/kafka_connect.keytab
+
+### Name of listener used by Kafka Connect to talk to Kafka
 kafka_connect_kafka_listener_name: internal
 
 ### Allows you to select a custom kafka listener for Kafka Connect producers
@@ -1193,7 +1199,10 @@ ksql_cert_path: "{{ ssl_file_dir_final }}/ksql.crt"
 ksql_key_path: "{{ ssl_file_dir_final }}/ksql.key"
 ksql_export_certs: "{{ True if ksql_authentication_type == 'mtls' else False }}"
 ksql_keytab_path: /etc/security/keytabs/ksql.keytab
+
+### Name of listener used by Schema Registry to talk to Kafka
 ksql_kafka_listener_name: internal
+
 ksql_processing_log_kafka_listener_name: "{{kafka_broker_inter_broker_listener_name if rbac_enabled else ksql_kafka_listener_name}}"
 
 ### Boolean to enable Jolokia Agent installation and configuration on ksqlDB
@@ -1309,7 +1318,14 @@ control_center_cert_path: "{{ ssl_file_dir_final }}/control_center.crt"
 control_center_key_path: "{{ ssl_file_dir_final }}/control_center.key"
 control_center_export_certs: "{{ssl_mutual_auth_enabled}}"
 control_center_keytab_path: /etc/security/keytabs/control_center.keytab
-control_center_kafka_listener_name: internal
+
+### Name of listener used by C3 to talk to Kafka
+control_center_kafka_listener_name: >-
+  {%- if rbac_enabled|bool and auth_mode=='mtls' -%}
+    internal_token
+  {%- else -%}
+    internal
+  {%- endif -%}
 
 ### Use to copy files from control node to Control Center hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '750') and file_mode (default: '640') to set directory and file permissions.
 control_center_copy_files: []

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -1584,12 +1584,6 @@ mds_file_based_user_store_remote_src: false
 ### Path of the destination file on the target host i.e MDS server. Should be a file path and not a directory.
 mds_file_based_user_store_dest_path: ""
 
-### This is the user for Control Center to Kafka communication over SASL_SSL (internal_token listener) in case of rbac_enabled, auth_mode mtls, file based user store, and no SSO in Control Center. This user must be present in the file given via mds_file_based_user_store_src_path.
-mds_file_based_control_center_user: ""
-
-### Password for the mds_file_based_control_center_user. This password must be present in the file given via mds_file_based_user_store_src_path.
-mds_file_based_control_center_password: ""
-
 ### Authorization mode on all cp components. Possible values are ldap, oauth, ldap_with_oauth, mtls and none. Set this to oauth for OAuth cluster and ldap_with_oauth for cluster with both ldap and oauth support. When set to oauth or ldap_with_oauth, you must set oauth_jwks_uri, oauth_token_uri, oauth_issuer_url, oauth_superuser_client_id, oauth_superuser_client_password. When MDS only has mTLS and no user store then set it to mTLS. In case of OAuth/LDAP + mTLS keep it to ldap/oauth
 auth_mode: "{% if rbac_enabled|bool %}ldap{% else %}none{% endif %}"
 

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -1572,7 +1572,25 @@ sso_cli: false
 ### Device Authorization endpoint of Idp, Required to enable SSO in cli.
 sso_device_authorization_uri: none
 
-### Authorization mode on all cp components. Possible values are ldap, oauth, ldap_with_oauth and none. Set this to oauth for OAuth cluster and ldap_with_oauth for cluster with both ldap and oauth support. When set to oauth or ldap_with_oauth, you must set oauth_jwks_uri, oauth_token_uri, oauth_issuer_url, oauth_superuser_client_id, oauth_superuser_client_password.
+### Boolean to enable file based user store on MDS. Can be helpful in case of no SSO in Control Center. When setting this true we must also define mds_file_based_user_store_src_path and mds_file_based_user_store_dest_path.
+mds_file_based_user_store_enabled: false
+
+### Path to the file containing the user store for MDS. This must be defined when mds_file_based_user_store_enabled is true. The file must have the format where each entry is newline seperated and in each entry we have username and password separated by a colon. For example: admin: admin-secret
+mds_file_based_user_store_src_path: ""
+
+### Boolean to indicate if the user store file is present on the control node or remote host. If false, the file will be copied from the control node to the target host. If true it will be moved from src to dst path on the target host.
+mds_file_based_user_store_remote_src: false
+
+### Path of the destination file on the target host i.e MDS server. Should be a file path and not a directory.
+mds_file_based_user_store_dest_path: ""
+
+### This is the user for Control Center to Kafka communication over SASL_SSL (internal_token listener) in case of rbac_enabled, auth_mode mtls, file based user store, and no SSO in Control Center. This user must be present in the file given via mds_file_based_user_store_src_path.
+mds_file_based_control_center_user: ""
+
+### Password for the mds_file_based_control_center_user. This password must be present in the file given via mds_file_based_user_store_src_path.
+mds_file_based_control_center_password: ""
+
+### Authorization mode on all cp components. Possible values are ldap, oauth, ldap_with_oauth, mtls and none. Set this to oauth for OAuth cluster and ldap_with_oauth for cluster with both ldap and oauth support. When set to oauth or ldap_with_oauth, you must set oauth_jwks_uri, oauth_token_uri, oauth_issuer_url, oauth_superuser_client_id, oauth_superuser_client_password. When MDS only has mTLS and no user store then set it to mTLS. In case of OAuth/LDAP + mTLS keep it to ldap/oauth
 auth_mode: "{% if rbac_enabled|bool %}ldap{% else %}none{% endif %}"
 
 ### Client id used to authorize and request token from IdP via cp components. This is the super user for all MDS api calls

--- a/roles/variables/vars/main.yml
+++ b/roles/variables/vars/main.yml
@@ -1611,7 +1611,7 @@ kafka_rest_properties:
                     'client.', kafka_rest_truststore_path, kafka_rest_truststore_storepass, public_certificates_enabled, kafka_rest_keystore_path, kafka_rest_keystore_storepass, kafka_rest_keystore_keypass,
                     false, sasl_plain_users_final.kafka_rest.principal, sasl_plain_users_final.kafka_rest.password, sasl_scram_users_final.kafka_rest.principal, sasl_scram_users_final.kafka_rest.password, sasl_scram256_users_final.kafka_rest.principal, sasl_scram256_users_final.kafka_rest.password,
                     kerberos_kafka_broker_primary, kafka_rest_keytab_path, kafka_rest_kerberos_principal|default('rp'),
-                    kafka_rest_kafka_listener_name == 'internal_token', kafka_rest_ldap_user, kafka_rest_ldap_password, mds_bootstrap_server_urls, oauth_enabled, kafka_rest_oauth_user, kafka_rest_oauth_password, oauth_groups_scope, oauth_token_uri, idp_self_signed, false) }}"
+                    kafka_rest_kafka_listener_name == 'internal_token' and auth_mode == 'mtls', kafka_rest_ldap_user, kafka_rest_ldap_password, mds_bootstrap_server_urls, oauth_enabled, kafka_rest_oauth_user, kafka_rest_oauth_password, oauth_groups_scope, oauth_token_uri, idp_self_signed, false) }}"
   kafka_client_password_protection:
     # Edge case for RP only- 'client' prefix not honored by secrets protection
     enabled: "{{ kafka_rest_secrets_protection_enabled }}"
@@ -1648,7 +1648,7 @@ kafka_rest_properties:
                             'client.confluent.monitoring.interceptor.', kafka_rest_truststore_path, kafka_rest_truststore_storepass, public_certificates_enabled, kafka_rest_keystore_path, kafka_rest_keystore_storepass, kafka_rest_keystore_keypass,
                             false, sasl_plain_users_final.kafka_rest.principal, sasl_plain_users_final.kafka_rest.password, sasl_scram_users_final.kafka_rest.principal, sasl_scram_users_final.kafka_rest.password, sasl_scram256_users_final.kafka_rest.principal, sasl_scram256_users_final.kafka_rest.password,
                             kerberos_kafka_broker_primary, kafka_rest_keytab_path, kafka_rest_kerberos_principal|default('rp'),
-                            kafka_rest_kafka_listener_name == 'internal_token', kafka_rest_ldap_user, kafka_rest_ldap_password, mds_bootstrap_server_urls, oauth_enabled, kafka_rest_oauth_user, kafka_rest_oauth_password, oauth_groups_scope, oauth_token_uri, idp_self_signed, false) }}"
+                            kafka_rest_kafka_listener_name == 'internal_token' and auth_mode == 'mtls', kafka_rest_ldap_user, kafka_rest_ldap_password, mds_bootstrap_server_urls, oauth_enabled, kafka_rest_oauth_user, kafka_rest_oauth_password, oauth_groups_scope, oauth_token_uri, idp_self_signed, false) }}"
   rbac:
     enabled: "{{rbac_enabled}}"
     properties:

--- a/roles/variables/vars/main.yml
+++ b/roles/variables/vars/main.yml
@@ -1648,7 +1648,7 @@ kafka_rest_properties:
                             'client.confluent.monitoring.interceptor.', kafka_rest_truststore_path, kafka_rest_truststore_storepass, public_certificates_enabled, kafka_rest_keystore_path, kafka_rest_keystore_storepass, kafka_rest_keystore_keypass,
                             false, sasl_plain_users_final.kafka_rest.principal, sasl_plain_users_final.kafka_rest.password, sasl_scram_users_final.kafka_rest.principal, sasl_scram_users_final.kafka_rest.password, sasl_scram256_users_final.kafka_rest.principal, sasl_scram256_users_final.kafka_rest.password,
                             kerberos_kafka_broker_primary, kafka_rest_keytab_path, kafka_rest_kerberos_principal|default('rp'),
-                            false, kafka_rest_ldap_user, kafka_rest_ldap_password, mds_bootstrap_server_urls, oauth_enabled, kafka_rest_oauth_user, kafka_rest_oauth_password, oauth_groups_scope, oauth_token_uri, idp_self_signed, false) }}"
+                            kafka_rest_kafka_listener_name == 'internal_token', kafka_rest_ldap_user, kafka_rest_ldap_password, mds_bootstrap_server_urls, oauth_enabled, kafka_rest_oauth_user, kafka_rest_oauth_password, oauth_groups_scope, oauth_token_uri, idp_self_signed, false) }}"
   rbac:
     enabled: "{{rbac_enabled}}"
     properties:

--- a/roles/variables/vars/main.yml
+++ b/roles/variables/vars/main.yml
@@ -620,9 +620,14 @@ kafka_broker_properties:
     properties:
       confluent.metadata.server.auth.ssl.principal.mapping.rules: "{{ principal_mapping_rules | join(',') }}"
   rbac_mds_mtls_only:
-    enabled: "{{ rbac_enabled and not external_mds_enabled and mds_ssl_enabled|bool and auth_mode == 'mtls' }}"
+    enabled: "{{ rbac_enabled and not external_mds_enabled and mds_ssl_enabled|bool and auth_mode == 'mtls' and not mds_file_based_user_store_enabled|bool }}"
     properties:
       confluent.metadata.server.user.store: NONE
+  rbac_mds_file_store:
+    enabled: "{{ rbac_enabled and not external_mds_enabled and mds_file_based_user_store_enabled|bool }}"
+    properties:
+      confluent.metadata.server.user.store: FILE
+      confluent.metadata.server.user.store.file.path: "{{ mds_file_based_user_store_dest_path }}"
   rbac_mds_client_authentication:
     enabled: "{{ rbac_enabled and not external_mds_enabled and mds_ssl_enabled|bool and mds_ssl_client_authentication != 'none' }}"
     properties:
@@ -1796,27 +1801,27 @@ control_center_properties:
     properties:
       confluent.controlcenter.streams.cprest.url: "{{mds_http_protocol}}://{{ groups['kafka_broker'] | default(['localhost']) | confluent.platform.resolve_hostnames(hostvars) | join(':' + mds_port|string + ',' + mds_http_protocol + '://') }}:{{mds_port}}"
   kafka_client_non_mtls:
-    enabled: "{{ auth_mode != 'mtls' or sso_mode != 'oidc' }}" # change this to auth_mode != mtls bcos the auth mode == mtls and sso_mode != oidc is going to be covered in next commented block
+    enabled: "{{ auth_mode != 'mtls' }}" # ldap/oauth enabled, dont omit oauth configs, use control_center_ldap_user or control_center_oauth_user based on oauth_enabled
     properties: "{{ kafka_broker_listeners[control_center_kafka_listener_name] | confluent.platform.client_properties(ssl_enabled, False, ssl_mutual_auth_enabled, sasl_protocol,
                     'confluent.controlcenter.streams.', control_center_truststore_path, control_center_truststore_storepass, public_certificates_enabled, control_center_keystore_path, control_center_keystore_storepass, control_center_keystore_keypass,
                     false, sasl_plain_users_final.control_center.principal, sasl_plain_users_final.control_center.password, sasl_scram_users_final.control_center.principal, sasl_scram_users_final.control_center.password, sasl_scram256_users_final.control_center.principal, sasl_scram256_users_final.control_center.password,
                     kerberos_kafka_broker_primary, control_center_keytab_path, control_center_kerberos_principal|default('c3'),
                     false, control_center_ldap_user, control_center_ldap_password, mds_bootstrap_server_urls, oauth_enabled, control_center_oauth_user, control_center_oauth_password, oauth_groups_scope, oauth_token_uri, idp_self_signed, false) }}"
-  # kafka_client_mtls:
-  #   enabled: "{{ auth_mode == 'mtls' }}" # file based condn add and replace ldap user,pass with file based user pass
-  #   properties: "{{ kafka_broker_listeners[control_center_kafka_listener_name] | confluent.platform.client_properties(ssl_enabled, False, ssl_mutual_auth_enabled, sasl_protocol,
-  #                   'confluent.controlcenter.streams.', control_center_truststore_path, control_center_truststore_storepass, public_certificates_enabled, control_center_keystore_path, control_center_keystore_storepass, control_center_keystore_keypass,
-  #                   false, sasl_plain_users_final.control_center.principal, sasl_plain_users_final.control_center.password, sasl_scram_users_final.control_center.principal, sasl_scram_users_final.control_center.password, sasl_scram256_users_final.control_center.principal, sasl_scram256_users_final.control_center.password,
-  #                   kerberos_kafka_broker_primary, control_center_keytab_path, control_center_kerberos_principal|default('c3'),
-  #                   true, control_center_ldap_user, control_center_ldap_password, mds_bootstrap_server_urls, oauth_enabled, control_center_oauth_user, control_center_oauth_password, oauth_groups_scope, oauth_token_uri, idp_self_signed, false) }}"
-  kafka_client_mtls_sso:
+  kafka_client_mtls: # dont omit oauth configs, i.e use similar to ldap, use mds_file_based_control_center_user
+    enabled: "{{ auth_mode == 'mtls' and sso_mode == 'none' and mds_file_based_user_store_enabled|bool }}" # Todo: if sso and file based both enabled then should we allow it and prefer sso for c3 to kafka or not allow it via config validations
+    properties: "{{ kafka_broker_listeners[control_center_kafka_listener_name] | confluent.platform.client_properties(ssl_enabled, False, ssl_mutual_auth_enabled, sasl_protocol,
+                    'confluent.controlcenter.streams.', control_center_truststore_path, control_center_truststore_storepass, public_certificates_enabled, control_center_keystore_path, control_center_keystore_storepass, control_center_keystore_keypass,
+                    false, sasl_plain_users_final.control_center.principal, sasl_plain_users_final.control_center.password, sasl_scram_users_final.control_center.principal, sasl_scram_users_final.control_center.password, sasl_scram256_users_final.control_center.principal, sasl_scram256_users_final.control_center.password,
+                    kerberos_kafka_broker_primary, control_center_keytab_path, control_center_kerberos_principal|default('c3'),
+                    false, mds_file_based_control_center_user, mds_file_based_control_center_password, mds_bootstrap_server_urls, oauth_enabled, control_center_oauth_user, control_center_oauth_password, oauth_groups_scope, oauth_token_uri, idp_self_signed, false) }}"
+  kafka_client_mtls_sso: # omit oauth configs as they are added via next kafka_client_mtls_sso_token_cert_lcbh section seperately
     enabled: "{{ auth_mode == 'mtls' and sso_mode == 'oidc' }}"
     properties: "{{ kafka_broker_listeners[control_center_kafka_listener_name] | confluent.platform.client_properties(ssl_enabled, False, ssl_mutual_auth_enabled, sasl_protocol,
                     'confluent.controlcenter.streams.', control_center_truststore_path, control_center_truststore_storepass, public_certificates_enabled, control_center_keystore_path, control_center_keystore_storepass, control_center_keystore_keypass,
                     false, sasl_plain_users_final.control_center.principal, sasl_plain_users_final.control_center.password, sasl_scram_users_final.control_center.principal, sasl_scram_users_final.control_center.password, sasl_scram256_users_final.control_center.principal, sasl_scram256_users_final.control_center.password,
                     kerberos_kafka_broker_primary, control_center_keytab_path, control_center_kerberos_principal|default('c3'),
                     true, control_center_ldap_user, control_center_ldap_password, mds_bootstrap_server_urls, oauth_enabled, control_center_oauth_user, control_center_oauth_password, oauth_groups_scope, oauth_token_uri, idp_self_signed, false) }}"
-  kafka_client_mtls_sso_token_cert_lcbh:
+  kafka_client_mtls_sso_token_cert_lcbh: # no username/clientId needed as cert based handler different from the handlers in other cases which do need username/clientId
     enabled: "{{ auth_mode == 'mtls' and sso_mode == 'oidc' }}"
     properties:
       confluent.controlcenter.streams.sasl.jaas.config: |-

--- a/roles/variables/vars/main.yml
+++ b/roles/variables/vars/main.yml
@@ -1611,7 +1611,7 @@ kafka_rest_properties:
                     'client.', kafka_rest_truststore_path, kafka_rest_truststore_storepass, public_certificates_enabled, kafka_rest_keystore_path, kafka_rest_keystore_storepass, kafka_rest_keystore_keypass,
                     false, sasl_plain_users_final.kafka_rest.principal, sasl_plain_users_final.kafka_rest.password, sasl_scram_users_final.kafka_rest.principal, sasl_scram_users_final.kafka_rest.password, sasl_scram256_users_final.kafka_rest.principal, sasl_scram256_users_final.kafka_rest.password,
                     kerberos_kafka_broker_primary, kafka_rest_keytab_path, kafka_rest_kerberos_principal|default('rp'),
-                    false, kafka_rest_ldap_user, kafka_rest_ldap_password, mds_bootstrap_server_urls, oauth_enabled, kafka_rest_oauth_user, kafka_rest_oauth_password, oauth_groups_scope, oauth_token_uri, idp_self_signed, false) }}"
+                    kafka_rest_kafka_listener_name == 'internal_token', kafka_rest_ldap_user, kafka_rest_ldap_password, mds_bootstrap_server_urls, oauth_enabled, kafka_rest_oauth_user, kafka_rest_oauth_password, oauth_groups_scope, oauth_token_uri, idp_self_signed, false) }}"
   kafka_client_password_protection:
     # Edge case for RP only- 'client' prefix not honored by secrets protection
     enabled: "{{ kafka_rest_secrets_protection_enabled }}"
@@ -1800,40 +1800,32 @@ control_center_properties:
     enabled: "{{kafka_broker_rest_proxy_enabled or rbac_enabled }}"
     properties:
       confluent.controlcenter.streams.cprest.url: "{{mds_http_protocol}}://{{ groups['kafka_broker'] | default(['localhost']) | confluent.platform.resolve_hostnames(hostvars) | join(':' + mds_port|string + ',' + mds_http_protocol + '://') }}:{{mds_port}}"
-  kafka_client_non_mtls:
-    enabled: "{{ auth_mode != 'mtls' }}" # ldap/oauth enabled, dont omit oauth configs, use control_center_ldap_user or control_center_oauth_user based on oauth_enabled
+  kafka_client:
+    enabled: true # ignore login callback handler related props using omit_oauth_configs when talking to internal_token listener
     properties: "{{ kafka_broker_listeners[control_center_kafka_listener_name] | confluent.platform.client_properties(ssl_enabled, False, ssl_mutual_auth_enabled, sasl_protocol,
                     'confluent.controlcenter.streams.', control_center_truststore_path, control_center_truststore_storepass, public_certificates_enabled, control_center_keystore_path, control_center_keystore_storepass, control_center_keystore_keypass,
                     false, sasl_plain_users_final.control_center.principal, sasl_plain_users_final.control_center.password, sasl_scram_users_final.control_center.principal, sasl_scram_users_final.control_center.password, sasl_scram256_users_final.control_center.principal, sasl_scram256_users_final.control_center.password,
                     kerberos_kafka_broker_primary, control_center_keytab_path, control_center_kerberos_principal|default('c3'),
-                    false, control_center_ldap_user, control_center_ldap_password, mds_bootstrap_server_urls, oauth_enabled, control_center_oauth_user, control_center_oauth_password, oauth_groups_scope, oauth_token_uri, idp_self_signed, false) }}"
-  kafka_client_mtls: # dont omit oauth configs, i.e use similar to ldap, use mds_file_based_control_center_user
-    enabled: "{{ auth_mode == 'mtls' and sso_mode == 'none' and mds_file_based_user_store_enabled|bool }}" # Todo: if sso and file based both enabled then should we allow it and prefer sso for c3 to kafka or not allow it via config validations
-    properties: "{{ kafka_broker_listeners[control_center_kafka_listener_name] | confluent.platform.client_properties(ssl_enabled, False, ssl_mutual_auth_enabled, sasl_protocol,
-                    'confluent.controlcenter.streams.', control_center_truststore_path, control_center_truststore_storepass, public_certificates_enabled, control_center_keystore_path, control_center_keystore_storepass, control_center_keystore_keypass,
-                    false, sasl_plain_users_final.control_center.principal, sasl_plain_users_final.control_center.password, sasl_scram_users_final.control_center.principal, sasl_scram_users_final.control_center.password, sasl_scram256_users_final.control_center.principal, sasl_scram256_users_final.control_center.password,
-                    kerberos_kafka_broker_primary, control_center_keytab_path, control_center_kerberos_principal|default('c3'),
-                    false, mds_file_based_control_center_user, mds_file_based_control_center_password, mds_bootstrap_server_urls, oauth_enabled, control_center_oauth_user, control_center_oauth_password, oauth_groups_scope, oauth_token_uri, idp_self_signed, false) }}"
-  kafka_client_mtls_sso: # omit oauth configs as they are added via next kafka_client_mtls_sso_token_cert_lcbh section seperately
-    enabled: "{{ auth_mode == 'mtls' and sso_mode == 'oidc' }}"
-    properties: "{{ kafka_broker_listeners[control_center_kafka_listener_name] | confluent.platform.client_properties(ssl_enabled, False, ssl_mutual_auth_enabled, sasl_protocol,
-                    'confluent.controlcenter.streams.', control_center_truststore_path, control_center_truststore_storepass, public_certificates_enabled, control_center_keystore_path, control_center_keystore_storepass, control_center_keystore_keypass,
-                    false, sasl_plain_users_final.control_center.principal, sasl_plain_users_final.control_center.password, sasl_scram_users_final.control_center.principal, sasl_scram_users_final.control_center.password, sasl_scram256_users_final.control_center.principal, sasl_scram256_users_final.control_center.password,
-                    kerberos_kafka_broker_primary, control_center_keytab_path, control_center_kerberos_principal|default('c3'),
-                    true, control_center_ldap_user, control_center_ldap_password, mds_bootstrap_server_urls, oauth_enabled, control_center_oauth_user, control_center_oauth_password, oauth_groups_scope, oauth_token_uri, idp_self_signed, false) }}"
-  kafka_client_mtls_sso_token_cert_lcbh: # no username/clientId needed as cert based handler different from the handlers in other cases which do need username/clientId
-    enabled: "{{ auth_mode == 'mtls' and sso_mode == 'oidc' }}"
+                    control_center_kafka_listener_name == 'internal_token', control_center_ldap_user, control_center_ldap_password, mds_bootstrap_server_urls, oauth_enabled, control_center_oauth_user, control_center_oauth_password, oauth_groups_scope, oauth_token_uri, idp_self_signed, false) }}"
+  kafka_client_token_cert_lcbh: # no username/clientId needed as cert based handler different from the handlers in other cases which do need username/clientId
+    enabled: "{{ control_center_kafka_listener_name == 'internal_token' }}"
     properties:
       confluent.controlcenter.streams.sasl.jaas.config: |-
         org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required metadataServerUrls="{{ mds_bootstrap_server_urls }}";
       confluent.controlcenter.streams.sasl.login.callback.handler.class: io.confluent.kafka.clients.plugins.auth.token.TokenCertificateLoginCallbackHandler
   kafka_interceptors:
-    enabled: true
+    enabled: true # ignore login callback handler related props using omit_oauth_configs when talking to internal_token listener
     properties: "{{ kafka_broker_listeners[control_center_kafka_listener_name] | confluent.platform.client_properties(ssl_enabled, False, ssl_mutual_auth_enabled, sasl_protocol,
                     'confluent.monitoring.interceptor.', control_center_truststore_path, control_center_truststore_storepass, public_certificates_enabled, control_center_keystore_path, control_center_keystore_storepass, control_center_keystore_keypass,
                     false, sasl_plain_users_final.control_center.principal, sasl_plain_users_final.control_center.password, sasl_scram_users_final.control_center.principal, sasl_scram_users_final.control_center.password, sasl_scram256_users_final.control_center.principal, sasl_scram256_users_final.control_center.password,
                     kerberos_kafka_broker_primary, control_center_keytab_path, control_center_kerberos_principal|default('c3'),
-                    false, control_center_ldap_user, control_center_ldap_password, mds_bootstrap_server_urls, oauth_enabled, control_center_oauth_user, control_center_oauth_password, oauth_groups_scope, oauth_token_uri, idp_self_signed, false) }}"
+                    control_center_kafka_listener_name == 'internal_token', control_center_ldap_user, control_center_ldap_password, mds_bootstrap_server_urls, oauth_enabled, control_center_oauth_user, control_center_oauth_password, oauth_groups_scope, oauth_token_uri, idp_self_signed, false) }}"
+  kafka_interceptors_token_cert_lcbh: # no username/clientId needed as cert based handler different from the handlers in other cases which do need username/clientId
+    enabled: "{{ control_center_kafka_listener_name == 'internal_token' }}"
+    properties:
+      confluent.monitoring.interceptor.sasl.jaas.config: |-
+        org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required metadataServerUrls="{{ mds_bootstrap_server_urls }}";
+      confluent.monitoring.interceptor.sasl.login.callback.handler.class: io.confluent.kafka.clients.plugins.auth.token.TokenCertificateLoginCallbackHandler
   sr:
     enabled: "{{ 'schema_registry' in groups }}"
     properties:

--- a/roles/variables/vars/main.yml
+++ b/roles/variables/vars/main.yml
@@ -1795,13 +1795,33 @@ control_center_properties:
     enabled: "{{kafka_broker_rest_proxy_enabled or rbac_enabled }}"
     properties:
       confluent.controlcenter.streams.cprest.url: "{{mds_http_protocol}}://{{ groups['kafka_broker'] | default(['localhost']) | confluent.platform.resolve_hostnames(hostvars) | join(':' + mds_port|string + ',' + mds_http_protocol + '://') }}:{{mds_port}}"
-  kafka_client:
-    enabled: true
+  kafka_client_non_mtls:
+    enabled: "{{ auth_mode != 'mtls' or sso_mode != 'oidc' }}" # change this to auth_mode != mtls bcos the auth mode == mtls and sso_mode != oidc is going to be covered in next commented block
     properties: "{{ kafka_broker_listeners[control_center_kafka_listener_name] | confluent.platform.client_properties(ssl_enabled, False, ssl_mutual_auth_enabled, sasl_protocol,
                     'confluent.controlcenter.streams.', control_center_truststore_path, control_center_truststore_storepass, public_certificates_enabled, control_center_keystore_path, control_center_keystore_storepass, control_center_keystore_keypass,
                     false, sasl_plain_users_final.control_center.principal, sasl_plain_users_final.control_center.password, sasl_scram_users_final.control_center.principal, sasl_scram_users_final.control_center.password, sasl_scram256_users_final.control_center.principal, sasl_scram256_users_final.control_center.password,
                     kerberos_kafka_broker_primary, control_center_keytab_path, control_center_kerberos_principal|default('c3'),
                     false, control_center_ldap_user, control_center_ldap_password, mds_bootstrap_server_urls, oauth_enabled, control_center_oauth_user, control_center_oauth_password, oauth_groups_scope, oauth_token_uri, idp_self_signed, false) }}"
+  # kafka_client_mtls:
+  #   enabled: "{{ auth_mode == 'mtls' }}" # file based condn add and replace ldap user,pass with file based user pass
+  #   properties: "{{ kafka_broker_listeners[control_center_kafka_listener_name] | confluent.platform.client_properties(ssl_enabled, False, ssl_mutual_auth_enabled, sasl_protocol,
+  #                   'confluent.controlcenter.streams.', control_center_truststore_path, control_center_truststore_storepass, public_certificates_enabled, control_center_keystore_path, control_center_keystore_storepass, control_center_keystore_keypass,
+  #                   false, sasl_plain_users_final.control_center.principal, sasl_plain_users_final.control_center.password, sasl_scram_users_final.control_center.principal, sasl_scram_users_final.control_center.password, sasl_scram256_users_final.control_center.principal, sasl_scram256_users_final.control_center.password,
+  #                   kerberos_kafka_broker_primary, control_center_keytab_path, control_center_kerberos_principal|default('c3'),
+  #                   true, control_center_ldap_user, control_center_ldap_password, mds_bootstrap_server_urls, oauth_enabled, control_center_oauth_user, control_center_oauth_password, oauth_groups_scope, oauth_token_uri, idp_self_signed, false) }}"
+  kafka_client_mtls_sso:
+    enabled: "{{ auth_mode == 'mtls' and sso_mode == 'oidc' }}"
+    properties: "{{ kafka_broker_listeners[control_center_kafka_listener_name] | confluent.platform.client_properties(ssl_enabled, False, ssl_mutual_auth_enabled, sasl_protocol,
+                    'confluent.controlcenter.streams.', control_center_truststore_path, control_center_truststore_storepass, public_certificates_enabled, control_center_keystore_path, control_center_keystore_storepass, control_center_keystore_keypass,
+                    false, sasl_plain_users_final.control_center.principal, sasl_plain_users_final.control_center.password, sasl_scram_users_final.control_center.principal, sasl_scram_users_final.control_center.password, sasl_scram256_users_final.control_center.principal, sasl_scram256_users_final.control_center.password,
+                    kerberos_kafka_broker_primary, control_center_keytab_path, control_center_kerberos_principal|default('c3'),
+                    true, control_center_ldap_user, control_center_ldap_password, mds_bootstrap_server_urls, oauth_enabled, control_center_oauth_user, control_center_oauth_password, oauth_groups_scope, oauth_token_uri, idp_self_signed, false) }}"
+  kafka_client_mtls_sso_token_cert_lcbh:
+    enabled: "{{ auth_mode == 'mtls' and sso_mode == 'oidc' }}"
+    properties:
+      confluent.controlcenter.streams.sasl.jaas.config: |-
+        org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required metadataServerUrls="{{ mds_bootstrap_server_urls }}";
+      confluent.controlcenter.streams.sasl.login.callback.handler.class: io.confluent.kafka.clients.plugins.auth.token.TokenCertificateLoginCallbackHandler
   kafka_interceptors:
     enabled: true
     properties: "{{ kafka_broker_listeners[control_center_kafka_listener_name] | confluent.platform.client_properties(ssl_enabled, False, ssl_mutual_auth_enabled, sasl_protocol,

--- a/roles/variables/vars/main.yml
+++ b/roles/variables/vars/main.yml
@@ -1807,11 +1807,9 @@ control_center_properties:
                     false, sasl_plain_users_final.control_center.principal, sasl_plain_users_final.control_center.password, sasl_scram_users_final.control_center.principal, sasl_scram_users_final.control_center.password, sasl_scram256_users_final.control_center.principal, sasl_scram256_users_final.control_center.password,
                     kerberos_kafka_broker_primary, control_center_keytab_path, control_center_kerberos_principal|default('c3'),
                     control_center_kafka_listener_name == 'internal_token', control_center_ldap_user, control_center_ldap_password, mds_bootstrap_server_urls, oauth_enabled, control_center_oauth_user, control_center_oauth_password, oauth_groups_scope, oauth_token_uri, idp_self_signed, false) }}"
-  kafka_client_token_cert_lcbh: # no username/clientId needed as cert based handler different from the handlers in other cases which do need username/clientId
+  kafka_client_token_cert_lcbh:
     enabled: "{{ control_center_kafka_listener_name == 'internal_token' }}"
     properties:
-      confluent.controlcenter.streams.sasl.jaas.config: |-
-        org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required metadataServerUrls="{{ mds_bootstrap_server_urls }}";
       confluent.controlcenter.streams.sasl.login.callback.handler.class: io.confluent.kafka.clients.plugins.auth.token.TokenCertificateLoginCallbackHandler
   kafka_interceptors:
     enabled: true # ignore login callback handler related props using omit_oauth_configs when talking to internal_token listener
@@ -1820,11 +1818,9 @@ control_center_properties:
                     false, sasl_plain_users_final.control_center.principal, sasl_plain_users_final.control_center.password, sasl_scram_users_final.control_center.principal, sasl_scram_users_final.control_center.password, sasl_scram256_users_final.control_center.principal, sasl_scram256_users_final.control_center.password,
                     kerberos_kafka_broker_primary, control_center_keytab_path, control_center_kerberos_principal|default('c3'),
                     control_center_kafka_listener_name == 'internal_token', control_center_ldap_user, control_center_ldap_password, mds_bootstrap_server_urls, oauth_enabled, control_center_oauth_user, control_center_oauth_password, oauth_groups_scope, oauth_token_uri, idp_self_signed, false) }}"
-  kafka_interceptors_token_cert_lcbh: # no username/clientId needed as cert based handler different from the handlers in other cases which do need username/clientId
+  kafka_interceptors_token_cert_lcbh:
     enabled: "{{ control_center_kafka_listener_name == 'internal_token' }}"
     properties:
-      confluent.monitoring.interceptor.sasl.jaas.config: |-
-        org.apache.kafka.common.security.oauthbearer.OAuthBearerLoginModule required metadataServerUrls="{{ mds_bootstrap_server_urls }}";
       confluent.monitoring.interceptor.sasl.login.callback.handler.class: io.confluent.kafka.clients.plugins.auth.token.TokenCertificateLoginCallbackHandler
   sr:
     enabled: "{{ 'schema_registry' in groups }}"


### PR DESCRIPTION
# Description

Changing the C3 to kafka listener from SSL to SASL_SSL in case of SSO.
Using the newly introduced TokenCert Login Callback Handler

Fixes # (issue)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This is tested by merging all PRs for RBAC mtls Brownfield in a single branch and then running the tests on that branch

old after using new TokenCert Handler for SSO in C3
[kraft](https://semaphore.ci.confluent.io/workflows/8d1c71c1-5c98-4471-925a-6a4cd4b089ff?pipeline_id=0d2872e8-65e0-43d5-ba2e-aaa8cdea7518)
[zookeeper](https://semaphore.ci.confluent.io/workflows/0f7a803c-f890-453c-a851-595d1428050a?pipeline_id=290bbf79-49f1-4d33-bbab-5d6124e31e78)

new - after using new TokenCert Handler for SSO and non SSO in C3
[kraft](https://semaphore.ci.confluent.io/workflows/8bd417f8-bb01-474e-92da-c0bdfb7a24b8?pipeline_id=68ec584a-d5f9-40e0-a834-fd0c3ccf49ff)
[zookeeper](https://semaphore.ci.confluent.io/workflows/6f8646b8-97d7-4193-8d51-00f7ec1f863d?pipeline_id=8710e0f4-7199-4cd5-9877-41e99bc3f7f2)

after updating the condition for rest proxy as kafka client creation 
[zookeeper](https://semaphore.ci.confluent.io/workflows/a66b1e74-b295-4210-a1e8-ec681e979ad2?pipeline_id=09290ea4-fd47-4a84-ac0c-dc9fdd739452)

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
