### PR TITLE
[ANSIENG-4993] | restart kafka trigger after adding sso cert to truststore

### DIFF
--- a/roles/common/tasks/idp_certs.yml
+++ b/roles/common/tasks/idp_certs.yml
@@ -35,6 +35,7 @@
       -alias {{alias}} \
       -import -file {{idp_cert_dest}} \
       -storepass {{truststore_storepass}}
+  notify: "{{ restart_handler_name }}"
   when:
     - cert_imported.rc == 1
   no_log: "{{mask_secrets|bool}}"
@@ -61,6 +62,7 @@
       -storepass {{truststore_storepass}} \
       -providerclass org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider \
       -providerpath {{ (binary_base_path, 'share/java/kafka/bc-fips-*.jar') | path_join }}
+  notify: "{{ restart_handler_name }}"
   when:
     - create_bouncy_castle_keystore|bool
     - cert_imported.rc == 1

--- a/roles/kafka_broker/tasks/main.yml
+++ b/roles/kafka_broker/tasks/main.yml
@@ -169,6 +169,7 @@
     truststore_path: "{{kafka_broker_pkcs12_truststore_path}}"
     bcfks_truststore_path: "{{kafka_broker_bcfks_truststore_path}}"
     create_bouncy_castle_keystore: "{{fips_enabled}}"
+  notify: restart kafka
   when:
     - sso_mode != 'none'
     - sso_idp_cert_path != ""

--- a/roles/kafka_broker/tasks/main.yml
+++ b/roles/kafka_broker/tasks/main.yml
@@ -169,22 +169,12 @@
     truststore_path: "{{kafka_broker_pkcs12_truststore_path}}"
     bcfks_truststore_path: "{{kafka_broker_bcfks_truststore_path}}"
     create_bouncy_castle_keystore: "{{fips_enabled}}"
+    restart_handler_name: "restart kafka" # adding cert to Truststore requires a restart of the service to get loaded
+    # cant directly call notify handler from include_role task.
   when:
     - sso_mode != 'none'
     - sso_idp_cert_path != ""
     - not external_mds_enabled|bool
-
-- name: Trigger Restart on Kafka Broker
-  ansible.builtin.debug:
-    msg: "trigger kafka broker restart"
-  notify: restart kafka
-  when:
-    - >
-      (
-        sso_mode != 'none' and
-        sso_idp_cert_path != "" and
-        not external_mds_enabled|bool
-      )
 
 - name: Configure Kerberos
   include_role:

--- a/roles/kafka_broker/tasks/main.yml
+++ b/roles/kafka_broker/tasks/main.yml
@@ -169,11 +169,22 @@
     truststore_path: "{{kafka_broker_pkcs12_truststore_path}}"
     bcfks_truststore_path: "{{kafka_broker_bcfks_truststore_path}}"
     create_bouncy_castle_keystore: "{{fips_enabled}}"
-  notify: restart kafka
   when:
     - sso_mode != 'none'
     - sso_idp_cert_path != ""
     - not external_mds_enabled|bool
+
+- name: Trigger Restart on Kafka Broker
+  ansible.builtin.debug:
+    msg: "trigger kafka broker restart"
+  notify: restart kafka
+  when:
+    - >
+      (
+        sso_mode != 'none' and
+        sso_idp_cert_path != "" and
+        not external_mds_enabled|bool
+      )
 
 - name: Configure Kerberos
   include_role:


### PR DESCRIPTION
# Description

After adding SSO IDP cert to truststore Kafka restart should be triggered.

Fixes # (issue)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
