### PR TITLE
[SETU-2700] Set explicit USM HTTP exporter buffer defaults

### DIFF
--- a/molecule/verify_usm_agent.yml
+++ b/molecule/verify_usm_agent.yml
@@ -85,3 +85,65 @@
           - metrics_endpoint_found | default(false)
         fail_msg: "USM Agent v1/metrics endpoint not found in logs or not returning 200 status"
       when: log_file_stat.stat.exists
+
+- name: Verify USM HTTP Exporter Configs - Kafka Controller
+  hosts: kafka_controller
+  gather_facts: false
+  tasks:
+    - name: Verify USM buffer.batch.items.max (Controller)
+      import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: /etc/controller/server.properties
+        property: confluent.telemetry.exporter._usm.buffer.batch.items.max
+        expected_value: "4000"
+
+    - name: Verify USM buffer.inflight.submissions.max (Controller)
+      import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: /etc/controller/server.properties
+        property: confluent.telemetry.exporter._usm.buffer.inflight.submissions.max
+        expected_value: "10"
+
+    - name: Verify USM buffer.pending.batches.max (Controller)
+      import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: /etc/controller/server.properties
+        property: confluent.telemetry.exporter._usm.buffer.pending.batches.max
+        expected_value: "80"
+
+- name: Verify USM HTTP Exporter Configs - Kafka Broker
+  hosts: kafka_broker
+  gather_facts: false
+  tasks:
+    - name: Verify USM buffer.batch.items.max (Broker)
+      import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: /etc/kafka/server.properties
+        property: confluent.telemetry.exporter._usm.buffer.batch.items.max
+        expected_value: "4000"
+
+    - name: Verify USM buffer.inflight.submissions.max (Broker)
+      import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: /etc/kafka/server.properties
+        property: confluent.telemetry.exporter._usm.buffer.inflight.submissions.max
+        expected_value: "10"
+
+    - name: Verify USM buffer.pending.batches.max (Broker)
+      import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: /etc/kafka/server.properties
+        property: confluent.telemetry.exporter._usm.buffer.pending.batches.max
+        expected_value: "80"

--- a/roles/variables/vars/main.yml
+++ b/roles/variables/vars/main.yml
@@ -386,6 +386,9 @@ kafka_controller_properties:
       confluent.telemetry.exporter._usm.enabled: true
       confluent.telemetry.exporter._usm.events.enabled: true
       confluent.telemetry.exporter._usm.type: http
+      confluent.telemetry.exporter._usm.buffer.batch.items.max: 4000
+      confluent.telemetry.exporter._usm.buffer.inflight.submissions.max: 10
+      confluent.telemetry.exporter._usm.buffer.pending.batches.max: 80
       confluent.telemetry.exporter._usm.client.base.url: "{{ usm_agent_url }}"
       confluent.telemetry.exporter._usm.events.client.base.url: "{{ usm_agent_url }}"
       confluent.catalog.collector.enable: true
@@ -999,6 +1002,9 @@ kafka_broker_properties:
       confluent.telemetry.exporter._usm.enabled: true
       confluent.telemetry.exporter._usm.client.base.url: "{{ usm_agent_url }}"
       confluent.telemetry.exporter._usm.type: http
+      confluent.telemetry.exporter._usm.buffer.batch.items.max: 4000
+      confluent.telemetry.exporter._usm.buffer.inflight.submissions.max: 10
+      confluent.telemetry.exporter._usm.buffer.pending.batches.max: 80
       confluent.client.topic.metrics.manager: org.apache.kafka.server.metrics.PlatformClientTopicMetricsManager
       confluent.consumer.lag.emitter.enabled: true
   usm_agent_telemetry_auth_basic:

--- a/test_roles/confluent.test/tasks/check_property.yml
+++ b/test_roles/confluent.test/tasks/check_property.yml
@@ -7,5 +7,5 @@
 - name: Assert property set as expected
   assert:
     that:
-      - expected_value == grep.stdout | regex_replace('^[-a-zA-Z0-9.]*[ ]?=[ ]?(.*)$', '\\1')
-    fail_msg: "Property: {{property}} set to {{ grep.stdout | regex_replace('^[-a-zA-Z0-9.]*[ ]?=[ ]?(.*)$', '\\1') }} not {{expected_value}}"
+      - expected_value == grep.stdout | regex_replace('^[-a-zA-Z0-9._]*[ ]?=[ ]?(.*)$', '\\1')
+    fail_msg: "Property: {{property}} set to {{ grep.stdout | regex_replace('^[-a-zA-Z0-9._]*[ ]?=[ ]?(.*)$', '\\1') }} not {{expected_value}}"


### PR DESCRIPTION
# Description

Configure batch/inflight/pending buffer limits for the _usm telemetry exporter on kafka_controller and kafka_broker, instead of relying on library defaults.

During debugging of metrics drop issue from usm exporter, It turned out that the metrics are getting dropped because of backpressure. It was because we were using the default buffer configs for _usm exporter. 

Updating these new values :
`confluent.telemetry.exporter._usm.buffer.batch.items.max: 4000
confluent.telemetry.exporter._usm.buffer.inflight.submissions.max: 10
confluent.telemetry.exporter._usm.buffer.pending.batches.max: 80`


Fixes https://confluentinc.atlassian.net/browse/SETU-2700
Reference PR : https://github.com/confluentinc/cp-ansible/pull/2482

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] yamllint roles/variables/vars/main.yml molecule/verify_usm_agent.yml
- [x]  Run a molecule scenario that includes a usm_agent host e.g. molecule/scram-rhel/ molecule/scram-rhel/plaintext-basic-rhel
 - [x] Inspect the rendered /etc/controller/server.properties, /etc/kafka/server.properties, and /etc/kafka/connect-distributed.properties after a converge and confirm all three confluent.telemetry.exporter._usm.buffer.* lines are present with values 4000, 10, 80.
- [x] Negative check: run a scenario without a usm_agent group and confirm the new properties are NOT emitted.

<img width="1471" height="133" alt="Screenshot 2026-04-28 at 12 43 06 PM" src="https://github.com/user-attachments/assets/908c5bcc-0917-4587-8dd4-28df90e6a149" />


# Checklist:

- [x] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
