### PR TITLE
fix: add no_log to prevent the masterkey to be leak in the ansible logs

### DIFF
--- a/roles/common/tasks/secrets_protection.yml
+++ b/roles/common/tasks/secrets_protection.yml
@@ -74,12 +74,14 @@
   vars:
     ansible_connection: local
     ansible_become: "{{ ansible_become_localhost }}"
+  no_log: "{{mask_secrets|bool}}"
   register: slurped_masterkey
   when: not secrets_protection_masterkey
 
 - name: Save Master Encryption Key
   set_fact:
     secrets_protection_masterkey: "{{ slurped_masterkey.content|b64decode}}"
+  no_log: "{{mask_secrets|bool}}"
   when: not secrets_protection_masterkey
 
 - name: Create Encrypt Properties List


### PR DESCRIPTION
# Description

Add no_log parameter to prevent the masterkey from being leaked in the ansible logs when using the secrets protection feature.
Related to this issue raised with Confluent Support: 269270

Fixes #269270 (MasterKey)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested on our deployments from the fork and confirmed that the masterkey doesn't appear in the ansible logs.

# Checklist:

- [X] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [X] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
