### PR TITLE
[ANSIENG-5137] | Fix ZK Chroot creation

### DIFF
--- a/molecule/zookeeper-digest-rhel/molecule.yml
+++ b/molecule/zookeeper-digest-rhel/molecule.yml
@@ -120,6 +120,11 @@ provisioner:
       all:
         scenario_name: zookeeper-digest-rhel
 
+        # Enable ansible_become to simulate customer production environment
+        ansible_become: true
+        ansible_become_method: sudo
+        ansible_become_user: root
+
         zookeeper_quorum_authentication_type: digest
         zookeeper_client_authentication_type: digest
         sasl_protocol: plain

--- a/molecule/zookeeper-digest-rhel/verify.yml
+++ b/molecule/zookeeper-digest-rhel/verify.yml
@@ -37,3 +37,28 @@
         file_path: /etc/schema-registry/schema-registry.properties
         property: kafkastore.security.protocol
         expected_value: SASL_PLAINTEXT
+
+- name: Verify - ZooKeeper chroot creation with digest authentication
+  hosts: kafka_broker
+  gather_facts: false
+  tasks:
+    - name: Import Variables
+      import_role:
+        name: variables
+
+    - name: Verify chroot exists in ZooKeeper with authentication
+      shell: >
+        {% if kafka_broker_final_properties['zookeeper.set.acl']|default('false')|lower == 'true' %}KAFKA_OPTS='-Djava.security.auth.login.config={{kafka_broker.jaas_file}}'{% endif %} \
+        {{ binary_base_path }}/bin/zookeeper-shell {{ hostvars[groups['zookeeper'][0]] | confluent.platform.resolve_hostname }}:{{zookeeper_client_port}} \
+        ls /
+      register: zk_root_listing
+      run_once: true
+      changed_when: false
+      failed_when: false
+
+    - name: Assert chroot creation succeeded
+      assert:
+        that:
+          - zk_root_listing.rc == 0
+          - "zookeeper_chroot.lstrip('/') in zk_root_listing.stdout"
+        fail_msg: ZOOKEEPER CHROOT CREATION FAILED

--- a/roles/kafka_broker/tasks/main.yml
+++ b/roles/kafka_broker/tasks/main.yml
@@ -432,6 +432,7 @@
 # Only runs with zookeeper
 - name: Create Zookeeper chroot
   shell: >
+    {% if kafka_broker_final_properties['zookeeper.set.acl']|default('false')|lower == 'true' %}KAFKA_OPTS='-Djava.security.auth.login.config={{kafka_broker.jaas_file}}'{% endif %} \
     {{ binary_base_path }}/bin/zookeeper-shell {{ hostvars[groups['zookeeper'][0]] | confluent.platform.resolve_hostname }}:{{zookeeper_client_port}} \
       {% if zookeeper_ssl_enabled|bool %}-zk-tls-config-file {{ kafka_broker.zookeeper_tls_client_config_file if kafka_broker_secrets_protection_enabled else kafka_broker.config_file }}{% endif %} \
       create {{zookeeper_chroot}} ""


### PR DESCRIPTION
# Description

### Fix ZooKeeper chroot creation when ACLs are enabled

**Problem**
The "Create Zookeeper chroot" task fails with "Insufficient permission" error when ZooKeeper digest authentication is configured (zookeeper_client_authentication_type: digest). This happens because the task doesn't include authentication context when zookeeper.set.acl=true is automatically set.

**Solution**
Add the same authentication conditional logic used by SCRAM user creation tasks:

`{% if kafka_broker_final_properties['zookeeper.set.acl']|default('false')|lower == 'true' %}KAFKA_OPTS='-Djava.security.auth.login.config={{kafka_broker.jaas_file}}'{% endif %}`

**Impact**
✅ Fixes chroot creation for digest/kerberos authenticated ZooKeeper setups
✅ Maintains backward compatibility with non-authenticated configurations
✅ Eliminates need for manual KAFKA_OPTS workarounds
✅ Makes chroot task consistent with other ZooKeeper operations

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
