### PR TITLE
Narrow proxy_env scope.

### DIFF
--- a/playbooks/all.yml
+++ b/playbooks/all.yml
@@ -2,7 +2,6 @@
 - name: Host Prerequisites
   hosts: kafka_controller:kafka_broker:schema_registry:kafka_connect:ksql:control_center_next_gen:kafka_rest:kafka_connect_replicator
   gather_facts: false
-  environment: "{{ proxy_env }}"
   tasks:
     - import_role:
         name: variables

--- a/playbooks/control_center_next_gen.yml
+++ b/playbooks/control_center_next_gen.yml
@@ -3,7 +3,6 @@
   hosts: control_center_next_gen
   gather_facts: false
   tags: control_center_next_gen
-  environment: "{{ proxy_env }}"
   tasks:
     - import_role:
         name: variables
@@ -26,7 +25,6 @@
   hosts: control_center_next_gen_parallel
   gather_facts: false
   tags: control_center_next_gen
-  environment: "{{ proxy_env }}"
   tasks:
     - import_role:
         name: control_center_next_gen
@@ -37,7 +35,6 @@
   any_errors_fatal: true
   gather_facts: false
   tags: control_center_next_gen
-  environment: "{{ proxy_env }}"
   tasks:
     - import_role:
         name: control_center_next_gen

--- a/playbooks/kafka_broker.yml
+++ b/playbooks/kafka_broker.yml
@@ -3,7 +3,6 @@
   hosts: kafka_broker
   gather_facts: false
   tags: kafka_broker
-  environment: "{{ proxy_env }}"
   tasks:
     - import_role:
         name: variables
@@ -26,7 +25,6 @@
   hosts: kafka_broker_parallel
   gather_facts: false
   tags: kafka_broker
-  environment: "{{ proxy_env }}"
   tasks:
     - import_role:
         name: kafka_broker
@@ -36,7 +34,6 @@
   gather_facts: false
   serial: 1
   tags: kafka_broker
-  environment: "{{ proxy_env }}"
   tasks:
     - import_role:
         name: kafka_broker

--- a/playbooks/kafka_connect.yml
+++ b/playbooks/kafka_connect.yml
@@ -3,7 +3,6 @@
   hosts: kafka_connect
   gather_facts: false
   tags: kafka_connect
-  environment: "{{ proxy_env }}"
   tasks:
     - import_role:
         name: variables
@@ -26,7 +25,6 @@
   hosts: kafka_connect_parallel
   gather_facts: false
   tags: kafka_connect
-  environment: "{{ proxy_env }}"
   tasks:
     - import_role:
         name: kafka_connect
@@ -37,7 +35,6 @@
   any_errors_fatal: true
   gather_facts: false
   tags: kafka_connect
-  environment: "{{ proxy_env }}"
   tasks:
     - import_role:
         name: kafka_connect

--- a/playbooks/kafka_connect_replicator.yml
+++ b/playbooks/kafka_connect_replicator.yml
@@ -3,7 +3,6 @@
   hosts: kafka_connect_replicator
   gather_facts: false
   tags: kafka_connect_replicator
-  environment: "{{ proxy_env }}"
   tasks:
     - import_role:
         name: variables
@@ -26,7 +25,6 @@
   hosts: kafka_connect_replicator_parallel
   gather_facts: false
   tags: kafka_connect_replicator
-  environment: "{{ proxy_env }}"
   tasks:
     - import_role:
         name: kafka_connect_replicator
@@ -37,7 +35,6 @@
   any_errors_fatal: true
   gather_facts: false
   tags: kafka_connect_replicator
-  environment: "{{ proxy_env }}"
   tasks:
     - import_role:
         name: kafka_connect_replicator

--- a/playbooks/kafka_controller.yml
+++ b/playbooks/kafka_controller.yml
@@ -3,7 +3,6 @@
   hosts: kafka_controller
   gather_facts: false
   tags: kafka_controller
-  environment: "{{ proxy_env }}"
   tasks:
     - import_role:
         name: variables
@@ -26,7 +25,6 @@
   hosts: kafka_controller_parallel
   gather_facts: false
   tags: kafka_controller
-  environment: "{{ proxy_env }}"
   tasks:
     - import_role:
         name: kafka_controller
@@ -36,7 +34,6 @@
   gather_facts: false
   serial: 1
   tags: kafka_controller
-  environment: "{{ proxy_env }}"
   tasks:
     - import_role:
         name: kafka_controller

--- a/playbooks/kafka_rest.yml
+++ b/playbooks/kafka_rest.yml
@@ -3,7 +3,6 @@
   hosts: kafka_rest
   gather_facts: false
   tags: kafka_rest
-  environment: "{{ proxy_env }}"
   tasks:
     - import_role:
         name: variables
@@ -26,7 +25,6 @@
   hosts: kafka_rest_parallel
   gather_facts: false
   tags: kafka_rest
-  environment: "{{ proxy_env }}"
   tasks:
     - import_role:
         name: kafka_rest
@@ -37,7 +35,6 @@
   any_errors_fatal: true
   gather_facts: false
   tags: kafka_rest
-  environment: "{{ proxy_env }}"
   tasks:
     - import_role:
         name: kafka_rest

--- a/playbooks/ksql.yml
+++ b/playbooks/ksql.yml
@@ -3,7 +3,6 @@
   hosts: ksql
   gather_facts: false
   tags: ksql
-  environment: "{{ proxy_env }}"
   tasks:
     - import_role:
         name: variables
@@ -26,7 +25,6 @@
   hosts: ksql_parallel
   gather_facts: false
   tags: ksql
-  environment: "{{ proxy_env }}"
   tasks:
     - import_role:
         name: ksql
@@ -36,7 +34,6 @@
   serial: 1
   gather_facts: false
   tags: ksql
-  environment: "{{ proxy_env }}"
   tasks:
     - import_role:
         name: ksql

--- a/playbooks/schema_registry.yml
+++ b/playbooks/schema_registry.yml
@@ -6,7 +6,6 @@
   any_errors_fatal: true
   gather_facts: false
   tags: schema_registry
-  environment: "{{ proxy_env }}"
   tasks:
     - import_role:
         name: schema_registry

--- a/roles/common/tasks/confluent_cli.yml
+++ b/roles/common/tasks/confluent_cli.yml
@@ -32,6 +32,7 @@
     mode: '755'
     extra_opts: [--strip-components=1]
     creates: "{{confluent_cli_base_path}}/{{confluent_cli_dir}}/{{confluent_cli_binary}}"
+  environment: "{{ proxy_env }}"
   when: confluent_cli_custom_download_url is not defined
 
 - name: Set Group and Owner for Confluent CLI archive
@@ -48,6 +49,7 @@
     url: "{{ confluent_cli_custom_download_url }}"
     dest: "{{confluent_cli_base_path}}/{{confluent_cli_dir}}/{{confluent_cli_binary}}"
     mode: '755'
+  environment: "{{ proxy_env }}"
   register: cli_download_result
   until: cli_download_result is success
   retries: 5

--- a/roles/common/tasks/debian.yml
+++ b/roles/common/tasks/debian.yml
@@ -283,6 +283,7 @@
   ansible.builtin.pip:
     name: pip
     extra_args: --upgrade
+  environment: "{{ proxy_env }}"
   tags:
     - package
     - pip-package
@@ -291,6 +292,7 @@
 - name: Install pip packages
   ansible.builtin.pip:
     name: "{{pip_packages}}"
+  environment: "{{ proxy_env }}"
   tags:
     - package
     - pip-package

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -76,6 +76,7 @@
     owner: "{{ omit if archive_owner == '' else archive_owner }}"
     mode: '755'
     creates: "{{binary_base_path}}"
+  environment: "{{ proxy_env }}"
   when: installation_method == "archive"
 
 - name: Set Group and Owner for Confluent Platform archive
@@ -112,6 +113,7 @@
     dest: "{{ jolokia_jar_path }}"
     force: "{{ jolokia_jar_url_force }}"
     mode: '755'
+  environment: "{{ proxy_env }}"
   register: jolokia_download_result
   until: jolokia_download_result is success
   retries: 5
@@ -144,6 +146,7 @@
     dest: "{{ jmxexporter_jar_path }}"
     force: "{{ jmxexporter_jar_url_force }}"
     mode: '755'
+  environment: "{{ proxy_env }}"
   register: prometheus_download_result
   until: prometheus_download_result is success
   retries: 5

--- a/roles/common/tasks/redhat.yml
+++ b/roles/common/tasks/redhat.yml
@@ -124,6 +124,7 @@
   ansible.builtin.pip:
     name: pip
     extra_args: --upgrade
+  environment: "{{ proxy_env }}"
   tags:
     - package
     - pip-package
@@ -132,6 +133,7 @@
 - name: Install pip packages
   ansible.builtin.pip:
     name: "{{pip_packages}}"
+  environment: "{{ proxy_env }}"
   tags:
     - package
     - pip-package

--- a/roles/common/tasks/ubuntu.yml
+++ b/roles/common/tasks/ubuntu.yml
@@ -170,6 +170,7 @@
   ansible.builtin.pip:
     name: pip
     extra_args: --upgrade
+  environment: "{{ proxy_env }}"
   tags:
     - package
     - pip-package
@@ -179,6 +180,7 @@
 - name: Install pip packages
   ansible.builtin.pip:
     name: "{{pip_packages}}"
+  environment: "{{ proxy_env }}"
   tags:
     - package
     - pip-package

--- a/roles/control_center_next_gen/tasks/main.yml
+++ b/roles/control_center_next_gen/tasks/main.yml
@@ -24,6 +24,7 @@
     owner: "{{ omit if archive_owner == '' else archive_owner }}"
     mode: '755'
     creates: "{{confluent_control_center_next_gen_binary_base_path}}"
+  environment: "{{ proxy_env }}"
   when: installation_method == "archive"
 
 - name: Stop Service and Remove Packages on Version Change

--- a/roles/kafka_connect/tasks/connect_plugins.yml
+++ b/roles/kafka_connect/tasks/connect_plugins.yml
@@ -52,6 +52,7 @@
     mode: '755'
     owner: "{{kafka_connect_user}}"
     group: "{{kafka_connect_group}}"
+  environment: "{{ proxy_env }}"
   register: download_remote_plugin_result
   until: download_remote_plugin_result is success or ansible_check_mode
   retries: 5

--- a/roles/ksql/tasks/ccloud_certs.yml
+++ b/roles/ksql/tasks/ccloud_certs.yml
@@ -4,6 +4,7 @@
     url: "https://letsencrypt.org/certs/{{item}}"
     dest: /tmp/{{item}}
     mode: '755'
+  environment: "{{ proxy_env }}"
   loop:
     - isrgrootx1.der
     - isrg-root-x2.der


### PR DESCRIPTION
# Description
When using ansible `proxy_env` to set environment variables, they end up being applied even to internal connectivity checks between components, which can cause those checks to fail.

This typically happens in environments where the proxy cannot directly connect to the target host, for example in lab setups behind NAT.

System default yum repositories might be pre-configured to use proxy, because Confluent yum repository will be registered with proxy statically by default in the playbook run.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

With a set of virtual hosts in a single physical host, where external proxy is required to connect to the Internet.

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
