### PR TITLE
fix: 269270 idempotency when using secrets protection feature

### DIFF
--- a/roles/common/tasks/secrets_protection.yml
+++ b/roles/common/tasks/secrets_protection.yml
@@ -66,6 +66,7 @@
     group: "{{ secrets_file_group }}"
     mode: '640'
   diff: "{{ not mask_sensitive_diff|bool }}"
+  when: regenerate_masterkey|bool
 
 - name: Load masterkey
   slurp:

--- a/roles/control_center/tasks/main.yml
+++ b/roles/control_center/tasks/main.yml
@@ -178,6 +178,11 @@
     - configuration
     - filesystem
 
+- name: Get control center secrets protection file status
+  stat:
+    path: "{{ control_center_secrets_protection_file }}"
+  register: control_center_secrets_protection_file_status
+
 - name: Create Control Center Config
   template:
     src: control-center.properties.j2
@@ -187,8 +192,14 @@
     group: "{{control_center_group}}"
   notify: restart control center
   diff: "{{ not mask_sensitive_diff|bool }}"
+  when: not control_center_secrets_protection_enabled|bool or not control_center_secrets_protection_file_status.stat.exists
   tags:
     - configuration
+
+- name: Empty master key fact when regenerate_masterkey
+  set_fact:
+    secrets_protection_masterkey: ""
+  when: regenerate_masterkey|bool
 
 - name: Create Control Center Config with Secrets Protection
   include_role:

--- a/roles/kafka_broker/tasks/main.yml
+++ b/roles/kafka_broker/tasks/main.yml
@@ -218,6 +218,10 @@
   tags:
     - filesystem
 
+- name: Get kafka broker secrets protection file status
+  stat:
+    path: "{{ kafka_broker_secrets_protection_file }}"
+  register: kafka_broker_secrets_protection_file_status
 
 - name: Create Kafka Broker Config
   template:
@@ -228,8 +232,14 @@
     group: "{{kafka_broker_group}}"
   notify: restart kafka
   diff: "{{ not mask_sensitive_diff|bool }}"
+  when: not kafka_broker_secrets_protection_enabled|bool or not kafka_broker_secrets_protection_file_status.stat.exists
   tags:
     - configuration
+
+- name: Get kafka broker client secrets protection file status
+  stat:
+    path: "{{ kafka_broker_client_secrets_protection_file }}"
+  register: kafka_broker_client_secrets_protection_file_status
 
 - name: Create Kafka Broker Client Config
   template:
@@ -239,6 +249,7 @@
     owner: "{{kafka_broker_user}}"
     group: "{{kafka_broker_group}}"
   diff: "{{ not mask_sensitive_diff|bool }}"
+  when: not kafka_broker_client_secrets_protection_enabled|bool or not kafka_broker_client_secrets_protection_file_status.stat.exists
   tags:
     - configuration
 

--- a/roles/kafka_broker/tasks/secrets_protection.yml
+++ b/roles/kafka_broker/tasks/secrets_protection.yml
@@ -1,4 +1,9 @@
 ---
+- name: Empty master key fact when regenerate_masterkey
+  set_fact:
+    secrets_protection_masterkey: ""
+  when: regenerate_masterkey|bool
+
 - name: Create Kafka Broker Config with Secrets Protection
   include_role:
     name: common
@@ -40,6 +45,7 @@
     mode: '640'
     owner: root
     group: root
+  notify: restart kafka
   diff: "{{ not mask_sensitive_diff|bool }}"
   tags:
     - systemd

--- a/roles/kafka_connect/tasks/main.yml
+++ b/roles/kafka_connect/tasks/main.yml
@@ -166,6 +166,11 @@
   tags:
     - filesystem
 
+- name: Get kafka connect secrets protection file status
+  stat:
+    path: "{{ kafka_connect_secrets_protection_file }}"
+  register: kafka_connect_secrets_protection_file_status
+
 - name: Create Kafka Connect Config
   template:
     src: connect-distributed.properties.j2
@@ -175,8 +180,14 @@
     group: "{{kafka_connect_group}}"
   notify: restart connect distributed
   diff: "{{ not mask_sensitive_diff|bool }}"
+  when: not kafka_connect_secrets_protection_enabled|bool or not kafka_connect_secrets_protection_file_status.stat.exists
   tags:
     - configuration
+
+- name: Empty master key fact when regenerate_masterkey
+  set_fact:
+    secrets_protection_masterkey: ""
+  when: regenerate_masterkey|bool
 
 - name: Create Kafka Connect Config with Secrets Protection
   include_role:


### PR DESCRIPTION
# Description

Fixes idempotency on config files when using secrets protection feature.
The plain version of the config files are always generated over the encrypted ones when the role is executed multiple times, causing unnecessary services restarts.
This fix checks for the existence of the secrets_protection_file so it only generate the plain config file when needed: 
- On first install
- When secrets protection is not in use

I have also noted that the masterkey is not correctly regenerated when passing the regenerate_masterkey variable. Overwriting the value to an empty string does the trick.

Fixes # 269270 (support ticket)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This has been deployed in our environments using our forked repository.

# Checklist:

- [X] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [X] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
