### PR TITLE
Ldaps fips image upgrade fix ansieng 3433

### DIFF
--- a/molecule/Dockerfile-centos8-base.j2
+++ b/molecule/Dockerfile-centos8-base.j2
@@ -1,0 +1,41 @@
+FROM {{ item.image }}
+LABEL maintainer="CP Ansible"
+ENV container=docker
+
+RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == \
+systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+rm -f /lib/systemd/system/multi-user.target.wants/*;\
+rm -f /etc/systemd/system/*.wants/*;\
+rm -f /lib/systemd/system/local-fs.target.wants/*; \
+rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+rm -f /lib/systemd/system/basic.target.wants/*;\
+rm -f /lib/systemd/system/anaconda.target.wants/*;
+
+# Fix EOL Mirror issue
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-*
+RUN sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-Linux-*
+
+# To install config manager
+RUN yum -y install dnf-plugins-core
+
+# To enable powertools repo which contains openldap-servers pkg
+RUN yum -y config-manager --set-enabled powertools
+
+# Install requirements.
+RUN yum -y install rpm \
+ && yum -y update \
+ && yum -y install sudo vim-enhanced \
+ && yum clean all
+
+# Disable requiretty.
+RUN sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers
+
+VOLUME ["/sys/fs/cgroup"]
+CMD ["/usr/lib/systemd/systemd"]
+
+RUN yum -y install java-11-openjdk \
+      rsync \
+      openssl \
+      procps \
+      procps-ng

--- a/molecule/rbac-mds-mtls-custom-rhel-fips/molecule.yml
+++ b/molecule/rbac-mds-mtls-custom-rhel-fips/molecule.yml
@@ -15,8 +15,8 @@ platforms:
     hostname: mds-ldap1.confluent
     groups:
       - ldap_server
-    image: geerlingguy/docker-centos7-ansible
-    dockerfile: ../Dockerfile.j2
+    image: centos:centos8
+    dockerfile: ../Dockerfile-centos8-base.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/molecule/rbac-mds-plain-custom-rhel-fips/molecule.yml
+++ b/molecule/rbac-mds-plain-custom-rhel-fips/molecule.yml
@@ -16,8 +16,8 @@ platforms:
     hostname: mds-ldap1.confluent
     groups:
       - ldap_server
-    image: geerlingguy/docker-centos7-ansible
-    dockerfile: ../Dockerfile.j2
+    image: centos:centos8
+    dockerfile: ../Dockerfile-centos8-base.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/molecule/rbac-mtls-rhel-fips/molecule.yml
+++ b/molecule/rbac-mtls-rhel-fips/molecule.yml
@@ -15,8 +15,8 @@ platforms:
     hostname: ldap1.confluent
     groups:
       - ldap_server
-    image: geerlingguy/docker-centos7-ansible
-    dockerfile: ../Dockerfile.j2
+    image: centos:centos8
+    dockerfile: ../Dockerfile-centos8-base.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/molecule/rbac-scram-custom-rhel-fips/molecule.yml
+++ b/molecule/rbac-scram-custom-rhel-fips/molecule.yml
@@ -16,8 +16,8 @@ platforms:
     hostname: ldap1${BUILD_NUMBER}.confluent${BUILD_NUMBER}
     groups:
       - ldap_server
-    image: geerlingguy/docker-centos7-ansible
-    dockerfile: ../Dockerfile.j2
+    image: centos:centos8
+    dockerfile: ../Dockerfile-centos8-base.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro


### PR DESCRIPTION
# Description

Test scenarios with LDAP server fips enabled are failing in 7.5.x due to older image version of centos OS. Made the versions same as 7.6.x and added the similar dockerfile

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
