### PR TITLE
[ANSIENG-4993] | restart kafka trigger after adding oauth idp cert to truststore

### DIFF
--- a/roles/common/tasks/idp_certs.yml
+++ b/roles/common/tasks/idp_certs.yml
@@ -36,6 +36,7 @@
       -alias {{alias}} \
       -import -file {{idp_cert_dest}} \
       -storepass {{truststore_storepass}}
+  notify: "{{ restart_handler_name }}"
   when:
     - cert_imported.rc == 1
   no_log: "{{mask_secrets|bool}}"
@@ -63,6 +64,7 @@
       -storepass {{truststore_storepass}} \
       -providerclass org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider \
       -providerpath {{ (binary_base_path, 'share/java/kafka/bc-fips-*.jar') | path_join }}
+  notify: "{{ restart_handler_name }}"
   when:
     - create_bouncy_castle_keystore|bool
     - cert_imported.rc == 1

--- a/roles/control_center/tasks/main.yml
+++ b/roles/control_center/tasks/main.yml
@@ -188,6 +188,7 @@
     truststore_storepass: "{{control_center_truststore_storepass}}"
     truststore_path: "{{control_center_truststore_path}}"
     create_bouncy_castle_keystore: false
+    restart_handler_name: "restart control center"
   when:
     - oauth_enabled|bool or schema_registry_oauth_enabled|bool or kafka_rest_oauth_enabled|bool or kafka_connect_oauth_enabled|bool or kafka_connect_replicator_oauth_enabled|bool
     - oauth_idp_cert_path != ""

--- a/roles/kafka_broker/tasks/main.yml
+++ b/roles/kafka_broker/tasks/main.yml
@@ -169,6 +169,8 @@
     truststore_path: "{{kafka_broker_pkcs12_truststore_path}}"
     bcfks_truststore_path: "{{kafka_broker_bcfks_truststore_path}}"
     create_bouncy_castle_keystore: "{{fips_enabled}}"
+    restart_handler_name: "restart kafka" # adding cert to Truststore requires a restart of the service to get loaded
+    # cant directly call notify handler from include_role task.
   when:
     - oauth_enabled|bool or schema_registry_oauth_enabled|bool or kafka_rest_oauth_enabled|bool or kafka_connect_oauth_enabled|bool or kafka_connect_replicator_oauth_enabled|bool
     - oauth_idp_cert_path != ""
@@ -185,31 +187,12 @@
     truststore_path: "{{kafka_broker_pkcs12_truststore_path}}"
     bcfks_truststore_path: "{{kafka_broker_bcfks_truststore_path}}"
     create_bouncy_castle_keystore: "{{fips_enabled}}"
+    restart_handler_name: "restart kafka" # adding cert to Truststore requires a restart of the service to get loaded
+    # cant directly call notify handler from include_role task.
   when:
     - sso_mode != 'none'
     - sso_idp_cert_path != ""
     - not external_mds_enabled|bool
-
-- name: Trigger Restart on Kafka Broker after Adding Self Signed IDP Certs
-  ansible.builtin.debug:
-    msg: "trigger kafka broker restart"
-  notify: restart kafka
-  when:
-    - >
-      (
-        sso_mode != 'none' and
-        sso_idp_cert_path != "" and
-        not external_mds_enabled|bool
-      ) or (
-        (
-          oauth_enabled|bool or
-          schema_registry_oauth_enabled|bool or
-          kafka_rest_oauth_enabled|bool or
-          kafka_connect_oauth_enabled|bool or
-          kafka_connect_replicator_oauth_enabled|bool
-        ) and
-        oauth_idp_cert_path != ""
-      )
 
 - name: Configure Kerberos
   include_role:

--- a/roles/kafka_broker/tasks/main.yml
+++ b/roles/kafka_broker/tasks/main.yml
@@ -169,7 +169,6 @@
     truststore_path: "{{kafka_broker_pkcs12_truststore_path}}"
     bcfks_truststore_path: "{{kafka_broker_bcfks_truststore_path}}"
     create_bouncy_castle_keystore: "{{fips_enabled}}"
-  notify: restart kafka
   when:
     - oauth_enabled|bool or schema_registry_oauth_enabled|bool or kafka_rest_oauth_enabled|bool or kafka_connect_oauth_enabled|bool or kafka_connect_replicator_oauth_enabled|bool
     - oauth_idp_cert_path != ""
@@ -190,6 +189,27 @@
     - sso_mode != 'none'
     - sso_idp_cert_path != ""
     - not external_mds_enabled|bool
+
+- name: Trigger Restart on Kafka Broker after Adding Self Signed IDP Certs
+  ansible.builtin.debug:
+    msg: "trigger kafka broker restart"
+  notify: restart kafka
+  when:
+    - >
+      (
+        sso_mode != 'none' and
+        sso_idp_cert_path != "" and
+        not external_mds_enabled|bool
+      ) or (
+        (
+          oauth_enabled|bool or
+          schema_registry_oauth_enabled|bool or
+          kafka_rest_oauth_enabled|bool or
+          kafka_connect_oauth_enabled|bool or
+          kafka_connect_replicator_oauth_enabled|bool
+        ) and
+        oauth_idp_cert_path != ""
+      )
 
 - name: Configure Kerberos
   include_role:

--- a/roles/kafka_broker/tasks/main.yml
+++ b/roles/kafka_broker/tasks/main.yml
@@ -169,6 +169,7 @@
     truststore_path: "{{kafka_broker_pkcs12_truststore_path}}"
     bcfks_truststore_path: "{{kafka_broker_bcfks_truststore_path}}"
     create_bouncy_castle_keystore: "{{fips_enabled}}"
+  notify: restart kafka
   when:
     - oauth_enabled|bool or schema_registry_oauth_enabled|bool or kafka_rest_oauth_enabled|bool or kafka_connect_oauth_enabled|bool or kafka_connect_replicator_oauth_enabled|bool
     - oauth_idp_cert_path != ""

--- a/roles/kafka_connect/tasks/main.yml
+++ b/roles/kafka_connect/tasks/main.yml
@@ -180,6 +180,7 @@
     truststore_storepass: "{{kafka_connect_truststore_storepass}}"
     truststore_path: "{{kafka_connect_truststore_path}}"
     create_bouncy_castle_keystore: false
+    restart_handler_name: "restart kafka connect distributed"
   when:
     - oauth_enabled|bool or schema_registry_oauth_enabled|bool or kafka_rest_oauth_enabled|bool or kafka_connect_oauth_enabled|bool or kafka_connect_replicator_oauth_enabled|bool
     - oauth_idp_cert_path != ""

--- a/roles/kafka_connect/tasks/main.yml
+++ b/roles/kafka_connect/tasks/main.yml
@@ -180,7 +180,7 @@
     truststore_storepass: "{{kafka_connect_truststore_storepass}}"
     truststore_path: "{{kafka_connect_truststore_path}}"
     create_bouncy_castle_keystore: false
-    restart_handler_name: "restart kafka connect distributed"
+    restart_handler_name: "restart connect distributed"
   when:
     - oauth_enabled|bool or schema_registry_oauth_enabled|bool or kafka_rest_oauth_enabled|bool or kafka_connect_oauth_enabled|bool or kafka_connect_replicator_oauth_enabled|bool
     - oauth_idp_cert_path != ""

--- a/roles/kafka_connect_replicator/tasks/main.yml
+++ b/roles/kafka_connect_replicator/tasks/main.yml
@@ -319,6 +319,7 @@
     truststore_storepass: "{{kafka_connect_replicator_truststore_storepass}}"
     truststore_path: "{{kafka_connect_replicator_truststore_path}}"
     create_bouncy_castle_keystore: false
+    restart_handler_name: "Restart Kafka Connect Replicator"
   when:
     - oauth_enabled|bool or schema_registry_oauth_enabled|bool or kafka_rest_oauth_enabled|bool or kafka_connect_oauth_enabled|bool or kafka_connect_replicator_oauth_enabled|bool
     - oauth_idp_cert_path != ""

--- a/roles/kafka_controller/tasks/main.yml
+++ b/roles/kafka_controller/tasks/main.yml
@@ -165,6 +165,7 @@
     truststore_path: "{{kafka_controller_pkcs12_truststore_path}}"
     bcfks_truststore_path: "{{kafka_controller_bcfks_truststore_path}}"
     create_bouncy_castle_keystore: "{{fips_enabled}}"
+    restart_handler_name: "restart Kafka Controller"
   when:
     - oauth_enabled|bool or schema_registry_oauth_enabled|bool or kafka_rest_oauth_enabled|bool or kafka_connect_oauth_enabled|bool or kafka_connect_replicator_oauth_enabled|bool
     - oauth_idp_cert_path != ""

--- a/roles/kafka_rest/tasks/main.yml
+++ b/roles/kafka_rest/tasks/main.yml
@@ -167,6 +167,7 @@
     truststore_storepass: "{{kafka_rest_truststore_storepass}}"
     truststore_path: "{{kafka_rest_truststore_path}}"
     create_bouncy_castle_keystore: false
+    restart_handler_name: "restart kafka-rest"
   when:
     - oauth_enabled|bool or schema_registry_oauth_enabled|bool or kafka_rest_oauth_enabled|bool or kafka_connect_oauth_enabled|bool or kafka_connect_replicator_oauth_enabled|bool
     - oauth_idp_cert_path != ""

--- a/roles/ksql/tasks/main.yml
+++ b/roles/ksql/tasks/main.yml
@@ -186,6 +186,7 @@
     truststore_storepass: "{{ksql_truststore_storepass}}"
     truststore_path: "{{ksql_truststore_path}}"
     create_bouncy_castle_keystore: false
+    restart_handler_name: "restart ksql"
   when:
     - oauth_enabled|bool or schema_registry_oauth_enabled|bool or kafka_rest_oauth_enabled|bool or kafka_connect_oauth_enabled|bool or kafka_connect_replicator_oauth_enabled|bool
     - oauth_idp_cert_path != ""

--- a/roles/schema_registry/tasks/main.yml
+++ b/roles/schema_registry/tasks/main.yml
@@ -167,6 +167,7 @@
     truststore_storepass: "{{schema_registry_truststore_storepass}}"
     truststore_path: "{{schema_registry_truststore_path}}"
     create_bouncy_castle_keystore: false
+    restart_handler_name: "restart schema-registry"
   when:
     - oauth_enabled|bool or schema_registry_oauth_enabled|bool or kafka_rest_oauth_enabled|bool or kafka_connect_oauth_enabled|bool or kafka_connect_replicator_oauth_enabled|bool
     - oauth_idp_cert_path != ""


### PR DESCRIPTION
# Description

After adding Certs to truststore a restart should be triggered to load the new certs in MDS.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
