### PR TITLE
[SETU-2155] Enable consumer lag view metrics

### DIFF
--- a/molecule/verify_usm_agent.yml
+++ b/molecule/verify_usm_agent.yml
@@ -147,3 +147,34 @@
         file_path: /etc/kafka/server.properties
         property: confluent.telemetry.exporter._usm.buffer.pending.batches.max
         expected_value: "80"
+
+- name: Verify USM Consumer Lag Configs - Kafka Broker
+  hosts: kafka_broker
+  gather_facts: false
+  tasks:
+    - name: Verify consumer.lag.calculator.enabled (Broker)
+      import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: /etc/kafka/server.properties
+        property: confluent.consumer.lag.calculator.enabled
+        expected_value: "true"
+
+    - name: Verify consumer.group.status.enabled (Broker)
+      import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: /etc/kafka/server.properties
+        property: confluent.consumer.group.status.enabled
+        expected_value: "true"
+
+    - name: Verify consumer.lag.calculator.empty.lag.retention.ms (Broker)
+      import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: /etc/kafka/server.properties
+        property: confluent.consumer.lag.calculator.empty.lag.retention.ms
+        expected_value: "86400000"

--- a/roles/variables/vars/main.yml
+++ b/roles/variables/vars/main.yml
@@ -1007,6 +1007,9 @@ kafka_broker_properties:
       confluent.telemetry.exporter._usm.buffer.pending.batches.max: 80
       confluent.client.topic.metrics.manager: org.apache.kafka.server.metrics.PlatformClientTopicMetricsManager
       confluent.consumer.lag.emitter.enabled: true
+      confluent.consumer.lag.calculator.enabled: "true"
+      confluent.consumer.group.status.enabled: "true"
+      confluent.consumer.lag.calculator.empty.lag.retention.ms: 86400000
   usm_agent_telemetry_auth_basic:
     enabled: "{{ 'usm_agent' in groups and usm_agent_basic_auth_enabled }}"
     properties:


### PR DESCRIPTION
# Description

Ansible changes to enable new consumer lag view for USM showing status and empty consumer groups

The configs that need to be updated are
1. confluent.consumer.lag.calculator.enabled=true
2. confluent.consumer.group.status.enabled=true
3. confluent.consumer.lag.calculator.empty.lag.retention.ms=86400000 #1 day

Fixes https://confluentinc.atlassian.net/browse/SETU-2155

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] yamllint roles/variables/vars/main.yml molecule/verify_usm_agent.yml
- [x]  Run a molecule scenario that includes a usm_agent host e.g. molecule/scram-rhel/ molecule/scram-rhel/plaintext-basic-rhel
 - [x] Inspect the rendered /etc/kafka/server.properties after a converge and confirm confluent.consumer.* config is set
- [x] Negative check: run a scenario without a usm_agent group and confirm the new properties are NOT emitted.

<img width="1453" height="115" alt="Screenshot 2026-04-30 at 12 06 00 PM" src="https://github.com/user-attachments/assets/2a10f379-7948-4162-98cc-840e3fdb0be3" />


# Checklist:

- [x] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
