### PR TITLE
feat: add possibility to customize logger in log4j

### DIFF
--- a/roles/common/tasks/update_log4j.yml
+++ b/roles/common/tasks/update_log4j.yml
@@ -6,6 +6,15 @@
     replace: 'log4j.rootLogger={{log4j_root_logger}}'
   notify: "{{handler}}"
 
+- name: Replace loggers
+  replace:
+    path: "{{log4j_file}}"
+    regexp: 'log4j.logger.{{item.logger}}=.*'
+    replace: 'log4j.logger.{{item.logger}}={{item.value}}'
+  notify: "{{handler}}"
+  when: log4j_replace_loggers is defined
+  with_items: "{{log4j_replace_loggers}}"
+
 - name: Replace DailyRollingFileAppender with RollingFileAppender
   replace:
     path: "{{log4j_file}}"

--- a/roles/kafka_broker/defaults/main.yml
+++ b/roles/kafka_broker/defaults/main.yml
@@ -4,6 +4,13 @@
 ### Boolean to reconfigure Kafka's logging with RollingFileAppender and log cleanup
 kafka_broker_custom_log4j: "{{ custom_log4j }}"
 
+### List of loggers to be replaced in the log4j file. Only honored if kafka_broker_custom_log4j: true
+### Example
+### kafka_broker_log4j_replace_loggers:
+### - { logger: "kafka", value: "INFO" }
+### - { logger: "org.apache.kafka", value: "INFO" }
+kafka_broker_log4j_replace_loggers: []
+
 ### Root logger within Kafka's log4j config. Only honored if kafka_broker_custom_log4j: true
 kafka_broker_log4j_root_logger: "INFO, stdout, kafkaAppender"
 

--- a/roles/kafka_broker/tasks/main.yml
+++ b/roles/kafka_broker/tasks/main.yml
@@ -272,7 +272,8 @@
     log4j_file: "{{kafka_broker.log4j_file}}"
     log4j_max_backup_index: "{{kafka_broker_max_log_files}}"
     log4j_max_file_size: "{{kafka_broker_log_file_size}}"
-    log4j_root_logger: "{{kafka_broker_log4j_root_logger}}"
+    log4j_root_logger: "{kafka_broker_log4j_root_logger}}"
+    log4j_replace_loggers: "{{kafka_broker_log4j_replace_loggers}}"
     handler: "restart kafka"
   when: kafka_broker_custom_log4j|bool
   tags:


### PR DESCRIPTION
# Description

We need the possiblity to override more the just the root logger in the log4j file for kafka broker.
This PR add the possiblity to override a list of loggers using the update_log4j task in the common role.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This has been deployed using our forked repo in our environments.
Like this: 
```
kafka_broker_log4j_replace_loggers:
  - { logger: "kafka", value: "INFO" }
  - { logger: "org.apache.kafka", value: "INFO" }
```

# Checklist:

- [X] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
