### PR TITLE
[ANSIENG-4681] | Replace Deprecated mTLS Variable

### DIFF
--- a/docs/sample_inventories/fips.yml
+++ b/docs/sample_inventories/fips.yml
@@ -12,7 +12,8 @@ all:
     ansible_ssh_private_key_file: /home/ec2-user/guest.pem
 
     ssl_enabled: true
-    ssl_mutual_auth_enabled: true
+    # ssl_mutual_auth_enabled: true  Deprecated in 7.8.x, use ssl_client_authentication instead
+    ssl_client_authentication: required  # <required/requested/none>
     # Specify the java package if required. FIPS is supported 7.3.x onwards for both java8 and java11
     # redhat_java_package_name: java-11-openjdk
     fips_enabled: true

--- a/docs/sample_inventories/kafka_connect_replicator.yml
+++ b/docs/sample_inventories/kafka_connect_replicator.yml
@@ -11,7 +11,8 @@ kafka_connect_replicator:
   vars:
     kafka_connect_replicator_listener:
       ssl_enabled: true
-      ssl_mutual_auth_enabled: false
+    # ssl_mutual_auth_enabled: false  Deprecated in 7.8.x, use ssl_client_authentication instead
+      ssl_client_authentication: none  # <required/requested/none>
       sasl_protocol: kerberos
 
     kafka_connect_replicator_white_list: test-replicator-source
@@ -25,7 +26,8 @@ kafka_connect_replicator:
 
     kafka_connect_replicator_consumer_listener:
       ssl_enabled: true
-      ssl_mutual_auth_enabled: false
+    # ssl_mutual_auth_enabled: false  Deprecated in 7.8.x, use ssl_client_authentication instead
+      ssl_client_authentication: none  # <required/requested/none>
       sasl_protocol: plain
 
     kafka_connect_replicator_consumer_bootstrap_servers: ip-10-0-0-250.eu-west-2.compute.internal:9092
@@ -38,7 +40,8 @@ kafka_connect_replicator:
 
     kafka_connect_replicator_producer_listener:
       ssl_enabled: true
-      ssl_mutual_auth_enabled: false
+    # ssl_mutual_auth_enabled: false  Deprecated in 7.8.x, use ssl_client_authentication instead
+      ssl_client_authentication: none  # <required/requested/none>
       sasl_protocol: kerberos
 
     kafka_connect_replicator_producer_bootstrap_servers: ip-10-0-0-223.eu-west-2.compute.internal:9092
@@ -53,7 +56,8 @@ kafka_connect_replicator:
 
     kafka_connect_replicator_monitoring_interceptor_listener:
       ssl_enabled: true
-      ssl_mutual_auth_enabled: false
+    # ssl_mutual_auth_enabled: false  Deprecated in 7.8.x, use ssl_client_authentication instead
+      ssl_client_authentication: none  # <required/requested/none>
       sasl_protocol: kerberos
 
     kafka_connect_replicator_monitoring_interceptor_bootstrap_servers: ip-10-0-0-10.eu-west-2.compute.internal:9092

--- a/docs/sample_inventories/kafka_connect_replicator_rbac.yml
+++ b/docs/sample_inventories/kafka_connect_replicator_rbac.yml
@@ -11,7 +11,8 @@ kafka_connect_replicator:
   vars:
     kafka_connect_replicator_listener:
       ssl_enabled: true
-      ssl_mutual_auth_enabled: false
+    # ssl_mutual_auth_enabled: false  Deprecated in 7.8.x, use ssl_client_authentication instead
+      ssl_client_authentication: none  # <required/requested/none>
       sasl_protocol: oauth
 
     kafka_connect_replicator_cluster_name: replicator
@@ -35,7 +36,8 @@ kafka_connect_replicator:
 
     kafka_connect_replicator_consumer_listener:
       ssl_enabled: true
-      ssl_mutual_auth_enabled: false
+    # ssl_mutual_auth_enabled: false  Deprecated in 7.8.x, use ssl_client_authentication instead
+      ssl_client_authentication: none  # <required/requested/none>
       sasl_protocol: plain
 
     kafka_connect_replicator_consumer_bootstrap_servers: ip-10-0-0-250.eu-west-2.compute.internal:9092
@@ -56,7 +58,8 @@ kafka_connect_replicator:
 
     kafka_connect_replicator_producer_listener:
       ssl_enabled: true
-      ssl_mutual_auth_enabled: false
+    # ssl_mutual_auth_enabled: false  Deprecated in 7.8.x, use ssl_client_authentication instead
+      ssl_client_authentication: none  # <required/requested/none>
       sasl_protocol: kerberos
 
     kafka_connect_replicator_producer_bootstrap_servers: ip-10-0-0-10.eu-west-2.compute.internal:9092
@@ -82,7 +85,8 @@ kafka_connect_replicator:
 
     kafka_connect_replicator_monitoring_interceptor_listener:
       ssl_enabled: true
-      ssl_mutual_auth_enabled: false
+    # ssl_mutual_auth_enabled: false  Deprecated in 7.8.x, use ssl_client_authentication instead
+      ssl_client_authentication: none  # <required/requested/none>
       sasl_protocol: kerberos
 
     kafka_connect_replicator_monitoring_interceptor_bootstrap_servers: ip-10-0-0-10.eu-west-2.compute.internal:9092

--- a/docs/sample_inventories/mtls_kraft.yml
+++ b/docs/sample_inventories/mtls_kraft.yml
@@ -11,7 +11,8 @@ all:
     ansible_python_interpreter: /usr/bin/python3
 
     ssl_enabled: true
-    ssl_mutual_auth_enabled: true
+    # ssl_mutual_auth_enabled: true  Deprecated in 7.8.x, use ssl_client_authentication instead
+    ssl_client_authentication: required  # <required/requested/none>
 
 
 kafka_controller:

--- a/docs/sample_inventories/rbac-over-mtls-centralized-mds
+++ b/docs/sample_inventories/rbac-over-mtls-centralized-mds
@@ -30,7 +30,8 @@ all:
     mds_bootstrap_server_urls: https://mds-kafka-broker1:8090,https://mds-kafka-broker2:8090
     mds_broker_listener:
       ssl_enabled: true
-      ssl_mutual_auth_enabled: true
+      # ssl_mutual_auth_enabled: true  Deprecated in 7.8.x, use ssl_client_authentication instead
+      ssl_client_authentication: required  # <required/requested/none>
       sasl_protocol: none
 
     # This should be a superuser cert. In cases of LDAP/OAuth based setup we only needed user names or client id of super user inside this cluster to give role bindings to all components like SR/RP/Connect. Here we need a certificate whose principal is super user in MDS.
@@ -41,7 +42,7 @@ all:
     token_services_public_pem_file: /home/ec2-user/keys/public.pem
     token_services_private_pem_file: /home/ec2-user/keys/tokenKeypair.pem
 
-    # ssl_mutual_auth_enabled: true  Deprecated in 7.8.x
+    # ssl_mutual_auth_enabled: true  Deprecated in 7.8.x, use ssl_client_authentication instead
     ssl_client_authentication: required  # <required/requested/none>
     # Sets mTLS on kafka broker listeners
 

--- a/docs/sample_inventories/rbac-over-mtls-file-based-user-store.yml
+++ b/docs/sample_inventories/rbac-over-mtls-file-based-user-store.yml
@@ -24,7 +24,7 @@ all:
     rbac_enabled: true
     auth_mode: mtls # MDS server will use mTLS certs for authentication, no user store like ldap/oauth will be setup on server
 
-    # ssl_mutual_auth_enabled: true  Deprecated in 7.8.x
+    # ssl_mutual_auth_enabled: true  Deprecated in 7.8.x, use ssl_client_authentication instead
     ssl_client_authentication: required  # <required/requested/none>
     # Sets mTLS on kafka broker listeners
 

--- a/docs/sample_inventories/rbac-over-oauth-and-mtls.yml
+++ b/docs/sample_inventories/rbac-over-oauth-and-mtls.yml
@@ -26,7 +26,7 @@ all:
     rbac_enabled: true
     auth_mode: oauth  # This sets up MDS so that it can accept OAuth token. Due to mds_ssl_client_authentication MDS can also accept certs for authnz.
 
-    # ssl_mutual_auth_enabled: true  Deprecated in 7.8.x
+    # ssl_mutual_auth_enabled: true  Deprecated in 7.8.x, use ssl_client_authentication instead
     ssl_client_authentication: required  # <required/requested/none>
     # Sets mtls on kafka broker listeners
 

--- a/docs/sample_inventories/rbac_centralized_mds_kerberos_custom_certs_example.yml
+++ b/docs/sample_inventories/rbac_centralized_mds_kerberos_custom_certs_example.yml
@@ -34,7 +34,8 @@ all:
     mds_bootstrap_server_urls: https://mds-kafka-broker1:8090,https://mds-kafka-broker2:8090
     mds_broker_listener:
       ssl_enabled: true
-      ssl_mutual_auth_enabled: true
+      # ssl_mutual_auth_enabled: true  Deprecated in 7.8.x, use ssl_client_authentication instead
+      ssl_client_authentication: required  # <required/requested/none>
       sasl_protocol: none
 
     create_mds_certs: false

--- a/docs/sample_inventories/single_dev_node.yml
+++ b/docs/sample_inventories/single_dev_node.yml
@@ -149,7 +149,8 @@ all:
 
     ssl_enabled: true
     mds_ssl_enabled: true
-    ssl_mutual_auth_enabled: false
+    # ssl_mutual_auth_enabled: false  Deprecated in 7.8.x, use ssl_client_authentication instead
+    ssl_client_authentication: none  # <required/requested/none>
 
     #### SSL Configuration ####
     # yamllint disable
@@ -193,7 +194,8 @@ all:
     ## ssl_enabled is set to true.
     ## To enable TLS encryption and mTLS authentication uncomment below
     zookeeper_ssl_enabled: false
-    zookeeper_ssl_mutual_auth_enabled: false
+  # zookeeper_ssl_mutual_auth_enabled: false  Deprecated in 7.8.x, use zookeeper_ssl_client_authentication instead
+    zookeeper_ssl_client_authentication: none  # <required/requested/none>
 
     #### Monitoring Configuration ####
     ## Jolokia
@@ -275,19 +277,22 @@ all:
     #     name: MTLS
     #     port: 9096
     #     ssl_enabled: true
-    #     ssl_mutual_auth_enabled: true
+    #     ssl_mutual_auth_enabled: true  Deprecated in 7.8.x, use ssl_client_authentication instead
+    #     ssl_client_authentication: required  # <required/requested/none>
     #     sasl_protocol: none
     #   ldaps_listener:
     #     name: LDAPS
     #     port: 9097
     #     ssl_enabled: true
-    #     ssl_mutual_auth_enabled: false
+    #     ssl_mutual_auth_enabled: false  Deprecated in 7.8.x, use ssl_client_authentication instead
+    #     ssl_client_authentication: none  # <required/requested/none>
     #     sasl_protocol: plain
     #   ldap_listener:
     #     name: ldap
     #     port: 9098
     #     ssl_enabled: false
-    #     ssl_mutual_auth_enabled: false
+    #     ssl_mutual_auth_enabled: false  Deprecated in 7.8.x, use ssl_client_authentication instead
+    #     ssl_client_authentication: none  # <required/requested/none>
     #     sasl_protocol: plain
     # yamllint enable
 


### PR DESCRIPTION
# Description

Replace deprecated mTLS parameter `ssl_mutual_auth_enabled` by `ssl_client_authentication` in sample inventories

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
