### PR TITLE
 [ANSIENG-5805] | Add Support Bundle collection feature

### DIFF
--- a/playbooks/support_bundle.yml
+++ b/playbooks/support_bundle.yml
@@ -1,0 +1,357 @@
+---
+# Support Bundle Collection Playbook
+# Collects comprehensive diagnostic information from Confluent Platform deployment
+# including configs, logs, system info, diagnostics, and SSL metadata
+
+- name: Support Bundle Setup
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  tags: always
+  vars:
+    ansible_become: false
+  tasks:
+    - name: Gather facts without become
+      setup:
+
+    - import_role:
+        name: confluent.platform.variables
+
+    - name: Generate bundle timestamp
+      set_fact:
+        bundle_timestamp: "{{ ansible_date_time.date | regex_replace('-','') }}_{{ ansible_date_time.time | regex_replace(':','') }}"
+
+    - name: Set bundle name
+      set_fact:
+        bundle_name: "support_bundle_{{ bundle_timestamp }}_{{ support_bundle_cluster_name }}"
+        bundle_path: "{{ support_bundle_output_path }}/support_bundle_{{ bundle_timestamp }}_{{ support_bundle_cluster_name }}"
+
+    - name: Create bundle directory structure
+      file:
+        path: "{{ bundle_path }}/ansible"
+        state: directory
+        mode: '0755'
+
+    - name: Save execution context
+      copy:
+        content: "{{ {'timestamp': ansible_date_time.iso8601, 'groups': groups, 'ansible_version': ansible_version.full} | to_nice_yaml }}"
+        dest: "{{ bundle_path }}/ansible/execution_context.yml"
+        mode: '0644'
+
+    - name: Determine inventory file path
+      set_fact:
+        resolved_inventory_path: "{{ support_bundle_inventory_file_path if (support_bundle_inventory_file_path | length > 0) else (ansible_inventory_sources[0] | default('', true)) }}"
+
+    - name: Debug - Show inventory resolution
+      debug:
+        msg:
+          - "Inventory Resolution:"
+          - "  support_bundle_inventory_file_path: {{ support_bundle_inventory_file_path | default('(not set)') }}"
+          - "  ansible_inventory_sources: {{ ansible_inventory_sources | default(['(not available)']) }}"
+          - "  resolved_inventory_path: {{ resolved_inventory_path | default('(no path resolved)') }}"
+
+    - name: Copy inventory file to bundle
+      copy:
+        src: "{{ resolved_inventory_path }}"
+        dest: "{{ bundle_path }}/ansible/inventory_raw.yml"
+        mode: '0644'
+      when:
+        - resolved_inventory_path is defined
+        - resolved_inventory_path | length > 0
+        - resolved_inventory_path is file
+      ignore_errors: true
+      register: inventory_file_copied
+
+    - name: Generate inventory structure from groups (fallback if no file provided)
+      copy:
+        content: |
+          # Inventory structure (generated from runtime groups)
+          # Note: This is a simplified view. Set support_bundle_inventory_file_path for full inventory.
+          {% for group_name in groups.keys() %}
+          {% if group_name != 'ungrouped' %}
+          {{ group_name }}:
+          {% if group_name == 'all' %}
+            vars: {}
+          {% else %}
+            hosts:
+          {% for host in groups[group_name] %}
+              {{ host }}: {}
+          {% endfor %}
+          {% endif %}
+          {% endif %}
+          {% endfor %}
+        dest: "{{ bundle_path }}/ansible/inventory_raw.yml"
+        mode: '0644'
+      when: inventory_file_copied is failed or inventory_file_copied is skipped
+
+    - name: Sanitize sensitive data in inventory
+      shell: |
+        # Add header indicating sanitization
+        echo "# THIS INVENTORY HAS BEEN SANITIZED - SENSITIVE VALUES REDACTED" > {{ bundle_path }}/ansible/inventory_sanitized.yml
+        echo "" >> {{ bundle_path }}/ansible/inventory_sanitized.yml
+        cat {{ bundle_path }}/ansible/inventory_raw.yml >> {{ bundle_path }}/ansible/inventory_sanitized.yml
+
+        # Redact SSH keys and credentials
+        sed -i.bak -E 's|(ansible_ssh_private_key_file:).*|\1 ***REDACTED***|g' {{ bundle_path }}/ansible/inventory_sanitized.yml
+        sed -i.bak -E 's|(ansible_password:).*|\1 ***REDACTED***|g' {{ bundle_path }}/ansible/inventory_sanitized.yml
+        sed -i.bak -E 's|(ansible_become_password:).*|\1 ***REDACTED***|g' {{ bundle_path }}/ansible/inventory_sanitized.yml
+
+        # Redact any password, secret, key, token, credential fields (but not comments)
+        sed -i.bak -E 's|^([[:space:]]*[^#]*password[^:]*:).*|\1 ***REDACTED***|gi' {{ bundle_path }}/ansible/inventory_sanitized.yml
+        sed -i.bak -E 's|^([[:space:]]*[^#]*secret[^:]*:).*|\1 ***REDACTED***|gi' {{ bundle_path }}/ansible/inventory_sanitized.yml
+        sed -i.bak -E 's|^([[:space:]]*[^#]*_key[^:]*:).*|\1 ***REDACTED***|gi' {{ bundle_path }}/ansible/inventory_sanitized.yml
+        sed -i.bak -E 's|^([[:space:]]*[^#]*token[^:]*:).*|\1 ***REDACTED***|gi' {{ bundle_path }}/ansible/inventory_sanitized.yml
+        sed -i.bak -E 's|^([[:space:]]*[^#]*credential[^:]*:).*|\1 ***REDACTED***|gi' {{ bundle_path }}/ansible/inventory_sanitized.yml
+
+        # Clean up
+        rm -f {{ bundle_path }}/ansible/inventory_raw.yml
+        rm -f {{ bundle_path }}/ansible/inventory_sanitized.yml.bak
+      args:
+        executable: /bin/bash
+      ignore_errors: true
+
+- name: Import all variables
+  hosts: all
+  tags: always
+  tasks:
+    - import_role:
+        name: confluent.platform.variables
+
+- name: Zookeeper Support Bundle
+  hosts: zookeeper
+  gather_facts: true
+  tags: zookeeper
+  tasks:
+    - include_role:
+        name: confluent.platform.common
+        tasks_from: collect_support_bundle.yml
+      vars:
+        service_name: "{{ zookeeper_service_name }}"
+        component_name: "zookeeper"
+        component: "{{ zookeeper }}"
+        config_file: "{{ zookeeper.config_file }}"
+        log_dir: "{{ zookeeper_log_dir }}"
+        user: "{{ zookeeper_user }}"
+        group: "{{ zookeeper_group }}"
+
+- name: Kafka Controller Support Bundle
+  hosts: kafka_controller
+  gather_facts: true
+  tags: kafka_controller
+  tasks:
+    - include_role:
+        name: confluent.platform.common
+        tasks_from: collect_support_bundle.yml
+      vars:
+        service_name: "{{ kafka_controller_service_name }}"
+        component_name: "kafka_controller"
+        component: "{{ kafka_controller }}"
+        config_file: "{{ kafka_controller.config_file }}"
+        log_dir: "{{ kafka_controller_log_dir }}"
+        user: "{{ kafka_controller_user }}"
+        group: "{{ kafka_controller_group }}"
+
+- name: Kafka Broker Support Bundle
+  hosts: kafka_broker
+  gather_facts: true
+  tags: kafka_broker
+  tasks:
+    - include_role:
+        name: confluent.platform.common
+        tasks_from: collect_support_bundle.yml
+      vars:
+        service_name: "{{ kafka_broker_service_name }}"
+        component_name: "kafka_broker"
+        component: "{{ kafka_broker }}"
+        config_file: "{{ kafka_broker.config_file }}"
+        log_dir: "{{ kafka_broker_log_dir }}"
+        user: "{{ kafka_broker_user }}"
+        group: "{{ kafka_broker_group }}"
+
+- name: Schema Registry Support Bundle
+  hosts: schema_registry
+  gather_facts: true
+  tags: schema_registry
+  tasks:
+    - include_role:
+        name: confluent.platform.common
+        tasks_from: collect_support_bundle.yml
+      vars:
+        service_name: "{{ schema_registry_service_name }}"
+        component_name: "schema_registry"
+        component: "{{ schema_registry }}"
+        config_file: "{{ schema_registry.config_file }}"
+        log_dir: "{{ schema_registry_log_dir }}"
+        user: "{{ schema_registry_user }}"
+        group: "{{ schema_registry_group }}"
+
+- name: Kafka Connect Support Bundle
+  hosts: kafka_connect
+  gather_facts: true
+  tags: kafka_connect
+  tasks:
+    - include_role:
+        name: confluent.platform.common
+        tasks_from: collect_support_bundle.yml
+      vars:
+        service_name: "{{ kafka_connect_service_name }}"
+        component_name: "kafka_connect"
+        component: "{{ kafka_connect }}"
+        config_file: "{{ kafka_connect.config_file }}"
+        log_dir: "{{ kafka_connect_log_dir }}"
+        user: "{{ kafka_connect_user }}"
+        group: "{{ kafka_connect_group }}"
+
+- name: Kafka Connect Replicator Support Bundle
+  hosts: kafka_connect_replicator
+  gather_facts: true
+  tags: kafka_connect_replicator
+  tasks:
+    - include_role:
+        name: confluent.platform.common
+        tasks_from: collect_support_bundle.yml
+      vars:
+        service_name: "{{ kafka_connect_replicator_service_name }}"
+        component_name: "kafka_connect_replicator"
+        component: "{{ kafka_connect_replicator }}"
+        config_file: "{{ kafka_connect_replicator.config_file }}"
+        log_dir: "{{ kafka_connect_replicator_log_dir }}"
+        user: "{{ kafka_connect_replicator_user }}"
+        group: "{{ kafka_connect_replicator_group }}"
+
+- name: KSQL Support Bundle
+  hosts: ksql
+  gather_facts: true
+  tags: ksql
+  tasks:
+    - include_role:
+        name: confluent.platform.common
+        tasks_from: collect_support_bundle.yml
+      vars:
+        service_name: "{{ ksql_service_name }}"
+        component_name: "ksql"
+        component: "{{ ksql }}"
+        config_file: "{{ ksql.config_file }}"
+        log_dir: "{{ ksql_log_dir }}"
+        user: "{{ ksql_user }}"
+        group: "{{ ksql_group }}"
+
+- name: Kafka Rest Support Bundle
+  hosts: kafka_rest
+  gather_facts: true
+  tags: kafka_rest
+  tasks:
+    - include_role:
+        name: confluent.platform.common
+        tasks_from: collect_support_bundle.yml
+      vars:
+        service_name: "{{ kafka_rest_service_name }}"
+        component_name: "kafka_rest"
+        component: "{{ kafka_rest }}"
+        config_file: "{{ kafka_rest.config_file }}"
+        log_dir: "{{ kafka_rest_log_dir }}"
+        user: "{{ kafka_rest_user }}"
+        group: "{{ kafka_rest_group }}"
+
+- name: Control Center Support Bundle
+  hosts: control_center
+  gather_facts: true
+  tags: control_center
+  tasks:
+    - include_role:
+        name: confluent.platform.common
+        tasks_from: collect_support_bundle.yml
+      vars:
+        service_name: "{{ control_center_service_name }}"
+        component_name: "control_center"
+        component: "{{ control_center }}"
+        config_file: "{{ control_center.config_file }}"
+        log_dir: "{{ control_center_log_dir }}"
+        user: "{{ control_center_user }}"
+        group: "{{ control_center_group }}"
+
+- name: Control Center Next Gen Support Bundle
+  hosts: control_center_next_gen
+  gather_facts: true
+  tags: control_center_next_gen
+  tasks:
+    - include_role:
+        name: confluent.platform.common
+        tasks_from: collect_support_bundle.yml
+      vars:
+        service_name: "{{ control_center_next_gen_service_name }}"
+        component_name: "control_center_next_gen"
+        component: "{{ control_center_next_gen }}"
+        config_file: "{{ control_center_next_gen.config_file }}"
+        log_dir: "{{ control_center_next_gen_log_dir }}"
+        user: "{{ control_center_next_gen_user }}"
+        group: "{{ control_center_next_gen_group }}"
+
+- name: USM Agent Support Bundle
+  hosts: usm_agent
+  gather_facts: true
+  tags: usm_agent
+  tasks:
+    - include_role:
+        name: confluent.platform.common
+        tasks_from: collect_support_bundle.yml
+      vars:
+        service_name: "{{ usm_agent_service_name }}"
+        component_name: "usm_agent"
+        component: "{{ usm_agent }}"
+        config_file: "{{ usm_agent.config_file }}"
+        log_dir: "{{ usm_agent.log_dir }}"
+        user: "{{ usm_agent_default_user }}"
+        group: "{{ usm_agent_default_group }}"
+
+- name: Finalize Support Bundle
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  tags: always
+  vars:
+    ansible_become: false
+  tasks:
+    - import_role:
+        name: confluent.platform.variables
+
+    - name: Generate bundle manifest
+      template:
+        src: "{{ playbook_dir }}/../roles/common/templates/bundle_manifest.yml.j2"
+        dest: "{{ hostvars['localhost']['bundle_path'] }}/bundle_manifest.yml"
+        mode: '0644'
+
+    - name: Copy Ansible playbook execution log to bundle
+      copy:
+        src: "{{ support_bundle_ansible_log_path }}"
+        dest: "{{ hostvars['localhost']['bundle_path'] }}/ansible/ansible_playbook.log"
+        mode: '0644'
+      when: support_bundle_ansible_log_path | length > 0
+      ignore_errors: true
+
+    - name: Archive support bundle
+      archive:
+        path: "{{ hostvars['localhost']['bundle_path'] }}"
+        dest: "{{ support_bundle_output_path }}/{{ hostvars['localhost']['bundle_name'] }}.tar.gz"
+        format: gz
+
+    - name: Remove uncompressed bundle directory
+      file:
+        path: "{{ hostvars['localhost']['bundle_path'] }}"
+        state: absent
+
+    - name: Get archive file stats
+      stat:
+        path: "{{ support_bundle_output_path }}/{{ hostvars['localhost']['bundle_name'] }}.tar.gz"
+      register: bundle_archive_stats
+
+    - name: Display completion message
+      debug:
+        msg: |
+          ========================================
+          Support Bundle Created Successfully
+          ========================================
+          Location: {{ support_bundle_output_path }}/{{ hostvars['localhost']['bundle_name'] }}.tar.gz
+          Size: {{ (bundle_archive_stats.stat.size / 1024 / 1024) | round(2) }} MB
+
+          Please upload this file to your support ticket.

--- a/playbooks/support_bundle.yml
+++ b/playbooks/support_bundle.yml
@@ -50,16 +50,28 @@
           - "  ansible_inventory_sources: {{ ansible_inventory_sources | default(['(not available)']) }}"
           - "  resolved_inventory_sources: {{ resolved_inventory_sources | default(['(no sources)']) }}"
 
-    - name: Copy inventory files to bundle
-      copy:
-        src: "{{ item }}"
-        dest: "{{ bundle_path }}/ansible/inventory_{{ loop.index }}_raw.yml"
-        mode: '0644'
+    - name: Check inventory file existence
+      stat:
+        path: "{{ item }}"
       loop: "{{ resolved_inventory_sources }}"
       when:
         - item is defined
         - item | length > 0
-        - item is file
+      register: inventory_file_stats
+      ignore_errors: true
+
+    - name: Copy inventory files to bundle
+      copy:
+        src: "{{ item.item }}"
+        dest: "{{ bundle_path }}/ansible/inventory_{{ idx + 1 }}_raw.yml"
+        mode: '0644'
+      loop: "{{ inventory_file_stats.results | default([]) }}"
+      loop_control:
+        index_var: idx
+      when:
+        - item.stat is defined
+        - item.stat.exists
+        - item.stat.isreg
       ignore_errors: true
       register: inventory_files_copied
 
@@ -83,43 +95,10 @@
           {% endfor %}
         dest: "{{ bundle_path }}/ansible/inventory_1_raw.yml"
         mode: '0644'
-      when: inventory_files_copied.results | selectattr('changed', 'equalto', true) | list | length == 0
+      when: (inventory_files_copied.results | default([]) | selectattr('changed', 'equalto', true) | list | length == 0)
 
-    - name: Sanitize inventory files using script module
-      script:
-        cmd: sanitize_properties.py "{{ item.dest }}" --type inventory
-        executable: python3
-      loop: "{{ inventory_files_copied.results | selectattr('changed', 'equalto', true) | list }}"
-      delegate_to: localhost
-      vars:
-        ansible_connection: local
-      ignore_errors: true
-      register: sanitize_inventory_results
-
-    - name: Sanitize generated inventory (if fallback was used)
-      script:
-        cmd: sanitize_properties.py "{{ bundle_path }}/ansible/inventory_1_raw.yml" --type inventory
-        executable: python3
-      when: inventory_files_copied.results | selectattr('changed', 'equalto', true) | list | length == 0
-      delegate_to: localhost
-      vars:
-        ansible_connection: local
-      ignore_errors: true
-
-    - name: Rename sanitized inventory files
-      shell: |
-        for file in {{ bundle_path }}/ansible/inventory_*_raw.yml; do
-          if [ -f "$file" ]; then
-            base=$(basename "$file" _raw.yml)
-            mv "$file" "{{ bundle_path }}/ansible/${base}_sanitized.yml"
-          fi
-        done
-      args:
-        executable: /bin/bash
-      delegate_to: localhost
-      vars:
-        ansible_connection: local
-      ignore_errors: true
+    - name: Sanitize inventory files
+      include_tasks: ../roles/common/tasks/sanitize_inventory_files_local.yml
 
 - name: Import all variables
   hosts: all

--- a/playbooks/support_bundle.yml
+++ b/playbooks/support_bundle.yml
@@ -38,9 +38,9 @@
         dest: "{{ bundle_path }}/ansible/execution_context.yml"
         mode: '0644'
 
-    - name: Determine inventory file path
+    - name: Determine inventory sources
       set_fact:
-        resolved_inventory_path: "{{ support_bundle_inventory_file_path if (support_bundle_inventory_file_path | length > 0) else (ansible_inventory_sources[0] | default('', true)) }}"
+        resolved_inventory_sources: "{{ [support_bundle_inventory_file_path] if (support_bundle_inventory_file_path | length > 0) else (ansible_inventory_sources | default([])) }}"
 
     - name: Debug - Show inventory resolution
       debug:
@@ -48,21 +48,22 @@
           - "Inventory Resolution:"
           - "  support_bundle_inventory_file_path: {{ support_bundle_inventory_file_path | default('(not set)') }}"
           - "  ansible_inventory_sources: {{ ansible_inventory_sources | default(['(not available)']) }}"
-          - "  resolved_inventory_path: {{ resolved_inventory_path | default('(no path resolved)') }}"
+          - "  resolved_inventory_sources: {{ resolved_inventory_sources | default(['(no sources)']) }}"
 
-    - name: Copy inventory file to bundle
+    - name: Copy inventory files to bundle
       copy:
-        src: "{{ resolved_inventory_path }}"
-        dest: "{{ bundle_path }}/ansible/inventory_raw.yml"
+        src: "{{ item }}"
+        dest: "{{ bundle_path }}/ansible/inventory_{{ loop.index }}_raw.yml"
         mode: '0644'
+      loop: "{{ resolved_inventory_sources }}"
       when:
-        - resolved_inventory_path is defined
-        - resolved_inventory_path | length > 0
-        - resolved_inventory_path is file
+        - item is defined
+        - item | length > 0
+        - item is file
       ignore_errors: true
-      register: inventory_file_copied
+      register: inventory_files_copied
 
-    - name: Generate inventory structure from groups (fallback if no file provided)
+    - name: Generate inventory structure from groups (fallback if no files copied)
       copy:
         content: |
           # Inventory structure (generated from runtime groups)
@@ -80,34 +81,44 @@
           {% endif %}
           {% endif %}
           {% endfor %}
-        dest: "{{ bundle_path }}/ansible/inventory_raw.yml"
+        dest: "{{ bundle_path }}/ansible/inventory_1_raw.yml"
         mode: '0644'
-      when: inventory_file_copied is failed or inventory_file_copied is skipped
+      when: inventory_files_copied.results | selectattr('changed', 'equalto', true) | list | length == 0
 
-    - name: Sanitize sensitive data in inventory
+    - name: Sanitize inventory files using script module
+      script:
+        cmd: sanitize_properties.py "{{ item.dest }}" --type inventory
+        executable: python3
+      loop: "{{ inventory_files_copied.results | selectattr('changed', 'equalto', true) | list }}"
+      delegate_to: localhost
+      vars:
+        ansible_connection: local
+      ignore_errors: true
+      register: sanitize_inventory_results
+
+    - name: Sanitize generated inventory (if fallback was used)
+      script:
+        cmd: sanitize_properties.py "{{ bundle_path }}/ansible/inventory_1_raw.yml" --type inventory
+        executable: python3
+      when: inventory_files_copied.results | selectattr('changed', 'equalto', true) | list | length == 0
+      delegate_to: localhost
+      vars:
+        ansible_connection: local
+      ignore_errors: true
+
+    - name: Rename sanitized inventory files
       shell: |
-        # Add header indicating sanitization
-        echo "# THIS INVENTORY HAS BEEN SANITIZED - SENSITIVE VALUES REDACTED" > {{ bundle_path }}/ansible/inventory_sanitized.yml
-        echo "" >> {{ bundle_path }}/ansible/inventory_sanitized.yml
-        cat {{ bundle_path }}/ansible/inventory_raw.yml >> {{ bundle_path }}/ansible/inventory_sanitized.yml
-
-        # Redact SSH keys and credentials
-        sed -i.bak -E 's|(ansible_ssh_private_key_file:).*|\1 ***REDACTED***|g' {{ bundle_path }}/ansible/inventory_sanitized.yml
-        sed -i.bak -E 's|(ansible_password:).*|\1 ***REDACTED***|g' {{ bundle_path }}/ansible/inventory_sanitized.yml
-        sed -i.bak -E 's|(ansible_become_password:).*|\1 ***REDACTED***|g' {{ bundle_path }}/ansible/inventory_sanitized.yml
-
-        # Redact any password, secret, key, token, credential fields (but not comments)
-        sed -i.bak -E 's|^([[:space:]]*[^#]*password[^:]*:).*|\1 ***REDACTED***|gi' {{ bundle_path }}/ansible/inventory_sanitized.yml
-        sed -i.bak -E 's|^([[:space:]]*[^#]*secret[^:]*:).*|\1 ***REDACTED***|gi' {{ bundle_path }}/ansible/inventory_sanitized.yml
-        sed -i.bak -E 's|^([[:space:]]*[^#]*_key[^:]*:).*|\1 ***REDACTED***|gi' {{ bundle_path }}/ansible/inventory_sanitized.yml
-        sed -i.bak -E 's|^([[:space:]]*[^#]*token[^:]*:).*|\1 ***REDACTED***|gi' {{ bundle_path }}/ansible/inventory_sanitized.yml
-        sed -i.bak -E 's|^([[:space:]]*[^#]*credential[^:]*:).*|\1 ***REDACTED***|gi' {{ bundle_path }}/ansible/inventory_sanitized.yml
-
-        # Clean up
-        rm -f {{ bundle_path }}/ansible/inventory_raw.yml
-        rm -f {{ bundle_path }}/ansible/inventory_sanitized.yml.bak
+        for file in {{ bundle_path }}/ansible/inventory_*_raw.yml; do
+          if [ -f "$file" ]; then
+            base=$(basename "$file" _raw.yml)
+            mv "$file" "{{ bundle_path }}/ansible/${base}_sanitized.yml"
+          fi
+        done
       args:
         executable: /bin/bash
+      delegate_to: localhost
+      vars:
+        ansible_connection: local
       ignore_errors: true
 
 - name: Import all variables

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -84,3 +84,37 @@ confluent_cli_archive_file_source: "{{confluent_cli_repository_baseurl}}/conflue
 
 ### Set to true to indicate the CLI archive file is remote (i.e. already on the target node) or a URL. Set to false if the archive file is on the control node.
 confluent_cli_archive_file_remote: true
+
+### Output path for support bundles on Ansible controller
+support_bundle_output_path: "{{ playbook_dir }}"
+
+### Cluster name to include in support bundle filename
+support_bundle_cluster_name: cp_cluster
+
+### Number of journalctl log lines to collect per service
+support_bundle_journalctl_lines: 1000
+
+### Base path on remote hosts for temporary diagnostic files during collection. Log and config files are fetched directly from their original locations.
+support_bundle_base_path: /tmp
+
+### File patterns to collect for logs, bounded defaults for reliability at scale
+support_bundle_log_patterns:
+  - "*.log"
+
+### Maximum number of log files to collect per component, most recent first
+support_bundle_log_max_count: 20
+
+### Whether to sanitize config files before collection. When true, passwords and sensitive values are redacted from config files.
+support_bundle_sanitize_configs: true
+
+### Whether to skip config file collection entirely. When true, only collect metadata about config files, not their contents.
+support_bundle_skip_configs: false
+
+### Whether to automatically collect support bundle when playbooks fail. Default is false and must be explicitly enabled.
+support_bundle_auto_collect_on_failure: false
+
+### Path to Ansible playbook execution log file on Ansible controller. When set, this log file will be included in the support bundle.
+support_bundle_ansible_log_path: ""
+
+### Path to inventory file on Ansible controller. When set, the full inventory file will be included in the support bundle after sanitization.
+support_bundle_inventory_file_path: ""

--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -84,37 +84,3 @@ confluent_cli_archive_file_source: "{{confluent_cli_repository_baseurl}}/conflue
 
 ### Set to true to indicate the CLI archive file is remote (i.e. already on the target node) or a URL. Set to false if the archive file is on the control node.
 confluent_cli_archive_file_remote: true
-
-### Output path for support bundles on Ansible controller
-support_bundle_output_path: "{{ playbook_dir }}"
-
-### Cluster name to include in support bundle filename
-support_bundle_cluster_name: cp_cluster
-
-### Number of journalctl log lines to collect per service
-support_bundle_journalctl_lines: 1000
-
-### Base path on remote hosts for temporary diagnostic files during collection. Log and config files are fetched directly from their original locations.
-support_bundle_base_path: /tmp
-
-### File patterns to collect for logs, bounded defaults for reliability at scale
-support_bundle_log_patterns:
-  - "*.log"
-
-### Maximum number of log files to collect per component, most recent first
-support_bundle_log_max_count: 20
-
-### Whether to sanitize config files before collection. When true, passwords and sensitive values are redacted from config files.
-support_bundle_sanitize_configs: true
-
-### Whether to skip config file collection entirely. When true, only collect metadata about config files, not their contents.
-support_bundle_skip_configs: false
-
-### Whether to automatically collect support bundle when playbooks fail. Default is false and must be explicitly enabled.
-support_bundle_auto_collect_on_failure: false
-
-### Path to Ansible playbook execution log file on Ansible controller. When set, this log file will be included in the support bundle.
-support_bundle_ansible_log_path: ""
-
-### Path to inventory file on Ansible controller. When set, the full inventory file will be included in the support bundle after sanitization.
-support_bundle_inventory_file_path: ""

--- a/roles/common/files/sanitize_properties.py
+++ b/roles/common/files/sanitize_properties.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""
+Confluent Platform Property File Sanitizer
+
+Sanitizes sensitive data from configuration files while preserving
+non-sensitive metadata like paths, algorithms, and timeout values.
+"""
+
+import re
+import sys
+import argparse
+from pathlib import Path
+
+
+class PropertySanitizer:
+    """Sanitizes Confluent Platform configuration files."""
+
+    # Properties that MUST be sanitized (exact matches)
+    EXACT_SENSITIVE = {
+        'confluent.license',
+        'ldap.java.naming.security.credentials',
+        'confluent.security.master.key',
+        'CONFLUENT_SECURITY_MASTER_KEY',
+    }
+
+    # Suffix patterns that indicate sensitive values
+    SENSITIVE_SUFFIXES = [
+        '.password',
+        '.secret',
+        '.basic.auth.user.info',
+        '.basic.auth.credentials',
+        '.sasl.jaas.config',
+        '.client.secret',
+        'keystorePassword',  # Jolokia format
+    ]
+
+    # Properties that should NOT be sanitized (even if they match sensitive patterns)
+    EXCLUDE_PATTERNS = [
+        r'.*\.path$',                           # File paths
+        r'.*\.location$',                       # File locations
+        r'.*\.algorithm$',                      # Algorithm names (RS256, etc.)
+        r'.*\.provider$',                       # Provider types (BASIC, BEARER)
+        r'.*\.lifetime\.ms$',                   # Timeout values
+        r'.*\.max\.lifetime\.ms$',              # Max lifetime values
+        r'.*\.interval\.ms$',                   # Interval values
+        r'.*\.authentication\.method$',         # Auth method types
+        r'.*\.security\.protocol$',             # Security protocols
+        r'.*\.mechanism$',                      # SASL mechanisms
+        r'.*\.enabled\.mechanisms$',            # Enabled mechanisms list
+        r'.*\.service\.name$',                  # Kerberos service names
+        r'.*\.protocol\.map$',                  # Protocol mappings
+    ]
+
+    def __init__(self):
+        self.exclude_compiled = [re.compile(pattern, re.IGNORECASE) for pattern in self.EXCLUDE_PATTERNS]
+
+    def is_excluded(self, key):
+        """Check if a property key should be excluded from sanitization."""
+        return any(pattern.match(key) for pattern in self.exclude_compiled)
+
+    def is_sensitive(self, key):
+        """Determine if a property key contains sensitive data."""
+        # Check exact matches first
+        if key in self.EXACT_SENSITIVE:
+            return True
+
+        # Check if excluded (takes precedence)
+        if self.is_excluded(key):
+            return False
+
+        # Check suffix patterns
+        key_lower = key.lower()
+        for suffix in self.SENSITIVE_SUFFIXES:
+            if key_lower.endswith(suffix.lower()):
+                return True
+
+        return False
+
+    def sanitize_jaas_partial(self, value):
+        """
+        Partially sanitize JAAS config: redact passwords and keytabs,
+        but preserve principals (they're identifiers, not secrets).
+        """
+        # Redact password values (quoted and unquoted)
+        value = re.sub(r'(password\s*=\s*")[^"]*"', r'\1***REDACTED***"', value, flags=re.IGNORECASE)
+        value = re.sub(r"(password\s*=\s*')[^']*'", r"\1***REDACTED***'", value, flags=re.IGNORECASE)
+        value = re.sub(r'(password\s*=\s*)([^;\s]+)', r'\1***REDACTED***', value, flags=re.IGNORECASE)
+
+        # Redact keyTab paths (they can reveal system structure)
+        value = re.sub(r'(keyTab\s*=\s*")[^"]*"', r'\1***REDACTED***"', value, flags=re.IGNORECASE)
+        value = re.sub(r"(keyTab\s*=\s*')[^']*'", r"\1***REDACTED***'", value, flags=re.IGNORECASE)
+
+        # Keep principals - they're identifiers, not secrets
+        return value
+
+    def sanitize_properties_file(self, file_path, in_place=True):
+        """
+        Sanitize a .properties file.
+
+        Args:
+            file_path: Path to the properties file
+            in_place: If True, modify file in place; if False, return sanitized content
+
+        Returns:
+            Sanitized content if in_place=False, else None
+        """
+        path = Path(file_path)
+        if not path.exists():
+            print(f"Warning: File not found: {file_path}", file=sys.stderr)
+            return None
+
+        lines = []
+        sanitized_count = 0
+
+        with open(path, 'r', encoding='utf-8', errors='replace') as f:
+            content = f.readlines()
+
+        # Add sanitization header
+        lines.append("# THIS FILE HAS BEEN SANITIZED - SENSITIVE VALUES REDACTED\n")
+
+        for line in content:
+            # Skip existing sanitization headers
+            if line.strip().startswith('# THIS FILE HAS BEEN SANITIZED'):
+                continue
+
+            # Preserve comments and empty lines
+            if line.strip().startswith('#') or not line.strip():
+                lines.append(line)
+                continue
+
+            # Parse property line (key=value format)
+            match = re.match(r'^([^=]+)=(.*)', line)
+            if not match:
+                lines.append(line)
+                continue
+
+            key = match.group(1).strip()
+            value = match.group(2)
+
+            # Check if this property should be sanitized
+            if self.is_sensitive(key):
+                # Special handling for JAAS configs - partial sanitization
+                if key.lower().endswith('.sasl.jaas.config'):
+                    sanitized_value = self.sanitize_jaas_partial(value)
+                    lines.append(f"{key}={sanitized_value}\n")
+                else:
+                    # Full redaction
+                    lines.append(f"{key}= ***REDACTED***\n")
+                sanitized_count += 1
+            else:
+                lines.append(line)
+
+        sanitized_content = ''.join(lines)
+
+        if in_place:
+            with open(path, 'w', encoding='utf-8') as f:
+                f.write(sanitized_content)
+            print(f"Sanitized {sanitized_count} properties in {file_path}")
+            return None
+        else:
+            return sanitized_content
+
+    def sanitize_jaas_file(self, file_path, in_place=True):
+        """
+        Sanitize a JAAS configuration file.
+
+        Args:
+            file_path: Path to the JAAS file
+            in_place: If True, modify file in place; if False, return sanitized content
+        """
+        path = Path(file_path)
+        if not path.exists():
+            print(f"Warning: File not found: {file_path}", file=sys.stderr)
+            return None
+
+        with open(path, 'r', encoding='utf-8', errors='replace') as f:
+            content = f.read()
+
+        # Add sanitization header
+        sanitized_content = "// THIS FILE HAS BEEN SANITIZED - SENSITIVE VALUES REDACTED\n\n"
+
+        # Remove existing header if present
+        content = re.sub(r'^//\s*THIS FILE HAS BEEN SANITIZED[^\n]*\n\n?', '', content)
+
+        # Partial sanitization: redact passwords and keytabs, preserve principals
+        sanitized_content += self.sanitize_jaas_partial(content)
+
+        if in_place:
+            with open(path, 'w', encoding='utf-8') as f:
+                f.write(sanitized_content)
+            print(f"Sanitized JAAS file: {file_path}")
+            return None
+        else:
+            return sanitized_content
+
+    def sanitize_override_file(self, file_path, in_place=True):
+        """
+        Sanitize a systemd override.conf file.
+
+        Args:
+            file_path: Path to the override.conf file
+            in_place: If True, modify file in place; if False, return sanitized content
+        """
+        path = Path(file_path)
+        if not path.exists():
+            print(f"Warning: File not found: {file_path}", file=sys.stderr)
+            return None
+
+        lines = []
+        sanitized_count = 0
+
+        with open(path, 'r', encoding='utf-8', errors='replace') as f:
+            content = f.readlines()
+
+        # Add sanitization header
+        lines.append("# THIS FILE HAS BEEN SANITIZED - SENSITIVE VALUES REDACTED\n")
+
+        sensitive_env_patterns = [
+            'PASSWORD', 'SECRET', 'KEY', 'TOKEN', 'CREDENTIAL',
+            'CONFLUENT_SECURITY_MASTER_KEY'
+        ]
+
+        for line in content:
+            # Skip existing sanitization headers
+            if 'THIS FILE HAS BEEN SANITIZED' in line:
+                continue
+
+            # Check for Environment= lines with sensitive variables
+            if line.strip().startswith('Environment='):
+                should_sanitize = any(pattern in line.upper() for pattern in sensitive_env_patterns)
+
+                if should_sanitize:
+                    # Extract variable name and redact value
+                    match = re.match(r'^(Environment=\s*[^=]+=).*', line)
+                    if match:
+                        lines.append(f"{match.group(1)}***REDACTED***\n")
+                        sanitized_count += 1
+                    else:
+                        lines.append(line)
+                else:
+                    lines.append(line)
+            else:
+                lines.append(line)
+
+        sanitized_content = ''.join(lines)
+
+        if in_place:
+            with open(path, 'w', encoding='utf-8') as f:
+                f.write(sanitized_content)
+            print(f"Sanitized {sanitized_count} environment variables in {file_path}")
+            return None
+        else:
+            return sanitized_content
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Sanitize Confluent Platform configuration files'
+    )
+    parser.add_argument('file', help='File to sanitize')
+    parser.add_argument('--type', choices=['properties', 'jaas', 'override'],
+                       help='File type (auto-detected if not specified)')
+    parser.add_argument('--dry-run', action='store_true',
+                       help='Print sanitized output without modifying file')
+
+    args = parser.parse_args()
+
+    # Auto-detect file type if not specified
+    file_path = Path(args.file)
+    file_type = args.type
+
+    if not file_type:
+        if file_path.suffix == '.properties':
+            file_type = 'properties'
+        elif 'jaas' in file_path.name.lower():
+            file_type = 'jaas'
+        elif file_path.name == 'override.conf':
+            file_type = 'override'
+        else:
+            print(f"Error: Cannot auto-detect file type for {args.file}", file=sys.stderr)
+            sys.exit(1)
+
+    sanitizer = PropertySanitizer()
+
+    # Sanitize based on file type
+    if file_type == 'properties':
+        result = sanitizer.sanitize_properties_file(args.file, in_place=not args.dry_run)
+    elif file_type == 'jaas':
+        result = sanitizer.sanitize_jaas_file(args.file, in_place=not args.dry_run)
+    elif file_type == 'override':
+        result = sanitizer.sanitize_override_file(args.file, in_place=not args.dry_run)
+
+    if args.dry_run and result:
+        print(result)
+
+
+if __name__ == '__main__':
+    main()

--- a/roles/common/files/sanitize_properties.py
+++ b/roles/common/files/sanitize_properties.py
@@ -252,13 +252,104 @@ class PropertySanitizer:
         else:
             return sanitized_content
 
+    def sanitize_inventory_file(self, file_path, in_place=True):
+        """
+        Sanitize an Ansible inventory file (YAML format).
+
+        Args:
+            file_path: Path to the inventory file
+            in_place: If True, modify file in place; if False, return sanitized content
+        """
+        path = Path(file_path)
+        if not path.exists():
+            print(f"Warning: File not found: {file_path}", file=sys.stderr)
+            return None
+
+        lines = []
+        sanitized_count = 0
+
+        with open(path, 'r', encoding='utf-8', errors='replace') as f:
+            content = f.readlines()
+
+        # Add sanitization header
+        lines.append("# THIS INVENTORY HAS BEEN SANITIZED - SENSITIVE VALUES REDACTED\n")
+
+        # Ansible-specific sensitive variables
+        ansible_sensitive_vars = [
+            'ansible_ssh_private_key_file',
+            'ansible_password',
+            'ansible_become_password',
+            'ansible_ssh_pass',
+            'ansible_become_pass',
+        ]
+
+        for line in content:
+            # Skip existing sanitization headers
+            if 'THIS INVENTORY HAS BEEN SANITIZED' in line:
+                continue
+
+            # Skip comments
+            if line.strip().startswith('#'):
+                lines.append(line)
+                continue
+
+            # Check for Ansible-specific sensitive variables (exact match)
+            sanitized = False
+            for var in ansible_sensitive_vars:
+                # Match: ansible_password: value or ansible_password=value
+                pattern = rf'^(\s*{var}\s*[:=]\s*).*$'
+                match = re.match(pattern, line)
+                if match:
+                    lines.append(f"{match.group(1)}***REDACTED***\n")
+                    sanitized_count += 1
+                    sanitized = True
+                    break
+
+            if sanitized:
+                continue
+
+            # Check for general sensitive patterns (password, secret, key, token, credential)
+            # But only in YAML value context (after : or =)
+            if ':' in line or '=' in line:
+                lower_line = line.lower()
+
+                # Avoid false positives like 'ssl_key_path' by being more specific
+                if any(pattern in lower_line for pattern in ['password:', 'password=',
+                                                               'secret:', 'secret=',
+                                                               'token:', 'token=',
+                                                               'credential:', 'credential=']):
+                    # Don't sanitize if it's a path/location/algorithm/provider
+                    if not any(exclude in lower_line for exclude in ['_path:', '_path=',
+                                                                      '_location:', '_location=',
+                                                                      '_algorithm:', '_algorithm=',
+                                                                      '_provider:', '_provider=']):
+                        # Extract key and redact value
+                        match = re.match(r'^(\s*[^#:=]+[:=]\s*).*$', line)
+                        if match:
+                            lines.append(f"{match.group(1)}***REDACTED***\n")
+                            sanitized_count += 1
+                            continue
+
+            # No sanitization needed, keep line as-is
+            lines.append(line)
+
+        sanitized_content = ''.join(lines)
+
+        if in_place:
+            with open(path, 'w', encoding='utf-8') as f:
+                f.write(sanitized_content)
+            print(f"Sanitized {sanitized_count} variables in {file_path}")
+            return None
+        else:
+            return sanitized_content
+
 
 def main():
     parser = argparse.ArgumentParser(
         description='Sanitize Confluent Platform configuration files'
     )
     parser.add_argument('file', help='File to sanitize')
-    parser.add_argument('--type', choices=['properties', 'jaas', 'override'],
+    parser.add_argument('--type', choices=['properties', 'jaas', 'override', 'inventory'],
                        help='File type (auto-detected if not specified)')
     parser.add_argument('--dry-run', action='store_true',
                        help='Print sanitized output without modifying file')
@@ -276,6 +367,8 @@ def main():
             file_type = 'jaas'
         elif file_path.name == 'override.conf':
             file_type = 'override'
+        elif file_path.suffix in ['.yml', '.yaml'] or 'inventory' in file_path.name.lower():
+            file_type = 'inventory'
         else:
             print(f"Error: Cannot auto-detect file type for {args.file}", file=sys.stderr)
             sys.exit(1)
@@ -289,6 +382,8 @@ def main():
         result = sanitizer.sanitize_jaas_file(args.file, in_place=not args.dry_run)
     elif file_type == 'override':
         result = sanitizer.sanitize_override_file(args.file, in_place=not args.dry_run)
+    elif file_type == 'inventory':
+        result = sanitizer.sanitize_inventory_file(args.file, in_place=not args.dry_run)
 
     if args.dry_run and result:
         print(result)

--- a/roles/common/tasks/collect_diagnostics.yml
+++ b/roles/common/tasks/collect_diagnostics.yml
@@ -1,0 +1,127 @@
+---
+# Runtime Diagnostics Collection Task
+# Collects service status, journalctl logs, and process info only
+# Direct fetch approach - creates temp files on remote and fetches to localhost
+
+- name: Check service status
+  shell: |
+    systemctl status {{ service_name }} --no-pager -l > /tmp/service_status_{{ inventory_hostname }}.txt 2>&1 || true
+  args:
+    executable: "{{ shell_executable }}"
+  ignore_errors: true
+
+- name: Fetch service status
+  fetch:
+    src: "/tmp/service_status_{{ inventory_hostname }}.txt"
+    dest: "{{ host_bundle_dir }}/diagnostics/service_status.txt"
+    flat: true
+  ignore_errors: true
+
+- name: Collect journalctl logs
+  shell: |
+    journalctl -u {{ service_name }} -n {{ support_bundle_journalctl_lines }} --no-pager > /tmp/journalctl_{{ inventory_hostname }}.log 2>&1 || true
+  args:
+    executable: "{{ shell_executable }}"
+  ignore_errors: true
+
+- name: Fetch journalctl logs
+  fetch:
+    src: "/tmp/journalctl_{{ inventory_hostname }}.log"
+    dest: "{{ host_bundle_dir }}/diagnostics/journalctl.log"
+    flat: true
+  ignore_errors: true
+
+- name: Collect process information
+  shell: |
+    ps aux | grep -E '{{ service_name }}|java' | grep -v grep > /tmp/processes_{{ inventory_hostname }}.txt 2>&1
+    echo "---" >> /tmp/processes_{{ inventory_hostname }}.txt
+    pgrep -f {{ service_name }} | xargs -r ps -f -p >> /tmp/processes_{{ inventory_hostname }}.txt 2>/dev/null || true
+  args:
+    executable: "{{ shell_executable }}"
+  ignore_errors: true
+
+- name: Fetch process information
+  fetch:
+    src: "/tmp/processes_{{ inventory_hostname }}.txt"
+    dest: "{{ host_bundle_dir }}/diagnostics/processes.txt"
+    flat: true
+  ignore_errors: true
+
+# REMOVED: Listening ports collection (not needed for basic diagnostics)
+# - name: Collect listening ports
+#   shell: |
+#     ss -tulpn > /tmp/ports_{{ inventory_hostname }}.txt 2>/dev/null || netstat -tulpn > /tmp/ports_{{ inventory_hostname }}.txt 2>&1 || true
+#   args:
+#     executable: "{{ shell_executable }}"
+#   ignore_errors: true
+#
+# - name: Fetch listening ports
+#   fetch:
+#     src: "/tmp/ports_{{ inventory_hostname }}.txt"
+#     dest: "{{ host_bundle_dir }}/diagnostics/ports.txt"
+#     flat: true
+#   ignore_errors: true
+
+# REMOVED: Open files collection (not needed for basic diagnostics)
+# - name: Collect open files for service
+#   shell: |
+#     pgrep -f {{ service_name }} | xargs -r lsof -p > /tmp/open_files_{{ inventory_hostname }}.txt 2>/dev/null || echo "lsof not available or no process found" > /tmp/open_files_{{ inventory_hostname }}.txt
+#   args:
+#     executable: "{{ shell_executable }}"
+#   ignore_errors: true
+#
+# - name: Fetch open files information
+#   fetch:
+#     src: "/tmp/open_files_{{ inventory_hostname }}.txt"
+#     dest: "{{ host_bundle_dir }}/diagnostics/open_files.txt"
+#     flat: true
+#   ignore_errors: true
+
+# REMOVED: Ulimit collection (not needed for basic diagnostics)
+# - name: Collect ulimit settings
+#   shell: |
+#     echo "Current user limits:" > /tmp/ulimit_{{ inventory_hostname }}.txt
+#     ulimit -a >> /tmp/ulimit_{{ inventory_hostname }}.txt 2>&1
+#     echo "---" >> /tmp/ulimit_{{ inventory_hostname }}.txt
+#     echo "Service user limits:" >> /tmp/ulimit_{{ inventory_hostname }}.txt
+#     su - {{ user }} -s /bin/bash -c "ulimit -a" >> /tmp/ulimit_{{ inventory_hostname }}.txt 2>/dev/null || echo "Could not retrieve service user limits" >> /tmp/ulimit_{{ inventory_hostname }}.txt
+#   args:
+#     executable: "{{ shell_executable }}"
+#   ignore_errors: true
+#
+# - name: Fetch ulimit settings
+#   fetch:
+#     src: "/tmp/ulimit_{{ inventory_hostname }}.txt"
+#     dest: "{{ host_bundle_dir }}/diagnostics/ulimit.txt"
+#     flat: true
+#   ignore_errors: true
+
+# REMOVED: Kernel parameters collection (not needed for basic diagnostics)
+# - name: Collect kernel parameters
+#   shell: |
+#     sysctl -a 2>/dev/null | grep -E 'vm\.|net\.|fs\.' > /tmp/sysctl_{{ inventory_hostname }}.txt || echo "Could not retrieve sysctl parameters" > /tmp/sysctl_{{ inventory_hostname }}.txt
+#   args:
+#     executable: "{{ shell_executable }}"
+#   ignore_errors: true
+#
+# - name: Fetch kernel parameters
+#   fetch:
+#     src: "/tmp/sysctl_{{ inventory_hostname }}.txt"
+#     dest: "{{ host_bundle_dir }}/diagnostics/sysctl.txt"
+#     flat: true
+#   ignore_errors: true
+
+- name: Clean up remote diagnostics temp files
+  file:
+    path: "/tmp/{{ item }}_{{ inventory_hostname }}.txt"
+    state: absent
+  loop:
+    - service_status
+    - processes
+  ignore_errors: true
+
+- name: Clean up remote journalctl temp file
+  file:
+    path: "/tmp/journalctl_{{ inventory_hostname }}.log"
+    state: absent
+  ignore_errors: true

--- a/roles/common/tasks/collect_support_bundle.yml
+++ b/roles/common/tasks/collect_support_bundle.yml
@@ -1,0 +1,170 @@
+---
+# Core Support Bundle Collection Task
+# Fetches diagnostic information directly from remote hosts to Ansible controller
+# No remote temporary directories - direct fetch approach per comment #8
+# Directory structure: bundle_path/<component_name>/<hostname>/
+
+- name: Set bundle facts
+  set_fact:
+    host_bundle_dir: "{{ hostvars['localhost']['bundle_path'] }}/{{ component_name }}/{{ inventory_hostname }}"
+  become: false
+
+- name: Create host bundle directories on localhost
+  file:
+    path: "{{ host_bundle_dir }}/{{ item }}"
+    state: directory
+    mode: '0755'
+  delegate_to: localhost
+  vars:
+    ansible_connection: local
+    ansible_become: "{{ ansible_become_localhost }}"
+  loop:
+    - configs
+    - logs
+    - diagnostics
+
+# COLLECT CONFIGURATION FILES
+- name: Collect config files (direct fetch)
+  block:
+    - name: Fetch main config file
+      fetch:
+        src: "{{ config_file }}"
+        dest: "{{ host_bundle_dir }}/configs/"
+        flat: true
+      become: true
+      ignore_errors: true
+      when: not support_bundle_skip_configs
+
+    - name: Fetch Log4j config file
+      fetch:
+        src: "{{ component.log4j_file }}"
+        dest: "{{ host_bundle_dir }}/configs/"
+        flat: true
+      become: true
+      ignore_errors: true
+      when:
+        - component.log4j_file is defined
+        - not support_bundle_skip_configs
+
+    - name: Fetch systemd service file
+      fetch:
+        src: "{{ component.systemd_file }}"
+        dest: "{{ host_bundle_dir }}/configs/"
+        flat: true
+      become: true
+      ignore_errors: true
+      when:
+        - component.systemd_file is defined
+        - not support_bundle_skip_configs
+
+    - name: Fetch systemd override file
+      fetch:
+        src: "{{ component.systemd_override }}"
+        dest: "{{ host_bundle_dir }}/configs/"
+        flat: true
+      become: true
+      ignore_errors: true
+      when:
+        - component.systemd_override is defined
+        - not support_bundle_skip_configs
+
+    - name: Fetch client config file (if exists)
+      fetch:
+        src: "{{ component.client_config_file }}"
+        dest: "{{ host_bundle_dir }}/configs/"
+        flat: true
+      become: true
+      ignore_errors: true
+      when:
+        - component.client_config_file is defined
+        - not support_bundle_skip_configs
+
+    # SANITIZE CONFIG FILES (on localhost after fetch)
+    - name: Sanitize sensitive data from config files
+      include_tasks: sanitize_config_files_local.yml
+      when:
+        - support_bundle_sanitize_configs
+        - not support_bundle_skip_configs
+
+    # COLLECT METADATA ONLY (if skipping configs)
+    - name: Collect config file metadata only
+      shell: |
+        echo "=== Configuration Files Metadata ===" > /tmp/config_files_metadata_{{ inventory_hostname }}.txt
+        {% if config_file is defined %}
+        ls -lh {{ config_file }} >> /tmp/config_files_metadata_{{ inventory_hostname }}.txt 2>&1 || echo "{{ config_file }}: Not found" >> /tmp/config_files_metadata_{{ inventory_hostname }}.txt
+        {% endif %}
+        {% if component.log4j_file is defined %}
+        ls -lh {{ component.log4j_file }} >> /tmp/config_files_metadata_{{ inventory_hostname }}.txt 2>&1 || echo "{{ component.log4j_file }}: Not found" >> /tmp/config_files_metadata_{{ inventory_hostname }}.txt
+        {% endif %}
+      args:
+        executable: "{{ shell_executable }}"
+      become: true
+      ignore_errors: true
+      when: support_bundle_skip_configs
+      register: metadata_created
+
+    - name: Fetch config metadata file
+      fetch:
+        src: "/tmp/config_files_metadata_{{ inventory_hostname }}.txt"
+        dest: "{{ host_bundle_dir }}/configs/config_files_metadata.txt"
+        flat: true
+      become: true
+      ignore_errors: true
+      when:
+        - support_bundle_skip_configs
+        - metadata_created is defined
+
+    - name: Clean up remote metadata file
+      file:
+        path: "/tmp/config_files_metadata_{{ inventory_hostname }}.txt"
+        state: absent
+      become: true
+      ignore_errors: true
+      when:
+        - support_bundle_skip_configs
+        - metadata_created is defined
+
+# COLLECT LOG FILES
+- name: Find log files
+  find:
+    paths: "{{ log_dir }}"
+    recurse: false
+  become: true
+  register: log_files_found
+  ignore_errors: true
+
+- name: Fetch log files directly to localhost
+  fetch:
+    src: "{{ item.path }}"
+    dest: "{{ host_bundle_dir }}/logs/"
+    flat: true
+  become: true
+  loop: "{{ log_files_found.files }}"
+  ignore_errors: true
+  when: log_files_found.matched > 0
+
+# COLLECT SSL CERTIFICATE METADATA - SKIPPED FOR SECURITY
+# Note: SSL metadata collection is disabled by default due to security concerns
+# See: Confluence one-pager comments #3 (security concern)
+# - name: Collect SSL metadata
+#   include_tasks: collect_ssl_metadata.yml
+#   when: ssl_enabled | default(false)
+
+# COLLECT SYSTEM INFORMATION - REMOVED (Comment #16: not needed by default)
+# - name: Collect system information
+#   include_tasks: collect_system_info.yml
+
+# COLLECT RUNTIME DIAGNOSTICS
+- name: Collect runtime diagnostics
+  include_tasks: collect_diagnostics.yml
+
+# GENERATE HOST MANIFEST
+- name: Generate host manifest on localhost
+  template:
+    src: host_manifest.yml.j2
+    dest: "{{ host_bundle_dir }}/host_manifest.yml"
+    mode: '0644'
+  delegate_to: localhost
+  vars:
+    ansible_connection: local
+  ignore_errors: true

--- a/roles/common/tasks/collect_support_bundle.yml
+++ b/roles/common/tasks/collect_support_bundle.yml
@@ -152,16 +152,9 @@
   ignore_errors: true
   when: log_files_found.matched | default(0) > 0
 
-# COLLECT SSL CERTIFICATE METADATA - SKIPPED FOR SECURITY
-# Note: SSL metadata collection is disabled by default due to security concerns
-# See: Confluence one-pager comments #3 (security concern)
-# - name: Collect SSL metadata
-#   include_tasks: collect_ssl_metadata.yml
-#   when: ssl_enabled | default(false)
-
 # COLLECT SYSTEM INFORMATION - REMOVED (Comment #16: not needed by default)
-# - name: Collect system information
-#   include_tasks: collect_system_info.yml
+- name: Collect system information
+  include_tasks: collect_system_info.yml
 
 # COLLECT RUNTIME DIAGNOSTICS
 - name: Collect runtime diagnostics
@@ -176,4 +169,5 @@
   delegate_to: localhost
   vars:
     ansible_connection: local
+    ansible_become: false
   ignore_errors: true

--- a/roles/common/tasks/collect_support_bundle.yml
+++ b/roles/common/tasks/collect_support_bundle.yml
@@ -125,23 +125,28 @@
         - metadata_created is defined
 
 # COLLECT LOG FILES
-- name: Find log files
+# Bounded collection to prevent bundle bloat - defaults to *.log files, max 20 most recent
+- name: Find log files with bounded defaults
   find:
     paths: "{{ log_dir }}"
     recurse: false
+    file_type: file
+    patterns: "{{ support_bundle_log_patterns | default(['*.log']) }}"
+    size: "{{ support_bundle_log_max_size | default(omit) }}"
+    age: "{{ support_bundle_log_age | default(omit) }}"
   become: true
   register: log_files_found
   ignore_errors: true
 
-- name: Fetch log files directly to localhost
+- name: Fetch selected log files directly to localhost
   fetch:
     src: "{{ item.path }}"
     dest: "{{ host_bundle_dir }}/logs/"
     flat: true
   become: true
-  loop: "{{ log_files_found.files }}"
+  loop: "{{ (log_files_found.files | default([]) | sort(attribute='mtime', reverse=true))[:(support_bundle_log_max_count | default(20) | int)] }}"
   ignore_errors: true
-  when: log_files_found.matched > 0
+  when: log_files_found.matched | default(0) > 0
 
 # COLLECT SSL CERTIFICATE METADATA - SKIPPED FOR SECURITY
 # Note: SSL metadata collection is disabled by default due to security concerns

--- a/roles/common/tasks/collect_support_bundle.yml
+++ b/roles/common/tasks/collect_support_bundle.yml
@@ -80,8 +80,12 @@
         - not support_bundle_skip_configs
 
     # SANITIZE CONFIG FILES (on localhost after fetch)
+    # Note: Always runs when sanitization enabled, even with secrets_protection,
+    #       because override.conf is not encrypted by secrets protection
     - name: Sanitize sensitive data from config files
       include_tasks: sanitize_config_files_local.yml
+      vars:
+        skip_properties_sanitization: "{{ secrets_protection_enabled | default(false) | bool }}"
       when:
         - support_bundle_sanitize_configs
         - not support_bundle_skip_configs

--- a/roles/common/tasks/collect_system_info.yml
+++ b/roles/common/tasks/collect_system_info.yml
@@ -22,7 +22,7 @@
 
 - name: Collect Java version
   shell: |
-    java -version 2>&1 > /tmp/java_version_{{ inventory_hostname }}.txt
+    java -version > /tmp/java_version_{{ inventory_hostname }}.txt 2>&1
     echo "---" >> /tmp/java_version_{{ inventory_hostname }}.txt
     echo "JAVA_HOME: $JAVA_HOME" >> /tmp/java_version_{{ inventory_hostname }}.txt
   args:

--- a/roles/common/tasks/collect_system_info.yml
+++ b/roles/common/tasks/collect_system_info.yml
@@ -84,6 +84,7 @@
   delegate_to: localhost
   vars:
     ansible_connection: local
+    ansible_become: false
   ignore_errors: true
 
 - name: Clean up remote system info temp files

--- a/roles/common/tasks/collect_system_info.yml
+++ b/roles/common/tasks/collect_system_info.yml
@@ -1,0 +1,151 @@
+---
+# System Information Collection Task
+# Collects OS, Java, memory, disk, network, hostname, and environment information
+# Direct fetch approach - creates temp files on remote and fetches to localhost
+
+- name: Collect OS information
+  shell: |
+    echo "=== OS Information ===" > /tmp/os_info_{{ inventory_hostname }}.txt
+    uname -a >> /tmp/os_info_{{ inventory_hostname }}.txt
+    echo "---" >> /tmp/os_info_{{ inventory_hostname }}.txt
+    cat /etc/os-release >> /tmp/os_info_{{ inventory_hostname }}.txt 2>/dev/null || true
+  args:
+    executable: "{{ shell_executable }}"
+  ignore_errors: true
+
+- name: Fetch OS information
+  fetch:
+    src: "/tmp/os_info_{{ inventory_hostname }}.txt"
+    dest: "{{ host_bundle_dir }}/system/os_info.txt"
+    flat: true
+  ignore_errors: true
+
+- name: Collect Java version
+  shell: |
+    java -version 2>&1 > /tmp/java_version_{{ inventory_hostname }}.txt
+    echo "---" >> /tmp/java_version_{{ inventory_hostname }}.txt
+    echo "JAVA_HOME: $JAVA_HOME" >> /tmp/java_version_{{ inventory_hostname }}.txt
+  args:
+    executable: "{{ shell_executable }}"
+  ignore_errors: true
+
+- name: Fetch Java version
+  fetch:
+    src: "/tmp/java_version_{{ inventory_hostname }}.txt"
+    dest: "{{ host_bundle_dir }}/system/java_version.txt"
+    flat: true
+  ignore_errors: true
+
+- name: Collect memory information
+  shell: |
+    free -h > /tmp/memory_{{ inventory_hostname }}.txt 2>&1
+    echo "---" >> /tmp/memory_{{ inventory_hostname }}.txt
+    cat /proc/meminfo >> /tmp/memory_{{ inventory_hostname }}.txt 2>/dev/null || true
+  args:
+    executable: "{{ shell_executable }}"
+  ignore_errors: true
+
+- name: Fetch memory information
+  fetch:
+    src: "/tmp/memory_{{ inventory_hostname }}.txt"
+    dest: "{{ host_bundle_dir }}/system/memory.txt"
+    flat: true
+  ignore_errors: true
+
+- name: Collect disk information
+  shell: |
+    df -h > /tmp/disk_{{ inventory_hostname }}.txt 2>&1
+    echo "---" >> /tmp/disk_{{ inventory_hostname }}.txt
+    lsblk >> /tmp/disk_{{ inventory_hostname }}.txt 2>/dev/null || true
+  args:
+    executable: "{{ shell_executable }}"
+  ignore_errors: true
+
+- name: Fetch disk information
+  fetch:
+    src: "/tmp/disk_{{ inventory_hostname }}.txt"
+    dest: "{{ host_bundle_dir }}/system/disk.txt"
+    flat: true
+  ignore_errors: true
+
+- name: Collect network configuration
+  shell: |
+    ip addr > /tmp/network_{{ inventory_hostname }}.txt 2>/dev/null || ifconfig >> /tmp/network_{{ inventory_hostname }}.txt 2>&1
+    echo "---" >> /tmp/network_{{ inventory_hostname }}.txt
+    ip route >> /tmp/network_{{ inventory_hostname }}.txt 2>/dev/null || netstat -rn >> /tmp/network_{{ inventory_hostname }}.txt 2>&1
+  args:
+    executable: "{{ shell_executable }}"
+  ignore_errors: true
+
+- name: Fetch network configuration
+  fetch:
+    src: "/tmp/network_{{ inventory_hostname }}.txt"
+    dest: "{{ host_bundle_dir }}/system/network.txt"
+    flat: true
+  ignore_errors: true
+
+- name: Collect hostname and DNS
+  shell: |
+    echo "Hostname: $(hostname)" > /tmp/hostname_{{ inventory_hostname }}.txt
+    echo "FQDN: $(hostname -f 2>/dev/null || hostname)" >> /tmp/hostname_{{ inventory_hostname }}.txt
+    echo "---" >> /tmp/hostname_{{ inventory_hostname }}.txt
+    cat /etc/hosts >> /tmp/hostname_{{ inventory_hostname }}.txt 2>/dev/null || true
+    echo "---" >> /tmp/hostname_{{ inventory_hostname }}.txt
+    cat /etc/resolv.conf >> /tmp/hostname_{{ inventory_hostname }}.txt 2>/dev/null || true
+  args:
+    executable: "{{ shell_executable }}"
+  ignore_errors: true
+
+- name: Fetch hostname and DNS info
+  fetch:
+    src: "/tmp/hostname_{{ inventory_hostname }}.txt"
+    dest: "{{ host_bundle_dir }}/system/hostname.txt"
+    flat: true
+  ignore_errors: true
+
+- name: Collect environment variables (sanitized)
+  shell: |
+    env | grep -E 'JAVA|KAFKA|CONFLUENT|PATH|USER|HOME' | grep -v -E 'PASSWORD|SECRET|KEY|TOKEN' > /tmp/environment_{{ inventory_hostname }}.txt 2>&1
+  args:
+    executable: "{{ shell_executable }}"
+  ignore_errors: true
+
+- name: Fetch environment variables
+  fetch:
+    src: "/tmp/environment_{{ inventory_hostname }}.txt"
+    dest: "{{ host_bundle_dir }}/system/environment.txt"
+    flat: true
+  ignore_errors: true
+
+- name: Save Ansible facts on localhost
+  copy:
+    content: |
+      Ansible Version: {{ ansible_version.full }}
+      OS Family: {{ ansible_os_family }}
+      Distribution: {{ ansible_distribution }} {{ ansible_distribution_version }}
+      Kernel: {{ ansible_kernel }}
+      Architecture: {{ ansible_architecture }}
+      Memory (MB): {{ ansible_memtotal_mb }}
+      Processor Count: {{ ansible_processor_count }}
+      Processor Cores: {{ ansible_processor_cores }}
+      Python Version: {{ ansible_python_version }}
+    dest: "{{ host_bundle_dir }}/system/ansible_facts.txt"
+    mode: '0644'
+  delegate_to: localhost
+  vars:
+    ansible_connection: local
+  ignore_errors: true
+
+- name: Clean up remote system info temp files
+  file:
+    path: "/tmp/{{ item }}_{{ inventory_hostname }}.txt"
+    state: absent
+  loop:
+    - os_info
+    - java_version
+    - memory
+    - disk
+    - network
+    - hostname
+    - environment
+  ignore_errors: true

--- a/roles/common/tasks/collect_system_info.yml
+++ b/roles/common/tasks/collect_system_info.yml
@@ -24,7 +24,6 @@
   shell: |
     java -version > /tmp/java_version_{{ inventory_hostname }}.txt 2>&1
     echo "---" >> /tmp/java_version_{{ inventory_hostname }}.txt
-    echo "JAVA_HOME: $JAVA_HOME" >> /tmp/java_version_{{ inventory_hostname }}.txt
   args:
     executable: "{{ shell_executable }}"
   ignore_errors: true
@@ -68,55 +67,6 @@
     flat: true
   ignore_errors: true
 
-- name: Collect network configuration
-  shell: |
-    ip addr > /tmp/network_{{ inventory_hostname }}.txt 2>/dev/null || ifconfig >> /tmp/network_{{ inventory_hostname }}.txt 2>&1
-    echo "---" >> /tmp/network_{{ inventory_hostname }}.txt
-    ip route >> /tmp/network_{{ inventory_hostname }}.txt 2>/dev/null || netstat -rn >> /tmp/network_{{ inventory_hostname }}.txt 2>&1
-  args:
-    executable: "{{ shell_executable }}"
-  ignore_errors: true
-
-- name: Fetch network configuration
-  fetch:
-    src: "/tmp/network_{{ inventory_hostname }}.txt"
-    dest: "{{ host_bundle_dir }}/system/network.txt"
-    flat: true
-  ignore_errors: true
-
-- name: Collect hostname and DNS
-  shell: |
-    echo "Hostname: $(hostname)" > /tmp/hostname_{{ inventory_hostname }}.txt
-    echo "FQDN: $(hostname -f 2>/dev/null || hostname)" >> /tmp/hostname_{{ inventory_hostname }}.txt
-    echo "---" >> /tmp/hostname_{{ inventory_hostname }}.txt
-    cat /etc/hosts >> /tmp/hostname_{{ inventory_hostname }}.txt 2>/dev/null || true
-    echo "---" >> /tmp/hostname_{{ inventory_hostname }}.txt
-    cat /etc/resolv.conf >> /tmp/hostname_{{ inventory_hostname }}.txt 2>/dev/null || true
-  args:
-    executable: "{{ shell_executable }}"
-  ignore_errors: true
-
-- name: Fetch hostname and DNS info
-  fetch:
-    src: "/tmp/hostname_{{ inventory_hostname }}.txt"
-    dest: "{{ host_bundle_dir }}/system/hostname.txt"
-    flat: true
-  ignore_errors: true
-
-- name: Collect environment variables (sanitized)
-  shell: |
-    env | grep -E 'JAVA|KAFKA|CONFLUENT|PATH|USER|HOME' | grep -v -E 'PASSWORD|SECRET|KEY|TOKEN' > /tmp/environment_{{ inventory_hostname }}.txt 2>&1
-  args:
-    executable: "{{ shell_executable }}"
-  ignore_errors: true
-
-- name: Fetch environment variables
-  fetch:
-    src: "/tmp/environment_{{ inventory_hostname }}.txt"
-    dest: "{{ host_bundle_dir }}/system/environment.txt"
-    flat: true
-  ignore_errors: true
-
 - name: Save Ansible facts on localhost
   copy:
     content: |
@@ -145,7 +95,4 @@
     - java_version
     - memory
     - disk
-    - network
-    - hostname
-    - environment
   ignore_errors: true

--- a/roles/common/tasks/sanitize_config_files_local.yml
+++ b/roles/common/tasks/sanitize_config_files_local.yml
@@ -1,9 +1,18 @@
 ---
-# Configuration File Sanitization Task (Localhost)
-# Redacts sensitive data (passwords, secrets, keys) from config files after fetching to localhost
+# Sanitizes config files: .properties (if not encrypted), override.conf (always)
+# Variable: skip_properties_sanitization - skips .properties if secrets protection enabled
 
-# Sanitize .properties files
-- name: Find all .properties files in configs directory
+- name: Copy sanitization script
+  copy:
+    src: sanitize_properties.py
+    dest: /tmp/sanitize_properties.py
+    mode: '0755'
+  delegate_to: localhost
+  vars:
+    ansible_connection: local
+  ignore_errors: true
+
+- name: Find .properties files
   find:
     paths: "{{ host_bundle_dir }}/configs"
     patterns: "*.properties"
@@ -11,81 +20,21 @@
   delegate_to: localhost
   vars:
     ansible_connection: local
+  when: not (skip_properties_sanitization | default(false) | bool)
   ignore_errors: true
 
 - name: Sanitize .properties files
-  shell: |
-    # Create backup
-    cp {{ item.path | quote }} {{ (item.path ~ '.original') | quote }}
-
-    # Sanitize sensitive values - replace anything after '=' for sensitive keys
-    sed -i.bak -E 's/(.*password.*=).*/\1 ***REDACTED***/gi' {{ item.path | quote }}
-    sed -i.bak -E 's/(.*secret.*=).*/\1 ***REDACTED***/gi' {{ item.path | quote }}
-    sed -i.bak -E 's/(.*\.key=).*/\1 ***REDACTED***/gi' {{ item.path | quote }}
-    sed -i.bak -E 's/(.*credential.*=).*/\1 ***REDACTED***/gi' {{ item.path | quote }}
-    sed -i.bak -E 's/(.*token.*=).*/\1 ***REDACTED***/gi' {{ item.path | quote }}
-    sed -i.bak -E 's/(.*truststore\.password.*=).*/\1 ***REDACTED***/gi' {{ item.path | quote }}
-    sed -i.bak -E 's/(.*keystore\.password.*=).*/\1 ***REDACTED***/gi' {{ item.path | quote }}
-    sed -i.bak -E 's/(.*ssl\.key\.password.*=).*/\1 ***REDACTED***/gi' {{ item.path | quote }}
-    sed -i.bak -E 's/(.*sasl\.jaas\.config.*=).*/\1 ***REDACTED***/gi' {{ item.path | quote }}
-    sed -i.bak -E 's/(.*basic\.auth\.credentials\.source.*=).*/\1 ***REDACTED***/gi' {{ item.path | quote }}
-    sed -i.bak -E 's/(.*ldap\..*password.*=).*/\1 ***REDACTED***/gi' {{ item.path | quote }}
-
-    # Add sanitization notice at the top
-    echo "# THIS FILE HAS BEEN SANITIZED - SENSITIVE VALUES REDACTED" | cat - {{ item.path | quote }} > {{ (item.path ~ '.tmp') | quote }}
-    mv {{ (item.path ~ '.tmp') | quote }} {{ item.path | quote }}
-
-    # Remove original and sed backup files
-    rm -f {{ (item.path ~ '.original') | quote }} {{ (item.path ~ '.bak') | quote }}
-  args:
-    executable: /bin/bash
-  loop: "{{ properties_files.files }}"
-  when: properties_files.matched | default(0) > 0
+  command: python3 /tmp/sanitize_properties.py "{{ item.path }}" --type properties
+  loop: "{{ properties_files.files | default([]) }}"
+  when:
+    - not (skip_properties_sanitization | default(false) | bool)
+    - properties_files.matched | default(0) > 0
   delegate_to: localhost
   vars:
     ansible_connection: local
   ignore_errors: true
 
-# Sanitize JAAS files (contain plaintext passwords)
-- name: Find all JAAS config files
-  find:
-    paths: "{{ host_bundle_dir }}/configs"
-    patterns:
-      - "*jaas.conf"
-      - "*_jaas.conf"
-  register: jaas_files
-  delegate_to: localhost
-  vars:
-    ansible_connection: local
-  ignore_errors: true
-
-- name: Sanitize JAAS files
-  shell: |
-    # Create backup
-    cp {{ item.path | quote }} {{ (item.path ~ '.original') | quote }}
-
-    # Redact password values in JAAS files
-    sed -i.bak -E 's/(password=")[^"]*"/\1***REDACTED***"/gi' {{ item.path | quote }}
-    sed -i.bak -E "s/(password=')[^']*'/\1***REDACTED***'/gi" {{ item.path | quote }}
-    sed -i.bak -E 's/(password=)[^; \t]*/\1***REDACTED***/gi' {{ item.path | quote }}
-
-    # Add sanitization notice at the top
-    echo "// THIS FILE HAS BEEN SANITIZED - SENSITIVE VALUES REDACTED" | cat - {{ item.path | quote }} > {{ (item.path ~ '.tmp') | quote }}
-    mv {{ (item.path ~ '.tmp') | quote }} {{ item.path | quote }}
-
-    # Remove original and sed backup files
-    rm -f {{ (item.path ~ '.original') | quote }} {{ (item.path ~ '.bak') | quote }}
-  args:
-    executable: /bin/bash
-  loop: "{{ jaas_files.files }}"
-  when: jaas_files.matched | default(0) > 0
-  delegate_to: localhost
-  vars:
-    ansible_connection: local
-  ignore_errors: true
-
-# Sanitize override.conf files (may contain env vars with secrets)
-- name: Find systemd override files
+- name: Find override.conf files
   find:
     paths: "{{ host_bundle_dir }}/configs"
     patterns: "override.conf"
@@ -95,41 +44,17 @@
     ansible_connection: local
   ignore_errors: true
 
-- name: Sanitize systemd override files
-  shell: |
-    # Create backup
-    cp {{ item.path | quote }} {{ (item.path ~ '.original') | quote }}
-
-    # Redact environment variables with sensitive values
-    sed -i.bak -E 's/(Environment=.*PASSWORD.*=).*/\1***REDACTED***/gi' {{ item.path | quote }}
-    sed -i.bak -E 's/(Environment=.*SECRET.*=).*/\1***REDACTED***/gi' {{ item.path | quote }}
-    sed -i.bak -E 's/(Environment=.*KEY.*=).*/\1***REDACTED***/gi' {{ item.path | quote }}
-    sed -i.bak -E 's/(Environment=.*TOKEN.*=).*/\1***REDACTED***/gi' {{ item.path | quote }}
-    sed -i.bak -E 's/(Environment=.*CREDENTIAL.*=).*/\1***REDACTED***/gi' {{ item.path | quote }}
-    sed -i.bak -E 's/(Environment=CONFLUENT_SECURITY_MASTER_KEY=).*/\1***REDACTED***/gi' {{ item.path | quote }}
-
-    # Add sanitization notice at the top
-    echo "# THIS FILE HAS BEEN SANITIZED - SENSITIVE VALUES REDACTED" | cat - {{ item.path | quote }} > {{ (item.path ~ '.tmp') | quote }}
-    mv {{ (item.path ~ '.tmp') | quote }} {{ item.path | quote }}
-
-    # Remove original and sed backup files
-    rm -f {{ (item.path ~ '.original') | quote }} {{ (item.path ~ '.bak') | quote }}
-  args:
-    executable: /bin/bash
-  loop: "{{ override_files.files }}"
+- name: Sanitize override files
+  command: python3 /tmp/sanitize_properties.py "{{ item.path }}" --type override
+  loop: "{{ override_files.files | default([]) }}"
   when: override_files.matched | default(0) > 0
   delegate_to: localhost
   vars:
     ansible_connection: local
   ignore_errors: true
 
-# Never collect password.properties files - just note their existence
-- name: Remove password.properties files if accidentally collected
-  shell: |
-    find {{ host_bundle_dir }}/configs -name "*password.properties" -type f -exec rm -f {} \;
-    find {{ host_bundle_dir }}/configs -name "*password.properties" -type f -exec echo "File removed: {}" \; > {{ host_bundle_dir }}/configs/removed_password_files.txt 2>&1 || true
-  args:
-    executable: /bin/bash
+- name: Remove password.properties files
+  shell: find {{ host_bundle_dir }}/configs -name "*password.properties" -type f -delete
   delegate_to: localhost
   vars:
     ansible_connection: local
@@ -138,23 +63,34 @@
 - name: Create sanitization report
   copy:
     content: |
-      === Configuration File Sanitization Report ===
-      Timestamp: {{ ansible_date_time.iso8601 }}
+      Sanitization Report - {{ ansible_date_time.iso8601 }}
 
-      Sanitized .properties files: {{ properties_files.matched | default(0) }}
-      Sanitized JAAS files: {{ jaas_files.matched | default(0) }}
-      Sanitized override files: {{ override_files.matched | default(0) }}
+      Files Processed:
+        .properties: {{ 'SKIPPED (encrypted)' if skip_properties_sanitization | default(false) else properties_files.matched | default(0) }}
+        override.conf: {{ override_files.matched | default(0) }}
 
-      Sensitive patterns redacted:
-        - password, secret, key, token, credential
-        - keystore.password, truststore.password
-        - sasl.jaas.config, ldap passwords
-        - CONFLUENT_SECURITY_MASTER_KEY
+      {% if skip_properties_sanitization | default(false) %}
+      Secrets Protection: ENABLED
+        - .properties files contain encrypted values (safe to share)
+        - override.conf sanitized (may contain MASTER_KEY)
+      {% else %}
+      Sanitization Applied:
+        - Passwords, secrets, credentials → ***REDACTED***
+        - Non-sensitive metadata preserved (paths, algorithms, timeouts)
+      {% endif %}
 
-      WARNING: While sanitization has been performed, please review
-               files before sharing to ensure no sensitive data remains.
+      Review files before sharing externally.
     dest: "{{ host_bundle_dir }}/configs/SANITIZATION_REPORT.txt"
     mode: '0644'
+  delegate_to: localhost
+  vars:
+    ansible_connection: local
+  ignore_errors: true
+
+- name: Cleanup
+  file:
+    path: /tmp/sanitize_properties.py
+    state: absent
   delegate_to: localhost
   vars:
     ansible_connection: local

--- a/roles/common/tasks/sanitize_config_files_local.yml
+++ b/roles/common/tasks/sanitize_config_files_local.yml
@@ -16,31 +16,31 @@
 - name: Sanitize .properties files
   shell: |
     # Create backup
-    cp {{ item.path }} {{ item.path }}.original
+    cp {{ item.path | quote }} {{ (item.path ~ '.original') | quote }}
 
     # Sanitize sensitive values - replace anything after '=' for sensitive keys
-    sed -i '' -E 's/(.*password.*=).*/\1 ***REDACTED***/gi' {{ item.path }}
-    sed -i '' -E 's/(.*secret.*=).*/\1 ***REDACTED***/gi' {{ item.path }}
-    sed -i '' -E 's/(.*\.key=).*/\1 ***REDACTED***/gi' {{ item.path }}
-    sed -i '' -E 's/(.*credential.*=).*/\1 ***REDACTED***/gi' {{ item.path }}
-    sed -i '' -E 's/(.*token.*=).*/\1 ***REDACTED***/gi' {{ item.path }}
-    sed -i '' -E 's/(.*truststore\.password.*=).*/\1 ***REDACTED***/gi' {{ item.path }}
-    sed -i '' -E 's/(.*keystore\.password.*=).*/\1 ***REDACTED***/gi' {{ item.path }}
-    sed -i '' -E 's/(.*ssl\.key\.password.*=).*/\1 ***REDACTED***/gi' {{ item.path }}
-    sed -i '' -E 's/(.*sasl\.jaas\.config.*=).*/\1 ***REDACTED***/gi' {{ item.path }}
-    sed -i '' -E 's/(.*basic\.auth\.credentials\.source.*=).*/\1 ***REDACTED***/gi' {{ item.path }}
-    sed -i '' -E 's/(.*ldap\..*password.*=).*/\1 ***REDACTED***/gi' {{ item.path }}
+    sed -i.bak -E 's/(.*password.*=).*/\1 ***REDACTED***/gi' {{ item.path | quote }}
+    sed -i.bak -E 's/(.*secret.*=).*/\1 ***REDACTED***/gi' {{ item.path | quote }}
+    sed -i.bak -E 's/(.*\.key=).*/\1 ***REDACTED***/gi' {{ item.path | quote }}
+    sed -i.bak -E 's/(.*credential.*=).*/\1 ***REDACTED***/gi' {{ item.path | quote }}
+    sed -i.bak -E 's/(.*token.*=).*/\1 ***REDACTED***/gi' {{ item.path | quote }}
+    sed -i.bak -E 's/(.*truststore\.password.*=).*/\1 ***REDACTED***/gi' {{ item.path | quote }}
+    sed -i.bak -E 's/(.*keystore\.password.*=).*/\1 ***REDACTED***/gi' {{ item.path | quote }}
+    sed -i.bak -E 's/(.*ssl\.key\.password.*=).*/\1 ***REDACTED***/gi' {{ item.path | quote }}
+    sed -i.bak -E 's/(.*sasl\.jaas\.config.*=).*/\1 ***REDACTED***/gi' {{ item.path | quote }}
+    sed -i.bak -E 's/(.*basic\.auth\.credentials\.source.*=).*/\1 ***REDACTED***/gi' {{ item.path | quote }}
+    sed -i.bak -E 's/(.*ldap\..*password.*=).*/\1 ***REDACTED***/gi' {{ item.path | quote }}
 
     # Add sanitization notice at the top
-    echo "# THIS FILE HAS BEEN SANITIZED - SENSITIVE VALUES REDACTED" | cat - {{ item.path }} > {{ item.path }}.tmp
-    mv {{ item.path }}.tmp {{ item.path }}
+    echo "# THIS FILE HAS BEEN SANITIZED - SENSITIVE VALUES REDACTED" | cat - {{ item.path | quote }} > {{ (item.path ~ '.tmp') | quote }}
+    mv {{ (item.path ~ '.tmp') | quote }} {{ item.path | quote }}
 
-    # Remove original backup
-    rm -f {{ item.path }}.original
+    # Remove original and sed backup files
+    rm -f {{ (item.path ~ '.original') | quote }} {{ (item.path ~ '.bak') | quote }}
   args:
     executable: /bin/bash
   loop: "{{ properties_files.files }}"
-  when: properties_files.matched > 0
+  when: properties_files.matched | default(0) > 0
   delegate_to: localhost
   vars:
     ansible_connection: local
@@ -50,7 +50,9 @@
 - name: Find all JAAS config files
   find:
     paths: "{{ host_bundle_dir }}/configs"
-    patterns: "*jaas.conf,*_jaas.conf"
+    patterns:
+      - "*jaas.conf"
+      - "*_jaas.conf"
   register: jaas_files
   delegate_to: localhost
   vars:
@@ -60,23 +62,23 @@
 - name: Sanitize JAAS files
   shell: |
     # Create backup
-    cp {{ item.path }} {{ item.path }}.original
+    cp {{ item.path | quote }} {{ (item.path ~ '.original') | quote }}
 
     # Redact password values in JAAS files
-    sed -i '' -E 's/(password=")[^"]*"/\1***REDACTED***"/gi' {{ item.path }}
-    sed -i '' -E "s/(password=')[^']*'/\1***REDACTED***'/gi" {{ item.path }}
-    sed -i '' -E 's/(password=)[^; \t]*/\1***REDACTED***/gi' {{ item.path }}
+    sed -i.bak -E 's/(password=")[^"]*"/\1***REDACTED***"/gi' {{ item.path | quote }}
+    sed -i.bak -E "s/(password=')[^']*'/\1***REDACTED***'/gi" {{ item.path | quote }}
+    sed -i.bak -E 's/(password=)[^; \t]*/\1***REDACTED***/gi' {{ item.path | quote }}
 
     # Add sanitization notice at the top
-    echo "// THIS FILE HAS BEEN SANITIZED - SENSITIVE VALUES REDACTED" | cat - {{ item.path }} > {{ item.path }}.tmp
-    mv {{ item.path }}.tmp {{ item.path }}
+    echo "// THIS FILE HAS BEEN SANITIZED - SENSITIVE VALUES REDACTED" | cat - {{ item.path | quote }} > {{ (item.path ~ '.tmp') | quote }}
+    mv {{ (item.path ~ '.tmp') | quote }} {{ item.path | quote }}
 
-    # Remove original backup
-    rm -f {{ item.path }}.original
+    # Remove original and sed backup files
+    rm -f {{ (item.path ~ '.original') | quote }} {{ (item.path ~ '.bak') | quote }}
   args:
     executable: /bin/bash
   loop: "{{ jaas_files.files }}"
-  when: jaas_files.matched > 0
+  when: jaas_files.matched | default(0) > 0
   delegate_to: localhost
   vars:
     ansible_connection: local
@@ -96,26 +98,26 @@
 - name: Sanitize systemd override files
   shell: |
     # Create backup
-    cp {{ item.path }} {{ item.path }}.original
+    cp {{ item.path | quote }} {{ (item.path ~ '.original') | quote }}
 
     # Redact environment variables with sensitive values
-    sed -i '' -E 's/(Environment=.*PASSWORD.*=).*/\1***REDACTED***/gi' {{ item.path }}
-    sed -i '' -E 's/(Environment=.*SECRET.*=).*/\1***REDACTED***/gi' {{ item.path }}
-    sed -i '' -E 's/(Environment=.*KEY.*=).*/\1***REDACTED***/gi' {{ item.path }}
-    sed -i '' -E 's/(Environment=.*TOKEN.*=).*/\1***REDACTED***/gi' {{ item.path }}
-    sed -i '' -E 's/(Environment=.*CREDENTIAL.*=).*/\1***REDACTED***/gi' {{ item.path }}
-    sed -i '' -E 's/(Environment=CONFLUENT_SECURITY_MASTER_KEY=).*/\1***REDACTED***/gi' {{ item.path }}
+    sed -i.bak -E 's/(Environment=.*PASSWORD.*=).*/\1***REDACTED***/gi' {{ item.path | quote }}
+    sed -i.bak -E 's/(Environment=.*SECRET.*=).*/\1***REDACTED***/gi' {{ item.path | quote }}
+    sed -i.bak -E 's/(Environment=.*KEY.*=).*/\1***REDACTED***/gi' {{ item.path | quote }}
+    sed -i.bak -E 's/(Environment=.*TOKEN.*=).*/\1***REDACTED***/gi' {{ item.path | quote }}
+    sed -i.bak -E 's/(Environment=.*CREDENTIAL.*=).*/\1***REDACTED***/gi' {{ item.path | quote }}
+    sed -i.bak -E 's/(Environment=CONFLUENT_SECURITY_MASTER_KEY=).*/\1***REDACTED***/gi' {{ item.path | quote }}
 
     # Add sanitization notice at the top
-    echo "# THIS FILE HAS BEEN SANITIZED - SENSITIVE VALUES REDACTED" | cat - {{ item.path }} > {{ item.path }}.tmp
-    mv {{ item.path }}.tmp {{ item.path }}
+    echo "# THIS FILE HAS BEEN SANITIZED - SENSITIVE VALUES REDACTED" | cat - {{ item.path | quote }} > {{ (item.path ~ '.tmp') | quote }}
+    mv {{ (item.path ~ '.tmp') | quote }} {{ item.path | quote }}
 
-    # Remove original backup
-    rm -f {{ item.path }}.original
+    # Remove original and sed backup files
+    rm -f {{ (item.path ~ '.original') | quote }} {{ (item.path ~ '.bak') | quote }}
   args:
     executable: /bin/bash
   loop: "{{ override_files.files }}"
-  when: override_files.matched > 0
+  when: override_files.matched | default(0) > 0
   delegate_to: localhost
   vars:
     ansible_connection: local

--- a/roles/common/tasks/sanitize_config_files_local.yml
+++ b/roles/common/tasks/sanitize_config_files_local.yml
@@ -1,0 +1,159 @@
+---
+# Configuration File Sanitization Task (Localhost)
+# Redacts sensitive data (passwords, secrets, keys) from config files after fetching to localhost
+
+# Sanitize .properties files
+- name: Find all .properties files in configs directory
+  find:
+    paths: "{{ host_bundle_dir }}/configs"
+    patterns: "*.properties"
+  register: properties_files
+  delegate_to: localhost
+  vars:
+    ansible_connection: local
+  ignore_errors: true
+
+- name: Sanitize .properties files
+  shell: |
+    # Create backup
+    cp {{ item.path }} {{ item.path }}.original
+
+    # Sanitize sensitive values - replace anything after '=' for sensitive keys
+    sed -i '' -E 's/(.*password.*=).*/\1 ***REDACTED***/gi' {{ item.path }}
+    sed -i '' -E 's/(.*secret.*=).*/\1 ***REDACTED***/gi' {{ item.path }}
+    sed -i '' -E 's/(.*\.key=).*/\1 ***REDACTED***/gi' {{ item.path }}
+    sed -i '' -E 's/(.*credential.*=).*/\1 ***REDACTED***/gi' {{ item.path }}
+    sed -i '' -E 's/(.*token.*=).*/\1 ***REDACTED***/gi' {{ item.path }}
+    sed -i '' -E 's/(.*truststore\.password.*=).*/\1 ***REDACTED***/gi' {{ item.path }}
+    sed -i '' -E 's/(.*keystore\.password.*=).*/\1 ***REDACTED***/gi' {{ item.path }}
+    sed -i '' -E 's/(.*ssl\.key\.password.*=).*/\1 ***REDACTED***/gi' {{ item.path }}
+    sed -i '' -E 's/(.*sasl\.jaas\.config.*=).*/\1 ***REDACTED***/gi' {{ item.path }}
+    sed -i '' -E 's/(.*basic\.auth\.credentials\.source.*=).*/\1 ***REDACTED***/gi' {{ item.path }}
+    sed -i '' -E 's/(.*ldap\..*password.*=).*/\1 ***REDACTED***/gi' {{ item.path }}
+
+    # Add sanitization notice at the top
+    echo "# THIS FILE HAS BEEN SANITIZED - SENSITIVE VALUES REDACTED" | cat - {{ item.path }} > {{ item.path }}.tmp
+    mv {{ item.path }}.tmp {{ item.path }}
+
+    # Remove original backup
+    rm -f {{ item.path }}.original
+  args:
+    executable: /bin/bash
+  loop: "{{ properties_files.files }}"
+  when: properties_files.matched > 0
+  delegate_to: localhost
+  vars:
+    ansible_connection: local
+  ignore_errors: true
+
+# Sanitize JAAS files (contain plaintext passwords)
+- name: Find all JAAS config files
+  find:
+    paths: "{{ host_bundle_dir }}/configs"
+    patterns: "*jaas.conf,*_jaas.conf"
+  register: jaas_files
+  delegate_to: localhost
+  vars:
+    ansible_connection: local
+  ignore_errors: true
+
+- name: Sanitize JAAS files
+  shell: |
+    # Create backup
+    cp {{ item.path }} {{ item.path }}.original
+
+    # Redact password values in JAAS files
+    sed -i '' -E 's/(password=")[^"]*"/\1***REDACTED***"/gi' {{ item.path }}
+    sed -i '' -E "s/(password=')[^']*'/\1***REDACTED***'/gi" {{ item.path }}
+    sed -i '' -E 's/(password=)[^; \t]*/\1***REDACTED***/gi' {{ item.path }}
+
+    # Add sanitization notice at the top
+    echo "// THIS FILE HAS BEEN SANITIZED - SENSITIVE VALUES REDACTED" | cat - {{ item.path }} > {{ item.path }}.tmp
+    mv {{ item.path }}.tmp {{ item.path }}
+
+    # Remove original backup
+    rm -f {{ item.path }}.original
+  args:
+    executable: /bin/bash
+  loop: "{{ jaas_files.files }}"
+  when: jaas_files.matched > 0
+  delegate_to: localhost
+  vars:
+    ansible_connection: local
+  ignore_errors: true
+
+# Sanitize override.conf files (may contain env vars with secrets)
+- name: Find systemd override files
+  find:
+    paths: "{{ host_bundle_dir }}/configs"
+    patterns: "override.conf"
+  register: override_files
+  delegate_to: localhost
+  vars:
+    ansible_connection: local
+  ignore_errors: true
+
+- name: Sanitize systemd override files
+  shell: |
+    # Create backup
+    cp {{ item.path }} {{ item.path }}.original
+
+    # Redact environment variables with sensitive values
+    sed -i '' -E 's/(Environment=.*PASSWORD.*=).*/\1***REDACTED***/gi' {{ item.path }}
+    sed -i '' -E 's/(Environment=.*SECRET.*=).*/\1***REDACTED***/gi' {{ item.path }}
+    sed -i '' -E 's/(Environment=.*KEY.*=).*/\1***REDACTED***/gi' {{ item.path }}
+    sed -i '' -E 's/(Environment=.*TOKEN.*=).*/\1***REDACTED***/gi' {{ item.path }}
+    sed -i '' -E 's/(Environment=.*CREDENTIAL.*=).*/\1***REDACTED***/gi' {{ item.path }}
+    sed -i '' -E 's/(Environment=CONFLUENT_SECURITY_MASTER_KEY=).*/\1***REDACTED***/gi' {{ item.path }}
+
+    # Add sanitization notice at the top
+    echo "# THIS FILE HAS BEEN SANITIZED - SENSITIVE VALUES REDACTED" | cat - {{ item.path }} > {{ item.path }}.tmp
+    mv {{ item.path }}.tmp {{ item.path }}
+
+    # Remove original backup
+    rm -f {{ item.path }}.original
+  args:
+    executable: /bin/bash
+  loop: "{{ override_files.files }}"
+  when: override_files.matched > 0
+  delegate_to: localhost
+  vars:
+    ansible_connection: local
+  ignore_errors: true
+
+# Never collect password.properties files - just note their existence
+- name: Remove password.properties files if accidentally collected
+  shell: |
+    find {{ host_bundle_dir }}/configs -name "*password.properties" -type f -exec rm -f {} \;
+    find {{ host_bundle_dir }}/configs -name "*password.properties" -type f -exec echo "File removed: {}" \; > {{ host_bundle_dir }}/configs/removed_password_files.txt 2>&1 || true
+  args:
+    executable: /bin/bash
+  delegate_to: localhost
+  vars:
+    ansible_connection: local
+  ignore_errors: true
+
+- name: Create sanitization report
+  copy:
+    content: |
+      === Configuration File Sanitization Report ===
+      Timestamp: {{ ansible_date_time.iso8601 }}
+
+      Sanitized .properties files: {{ properties_files.matched | default(0) }}
+      Sanitized JAAS files: {{ jaas_files.matched | default(0) }}
+      Sanitized override files: {{ override_files.matched | default(0) }}
+
+      Sensitive patterns redacted:
+        - password, secret, key, token, credential
+        - keystore.password, truststore.password
+        - sasl.jaas.config, ldap passwords
+        - CONFLUENT_SECURITY_MASTER_KEY
+
+      WARNING: While sanitization has been performed, please review
+               files before sharing to ensure no sensitive data remains.
+    dest: "{{ host_bundle_dir }}/configs/SANITIZATION_REPORT.txt"
+    mode: '0644'
+  delegate_to: localhost
+  vars:
+    ansible_connection: local
+  ignore_errors: true

--- a/roles/common/tasks/sanitize_config_files_local.yml
+++ b/roles/common/tasks/sanitize_config_files_local.yml
@@ -11,6 +11,7 @@
   delegate_to: localhost
   vars:
     ansible_connection: local
+    ansible_become: false
   when: not (skip_properties_sanitization | default(false) | bool)
   ignore_errors: true
 
@@ -25,6 +26,7 @@
   delegate_to: localhost
   vars:
     ansible_connection: local
+    ansible_become: false
   ignore_errors: true
 
 - name: Find override.conf files
@@ -35,6 +37,7 @@
   delegate_to: localhost
   vars:
     ansible_connection: local
+    ansible_become: false
   ignore_errors: true
 
 - name: Sanitize override files
@@ -46,6 +49,7 @@
   delegate_to: localhost
   vars:
     ansible_connection: local
+    ansible_become: false
   ignore_errors: true
 
 - name: Remove password.properties files
@@ -53,6 +57,7 @@
   delegate_to: localhost
   vars:
     ansible_connection: local
+    ansible_become: false
   ignore_errors: true
 
 - name: Create sanitization report
@@ -80,4 +85,5 @@
   delegate_to: localhost
   vars:
     ansible_connection: local
+    ansible_become: false
   ignore_errors: true

--- a/roles/common/tasks/sanitize_config_files_local.yml
+++ b/roles/common/tasks/sanitize_config_files_local.yml
@@ -1,16 +1,7 @@
 ---
 # Sanitizes config files: .properties (if not encrypted), override.conf (always)
 # Variable: skip_properties_sanitization - skips .properties if secrets protection enabled
-
-- name: Copy sanitization script
-  copy:
-    src: sanitize_properties.py
-    dest: /tmp/sanitize_properties.py
-    mode: '0755'
-  delegate_to: localhost
-  vars:
-    ansible_connection: local
-  ignore_errors: true
+# Uses script module - automatically finds sanitize_properties.py in roles/common/files/
 
 - name: Find .properties files
   find:
@@ -24,7 +15,9 @@
   ignore_errors: true
 
 - name: Sanitize .properties files
-  command: python3 /tmp/sanitize_properties.py "{{ item.path }}" --type properties
+  script:
+    cmd: sanitize_properties.py "{{ item.path }}" --type properties
+    executable: python3
   loop: "{{ properties_files.files | default([]) }}"
   when:
     - not (skip_properties_sanitization | default(false) | bool)
@@ -45,7 +38,9 @@
   ignore_errors: true
 
 - name: Sanitize override files
-  command: python3 /tmp/sanitize_properties.py "{{ item.path }}" --type override
+  script:
+    cmd: sanitize_properties.py "{{ item.path }}" --type override
+    executable: python3
   loop: "{{ override_files.files | default([]) }}"
   when: override_files.matched | default(0) > 0
   delegate_to: localhost
@@ -82,15 +77,6 @@
       Review files before sharing externally.
     dest: "{{ host_bundle_dir }}/configs/SANITIZATION_REPORT.txt"
     mode: '0644'
-  delegate_to: localhost
-  vars:
-    ansible_connection: local
-  ignore_errors: true
-
-- name: Cleanup
-  file:
-    path: /tmp/sanitize_properties.py
-    state: absent
   delegate_to: localhost
   vars:
     ansible_connection: local

--- a/roles/common/tasks/sanitize_inventory_files_local.yml
+++ b/roles/common/tasks/sanitize_inventory_files_local.yml
@@ -1,0 +1,44 @@
+---
+# Sanitizes inventory files collected in the support bundle
+# Called from support_bundle.yml playbook after inventory files are copied
+# Uses script module - automatically finds sanitize_properties.py in roles/common/files/
+
+- name: Sanitize copied inventory files
+  script:
+    cmd: sanitize_properties.py "{{ item.dest }}" --type inventory
+    executable: python3
+  loop: "{{ inventory_files_copied.results | default([]) | selectattr('changed', 'equalto', true) | list }}"
+  when: inventory_files_copied.results | default([]) | selectattr('changed', 'equalto', true) | list | length > 0
+  delegate_to: localhost
+  vars:
+    ansible_connection: local
+    ansible_become: false
+  ignore_errors: true
+  register: sanitize_inventory_results
+
+- name: Sanitize generated inventory (if fallback was used)
+  script:
+    cmd: sanitize_properties.py "{{ hostvars['localhost']['bundle_path'] }}/ansible/inventory_1_raw.yml" --type inventory
+    executable: python3
+  when: inventory_files_copied.results | default([]) | selectattr('changed', 'equalto', true) | list | length == 0
+  delegate_to: localhost
+  vars:
+    ansible_connection: local
+    ansible_become: false
+  ignore_errors: true
+
+- name: Rename sanitized inventory files
+  shell: |
+    for file in {{ hostvars['localhost']['bundle_path'] }}/ansible/inventory_*_raw.yml; do
+      if [ -f "$file" ]; then
+        base=$(basename "$file" _raw.yml)
+        mv "$file" "{{ hostvars['localhost']['bundle_path'] }}/ansible/${base}_sanitized.yml"
+      fi
+    done
+  args:
+    executable: /bin/bash
+  delegate_to: localhost
+  vars:
+    ansible_connection: local
+    ansible_become: false
+  ignore_errors: true

--- a/roles/common/templates/bundle_manifest.yml.j2
+++ b/roles/common/templates/bundle_manifest.yml.j2
@@ -1,0 +1,66 @@
+support_bundle_info:
+  bundle_name: {{ hostvars['localhost']['bundle_name'] }}
+  timestamp: {{ hostvars['localhost']['bundle_timestamp'] }}
+  cluster_name: {{ support_bundle_cluster_name }}
+  output_path: {{ support_bundle_output_path }}
+  directory_structure: "<component_name>/<hostname>/"
+
+ansible_controller:
+  ansible_version: {{ ansible_version.full }}
+  python_version: {{ ansible_python.version.major }}.{{ ansible_python.version.minor }}.{{ ansible_python.version.micro }}
+  playbook: support_bundle.yml
+  timestamp: {{ ansible_date_time.iso8601 }}
+
+target_nodes_summary:
+{% for host in groups['all'] %}
+  {{ host }}:
+    ansible_version: {{ hostvars[host].ansible_version.full | default('N/A') }}
+    python_version: {{ hostvars[host].ansible_python_version | default('N/A') }}
+    os_family: {{ hostvars[host].ansible_os_family | default('N/A') }}
+    distribution: {{ hostvars[host].ansible_distribution | default('N/A') }} {{ hostvars[host].ansible_distribution_version | default('') }}
+    kernel: {{ hostvars[host].ansible_kernel | default('N/A') }}
+    architecture: {{ hostvars[host].ansible_architecture | default('N/A') }}
+{% endfor %}
+
+inventory_summary:
+  total_hosts: {{ groups['all'] | length }}
+  components:
+    zookeeper:
+      count: {{ groups['zookeeper'] | default([]) | length }}
+      hosts: {{ groups['zookeeper'] | default([]) | list }}
+    kafka_controller:
+      count: {{ groups['kafka_controller'] | default([]) | length }}
+      hosts: {{ groups['kafka_controller'] | default([]) | list }}
+    kafka_broker:
+      count: {{ groups['kafka_broker'] | default([]) | length }}
+      hosts: {{ groups['kafka_broker'] | default([]) | list }}
+    schema_registry:
+      count: {{ groups['schema_registry'] | default([]) | length }}
+      hosts: {{ groups['schema_registry'] | default([]) | list }}
+    kafka_connect:
+      count: {{ groups['kafka_connect'] | default([]) | length }}
+      hosts: {{ groups['kafka_connect'] | default([]) | list }}
+    kafka_connect_replicator:
+      count: {{ groups['kafka_connect_replicator'] | default([]) | length }}
+      hosts: {{ groups['kafka_connect_replicator'] | default([]) | list }}
+    ksql:
+      count: {{ groups['ksql'] | default([]) | length }}
+      hosts: {{ groups['ksql'] | default([]) | list }}
+    kafka_rest:
+      count: {{ groups['kafka_rest'] | default([]) | length }}
+      hosts: {{ groups['kafka_rest'] | default([]) | list }}
+    control_center:
+      count: {{ groups['control_center'] | default([]) | length }}
+      hosts: {{ groups['control_center'] | default([]) | list }}
+    control_center_next_gen:
+      count: {{ groups['control_center_next_gen'] | default([]) | length }}
+      hosts: {{ groups['control_center_next_gen'] | default([]) | list }}
+    usm_agent:
+      count: {{ groups['usm_agent'] | default([]) | length }}
+      hosts: {{ groups['usm_agent'] | default([]) | list }}
+
+collection_settings:
+  journalctl_lines: {{ support_bundle_journalctl_lines }}
+  base_path: {{ support_bundle_base_path }}
+  sanitize_configs: {{ support_bundle_sanitize_configs }}
+  skip_configs: {{ support_bundle_skip_configs }}

--- a/roles/common/templates/bundle_manifest.yml.j2
+++ b/roles/common/templates/bundle_manifest.yml.j2
@@ -7,7 +7,7 @@ support_bundle_info:
 
 ansible_controller:
   ansible_version: {{ ansible_version.full }}
-  python_version: {{ ansible_python.version.major }}.{{ ansible_python.version.minor }}.{{ ansible_python.version.micro }}
+  python_version: {{ ansible_python_version | default('N/A') }}
   playbook: support_bundle.yml
   timestamp: {{ ansible_date_time.iso8601 }}
 
@@ -64,3 +64,7 @@ collection_settings:
   base_path: {{ support_bundle_base_path }}
   sanitize_configs: {{ support_bundle_sanitize_configs }}
   skip_configs: {{ support_bundle_skip_configs }}
+  log_patterns: {{ support_bundle_log_patterns | default(['*.log']) }}
+  log_max_count: {{ support_bundle_log_max_count | default(20) }}
+  log_max_size: {{ support_bundle_log_max_size | default('not set') }}
+  log_age: {{ support_bundle_log_age | default('not set') }}

--- a/roles/common/templates/host_manifest.yml.j2
+++ b/roles/common/templates/host_manifest.yml.j2
@@ -1,0 +1,30 @@
+collection_info:
+  timestamp: {{ ansible_date_time.iso8601 }}
+  hostname: {{ inventory_hostname }}
+  component: {{ component_name }}
+  service_name: {{ service_name }}
+
+host_info:
+  os_family: {{ ansible_os_family }}
+  distribution: {{ ansible_distribution }} {{ ansible_distribution_version }}
+  kernel: {{ ansible_kernel }}
+  architecture: {{ ansible_architecture }}
+  memory_mb: {{ ansible_memtotal_mb }}
+
+ansible_info:
+  ansible_version: {{ ansible_version.full }}
+  python_version: {{ ansible_python_version }}
+
+component_info:
+  config_file: {{ config_file }}
+  log_dir: {{ log_dir }}
+  user: {{ user }}
+  group: {{ group }}
+  service_file: {{ component.systemd_file | default('N/A') }}
+
+collection_scope:
+  configs_collected: {{ not support_bundle_skip_configs }}
+  configs_sanitized: {{ support_bundle_sanitize_configs and not support_bundle_skip_configs }}
+  logs_collected: true
+  system_info_collected: false
+  diagnostics_collected: true

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -16,6 +16,46 @@ mask_secrets: true
 ### Path on component to store logs collected during fetch_logs playbook
 fetch_logs_path: /tmp
 
+### Support Bundle Collection Settings
+# Output path for support bundles (on Ansible controller)
+support_bundle_output_path: "{{ playbook_dir }}"
+
+# Cluster name to include in bundle filename
+support_bundle_cluster_name: cp_cluster
+
+# Number of journalctl log lines to collect per service
+support_bundle_journalctl_lines: 1000
+
+# Base path on remote hosts for temporary files during collection
+# Note: Files are fetched directly to controller, no remote staging
+support_bundle_base_path: /tmp
+
+# Whether to sanitize config files before collection
+# When true, passwords and sensitive values are redacted from config files
+# Enabled by default for security when sharing bundles externally
+support_bundle_sanitize_configs: true
+
+# Whether to skip config file collection entirely (most restrictive)
+# When true, only collect metadata about config files, not their contents
+support_bundle_skip_configs: false
+
+# Automatic support bundle collection on playbook failures
+# When true, support bundle is automatically collected when playbooks fail
+# Default: false (must be explicitly enabled)
+support_bundle_auto_collect_on_failure: false
+
+# Path to Ansible playbook execution log file (on Ansible controller)
+# When set, this log file will be included in the support bundle
+# Example: support_bundle_ansible_log_path: /path/to/ansible.log
+# Can also be set via extra vars: -e "support_bundle_ansible_log_path=ansible_run.log"
+support_bundle_ansible_log_path: ""
+
+# Path to inventory file (on Ansible controller)
+# When set, the full inventory file will be included in the support bundle (sanitized)
+# Example: support_bundle_inventory_file_path: /path/to/inventory.yml
+# Can also be set via extra vars: -e "support_bundle_inventory_file_path=docs/sample_inventories/mtls_kraft.yml"
+support_bundle_inventory_file_path: ""
+
 ### Boolean to specify the become value for localhost, used when dealing with any file present on localhost/controller.
 ansible_become_localhost: false
 

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -16,61 +16,6 @@ mask_secrets: true
 ### Path on component to store logs collected during fetch_logs playbook
 fetch_logs_path: /tmp
 
-### Support Bundle Collection Settings
-# Output path for support bundles (on Ansible controller)
-support_bundle_output_path: "{{ playbook_dir }}"
-
-# Cluster name to include in bundle filename
-support_bundle_cluster_name: cp_cluster
-
-# Number of journalctl log lines to collect per service
-support_bundle_journalctl_lines: 1000
-
-# Base path on remote hosts for temporary diagnostic files during collection
-# Used for: system info, diagnostics, config metadata temporary files
-# Note: Log and config files are fetched directly from their original locations
-support_bundle_base_path: /tmp
-
-# Log collection control variables (bounded defaults for reliability at scale)
-# File patterns to collect (default: *.log files only)
-support_bundle_log_patterns:
-  - "*.log"
-
-# Maximum number of log files to collect per component (most recent first)
-support_bundle_log_max_count: 20
-
-# Optional: Maximum log file size (e.g., "100m" for 100MB)
-# Uncomment to enable: support_bundle_log_max_size: "100m"
-
-# Optional: Maximum log file age (e.g., "7d" for 7 days)
-# Uncomment to enable: support_bundle_log_age: "7d"
-
-# Whether to sanitize config files before collection
-# When true, passwords and sensitive values are redacted from config files
-# Enabled by default for security when sharing bundles externally
-support_bundle_sanitize_configs: true
-
-# Whether to skip config file collection entirely (most restrictive)
-# When true, only collect metadata about config files, not their contents
-support_bundle_skip_configs: false
-
-# Automatic support bundle collection on playbook failures
-# When true, support bundle is automatically collected when playbooks fail
-# Default: false (must be explicitly enabled)
-support_bundle_auto_collect_on_failure: false
-
-# Path to Ansible playbook execution log file (on Ansible controller)
-# When set, this log file will be included in the support bundle
-# Example: support_bundle_ansible_log_path: /path/to/ansible.log
-# Can also be set via extra vars: -e "support_bundle_ansible_log_path=ansible_run.log"
-support_bundle_ansible_log_path: ""
-
-# Path to inventory file (on Ansible controller)
-# When set, the full inventory file will be included in the support bundle (sanitized)
-# Example: support_bundle_inventory_file_path: /path/to/inventory.yml
-# Can also be set via extra vars: -e "support_bundle_inventory_file_path=docs/sample_inventories/mtls_kraft.yml"
-support_bundle_inventory_file_path: ""
-
 ### Boolean to specify the become value for localhost, used when dealing with any file present on localhost/controller.
 ansible_become_localhost: false
 

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -26,9 +26,24 @@ support_bundle_cluster_name: cp_cluster
 # Number of journalctl log lines to collect per service
 support_bundle_journalctl_lines: 1000
 
-# Base path on remote hosts for temporary files during collection
-# Note: Files are fetched directly to controller, no remote staging
+# Base path on remote hosts for temporary diagnostic files during collection
+# Used for: system info, diagnostics, config metadata temporary files
+# Note: Log and config files are fetched directly from their original locations
 support_bundle_base_path: /tmp
+
+# Log collection control variables (bounded defaults for reliability at scale)
+# File patterns to collect (default: *.log files only)
+support_bundle_log_patterns:
+  - "*.log"
+
+# Maximum number of log files to collect per component (most recent first)
+support_bundle_log_max_count: 20
+
+# Optional: Maximum log file size (e.g., "100m" for 100MB)
+# Uncomment to enable: support_bundle_log_max_size: "100m"
+
+# Optional: Maximum log file age (e.g., "7d" for 7 days)
+# Uncomment to enable: support_bundle_log_age: "7d"
 
 # Whether to sanitize config files before collection
 # When true, passwords and sensitive values are redacted from config files

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -16,6 +16,40 @@ mask_secrets: true
 ### Path on component to store logs collected during fetch_logs playbook
 fetch_logs_path: /tmp
 
+### Output path for support bundles on Ansible controller
+support_bundle_output_path: "{{ playbook_dir }}"
+
+### Cluster name to include in support bundle filename
+support_bundle_cluster_name: cp_cluster
+
+### Number of journalctl log lines to collect per service
+support_bundle_journalctl_lines: 1000
+
+### Base path on remote hosts for temporary diagnostic files during collection. Log and config files are fetched directly from their original locations.
+support_bundle_base_path: /tmp
+
+### File patterns to collect for logs, bounded defaults for reliability at scale
+support_bundle_log_patterns:
+  - "*.log"
+
+### Maximum number of log files to collect per component, most recent first
+support_bundle_log_max_count: 20
+
+### Whether to sanitize config files before collection. When true, passwords and sensitive values are redacted from config files.
+support_bundle_sanitize_configs: true
+
+### Whether to skip config file collection entirely. When true, only collect metadata about config files, not their contents.
+support_bundle_skip_configs: false
+
+### Whether to automatically collect support bundle when playbooks fail. Default is false and must be explicitly enabled.
+support_bundle_auto_collect_on_failure: false
+
+### Path to Ansible playbook execution log file on Ansible controller. When set, this log file will be included in the support bundle.
+support_bundle_ansible_log_path: ""
+
+### Path to inventory file on Ansible controller. When set, the full inventory file will be included in the support bundle after sanitization.
+support_bundle_inventory_file_path: ""
+
 ### Boolean to specify the become value for localhost, used when dealing with any file present on localhost/controller.
 ansible_become_localhost: false
 


### PR DESCRIPTION
# Description

Implements comprehensive support bundle collection for Confluent Platform:
One pager: https://confluentinc.atlassian.net/wiki/spaces/OAAC/pages/5217419655/1-pager+Support+Bundle+in+CP-Ansible

Features:
- Manual support bundle collection playbook (playbooks/support_bundle.yml)
- Collects configs, logs, diagnostics from all CP components
- Component-first directory structure for easy troubleshooting
- Configuration sanitization (passwords/secrets redacted)
- Inventory auto-detection from ansible_inventory_sources
- Per-component and bundle-level manifests
- Streamlined diagnostics (systemctl status, journalctl, processes)

Components supported:
- Zookeeper, Kafka Controller, Kafka Broker
- Schema Registry, Kafka Connect, KSQL
- Control Center, USM Agent

Variables:
- support_bundle_output_path: Output directory
- support_bundle_cluster_name: Cluster identifier
- support_bundle_sanitize_configs: Enable/disable sanitization
- support_bundle_inventory_file_path: Optional inventory file path
- support_bundle_journalctl_lines: Number of journalctl lines to collect

Usage:
  ansible-playbook playbooks/support_bundle.yml -i inventory.yml

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
