### PR TITLE
[ANSIENG-4700] | Handle space in certs 7.9.x

### DIFF
--- a/docs/sample_inventories/rbac-over-mtls-file-based-user-store.yml
+++ b/docs/sample_inventories/rbac-over-mtls-file-based-user-store.yml
@@ -44,7 +44,7 @@ all:
 
     # List of super user principals who can get an impersonation token on behalf of other users
     # Needed for principal propogation for Rest Proxy.
-    # To extract dn from cert check use openssl x509 -in <cert> -noout -subject -nameopt RFC2253
+    # To extract dn from cert check use openssl x509 -noout -subject -nameopt RFC2253 -in <cert>
     # using this the dn would be something like 'C=US,ST=Ca,L=PaloAlto,O=CONFLUENT,OU=TEST,CN=kafka_broker'
     # Then applying the principal mapping rules it would give the principal kafka_broker
     impersonation_super_users:

--- a/molecule/certs-create.sh
+++ b/molecule/certs-create.sh
@@ -16,7 +16,7 @@ openssl req -new -x509 \
     -keyout $CA_KEY \
     -out $CA_CRT \
     -days 365 \
-    -subj '/CN=test.confluent.io/OU=TEST/O=CONFLUENT/L=MountainView/S=Ca/C=US' \
+    -subj '/CN=test.confluent.io/OU=TEST TEAM/O=CONFLUENT/L=MountainView/S=Ca/C=US' \
     -passin pass:capassword \
     -passout pass:capassword
 
@@ -69,7 +69,7 @@ for line in `sed '/^$/d' $filename`; do
       keytool -genkeypair -noprompt \
           -keystore $KEYSTORE_FILENAME \
           -alias $alias \
-          -dname "CN=$service,OU=TEST,O=CONFLUENT,L=PaloAlto,ST=Ca,C=US" \
+          -dname "CN=$service,OU=TEST TEAM,O=CONFLUENT,L=PaloAlto,ST=Ca,C=US" \
           -ext $EXT \
           -keyalg RSA \
           -storetype $FORMAT \

--- a/molecule/oauth-rbac-kafka-connect-replicator-kerberos-mtls-custom-rhel/molecule.yml
+++ b/molecule/oauth-rbac-kafka-connect-replicator-kerberos-mtls-custom-rhel/molecule.yml
@@ -199,8 +199,8 @@ provisioner:
         rbac_super_users:
           - User:C=US,ST=Ca,L=PaloAlto,O=CONFLUENT,OU=TEST,CN=kafka_broker
           - User:C=US,ST=Ca,L=PaloAlto,O=CONFLUENT,OU=TEST,CN=kafka_controller
-          - User:CN=kafka_controller,OU=TEST,O=CONFLUENT,L=PaloAlto,ST=Ca,C=US
-          - User:CN=kafka_broker,OU=TEST,O=CONFLUENT,L=PaloAlto,ST=Ca,C=US
+          - User:CN=kafka_controller,OU=TEST TEAM,O=CONFLUENT,L=PaloAlto,ST=Ca,C=US
+          - User:CN=kafka_broker,OU=TEST TEAM,O=CONFLUENT,L=PaloAlto,ST=Ca,C=US
 
         create_mds_certs: false
         token_services_public_pem_file: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/public.pem"

--- a/molecule/rbac-kafka-connect-replicator-kerberos-mtls-custom-debian/molecule.yml
+++ b/molecule/rbac-kafka-connect-replicator-kerberos-mtls-custom-debian/molecule.yml
@@ -164,8 +164,8 @@ provisioner:
         rbac_super_users:
           - User:C=US,ST=Ca,L=PaloAlto,O=CONFLUENT,OU=TEST,CN=kafka_broker
           - User:C=US,ST=Ca,L=PaloAlto,O=CONFLUENT,OU=TEST,CN=kafka_controller
-          - User:CN=kafka_controller,OU=TEST,O=CONFLUENT,L=PaloAlto,ST=Ca,C=US
-          - User:CN=kafka_broker,OU=TEST,O=CONFLUENT,L=PaloAlto,ST=Ca,C=US
+          - User:CN=kafka_controller,OU=TEST TEAM,O=CONFLUENT,L=PaloAlto,ST=Ca,C=US
+          - User:CN=kafka_broker,OU=TEST TEAM,O=CONFLUENT,L=PaloAlto,ST=Ca,C=US
 
         rbac_enabled: true
         debian_java_package_name: openjdk-17-jdk

--- a/molecule/rbac-kafka-connect-replicator-kerberos-mtls-custom-ubuntu/molecule.yml
+++ b/molecule/rbac-kafka-connect-replicator-kerberos-mtls-custom-ubuntu/molecule.yml
@@ -168,8 +168,8 @@ provisioner:
         rbac_super_users:
           - User:C=US,ST=Ca,L=PaloAlto,O=CONFLUENT,OU=TEST,CN=kafka_broker
           - User:C=US,ST=Ca,L=PaloAlto,O=CONFLUENT,OU=TEST,CN=kafka_controller
-          - User:CN=kafka_controller,OU=TEST,O=CONFLUENT,L=PaloAlto,ST=Ca,C=US
-          - User:CN=kafka_broker,OU=TEST,O=CONFLUENT,L=PaloAlto,ST=Ca,C=US
+          - User:CN=kafka_controller,OU=TEST TEAM,O=CONFLUENT,L=PaloAlto,ST=Ca,C=US
+          - User:CN=kafka_broker,OU=TEST TEAM,O=CONFLUENT,L=PaloAlto,ST=Ca,C=US
 
         create_mds_certs: false
         token_services_public_pem_file: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/public.pem"

--- a/molecule/rbac-mds-mtls-custom-kerberos-rhel/molecule.yml
+++ b/molecule/rbac-mds-mtls-custom-kerberos-rhel/molecule.yml
@@ -266,8 +266,8 @@ provisioner:
         rbac_super_users:
           - User:C=US,ST=Ca,L=PaloAlto,O=CONFLUENT,OU=TEST,CN=kafka_broker
           - User:C=US,ST=Ca,L=PaloAlto,O=CONFLUENT,OU=TEST,CN=kafka_controller
-          - User:CN=kafka_controller,OU=TEST,O=CONFLUENT,L=PaloAlto,ST=Ca,C=US
-          - User:CN=kafka_broker,OU=TEST,O=CONFLUENT,L=PaloAlto,ST=Ca,C=US
+          - User:CN=kafka_controller,OU=TEST TEAM,O=CONFLUENT,L=PaloAlto,ST=Ca,C=US
+          - User:CN=kafka_broker,OU=TEST TEAM,O=CONFLUENT,L=PaloAlto,ST=Ca,C=US
 
         create_mds_certs: false
         token_services_public_pem_file: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/public.pem"

--- a/molecule/rbac-mds-mtls-custom-rhel-fips/molecule.yml
+++ b/molecule/rbac-mds-mtls-custom-rhel-fips/molecule.yml
@@ -269,8 +269,8 @@ provisioner:
         rbac_super_users:
           - User:C=US,ST=Ca,L=PaloAlto,O=CONFLUENT,OU=TEST,CN=kafka_broker
           - User:C=US,ST=Ca,L=PaloAlto,O=CONFLUENT,OU=TEST,CN=kafka_controller
-          - User:CN=kafka_controller,OU=TEST,O=CONFLUENT,L=PaloAlto,ST=Ca,C=US
-          - User:CN=kafka_broker,OU=TEST,O=CONFLUENT,L=PaloAlto,ST=Ca,C=US
+          - User:CN=kafka_controller,OU=TEST TEAM,O=CONFLUENT,L=PaloAlto,ST=Ca,C=US
+          - User:CN=kafka_broker,OU=TEST TEAM,O=CONFLUENT,L=PaloAlto,ST=Ca,C=US
 
         create_mds_certs: false
         token_services_public_pem_file: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/public.pem"

--- a/molecule/rbac-mds-mtls-existing-keystore-truststore-ubuntu/molecule.yml
+++ b/molecule/rbac-mds-mtls-existing-keystore-truststore-ubuntu/molecule.yml
@@ -190,9 +190,9 @@ provisioner:
           - User:C=US,ST=Ca,L=PaloAlto,O=CONFLUENT,OU=TEST,CN=kafka_broker
           - User:C=US,ST=Ca,L=PaloAlto,O=CONFLUENT,OU=TEST,CN=kafka_controller
           - User:C=US,ST=Ca,L=PaloAlto,O=CONFLUENT,OU=TEST,CN=kafka_controller_migration
-          - User:CN=kafka_broker,OU=TEST,O=CONFLUENT,L=PaloAlto,ST=Ca,C=US
-          - User:CN=kafka_controller,OU=TEST,O=CONFLUENT,L=PaloAlto,ST=Ca,C=US
-          - User:CN=kafka_controller_migration,OU=TEST,O=CONFLUENT,L=PaloAlto,ST=Ca,C=US
+          - User:CN=kafka_broker,OU=TEST TEAM,O=CONFLUENT,L=PaloAlto,ST=Ca,C=US
+          - User:CN=kafka_controller,OU=TEST TEAM,O=CONFLUENT,L=PaloAlto,ST=Ca,C=US
+          - User:CN=kafka_controller_migration,OU=TEST TEAM,O=CONFLUENT,L=PaloAlto,ST=Ca,C=US
 
         ssl_enabled: true
         ssl_mutual_auth_enabled: true

--- a/molecule/rbac-mds-mtls-existing-keystore-truststore-ubuntu/verify.yml
+++ b/molecule/rbac-mds-mtls-existing-keystore-truststore-ubuntu/verify.yml
@@ -30,8 +30,8 @@
     - name: Assert full dname found in server.properties
       assert:
         that:
-          - "'User:CN=kafka_broker,OU=TEST,O=CONFLUENT,L=PaloAlto,ST=Ca,C=US' in super_users_grep.stdout"
-        fail_msg: "Super Users property: {{super_users_grep.stdout}} does not contain User:CN=kafka_broker,OU=TEST,O=CONFLUENT,L=PaloAlto,ST=Ca,C=US"
+          - "'User:CN=kafka_broker,OU=TEST TEAM,O=CONFLUENT,L=PaloAlto,ST=Ca,C=US' in super_users_grep.stdout"
+        fail_msg: "Super Users property: {{super_users_grep.stdout}} does not contain User:CN=kafka_broker,OU=TEST TEAM,O=CONFLUENT,L=PaloAlto,ST=Ca,C=US"
 
 - name: Verify - kafka_controller
   hosts: kafka_controller

--- a/roles/control_center/tasks/main.yml
+++ b/roles/control_center/tasks/main.yml
@@ -204,7 +204,7 @@
 - name: Configure RBAC for mTLS User
   include_tasks: rbac.yml
   vars:
-    c3_user: "{{ks_extracted_principal}}"
+    c3_user: "{{ ks_extracted_principal | urlencode }}"
   when:
     - rbac_enabled|bool
     - mds_ssl_client_authentication != 'none'

--- a/roles/control_center_next_gen/tasks/main.yml
+++ b/roles/control_center_next_gen/tasks/main.yml
@@ -336,7 +336,7 @@
 - name: Configure RBAC for mTLS User
   include_tasks: rbac.yml
   vars:
-    c3_user: "{{ks_extracted_principal}}"
+    c3_user: "{{ ks_extracted_principal | urlencode }}"
   when:
     - rbac_enabled|bool
     - mds_ssl_client_authentication != 'none'

--- a/roles/kafka_connect/tasks/deploy_connectors.yml
+++ b/roles/kafka_connect/tasks/deploy_connectors.yml
@@ -21,7 +21,7 @@
 - name: Add Role Bindings for Connect mTLS User
   include_tasks: rbac_connectors.yml
   vars:
-    connect_user: "{{ks_extracted_principal}}"
+    connect_user: "{{ ks_extracted_principal | urlencode }}"
   when:
     - rbac_enabled|bool
     - mds_ssl_client_authentication != 'none'

--- a/roles/kafka_connect/tasks/main.yml
+++ b/roles/kafka_connect/tasks/main.yml
@@ -182,7 +182,7 @@
 - name: Configure RBAC for mTLS User
   include_tasks: rbac.yml
   vars:
-    connect_user: "{{ks_extracted_principal}}"
+    connect_user: "{{ ks_extracted_principal | urlencode }}"
   when:
     - rbac_enabled|bool
     - mds_ssl_client_authentication != 'none'

--- a/roles/kafka_connect_replicator/tasks/main.yml
+++ b/roles/kafka_connect_replicator/tasks/main.yml
@@ -271,7 +271,7 @@
 - name: Configure RBAC on Replicator configuration for mTLS User
   include_tasks: rbac_replicator.yml
   vars:
-    replicator_user: "{{ks_extracted_principal}}"
+    replicator_user: "{{ ks_extracted_principal | urlencode }}"
   when:
     - kafka_connect_replicator_rbac_enabled|bool
     - mds_ssl_client_authentication != 'none'
@@ -307,7 +307,7 @@
 - name: Configure RBAC on Replicator Consumer configuration for mTLS User
   include_tasks: rbac_replicator_consumer.yml
   vars:
-    replicator_consumer_user: "{{ks_extracted_principal}}"
+    replicator_consumer_user: "{{ ks_extracted_principal | urlencode }}"
   when:
     - kafka_connect_replicator_consumer_rbac_enabled|bool
     - not kafka_connect_replicator_oauth_enabled
@@ -344,7 +344,7 @@
 - name: Configure RBAC on Replicator Producer configuration for mTLS User
   include_tasks: rbac_replicator_producer.yml
   vars:
-    replicator_producer_user: "{{ks_extracted_principal}}"
+    replicator_producer_user: "{{ ks_extracted_principal | urlencode }}"
   when:
     - kafka_connect_replicator_producer_rbac_enabled|bool
     - not kafka_connect_replicator_oauth_enabled
@@ -381,7 +381,7 @@
 - name: Configure RBAC on Replicator monitoring interceptor configuration for mTLS User
   include_tasks: rbac_replicator_monitoring.yml
   vars:
-    replicator_monitoring_user: "{{ks_extracted_principal}}"
+    replicator_monitoring_user: "{{ ks_extracted_principal | urlencode }}"
   when:
     - kafka_connect_replicator_monitoring_interceptor_rbac_enabled|bool
     - not kafka_connect_replicator_oauth_enabled

--- a/roles/kafka_rest/tasks/main.yml
+++ b/roles/kafka_rest/tasks/main.yml
@@ -198,7 +198,7 @@
 - name: Configure RBAC for mTLS User
   include_tasks: rbac.yml
   vars:
-    rest_user: "{{ks_extracted_principal}}"
+    rest_user: "{{ ks_extracted_principal | urlencode }}"
   when:
     - rbac_enabled|bool
     - mds_ssl_client_authentication != 'none'

--- a/roles/ksql/tasks/main.yml
+++ b/roles/ksql/tasks/main.yml
@@ -188,7 +188,7 @@
 - name: Configure RBAC on KSQL for mTLS User
   include_tasks: rbac.yml
   vars:
-    ksqldb_user: "{{ks_extracted_principal}}"
+    ksqldb_user: "{{ ks_extracted_principal | urlencode }}"
   when:
     - rbac_enabled|bool
     - mds_ssl_client_authentication != 'none'

--- a/roles/schema_registry/tasks/main.yml
+++ b/roles/schema_registry/tasks/main.yml
@@ -183,7 +183,7 @@
 - name: Configure RBAC for mTLS User
   include_tasks: rbac.yml
   vars:
-    sr_user: "{{ks_extracted_principal}}"
+    sr_user: "{{ ks_extracted_principal | urlencode }}"
   when:
     - rbac_enabled|bool
     - mds_ssl_client_authentication != 'none'


### PR DESCRIPTION
# Description

Handle Spaces in Cert principals. Space is not allowed in urls. It should be properly encoded before putting in urls. Thus using urlencode filter to do that.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
