### PR TITLE
fix: hostname resolution in the kafka broker health check with secrets protection

### DIFF
--- a/roles/kafka_broker/tasks/health_check.yml
+++ b/roles/kafka_broker/tasks/health_check.yml
@@ -17,7 +17,7 @@
 
 - name: Get Topics with UnderReplicatedPartitions with Secrets Protection enabled
   shell: |
-    {{ binary_base_path }}/bin/kafka-topics --bootstrap-server {{inventory_hostname}}:{{kafka_broker_listeners[kafka_broker_inter_broker_listener_name]['port']}} \
+    {{ binary_base_path }}/bin/kafka-topics --bootstrap-server {{ hostvars[inventory_hostname]|confluent.platform.resolve_hostname }}:{{kafka_broker_listeners[kafka_broker_inter_broker_listener_name]['port']}} \
       --describe --under-replicated-partitions --command-config {{kafka_broker.client_config_file}}
   environment:
     CONFLUENT_SECURITY_MASTER_KEY: "{{ secrets_protection_masterkey }}"


### PR DESCRIPTION
# Description

Use the filter "confluent.platform.resolve_hostname" in the kafka_broker health_check step when the secrets protection feature is used instead of simply using the "inventory_hostname" variable. This is required when using the "hostname_aliasing_enabled" variable.

Related to this issue raised with Confluent Support: 269270

Fixes #269270 (Hostname resolution)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested on our deployments from the fork and confirmed that the health check step works as expected when using the secrets protection feature.

# Checklist:

- [X] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [X] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
