### PR TITLE
ANSIENG-5843 | Update JVM level FIPS disable flag for RHEL deployments

### DIFF
--- a/roles/common/tasks/fips-redhat.yml
+++ b/roles/common/tasks/fips-redhat.yml
@@ -11,7 +11,7 @@
     path: "{{java_path.stdout}}/conf/security/redhat/crypto-policies.properties"
   register: crypto_policies_file
 
-- name: Disable JVM level FIPS (legacy, JDK <= 21)
+- name: Disable JVM level FIPS (JDK < 25)
   lineinfile:
     path: "{{java_path.stdout}}/conf/security/java.security"
     search_string: 'security.useSystemPropertiesFile=true'

--- a/roles/common/tasks/fips-redhat.yml
+++ b/roles/common/tasks/fips-redhat.yml
@@ -4,7 +4,12 @@
   register: java_path
   changed_when: false
 
-- name: Disable JVM level FIPS
+- name: Check for JDK 25+ crypto-policies file
+  stat:
+    path: "{{java_path.stdout}}/conf/security/redhat/crypto-policies.properties"
+  register: crypto_policies_file
+
+- name: Disable JVM level FIPS (legacy, JDK <= 21)
   lineinfile:
     path: "{{java_path.stdout}}/conf/security/java.security"
     search_string: 'security.useSystemPropertiesFile=true'
@@ -12,6 +17,17 @@
     owner: root
     group: root
     mode: '644'
+  when: not crypto_policies_file.stat.exists
+
+- name: Disable JVM level FIPS (JDK 25+)
+  lineinfile:
+    path: "{{java_path.stdout}}/conf/security/redhat/crypto-policies.properties"
+    search_string: 'include true/crypto-policies.properties'
+    line: 'include false/crypto-policies.properties'
+    owner: root
+    group: root
+    mode: '644'
+  when: crypto_policies_file.stat.exists
 
 - name: Configure crypto policies for Redhat
   command: update-crypto-policies --set FIPS

--- a/roles/common/tasks/fips-redhat.yml
+++ b/roles/common/tasks/fips-redhat.yml
@@ -4,6 +4,8 @@
   register: java_path
   changed_when: false
 
+# JDK 25 deprecated security.useSystemPropertiesFile. Presence of this Red Hat
+# crypto-policies file marks the new mechanism; absence means use the legacy path.
 - name: Check for JDK 25+ crypto-policies file
   stat:
     path: "{{java_path.stdout}}/conf/security/redhat/crypto-policies.properties"


### PR DESCRIPTION
# Description

This PR updates the existing FIPS task in `roles/common/tasks/fips-redhat.yml`. The existing `security.useSystemPropertiesFile` that is used to disable JVM level FIPS in ansible has been deprecated from JDK 25, JDK 25 replaces the deprecated property with an include directive in a Red Hat shipped crypto-policies.properties file.

This change keeps the legacy write for older JDKs and adds the new write for JDK 25+. Dispatch is via stat on `{{java_path}}/conf/security/redhat/crypto-policies.properties` - **its presence is the actual signal that the new mechanism is in effect**, avoiding string-parsing of java -version and remaining correct if Red Hat backports or omits the file in custom builds.

**Property presence on JDK 21 vs JDK 25**

<img width="860" height="206" alt="Screenshot 2026-04-28 at 5 53 49 PM" src="https://github.com/user-attachments/assets/5e2ded9b-cd29-4ebe-bdca-a2f7951a5d9e" />
<br>
<br>

<img width="867" height="168" alt="Screenshot 2026-04-28 at 5 54 01 PM" src="https://github.com/user-attachments/assets/834368c9-ca9c-48ca-a034-1c6c6eebf9c0" />


**Fixes** - https://confluentinc.atlassian.net/browse/ANSIENG-5843

### Changes Made
- Added stat check for `{{java_path}}/conf/security/redhat/crypto-policies.properties` to detect JDK 25+ FIPS mechanism. Existing logic for JDK<=21 is preserved using the stat check as well.
- Added new task for JDK 25+ that flips `true/crypto-policies.properties` to `false/crypto-policies.properties` in the Red Hat crypto-policies file.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Molecule Run with all FIPS tests passing: https://semaphore.ci.confluent.io/jobs/e95d94fe-3e7e-4df7-8a4d-06594cf175d5/summary?report_id=63a7566e-bb24-3b6d-a18c-7af5cdce63f5&suite_id=c80bf498-7926-3d9a-929d-8060be0c1ed5

All test run: https://semaphore.ci.confluent.io/jobs/51445a17-44f0-4b30-8051-e7971267b0f1/summary?report_id=63a7566e-bb24-3b6d-a18c-7af5cdce63f5

Re-run of flaky test: https://semaphore.ci.confluent.io/jobs/09b24d29-854c-414a-910c-3a758ba9f0a2/summary?report_id=63a7566e-bb24-3b6d-a18c-7af5cdce63f5&suite_id=c80bf498-7926-3d9a-929d-8060be0c1ed5

# Checklist:

- [X] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [NA] I have added tests that prove my fix is effective or that my feature works
- [NA] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [NA] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
