### PR TITLE
Fix Control Center Next Gen custom file copy variable

### DIFF
--- a/roles/control_center_next_gen/tasks/main.yml
+++ b/roles/control_center_next_gen/tasks/main.yml
@@ -291,10 +291,10 @@
     name: common
     tasks_from: copy_files.yml
   vars:
-    copy_files: "{{control_center_copy_files}}"
+    copy_files: "{{control_center_next_gen_copy_files}}"
     user: "{{control_center_next_gen_user}}"
     group: "{{control_center_next_gen_group}}"
-  when: control_center_copy_files | length > 0
+  when: control_center_next_gen_copy_files | length > 0
   tags:
     - configuration
 


### PR DESCRIPTION
# Description

This PR fixes a variable mismatch in the Control Center Next Gen custom file copy task on 7.9.x.

The task currently references `control_center_copy_files`, but for Control Center Next Gen the correct variable is `control_center_next_gen_copy_files`.

Because of this, custom files defined for Control Center Next Gen are not copied.

This change updates both the 'copy_files' mapping and the `when`'condition to use `control_center_next_gen_copy_files`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested manually on 7.9.x with inventory defining `control_center_next_gen_copy_files`.

Steps:
1. Define `control_center_next_gen_copy_files` with a test file.
2. Run the Control Center Next Gen play.
3. Observe that before the fix the file is not copied.
4. Apply the fix and rerun.
5. Confirm that the file is copied successfully.

# Checklist:

- [x] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
