### PR TITLE
[ANSIENG-5796] Add KRaft migration rollback playbook with auto-phase detection

### DIFF
--- a/molecule/migration_rollback_phase2_converge.yml
+++ b/molecule/migration_rollback_phase2_converge.yml
@@ -1,0 +1,69 @@
+---
+# migration_rollback_phase2_converge.yml
+#
+# Molecule converge for the plaintext-rhel-rollback-phase2 scenario.
+#
+# Cluster state reached before rollback: PREMIGRATION (Phase 2)
+#   - KRaft controllers provisioned and running with zookeeper.connect set
+#   - Brokers untouched — still in pure ZooKeeper mode, no migration flag
+#
+# This is the state after kafka_controller.yml has run with kraft_migration: true
+# but BEFORE the broker restart that activates dual-write (migrate_to_dual_write).
+#
+# Rollback action: stop controllers only, no broker changes needed.
+
+# ── Step 1: Transform inventory groups ────────────────────────────────────────
+# Rename ZK-cluster groups so the KRaft group names can take their place.
+# After this transformation:
+#   - zookeeper    → original ZK node (was zookeeper_migration)
+#   - kafka_broker → original ZK-mode broker (was kafka_broker_migration)
+#   - kafka_controller → dedicated KRaft controller (was kafka_controller_migration)
+- name: Transform inventory groups for migration
+  hosts: kafka_broker
+  gather_facts: false
+  tasks:
+    - name: Rename ZK cluster groups out of the way
+      lineinfile:
+        path: "{{ inventory_dir }}/ansible_inventory.yml"
+        regexp: "{{ item }}:"
+        line: "{{ item }}_zoo:"
+      delegate_to: 127.0.0.1
+      run_once: true
+      loop:
+        - zookeeper
+        - kafka_broker
+
+    - name: Activate KRaft cluster groups
+      lineinfile:
+        path: "{{ inventory_dir }}/ansible_inventory.yml"
+        regexp: "{{ item }}_migration:"
+        line: "{{ item }}:"
+      delegate_to: 127.0.0.1
+      run_once: true
+      loop:
+        - kafka_controller
+        - kafka_broker
+        - zookeeper
+
+    - name: Refresh inventory
+      meta: refresh_inventory
+
+# ── Step 2: Pre-migration checks ─────────────────────────────────────────────
+- name: Run migration pre-flight checks
+  import_playbook: ../playbooks/migration_precheck.yml
+  vars:
+    kraft_migration: true
+
+# ── Step 3: Provision KRaft controllers (PREMIGRATION state) ─────────────────
+# kafka_controller.yml with kraft_migration: true configures controllers with
+# zookeeper.connect so they join the existing ZK quorum. Brokers are untouched.
+- name: Provision KRaft controllers
+  import_playbook: ../playbooks/kafka_controller.yml
+  vars:
+    kraft_migration: true
+
+# ── Step 4: Run Phase 2 rollback ──────────────────────────────────────────────
+- name: Run KRaft migration rollback
+  import_playbook: ../playbooks/kraft_migration_rollback.yml
+  vars:
+    kraft_migration: true

--- a/molecule/migration_rollback_phase3_converge.yml
+++ b/molecule/migration_rollback_phase3_converge.yml
@@ -1,0 +1,153 @@
+---
+# migration_rollback_phase3_converge.yml
+#
+# Molecule converge for the plaintext-rhel-rollback-phase3 scenario.
+#
+# Cluster state reached before rollback: HYBRID_DUAL_WRITE (Phase 3)
+#   - KRaft controllers running in dual-write mode (zookeeper.connect present)
+#   - Brokers have zookeeper.metadata.migration.enable=true and zookeeper.connect
+#   - Brokers do NOT have process.roles=broker
+#   - ZkMigrationState=1 via Jolokia
+#
+# This is the state after ZKtoKraftMigration.yml --tags migrate_to_dual_write.
+# The playbooks are imported directly (not via ZKtoKraftMigration.yml) to avoid
+# running the migrate_to_kraft and rollback plays that share the same file.
+#
+# Rollback action: stop controllers, clean ZK znodes, one rolling broker restart.
+
+# ── Step 1: Transform inventory groups ────────────────────────────────────────
+- name: Transform inventory groups for migration
+  hosts: kafka_broker
+  gather_facts: false
+  tasks:
+    - name: Rename ZK cluster groups out of the way
+      lineinfile:
+        path: "{{ inventory_dir }}/ansible_inventory.yml"
+        regexp: "{{ item }}:"
+        line: "{{ item }}_zoo:"
+      delegate_to: 127.0.0.1
+      run_once: true
+      loop:
+        - zookeeper
+        - kafka_broker
+
+    - name: Activate KRaft cluster groups
+      lineinfile:
+        path: "{{ inventory_dir }}/ansible_inventory.yml"
+        regexp: "{{ item }}_migration:"
+        line: "{{ item }}:"
+      delegate_to: 127.0.0.1
+      run_once: true
+      loop:
+        - kafka_controller
+        - kafka_broker
+        - zookeeper
+
+    - name: Refresh inventory
+      meta: refresh_inventory
+
+# ── Step 2: Pre-migration checks ─────────────────────────────────────────────
+- name: Run migration pre-flight checks
+  import_playbook: ../playbooks/migration_precheck.yml
+  vars:
+    kraft_migration: true
+
+# ── Step 3: Provision KRaft controllers ──────────────────────────────────────
+- name: Provision KRaft controllers
+  import_playbook: ../playbooks/kafka_controller.yml
+  vars:
+    kraft_migration: true
+
+# ── Step 4: Validate Jolokia endpoint is reachable ───────────────────────────
+# Mirrors the untagged inline play in ZKtoKraftMigration.yml (lines 8-42).
+# Ensures controllers are fully up and Jolokia is serving before broker migration.
+- name: Validate Jolokia endpoint access on controllers
+  hosts: kafka_controller
+  gather_facts: false
+  any_errors_fatal: true
+  tasks:
+    - name: Import variables role
+      import_role:
+        name: variables
+
+    - name: Test Jolokia ZkMigrationState endpoint access
+      uri:
+        url: "{{ 'https' if kafka_controller_jolokia_ssl_enabled | bool else 'http' }}://localhost:{{ kafka_controller_jolokia_port }}/jolokia/read/kafka.controller:type=KafkaController,name=ZkMigrationState"
+        validate_certs: false
+        return_content: true
+        status_code: 200
+        force_basic_auth: "{{ item.auth }}"
+        url_username: "{{ item.username if item.auth else omit }}"
+        url_password: "{{ item.password if item.auth else omit }}"
+      register: jolokia_auth_results
+      failed_when: false
+      retries: "{{ jolokia_endpoint_health_check_retries }}"
+      delay: "{{ jolokia_endpoint_health_check_delay }}"
+      loop:
+        - {name: "no_auth",   auth: false}
+        - {name: "basic_auth", auth: true, username: "{{ jolokia_user }}", password: "{{ jolokia_password }}"}
+
+    - name: Check if either auth method succeeded
+      set_fact:
+        jolokia_accessible: >-
+          {{ jolokia_auth_results.results
+             | map(attribute='status') | select('defined') | select('equalto', 200)
+             | list | length > 0 }}
+
+    - name: Fail if Jolokia endpoint is not reachable
+      fail:
+        msg: "ERROR: Unable to access Jolokia ZkMigrationState endpoint on controllers."
+      when: not jolokia_accessible | bool
+
+# ── Step 5: Migrate brokers to dual-write mode ───────────────────────────────
+# kafka_broker.yml with kraft_migration: true sets:
+#   zookeeper.metadata.migration.enable=true, zookeeper.connect, keeps no process.roles
+# Serial restart mirrors ZKtoKraftMigration.yml's deployment_strategy: serial.
+- name: Migrate brokers to dual-write mode
+  import_playbook: ../playbooks/kafka_broker.yml
+  vars:
+    kraft_migration: true
+    deployment_strategy: serial
+
+# ── Step 6: Wait for ZkMigrationState=1 (HYBRID_DUAL_WRITE confirmed) ────────
+- name: Wait for metadata migration to reach HYBRID_DUAL_WRITE
+  hosts: kafka_controller
+  gather_facts: false
+  any_errors_fatal: true
+  tasks:
+    - name: Import variables role
+      import_role:
+        name: variables
+
+    - name: Wait for ZkMigrationState=1 (no auth)
+      uri:
+        url: "{{ 'https' if kafka_controller_jolokia_ssl_enabled | bool else 'http' }}://localhost:{{ kafka_controller_jolokia_port }}/jolokia/read/kafka.controller:type=KafkaController,name=ZkMigrationState"
+        validate_certs: false
+        return_content: true
+        status_code: 200
+      retries: "{{ metadata_migration_retries }}"
+      delay: 90
+      until: (jolokia_output.content | from_json).value.Value == 1
+      register: jolokia_output
+      when: jolokia_auth_mode == "none"
+
+    - name: Wait for ZkMigrationState=1 (basic auth)
+      uri:
+        url: "{{ 'https' if kafka_controller_jolokia_ssl_enabled | bool else 'http' }}://localhost:{{ kafka_controller_jolokia_port }}/jolokia/read/kafka.controller:type=KafkaController,name=ZkMigrationState"
+        validate_certs: false
+        return_content: true
+        force_basic_auth: true
+        url_username: "{{ jolokia_user }}"
+        url_password: "{{ jolokia_password }}"
+        status_code: 200
+      retries: "{{ metadata_migration_retries }}"
+      delay: 90
+      until: (jolokia_output.content | from_json).value.Value == 1
+      register: jolokia_output
+      when: jolokia_auth_mode == "basic"
+
+# ── Step 7: Run Phase 3 rollback ──────────────────────────────────────────────
+- name: Run KRaft migration rollback
+  import_playbook: ../playbooks/kraft_migration_rollback.yml
+  vars:
+    kraft_migration: true

--- a/molecule/migration_rollback_phase4_converge.yml
+++ b/molecule/migration_rollback_phase4_converge.yml
@@ -1,0 +1,192 @@
+---
+# migration_rollback_phase4_converge.yml
+#
+# Molecule converge for the plaintext-rhel-rollback-phase4 scenario.
+#
+# Cluster state reached before rollback: PURE_DUAL_WRITE (Phase 4)
+#   - KRaft controllers running in dual-write mode (zookeeper.connect present)
+#   - Brokers fully in KRaft mode: process.roles=broker set,
+#     zookeeper.connect and inter.broker.protocol.version removed by migration
+#   - ZkMigrationState=1 via Jolokia (same as Phase 3 — differentiated by config)
+#
+# This is the state after ZKtoKraftMigration.yml migrate_to_dual_write +
+# the broker migration steps (lineinfile + restart), but BEFORE
+# "Take Controllers out of migration mode" (which would make state FINALIZED).
+#
+# Rollback action: 3 rolling broker restarts + controller stop + ZK cleanup.
+
+# ── Step 1: Transform inventory groups ────────────────────────────────────────
+- name: Transform inventory groups for migration
+  hosts: kafka_broker
+  gather_facts: false
+  tasks:
+    - name: Rename ZK cluster groups out of the way
+      lineinfile:
+        path: "{{ inventory_dir }}/ansible_inventory.yml"
+        regexp: "{{ item }}:"
+        line: "{{ item }}_zoo:"
+      delegate_to: 127.0.0.1
+      run_once: true
+      loop:
+        - zookeeper
+        - kafka_broker
+
+    - name: Activate KRaft cluster groups
+      lineinfile:
+        path: "{{ inventory_dir }}/ansible_inventory.yml"
+        regexp: "{{ item }}_migration:"
+        line: "{{ item }}:"
+      delegate_to: 127.0.0.1
+      run_once: true
+      loop:
+        - kafka_controller
+        - kafka_broker
+        - zookeeper
+
+    - name: Refresh inventory
+      meta: refresh_inventory
+
+# ── Step 2: Pre-migration checks ─────────────────────────────────────────────
+- name: Run migration pre-flight checks
+  import_playbook: ../playbooks/migration_precheck.yml
+  vars:
+    kraft_migration: true
+
+# ── Step 3: Provision KRaft controllers ──────────────────────────────────────
+- name: Provision KRaft controllers
+  import_playbook: ../playbooks/kafka_controller.yml
+  vars:
+    kraft_migration: true
+
+# ── Step 4: Validate Jolokia endpoint is reachable ───────────────────────────
+# Mirrors the untagged inline play in ZKtoKraftMigration.yml (lines 8-42).
+- name: Validate Jolokia endpoint access on controllers
+  hosts: kafka_controller
+  gather_facts: false
+  any_errors_fatal: true
+  tasks:
+    - name: Import variables role
+      import_role:
+        name: variables
+
+    - name: Test Jolokia ZkMigrationState endpoint access
+      uri:
+        url: "{{ 'https' if kafka_controller_jolokia_ssl_enabled | bool else 'http' }}://localhost:{{ kafka_controller_jolokia_port }}/jolokia/read/kafka.controller:type=KafkaController,name=ZkMigrationState"
+        validate_certs: false
+        return_content: true
+        status_code: 200
+        force_basic_auth: "{{ item.auth }}"
+        url_username: "{{ item.username if item.auth else omit }}"
+        url_password: "{{ item.password if item.auth else omit }}"
+      register: jolokia_auth_results
+      failed_when: false
+      retries: "{{ jolokia_endpoint_health_check_retries }}"
+      delay: "{{ jolokia_endpoint_health_check_delay }}"
+      loop:
+        - {name: "no_auth",   auth: false}
+        - {name: "basic_auth", auth: true, username: "{{ jolokia_user }}", password: "{{ jolokia_password }}"}
+
+    - name: Check if either auth method succeeded
+      set_fact:
+        jolokia_accessible: >-
+          {{ jolokia_auth_results.results
+             | map(attribute='status') | select('defined') | select('equalto', 200)
+             | list | length > 0 }}
+
+    - name: Fail if Jolokia endpoint is not reachable
+      fail:
+        msg: "ERROR: Unable to access Jolokia ZkMigrationState endpoint on controllers."
+      when: not jolokia_accessible | bool
+
+# ── Step 5: Migrate brokers to dual-write mode ───────────────────────────────
+- name: Migrate brokers to dual-write mode
+  import_playbook: ../playbooks/kafka_broker.yml
+  vars:
+    kraft_migration: true
+    deployment_strategy: serial
+
+# ── Step 6: Wait for ZkMigrationState=1 ──────────────────────────────────────
+- name: Wait for metadata migration to reach dual-write
+  hosts: kafka_controller
+  gather_facts: false
+  any_errors_fatal: true
+  tasks:
+    - name: Import variables role
+      import_role:
+        name: variables
+
+    - name: Wait for ZkMigrationState=1 (no auth)
+      uri:
+        url: "{{ 'https' if kafka_controller_jolokia_ssl_enabled | bool else 'http' }}://localhost:{{ kafka_controller_jolokia_port }}/jolokia/read/kafka.controller:type=KafkaController,name=ZkMigrationState"
+        validate_certs: false
+        return_content: true
+        status_code: 200
+      retries: "{{ metadata_migration_retries }}"
+      delay: 90
+      until: (jolokia_output.content | from_json).value.Value == 1
+      register: jolokia_output
+      when: jolokia_auth_mode == "none"
+
+    - name: Wait for ZkMigrationState=1 (basic auth)
+      uri:
+        url: "{{ 'https' if kafka_controller_jolokia_ssl_enabled | bool else 'http' }}://localhost:{{ kafka_controller_jolokia_port }}/jolokia/read/kafka.controller:type=KafkaController,name=ZkMigrationState"
+        validate_certs: false
+        return_content: true
+        force_basic_auth: true
+        url_username: "{{ jolokia_user }}"
+        url_password: "{{ jolokia_password }}"
+        status_code: 200
+      retries: "{{ metadata_migration_retries }}"
+      delay: 90
+      until: (jolokia_output.content | from_json).value.Value == 1
+      register: jolokia_output
+      when: jolokia_auth_mode == "basic"
+
+# ── Step 7: Advance brokers to KRaft mode (PURE_DUAL_WRITE) ──────────────────
+# Mirrors ZKtoKraftMigration.yml "Migrate Brokers to Kraft" + "Restart Kafka Broker"
+# but stops before "Take Controllers out of migration mode" to keep controllers
+# in dual-write (zookeeper.connect still present on controllers → not FINALIZED).
+- name: Migrate brokers to KRaft mode
+  hosts: kafka_broker
+  gather_facts: true
+  any_errors_fatal: true
+  tasks:
+    - name: Import variables role
+      import_role:
+        name: variables
+
+    - name: Remove ZooKeeper and inter.broker.protocol.version from broker config
+      lineinfile:
+        path: "{{ kafka_broker.config_file }}"
+        state: absent
+        regexp: "^{{ item }}*"
+      loop:
+        - zookeeper
+        - inter.broker.protocol.version
+
+    - name: Set process.roles=broker in broker config
+      lineinfile:
+        path: "{{ kafka_broker.config_file }}"
+        line: process.roles=broker
+
+- name: Restart brokers into KRaft mode (serial)
+  hosts: kafka_broker
+  gather_facts: true
+  serial: '1'
+  any_errors_fatal: true
+  tasks:
+    - name: Restart broker and wait
+      include_role:
+        name: kafka_broker
+        tasks_from: restart_and_wait.yml
+
+    - name: Run broker health check
+      include_role:
+        name: kafka_broker
+        tasks_from: health_check.yml
+
+# ── Step 8: Run Phase 4 rollback ──────────────────────────────────────────────
+- name: Run KRaft migration rollback
+  import_playbook: ../playbooks/kraft_migration_rollback.yml
+  vars:
+    kraft_migration: true

--- a/molecule/plaintext-rhel-rollback-phase2/molecule.yml
+++ b/molecule/plaintext-rhel-rollback-phase2/molecule.yml
@@ -7,8 +7,8 @@ driver:
   name: docker
 platforms:
   # ZooKeeper node — also serves as the ZK target after rollback
-  - name: zookeeper1${JOB_BASE_NAME}${BUILD_NUMBER}
-    hostname: zookeeper1${JOB_BASE_NAME}${BUILD_NUMBER}.confluent${JOB_BASE_NAME}${BUILD_NUMBER}
+  - name: zookeeper1
+    hostname: zookeeper1.confluent
     groups:
       - zookeeper
       - zookeeper_migration
@@ -20,11 +20,11 @@ platforms:
     cgroupns_mode: host
     privileged: true
     networks:
-      - name: confluent${JOB_BASE_NAME}${BUILD_NUMBER}
+      - name: confluent
 
   # Kafka broker — starts in ZK mode, stays in ZK mode (no migration activation)
-  - name: kafka-broker1${JOB_BASE_NAME}${BUILD_NUMBER}
-    hostname: kafka-broker1${JOB_BASE_NAME}${BUILD_NUMBER}.confluent${JOB_BASE_NAME}${BUILD_NUMBER}
+  - name: kafka-broker1
+    hostname: kafka-broker1.confluent
     groups:
       - kafka_broker
       - kafka_broker_migration
@@ -36,7 +36,7 @@ platforms:
     cgroupns_mode: host
     privileged: true
     networks:
-      - name: confluent${JOB_BASE_NAME}${BUILD_NUMBER}
+      - name: confluent
 
   # Dedicated KRaft controller — provisioned during migration, stopped by rollback
   - name: controller1-mig
@@ -51,7 +51,7 @@ platforms:
     cgroupns_mode: host
     privileged: true
     networks:
-      - name: confluent${JOB_BASE_NAME}${BUILD_NUMBER}
+      - name: confluent
 
 provisioner:
   playbooks:

--- a/molecule/plaintext-rhel-rollback-phase2/molecule.yml
+++ b/molecule/plaintext-rhel-rollback-phase2/molecule.yml
@@ -1,0 +1,63 @@
+---
+### KRaft Migration Rollback — Phase 2 (PREMIGRATION)
+### Tests that controllers can be stopped cleanly when migration has not yet
+### activated dual-write mode (brokers are still in pure ZooKeeper mode).
+
+driver:
+  name: docker
+platforms:
+  # ZooKeeper node — also serves as the ZK target after rollback
+  - name: zookeeper1${JOB_BASE_NAME}${BUILD_NUMBER}
+    hostname: zookeeper1${JOB_BASE_NAME}${BUILD_NUMBER}.confluent${JOB_BASE_NAME}${BUILD_NUMBER}
+    groups:
+      - zookeeper
+      - zookeeper_migration
+    image: redhat/ubi9-minimal
+    dockerfile: ../Dockerfile-rhel-java17.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent${JOB_BASE_NAME}${BUILD_NUMBER}
+
+  # Kafka broker — starts in ZK mode, stays in ZK mode (no migration activation)
+  - name: kafka-broker1${JOB_BASE_NAME}${BUILD_NUMBER}
+    hostname: kafka-broker1${JOB_BASE_NAME}${BUILD_NUMBER}.confluent${JOB_BASE_NAME}${BUILD_NUMBER}
+    groups:
+      - kafka_broker
+      - kafka_broker_migration
+    image: redhat/ubi9-minimal
+    dockerfile: ../Dockerfile-rhel-java17.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent${JOB_BASE_NAME}${BUILD_NUMBER}
+
+  # Dedicated KRaft controller — provisioned during migration, stopped by rollback
+  - name: controller1-mig
+    hostname: controller1-mig.confluent
+    groups:
+      - kafka_controller_migration
+    image: redhat/ubi9-minimal
+    dockerfile: ../Dockerfile-rhel-java17.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent${JOB_BASE_NAME}${BUILD_NUMBER}
+
+provisioner:
+  playbooks:
+    converge: ../migration_rollback_phase2_converge.yml
+  inventory:
+    group_vars:
+      all:
+        scenario_name: plaintext-rhel-rollback-phase2
+        kraft_migration: true

--- a/molecule/plaintext-rhel-rollback-phase2/prepare.yml
+++ b/molecule/plaintext-rhel-rollback-phase2/prepare.yml
@@ -1,0 +1,5 @@
+---
+# Rollback scenarios always need a running ZooKeeper cluster before migration
+# steps begin. Install it unconditionally (no MIGRATION env var guard needed).
+- name: Install ZooKeeper cluster (pre-migration baseline)
+  import_playbook: confluent.platform.all

--- a/molecule/plaintext-rhel-rollback-phase2/verify.yml
+++ b/molecule/plaintext-rhel-rollback-phase2/verify.yml
@@ -1,0 +1,71 @@
+---
+### Verify Phase 2 (PREMIGRATION) Rollback
+### After rollback, the cluster must be in pure ZooKeeper mode:
+###   - Controller service stopped and disabled
+###   - Broker config: broker.id set, zookeeper.connect present
+###   - Broker config: no KRaft-only properties (process.roles, migration flag)
+###   - Broker service healthy
+
+- name: Verify KRaft controller is stopped after Phase 2 rollback
+  hosts: kafka_controller
+  gather_facts: false
+  tasks:
+    - name: Import variables role
+      import_role:
+        name: variables
+
+    - name: Assert controller service is stopped
+      systemd:
+        name: "{{ kafka_controller_service_name }}"
+      register: ctrl_state
+
+    - name: Fail if controller service is still running
+      assert:
+        that:
+          - ctrl_state.status.ActiveState != 'active'
+        fail_msg: >-
+          Controller service '{{ kafka_controller_service_name }}' is still running
+          after Phase 2 rollback. It must be stopped.
+
+- name: Verify broker config is in ZooKeeper-only mode after Phase 2 rollback
+  hosts: kafka_broker
+  gather_facts: false
+  tasks:
+    - name: Import variables role
+      import_role:
+        name: variables
+
+    - name: Check broker.id is set
+      import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: "{{ kafka_broker.config_file }}"
+        property: broker.id
+        expected_value: "1"
+
+    - name: Check zookeeper.connect is present
+      import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: "{{ kafka_broker.config_file }}"
+        property: zookeeper.connect
+
+    - name: Verify process.roles is absent from broker config
+      shell: grep -E '^process\.roles\s*=' {{ kafka_broker.config_file }}
+      register: process_roles_check
+      changed_when: false
+      failed_when: process_roles_check.rc == 0
+      # rc=1 means grep found nothing — that is the expected (passing) result
+
+    - name: Verify migration flag is absent from broker config
+      shell: grep -E '^zookeeper\.metadata\.migration\.enable\s*=' {{ kafka_broker.config_file }}
+      register: migration_flag_check
+      changed_when: false
+      failed_when: migration_flag_check.rc == 0
+
+    - name: Run broker health check
+      import_role:
+        name: kafka_broker
+        tasks_from: health_check.yml

--- a/molecule/plaintext-rhel-rollback-phase3/molecule.yml
+++ b/molecule/plaintext-rhel-rollback-phase3/molecule.yml
@@ -1,0 +1,63 @@
+---
+### KRaft Migration Rollback — Phase 3 (HYBRID_DUAL_WRITE)
+### Tests rollback from dual-write mode: controllers stopped, ZK znodes cleaned,
+### one rolling broker restart to remove migration properties.
+
+driver:
+  name: docker
+platforms:
+  # ZooKeeper node — serves as ZK quorum during migration and after rollback
+  - name: zookeeper1${JOB_BASE_NAME}${BUILD_NUMBER}
+    hostname: zookeeper1${JOB_BASE_NAME}${BUILD_NUMBER}.confluent${JOB_BASE_NAME}${BUILD_NUMBER}
+    groups:
+      - zookeeper
+      - zookeeper_migration
+    image: redhat/ubi9-minimal
+    dockerfile: ../Dockerfile-rhel-java17.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent${JOB_BASE_NAME}${BUILD_NUMBER}
+
+  # Kafka broker — enters dual-write mode then rolled back to ZK-only mode
+  - name: kafka-broker1${JOB_BASE_NAME}${BUILD_NUMBER}
+    hostname: kafka-broker1${JOB_BASE_NAME}${BUILD_NUMBER}.confluent${JOB_BASE_NAME}${BUILD_NUMBER}
+    groups:
+      - kafka_broker
+      - kafka_broker_migration
+    image: redhat/ubi9-minimal
+    dockerfile: ../Dockerfile-rhel-java17.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent${JOB_BASE_NAME}${BUILD_NUMBER}
+
+  # Dedicated KRaft controller — provisioned during migration, stopped by rollback
+  - name: controller1-mig
+    hostname: controller1-mig.confluent
+    groups:
+      - kafka_controller_migration
+    image: redhat/ubi9-minimal
+    dockerfile: ../Dockerfile-rhel-java17.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent${JOB_BASE_NAME}${BUILD_NUMBER}
+
+provisioner:
+  playbooks:
+    converge: ../migration_rollback_phase3_converge.yml
+  inventory:
+    group_vars:
+      all:
+        scenario_name: plaintext-rhel-rollback-phase3
+        kraft_migration: true

--- a/molecule/plaintext-rhel-rollback-phase3/molecule.yml
+++ b/molecule/plaintext-rhel-rollback-phase3/molecule.yml
@@ -7,8 +7,8 @@ driver:
   name: docker
 platforms:
   # ZooKeeper node — serves as ZK quorum during migration and after rollback
-  - name: zookeeper1${JOB_BASE_NAME}${BUILD_NUMBER}
-    hostname: zookeeper1${JOB_BASE_NAME}${BUILD_NUMBER}.confluent${JOB_BASE_NAME}${BUILD_NUMBER}
+  - name: zookeeper1
+    hostname: zookeeper1.confluent
     groups:
       - zookeeper
       - zookeeper_migration
@@ -20,11 +20,11 @@ platforms:
     cgroupns_mode: host
     privileged: true
     networks:
-      - name: confluent${JOB_BASE_NAME}${BUILD_NUMBER}
+      - name: confluent
 
   # Kafka broker — enters dual-write mode then rolled back to ZK-only mode
-  - name: kafka-broker1${JOB_BASE_NAME}${BUILD_NUMBER}
-    hostname: kafka-broker1${JOB_BASE_NAME}${BUILD_NUMBER}.confluent${JOB_BASE_NAME}${BUILD_NUMBER}
+  - name: kafka-broker1
+    hostname: kafka-broker1.confluent
     groups:
       - kafka_broker
       - kafka_broker_migration
@@ -36,7 +36,7 @@ platforms:
     cgroupns_mode: host
     privileged: true
     networks:
-      - name: confluent${JOB_BASE_NAME}${BUILD_NUMBER}
+      - name: confluent
 
   # Dedicated KRaft controller — provisioned during migration, stopped by rollback
   - name: controller1-mig
@@ -51,7 +51,7 @@ platforms:
     cgroupns_mode: host
     privileged: true
     networks:
-      - name: confluent${JOB_BASE_NAME}${BUILD_NUMBER}
+      - name: confluent
 
 provisioner:
   playbooks:

--- a/molecule/plaintext-rhel-rollback-phase3/prepare.yml
+++ b/molecule/plaintext-rhel-rollback-phase3/prepare.yml
@@ -1,0 +1,5 @@
+---
+# Rollback scenarios always need a running ZooKeeper cluster before migration
+# steps begin. Install it unconditionally (no MIGRATION env var guard needed).
+- name: Install ZooKeeper cluster (pre-migration baseline)
+  import_playbook: confluent.platform.all

--- a/molecule/plaintext-rhel-rollback-phase3/verify.yml
+++ b/molecule/plaintext-rhel-rollback-phase3/verify.yml
@@ -1,0 +1,74 @@
+---
+### Verify Phase 3 (HYBRID_DUAL_WRITE) Rollback
+### After rollback, the cluster must be in pure ZooKeeper mode:
+###   - Controller service stopped and disabled
+###   - Broker config: broker.id set, zookeeper.connect present
+###   - Broker config: no KRaft/migration properties (process.roles, migration flag,
+###     controller.quorum.voters, controller.listener.names)
+###   - Broker service healthy and connected to ZooKeeper
+
+- name: Verify KRaft controller is stopped after Phase 3 rollback
+  hosts: kafka_controller
+  gather_facts: false
+  tasks:
+    - name: Import variables role
+      import_role:
+        name: variables
+
+    - name: Check controller service state
+      systemd:
+        name: "{{ kafka_controller_service_name }}"
+      register: ctrl_state
+
+    - name: Assert controller service is stopped
+      assert:
+        that:
+          - ctrl_state.status.ActiveState != 'active'
+        fail_msg: >-
+          Controller service '{{ kafka_controller_service_name }}' is still running
+          after Phase 3 rollback. It must be stopped.
+
+- name: Verify broker config is in ZooKeeper-only mode after Phase 3 rollback
+  hosts: kafka_broker
+  gather_facts: false
+  tasks:
+    - name: Import variables role
+      import_role:
+        name: variables
+
+    - name: Check broker.id is set
+      import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: "{{ kafka_broker.config_file }}"
+        property: broker.id
+        expected_value: "1"
+
+    - name: Check zookeeper.connect is present
+      import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: "{{ kafka_broker.config_file }}"
+        property: zookeeper.connect
+
+    - name: Verify KRaft and migration properties are absent
+      shell: |
+        grep -E '^(process\.roles|zookeeper\.metadata\.migration\.enable|controller\.quorum\.voters|controller\.listener\.names)\s*=' \
+          {{ kafka_broker.config_file }} || echo "CLEAN"
+      register: kraft_props_check
+      changed_when: false
+
+    - name: Assert no KRaft/migration properties remain
+      assert:
+        that:
+          - kraft_props_check.stdout == 'CLEAN'
+        fail_msg: >-
+          Unexpected KRaft/migration properties still present in broker config
+          after Phase 3 rollback: {{ kraft_props_check.stdout_lines }}
+
+    - name: Run broker health check
+      import_role:
+        name: kafka_broker
+        tasks_from: health_check.yml

--- a/molecule/plaintext-rhel-rollback-phase4/molecule.yml
+++ b/molecule/plaintext-rhel-rollback-phase4/molecule.yml
@@ -7,8 +7,8 @@ driver:
   name: docker
 platforms:
   # ZooKeeper node — serves as ZK quorum during migration and after rollback
-  - name: zookeeper1${JOB_BASE_NAME}${BUILD_NUMBER}
-    hostname: zookeeper1${JOB_BASE_NAME}${BUILD_NUMBER}.confluent${JOB_BASE_NAME}${BUILD_NUMBER}
+  - name: zookeeper1
+    hostname: zookeeper1.confluent
     groups:
       - zookeeper
       - zookeeper_migration
@@ -20,11 +20,11 @@ platforms:
     cgroupns_mode: host
     privileged: true
     networks:
-      - name: confluent${JOB_BASE_NAME}${BUILD_NUMBER}
+      - name: confluent
 
   # Kafka broker — migrates fully to KRaft mode then rolled all the way back
-  - name: kafka-broker1${JOB_BASE_NAME}${BUILD_NUMBER}
-    hostname: kafka-broker1${JOB_BASE_NAME}${BUILD_NUMBER}.confluent${JOB_BASE_NAME}${BUILD_NUMBER}
+  - name: kafka-broker1
+    hostname: kafka-broker1.confluent
     groups:
       - kafka_broker
       - kafka_broker_migration
@@ -36,7 +36,7 @@ platforms:
     cgroupns_mode: host
     privileged: true
     networks:
-      - name: confluent${JOB_BASE_NAME}${BUILD_NUMBER}
+      - name: confluent
 
   # Dedicated KRaft controller — provisioned during migration, stopped by rollback
   - name: controller1-mig
@@ -51,7 +51,7 @@ platforms:
     cgroupns_mode: host
     privileged: true
     networks:
-      - name: confluent${JOB_BASE_NAME}${BUILD_NUMBER}
+      - name: confluent
 
 provisioner:
   playbooks:

--- a/molecule/plaintext-rhel-rollback-phase4/molecule.yml
+++ b/molecule/plaintext-rhel-rollback-phase4/molecule.yml
@@ -1,0 +1,63 @@
+---
+### KRaft Migration Rollback — Phase 4 (PURE_DUAL_WRITE)
+### Tests rollback from fully-migrated broker state: brokers had process.roles=broker
+### and no zookeeper.connect. Requires three rolling broker restarts.
+
+driver:
+  name: docker
+platforms:
+  # ZooKeeper node — serves as ZK quorum during migration and after rollback
+  - name: zookeeper1${JOB_BASE_NAME}${BUILD_NUMBER}
+    hostname: zookeeper1${JOB_BASE_NAME}${BUILD_NUMBER}.confluent${JOB_BASE_NAME}${BUILD_NUMBER}
+    groups:
+      - zookeeper
+      - zookeeper_migration
+    image: redhat/ubi9-minimal
+    dockerfile: ../Dockerfile-rhel-java17.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent${JOB_BASE_NAME}${BUILD_NUMBER}
+
+  # Kafka broker — migrates fully to KRaft mode then rolled all the way back
+  - name: kafka-broker1${JOB_BASE_NAME}${BUILD_NUMBER}
+    hostname: kafka-broker1${JOB_BASE_NAME}${BUILD_NUMBER}.confluent${JOB_BASE_NAME}${BUILD_NUMBER}
+    groups:
+      - kafka_broker
+      - kafka_broker_migration
+    image: redhat/ubi9-minimal
+    dockerfile: ../Dockerfile-rhel-java17.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent${JOB_BASE_NAME}${BUILD_NUMBER}
+
+  # Dedicated KRaft controller — provisioned during migration, stopped by rollback
+  - name: controller1-mig
+    hostname: controller1-mig.confluent
+    groups:
+      - kafka_controller_migration
+    image: redhat/ubi9-minimal
+    dockerfile: ../Dockerfile-rhel-java17.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent${JOB_BASE_NAME}${BUILD_NUMBER}
+
+provisioner:
+  playbooks:
+    converge: ../migration_rollback_phase4_converge.yml
+  inventory:
+    group_vars:
+      all:
+        scenario_name: plaintext-rhel-rollback-phase4
+        kraft_migration: true

--- a/molecule/plaintext-rhel-rollback-phase4/prepare.yml
+++ b/molecule/plaintext-rhel-rollback-phase4/prepare.yml
@@ -1,0 +1,5 @@
+---
+# Rollback scenarios always need a running ZooKeeper cluster before migration
+# steps begin. Install it unconditionally (no MIGRATION env var guard needed).
+- name: Install ZooKeeper cluster (pre-migration baseline)
+  import_playbook: confluent.platform.all

--- a/molecule/plaintext-rhel-rollback-phase4/verify.yml
+++ b/molecule/plaintext-rhel-rollback-phase4/verify.yml
@@ -1,0 +1,75 @@
+---
+### Verify Phase 4 (PURE_DUAL_WRITE) Rollback
+### After rollback, the cluster must be in pure ZooKeeper mode:
+###   - Controller service stopped and disabled
+###   - Broker config: broker.id set, zookeeper.connect present
+###   - Broker config: no KRaft/migration properties (process.roles, migration flag,
+###     controller.quorum.voters, controller.listener.names, node.id)
+###   - Broker service healthy and connected to ZooKeeper
+
+- name: Verify KRaft controller is stopped after Phase 4 rollback
+  hosts: kafka_controller
+  gather_facts: false
+  tasks:
+    - name: Import variables role
+      import_role:
+        name: variables
+
+    - name: Check controller service state
+      systemd:
+        name: "{{ kafka_controller_service_name }}"
+      register: ctrl_state
+
+    - name: Assert controller service is stopped
+      assert:
+        that:
+          - ctrl_state.status.ActiveState != 'active'
+        fail_msg: >-
+          Controller service '{{ kafka_controller_service_name }}' is still running
+          after Phase 4 rollback. It must be stopped.
+
+- name: Verify broker config is in ZooKeeper-only mode after Phase 4 rollback
+  hosts: kafka_broker
+  gather_facts: false
+  tasks:
+    - name: Import variables role
+      import_role:
+        name: variables
+
+    - name: Check broker.id is set
+      import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: "{{ kafka_broker.config_file }}"
+        property: broker.id
+        expected_value: "1"
+
+    - name: Check zookeeper.connect is present
+      import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: "{{ kafka_broker.config_file }}"
+        property: zookeeper.connect
+
+    - name: Verify KRaft and migration properties are absent
+      # Phase 4 rollback also strips node.id (added by ZKtoKraftMigration.yml lineinfile)
+      shell: |
+        grep -E '^(process\.roles|zookeeper\.metadata\.migration\.enable|controller\.quorum\.voters|controller\.listener\.names|node\.id)\s*=' \
+          {{ kafka_broker.config_file }} || echo "CLEAN"
+      register: kraft_props_check
+      changed_when: false
+
+    - name: Assert no KRaft/migration properties remain
+      assert:
+        that:
+          - kraft_props_check.stdout == 'CLEAN'
+        fail_msg: >-
+          Unexpected KRaft/migration properties still present in broker config
+          after Phase 4 rollback: {{ kraft_props_check.stdout_lines }}
+
+    - name: Run broker health check
+      import_role:
+        name: kafka_broker
+        tasks_from: health_check.yml

--- a/playbooks/ZKtoKraftMigration.yml
+++ b/playbooks/ZKtoKraftMigration.yml
@@ -211,3 +211,11 @@
   tasks:
     - debug:
         msg: "Migration from Zookeeper to Kraft has completed, you may shut down your Zookeeper. Please remove Zookeeper section and migration flag from your inventory file."
+
+# Rollback entry point.
+# Detects the current migration phase automatically and runs the applicable
+# rollback steps. Does not run during normal migration (migrate_to_dual_write /
+# migrate_to_kraft tags). Invoke with:
+#   ansible-playbook ZKtoKraftMigration.yml --tags rollback
+- import_playbook: kraft_migration_rollback.yml
+  tags: rollback

--- a/playbooks/ZKtoKraftMigration.yml
+++ b/playbooks/ZKtoKraftMigration.yml
@@ -215,7 +215,10 @@
 # Rollback entry point.
 # Detects the current migration phase automatically and runs the applicable
 # rollback steps. Does not run during normal migration (migrate_to_dual_write /
-# migrate_to_kraft tags). Invoke with:
+# migrate_to_kraft tags). The 'never' tag prevents this from running unless
+# --tags rollback is explicitly passed. Invoke with:
 #   ansible-playbook ZKtoKraftMigration.yml --tags rollback
 - import_playbook: kraft_migration_rollback.yml
-  tags: rollback
+  tags:
+    - rollback
+    - never

--- a/playbooks/kraft_migration_rollback.yml
+++ b/playbooks/kraft_migration_rollback.yml
@@ -1,0 +1,807 @@
+---
+# KRaft Migration Rollback Playbook
+#
+# Reverts a ZooKeeper → KRaft migration back to ZooKeeper-only mode.
+# Supports Phase 2, 3, and 4 rollback. Phase 5 is irreversible.
+#
+# Reference:
+#   https://docs.confluent.io/ansible/7.9/ansible-migrate-kraft.html#roll-back-to-zk
+#   https://docs.confluent.io/platform/8.2/installation/migrate-zk-kraft.html
+#
+# ┌──────────────────────────────────────────────────────────────────────────┐
+# │ MIGRATION PHASE → ROLLBACK COMPLEXITY                                    │
+# │                                                                          │
+# │ Phase 2: Controllers provisioned, no dual-write started                  │
+# │          → Stop controllers only. No broker changes. (LOW)               │
+# │                                                                          │
+# │ Phase 3: Hybrid/dual-write mode (ZkMigrationState=1, brokers have       │
+# │          zookeeper.connect, no process.roles=broker)                     │
+# │          → 1 rolling broker restart + controller stop. (MEDIUM)          │
+# │                                                                          │
+# │ Phase 4: Brokers in KRaft mode (ZkMigrationState=1, process.roles=broker│
+# │          set, zookeeper.connect removed by ZKtoKraftMigration.yml:96)    │
+# │          → 3 rolling broker restarts + controller stop. (HIGH)           │
+# │                                                                          │
+# │ Phase 5: ZkMigrationState=3 — IRREVERSIBLE. Playbook aborts.            │
+# └──────────────────────────────────────────────────────────────────────────┘
+#
+# USAGE:
+#   # Auto-detects phase and runs only the applicable rollback plays:
+#   ansible-playbook -i <inventory> playbooks/kraft_migration_rollback.yml
+#
+#   # Or invoke from the migration playbook directly:
+#   ansible-playbook -i <inventory> playbooks/ZKtoKraftMigration.yml --tags rollback
+#
+#   # Dry run (pre-flight + phase detection only):
+#   ansible-playbook -i <inventory> playbooks/kraft_migration_rollback.yml \
+#     --tags validate --check
+#
+#   # Phase-specific tags (for re-runs or manual override — phase guard still enforced):
+#   ansible-playbook -i <inventory> playbooks/kraft_migration_rollback.yml \
+#     --tags rollback_phase2   # or rollback_phase3 / rollback_phase4
+#
+# REQUIRED INVENTORY STATE:
+#   all:vars:
+#     kraft_migration: true     ← MUST remain true until rollback is complete
+#   Groups: zookeeper, kafka_broker, kafka_controller all must be present.
+#
+# KEY IMPLEMENTATION NOTES:
+#
+# 1. kraft_migration: true must stay set during rollback — it is what allows
+#    ZooKeeper + kafka_controller to coexist without failing the common role
+#    check (roles/common/tasks/main.yml:26).
+#
+# 2. zookeeper_connect is auto-computed from the 'zookeeper' inventory group
+#    (roles/variables/vars/main.yml:406). No manual variable needed.
+#
+# 3. broker.id is NOT changed to node.id for brokers in this codebase.
+#    node.id is only for controllers (index + 9991). Brokers always use
+#    broker.id = index + 1 (roles/variables/vars/main.yml:437-441).
+#
+# 4. Phase 5 is COMMENTED OUT in ZKtoKraftMigration.yml (lines 140-213).
+#    ZkMigrationState=3 can only be reached by manual intervention.
+#
+# 5. The RBAC ACL (confluent.authorizer.access.rule.providers) is auto-set to
+#    ZK_ACL when kraft_migration=true (roles/variables/vars/main.yml:548).
+#    In Phase 4, the lineinfile change (KRAFT_ACL) must be explicitly reverted
+#    before ZK_ACL takes effect via the template.
+
+#==============================================================================
+# PRE-FLIGHT VALIDATIONS (always runs)
+#==============================================================================
+- import_playbook: validations/kraft_migration_rollback_validations.yml
+  tags:
+    - validate
+    - always
+
+#==============================================================================
+# PROPAGATE PHASE DETECTION TO ALL TARGET HOSTS
+# Makes the migration_state, rollback_allowed facts (set on
+# localhost in validations) available to all plays targeting remote hosts.
+#==============================================================================
+- name: Propagate migration state facts to all hosts
+  hosts: kafka_controller:kafka_broker:zookeeper
+  gather_facts: false
+  tags: always
+
+  tasks:
+    - name: Inherit migration state from localhost detection
+      set_fact:
+        migration_state: "{{ hostvars['localhost']['migration_state'] }}"
+        rollback_allowed: "{{ hostvars['localhost']['rollback_allowed'] }}"
+
+#==============================================================================
+# PHASE 2 ROLLBACK: Stop KRaft Controllers
+#
+# State: Controllers are running but no dual-write has started.
+# Brokers are still fully in ZooKeeper mode — no changes needed.
+# Action: Stop and disable controller services. Optionally clean data dirs.
+#==============================================================================
+- name: "Rollback Phase 2: Stop KRaft Controllers"
+  hosts: kafka_controller
+  gather_facts: false
+  serial: 1
+  any_errors_fatal: true
+  tags: rollback_phase2
+
+  tasks:
+    - name: Skip — detected state is '{{ migration_state }}', Phase 2 rollback requires PREMIGRATION
+      meta: end_play
+      when: migration_state != 'PREMIGRATION'
+
+    - name: Import variables role
+      import_role:
+        name: variables
+
+    - name: Back up controller configuration before stopping
+      copy:
+        src: "{{ kafka_controller.config_file }}"
+        dest: "{{ kafka_controller.config_file }}.phase2_rollback"
+        remote_src: true
+        mode: preserve
+
+    - name: Stop KRaft controller service
+      systemd:
+        name: "{{ kafka_controller_service_name }}"
+        state: stopped
+        enabled: false
+
+    - name: Verify controller service is stopped
+      systemd:
+        name: "{{ kafka_controller_service_name }}"
+      register: ctrl_state
+      failed_when: ctrl_state.status.ActiveState == 'active'
+
+    - name: Phase 2 rollback complete on {{ inventory_hostname }}
+      debug:
+        msg: >-
+          Controller stopped. Brokers were never affected — cluster continues in ZooKeeper mode.
+          NEXT STEPS: Remove kafka_controller group from inventory. Set kraft_migration: false.
+
+#==============================================================================
+# PHASE 3 ROLLBACK
+#
+# State: Brokers are in hybrid/dual-write mode (ZkMigrationState=1).
+#        Broker config has zookeeper.metadata.migration.enable=true and
+#        zookeeper.connect. process.roles is NOT set on brokers.
+#
+# Order (per official Confluent docs):
+#   Step 1: Stop KRaft controllers + clean controller __cluster_metadata
+#   Step 2: Clean ZooKeeper znodes (/controller, /migration) + wait for election
+#   Step 3: Clean broker __cluster_metadata dirs (all brokers, no restart yet)
+#   Step 4: Rolling broker restart — remove KRaft props, restore ZK config
+#
+# Stopping controllers FIRST is critical: it prevents further KRaft metadata
+# writes while brokers are being reconfigured. Only then is it safe to restart
+# brokers into ZooKeeper-only mode.
+#==============================================================================
+
+# STEP 1: Stop KRaft controllers and clean their metadata
+- name: "Rollback Phase 3 - Step 1: Stop KRaft Controllers"
+  hosts: kafka_controller
+  gather_facts: true
+  any_errors_fatal: true
+  tags: rollback_phase3
+
+  tasks:
+    - name: Import variables role
+      import_role:
+        name: variables
+
+    - block:
+        - name: Back up controller config
+          copy:
+            src: "{{ kafka_controller.config_file }}"
+            dest: "{{ kafka_controller.config_file }}.pre_rollback"
+            remote_src: true
+            mode: preserve
+
+        - name: Stop KRaft controller service
+          systemd:
+            name: "{{ kafka_controller_service_name }}"
+            state: stopped
+
+        - name: Disable KRaft controller service
+          systemd:
+            name: "{{ kafka_controller_service_name }}"
+            enabled: false
+
+        # Controllers also write __cluster_metadata. Clean them here while
+        # the process is stopped to avoid stale KRaft log on future re-migration.
+        - name: Find __cluster_metadata directories on controller
+          find:
+            paths: "{{ kafka_controller_final_properties['log.dirs'].split(',') | map('trim') | list }}"
+            patterns: "__cluster_metadata*"
+            file_type: directory
+          register: controller_metadata_dirs
+
+        - name: Delete __cluster_metadata directories from controller
+          file:
+            path: "{{ item.path }}"
+            state: absent
+          loop: "{{ controller_metadata_dirs.files }}"
+          loop_control:
+            label: "{{ item.path }}"
+          when: controller_metadata_dirs.files | length > 0
+
+        - debug:
+            msg: "Controller {{ inventory_hostname }} stopped, disabled, and metadata cleaned"
+      when: migration_state == 'HYBRID_DUAL_WRITE'
+
+# STEP 2: Clean ZooKeeper migration state and wait for broker election
+- name: "Rollback Phase 3 - Step 2: Clean ZooKeeper Migration State"
+  hosts: zookeeper[0]
+  gather_facts: true
+  any_errors_fatal: true
+  tags: rollback_phase3
+
+  tasks:
+    - name: Import variables role
+      import_role:
+        name: variables
+
+    - block:
+        # deleteall handles child znodes; plain delete fails if children exist.
+        - name: Delete ZooKeeper /controller znode
+          shell: |
+            echo "deleteall /controller" | {{ zookeeper_cli_path }} localhost:{{ zookeeper_client_port }}
+          register: zk_delete_controller
+          failed_when: false
+          changed_when: "'Node does not exist' not in zk_delete_controller.stderr"
+          vars:
+            zookeeper_cli_path: "{% if installation_method == 'archive' %}{{ archive_destination_path }}/confluent-{{ confluent_package_version }}/bin/zookeeper-shell{% else %}/usr/bin/zookeeper-shell{% endif %}"
+
+        - name: Delete ZooKeeper /migration znode
+          shell: |
+            echo "delete /migration" | {{ zookeeper_cli_path }} localhost:{{ zookeeper_client_port }}
+          register: zk_delete_migration
+          failed_when: false
+          changed_when: "'Node does not exist' not in zk_delete_migration.stderr"
+          vars:
+            zookeeper_cli_path: "{% if installation_method == 'archive' %}{{ archive_destination_path }}/confluent-{{ confluent_package_version }}/bin/zookeeper-shell{% else %}/usr/bin/zookeeper-shell{% endif %}"
+
+        # Wait for a broker to register itself as the ZK controller before
+        # proceeding — confirms the cluster is operational in ZK-only mode.
+        - name: Wait for ZooKeeper to elect a new broker controller
+          shell: |
+            echo "get /controller" | {{ zookeeper_cli_path }} localhost:{{ zookeeper_client_port }} \
+              | grep -v "^Connecting\|^Welcome\|^WATCHER\|^$" || true
+          register: zk_controller_elected
+          retries: 10
+          delay: 5
+          until: zk_controller_elected.stdout | length > 0
+          changed_when: false
+          failed_when: false
+          vars:
+            zookeeper_cli_path: "{% if installation_method == 'archive' %}{{ archive_destination_path }}/confluent-{{ confluent_package_version }}/bin/zookeeper-shell{% else %}/usr/bin/zookeeper-shell{% endif %}"
+
+        - debug:
+            msg: "ZooKeeper state cleaned. New broker controller: {{ zk_controller_elected.stdout | default('(still electing — verify manually)') }}"
+      when: migration_state == 'HYBRID_DUAL_WRITE'
+
+# STEP 3: Clean __cluster_metadata on all brokers before restart
+# Done as a separate non-rolling step so all brokers are cleaned before any
+# restart begins — avoids a situation where a restarted broker tries to
+# replicate stale metadata from a peer that hasn't been cleaned yet.
+- name: "Rollback Phase 3 - Step 3: Clean Broker Metadata Logs"
+  hosts: kafka_broker
+  gather_facts: true
+  any_errors_fatal: true
+  tags: rollback_phase3
+
+  tasks:
+    - name: Import variables role
+      import_role:
+        name: variables
+
+    - block:
+        - name: Find __cluster_metadata directories in broker log dirs
+          find:
+            paths: "{{ kafka_broker_final_properties['log.dirs'].split(',') | map('trim') | list }}"
+            patterns: "__cluster_metadata*"
+            file_type: directory
+          register: broker_metadata_dirs
+
+        - name: Delete __cluster_metadata directories
+          file:
+            path: "{{ item.path }}"
+            state: absent
+          loop: "{{ broker_metadata_dirs.files }}"
+          loop_control:
+            label: "{{ item.path }}"
+          when: broker_metadata_dirs.files | length > 0
+
+        - debug:
+            msg: "Metadata logs cleaned on {{ inventory_hostname }}"
+      when: migration_state == 'HYBRID_DUAL_WRITE'
+
+# STEP 4: Rolling broker restart — remove KRaft props, restore ZK-only config
+- name: "Rollback Phase 3 - Step 4: Rolling Broker Restart to ZooKeeper Mode"
+  hosts: kafka_broker
+  gather_facts: true
+  serial: '1'
+  any_errors_fatal: true
+  tags: rollback_phase3
+
+  tasks:
+    - name: Import variables role
+      import_role:
+        name: variables
+
+    - block:
+        - name: Back up broker config before modification
+          copy:
+            src: "{{ kafka_broker.config_file }}"
+            dest: "{{ kafka_broker.config_file }}.pre_rollback"
+            remote_src: true
+            mode: preserve
+
+        # Remove all KRaft and migration-mode properties. Each is a no-op if
+        # the property is already absent, so this is safe to re-run.
+        - name: Remove KRaft and migration properties from broker config
+          lineinfile:
+            path: "{{ kafka_broker.config_file }}"
+            state: absent
+            regexp: "^{{ item }}.*"
+          loop:
+            - process\.roles
+            - controller\.listener\.names
+            - controller\.quorum\.voters
+            - controller\.quorum\.bootstrap\.servers
+            - zookeeper\.metadata\.migration\.enable
+            - inter\.broker\.protocol\.version
+            - confluent\.cluster\.link\.metadata\.topic\.enable
+
+        # zookeeper.connect was removed by ZKtoKraftMigration.yml (regexp "^zookeeper*").
+        # Reconstruct it from the zookeeper inventory group, including chroot if set.
+        - name: Ensure zookeeper.connect is present in broker config
+          lineinfile:
+            path: "{{ kafka_broker.config_file }}"
+            regexp: '^zookeeper\.connect\s*='
+            line: "zookeeper.connect={% for host in groups['zookeeper'] %}{{ host }}:{{ zookeeper_client_port }}{% if not loop.last %},{% endif %}{% endfor %}{{ '/' + kafka_broker_default_final_properties['zookeeper.chroot'] if kafka_broker_default_final_properties['zookeeper.chroot'] | default('') != '' else '' }}"
+            state: present
+
+        # ZKtoKraftMigration.yml:117-123 set KRAFT_ACL via lineinfile, bypassing
+        # the template. Revert explicitly — vars/main.yml:548 keeps ZK_ACL correct
+        # on subsequent kafka_broker.yml runs once kraft_migration=true.
+        - name: Revert KRAFT_ACL to ZK_ACL (RBAC clusters only)
+          lineinfile:
+            path: "{{ kafka_broker.config_file }}"
+            regexp: '^confluent\.authorizer\.access\.rule\.providers\s*='
+            line: "confluent.authorizer.access.rule.providers=CONFLUENT,ZK_ACL"
+            state: present
+          when: rbac_enabled | bool
+
+        - name: Restart broker and wait
+          include_role:
+            name: kafka_broker
+            tasks_from: restart_and_wait.yml
+
+        - name: Run broker health check
+          include_role:
+            name: kafka_broker
+            tasks_from: health_check.yml
+          tags: health_check
+
+        - debug:
+            msg: "Broker {{ inventory_hostname }} rolled back and rejoined ZooKeeper cluster"
+      when: migration_state == 'HYBRID_DUAL_WRITE'
+
+#==============================================================================
+# PHASE 4 ROLLBACK
+#
+# State: Brokers fully in KRaft mode (process.roles=broker set, zookeeper.*
+#        removed by ZKtoKraftMigration.yml). Controllers still in dual-write.
+#
+# Steps:
+#   Step 1: Rolling broker restart — regenerate config from template.
+#           With kraft_migration=true still in inventory, the variables role
+#           activates migration_mode (zookeeper.connect + migration.enable +
+#           inter.broker.protocol.version) and omits process.roles automatically.
+#           No manual property patching needed.
+#   Step 2: Deprovision KRaft controllers + clean controller __cluster_metadata
+#   Step 3: Clean ZooKeeper state (/controller, /migration znodes)
+#   Step 4: Clean broker __cluster_metadata (parallel, no restart — controllers
+#           are already stopped so these dirs are no longer written to)
+#   Step 5: Final rolling broker restart — regenerate config, then strip
+#           remaining migration-mode properties, restart into pure ZK mode.
+#
+# ACL HANDLING:
+#   RBAC clusters: confluent.authorizer.access.rule.providers is reverted from
+#     KRAFT_ACL to ZK_ACL via lineinfile in Step 5. Single run sufficient.
+#
+#   Non-RBAC ACL clusters (authorizer.class.name): the customer changed this
+#     in inventory between Phase 1 and Phase 2 of forward migration. To revert:
+#
+#     Run 1 — complete Steps 1-4 only:
+#       ansible-playbook kraft_migration_rollback.yml --skip-tags phase4_rollback_finalize
+#
+#     Then revert in inventory:
+#       kafka_broker_custom_properties:
+#         authorizer.class.name: kafka.security.authorizer.AclAuthorizer
+#
+#     Run 2 — complete Step 5 (template picks up the reverted authorizer):
+#       ansible-playbook kraft_migration_rollback.yml --skip-tags phase4_rollback_prepare
+#==============================================================================
+
+# ── Step 1: First broker restart — revert to hybrid/migration mode ─────────
+- name: "Rollback Phase 4 - Step 1: First Broker Restart (Revert to Hybrid Mode)"
+  hosts: kafka_broker
+  gather_facts: true
+  serial: '1'
+  any_errors_fatal: true
+  tags:
+    - rollback_phase4
+    - phase4_rollback_prepare
+
+  tasks:
+    - name: Import variables role
+      import_role:
+        name: variables
+
+    - block:
+        - name: Back up broker config before Phase 4 Step 1
+          copy:
+            src: "{{ kafka_broker.config_file }}"
+            dest: "{{ kafka_broker.config_file }}.phase4_rollback_step1"
+            remote_src: true
+
+        # Regenerate server.properties from template.
+        # With kraft_migration=true in inventory the variables role sets:
+        #   migration_mode enabled  → zookeeper.connect, zookeeper.metadata.migration.enable=true,
+        #                             inter.broker.protocol.version included automatically
+        #   non_migration_mode disabled → process.roles=broker NOT included
+        # No manual lineinfile patching required.
+        - name: Regenerate broker config from template (migration_mode active)
+          template:
+            src: server.properties.j2
+            dest: "{{ kafka_broker.config_file }}"
+            mode: '640'
+            owner: "{{ kafka_broker_user }}"
+            group: "{{ kafka_broker_group }}"
+
+        - name: Apply secrets protection to broker config
+          include_role:
+            name: common
+            tasks_from: secrets_protection.yml
+          vars:
+            final_properties: "{{ kafka_broker_final_properties }}"
+            encrypt_passwords: "{{ kafka_broker_secrets_protection_encrypt_passwords }}"
+            encrypt_properties: "{{ kafka_broker_secrets_protection_encrypt_properties }}"
+            config_path: "{{ kafka_broker.config_file }}"
+            secrets_file: "{{ kafka_broker_secrets_protection_file }}"
+            secrets_file_owner: "{{ kafka_broker_user }}"
+            secrets_file_group: "{{ kafka_broker_group }}"
+            ca_cert_path: "{{ kafka_broker_ca_cert_path if ssl_enabled | bool else '' }}"
+            handler: "no-op"
+          when:
+            - kafka_broker_secrets_protection_enabled | bool
+            - rbac_enabled | bool or confluent_cli_version is version('3.0.0', '>=')
+
+        - name: Restart broker and wait
+          include_role:
+            name: kafka_broker
+            tasks_from: restart_and_wait.yml
+
+        - name: Run broker health check after Step 1
+          include_role:
+            name: kafka_broker
+            tasks_from: health_check.yml
+
+        - debug:
+            msg: "Broker {{ inventory_hostname }} Step 1 done — reverted to hybrid/migration mode"
+      when: migration_state == 'PURE_DUAL_WRITE'
+
+# ── Step 2: Deprovision KRaft controllers ─────────────────────────────────
+- name: "Rollback Phase 4 - Step 2: Deprovision KRaft Controllers"
+  hosts: kafka_controller
+  gather_facts: true
+  any_errors_fatal: true
+  tags:
+    - rollback_phase4
+    - phase4_rollback_prepare
+
+  tasks:
+    - name: Import variables role
+      import_role:
+        name: variables
+
+    - block:
+        - name: Back up controller config
+          copy:
+            src: "{{ kafka_controller.config_file }}"
+            dest: "{{ kafka_controller.config_file }}.phase4_rollback"
+            remote_src: true
+
+        - name: Stop KRaft controller service
+          systemd:
+            name: "{{ kafka_controller_service_name }}"
+            state: stopped
+
+        - name: Disable KRaft controller service
+          systemd:
+            name: "{{ kafka_controller_service_name }}"
+            enabled: false
+
+        - name: Find __cluster_metadata directories on controller
+          find:
+            paths: "{{ kafka_controller_final_properties['log.dirs'].split(',') | map('trim') | list }}"
+            patterns: "__cluster_metadata*"
+            file_type: directory
+          register: controller_metadata_dirs
+
+        - name: Delete __cluster_metadata directories from controller
+          file:
+            path: "{{ item.path }}"
+            state: absent
+          loop: "{{ controller_metadata_dirs.files }}"
+          loop_control:
+            label: "{{ item.path }}"
+          when: controller_metadata_dirs.files | length > 0
+
+        - debug:
+            msg: "Controller {{ inventory_hostname }} stopped, disabled, and metadata cleaned"
+      when: migration_state == 'PURE_DUAL_WRITE'
+
+# ── Step 3: Clean ZooKeeper migration state ────────────────────────────────
+- name: "Rollback Phase 4 - Step 3: Clean ZooKeeper State"
+  hosts: zookeeper[0]
+  gather_facts: true
+  any_errors_fatal: true
+  tags:
+    - rollback_phase4
+    - phase4_rollback_prepare
+
+  tasks:
+    - name: Import variables role
+      import_role:
+        name: variables
+
+    - block:
+        - name: Delete ZooKeeper /controller znode
+          shell: |
+            echo "deleteall /controller" | {{ zookeeper_cli_path }} localhost:{{ zookeeper_client_port }}
+          register: zk_delete_controller
+          failed_when: false
+          changed_when: "'Node does not exist' not in zk_delete_controller.stderr"
+          vars:
+            zookeeper_cli_path: "{% if installation_method == 'archive' %}{{ archive_destination_path }}/confluent-{{ confluent_package_version }}/bin/zookeeper-shell{% else %}/usr/bin/zookeeper-shell{% endif %}"
+
+        - name: Delete ZooKeeper /migration znode
+          shell: |
+            echo "delete /migration" | {{ zookeeper_cli_path }} localhost:{{ zookeeper_client_port }}
+          register: zk_delete_migration
+          failed_when: false
+          changed_when: "'Node does not exist' not in zk_delete_migration.stderr"
+          vars:
+            zookeeper_cli_path: "{% if installation_method == 'archive' %}{{ archive_destination_path }}/confluent-{{ confluent_package_version }}/bin/zookeeper-shell{% else %}/usr/bin/zookeeper-shell{% endif %}"
+
+        - name: Wait for ZooKeeper to elect a new broker controller
+          shell: |
+            echo "get /controller" | {{ zookeeper_cli_path }} localhost:{{ zookeeper_client_port }} \
+              | grep -v "^Connecting\|^Welcome\|^WATCHER\|^$" || true
+          register: zk_new_controller
+          retries: 10
+          delay: 5
+          until: zk_new_controller.stdout | length > 0
+          changed_when: false
+          failed_when: false
+          vars:
+            zookeeper_cli_path: "{% if installation_method == 'archive' %}{{ archive_destination_path }}/confluent-{{ confluent_package_version }}/bin/zookeeper-shell{% else %}/usr/bin/zookeeper-shell{% endif %}"
+
+        - debug:
+            msg: "ZooKeeper state cleaned. New broker controller: {{ zk_new_controller.stdout | default('(still electing — verify manually)') }}"
+      when: migration_state == 'PURE_DUAL_WRITE'
+
+# ── Step 4: Clean broker __cluster_metadata (parallel, no restart) ─────────
+# Controllers are stopped — these dirs are no longer written to.
+# Cleaning without a broker restart avoids unnecessary downtime per broker.
+- name: "Rollback Phase 4 - Step 4: Clean Broker Metadata Logs"
+  hosts: kafka_broker
+  gather_facts: true
+  any_errors_fatal: true
+  tags:
+    - rollback_phase4
+    - phase4_rollback_prepare
+
+  tasks:
+    - name: Import variables role
+      import_role:
+        name: variables
+
+    - block:
+        - name: Find __cluster_metadata directories in broker log dirs
+          find:
+            paths: "{{ kafka_broker_final_properties['log.dirs'].split(',') | map('trim') | list }}"
+            patterns: "__cluster_metadata*"
+            file_type: directory
+          register: broker_metadata_dirs
+
+        - name: Delete __cluster_metadata directories
+          file:
+            path: "{{ item.path }}"
+            state: absent
+          loop: "{{ broker_metadata_dirs.files }}"
+          loop_control:
+            label: "{{ item.path }}"
+          when: broker_metadata_dirs.files | length > 0
+
+        - debug:
+            msg: "Broker metadata logs cleaned on {{ inventory_hostname }}"
+      when: migration_state == 'PURE_DUAL_WRITE'
+
+# ── Step 5: Final broker restart — pure ZooKeeper mode ─────────────────────
+- name: "Rollback Phase 4 - Step 5: Final Broker Restart (Pure ZooKeeper Mode)"
+  hosts: kafka_broker
+  gather_facts: true
+  serial: '1'
+  any_errors_fatal: true
+  tags:
+    - rollback_phase4
+    - phase4_rollback_finalize
+
+  tasks:
+    - name: Import variables role
+      import_role:
+        name: variables
+
+    - block:
+        - name: Back up broker config before final restart
+          copy:
+            src: "{{ kafka_broker.config_file }}"
+            dest: "{{ kafka_broker.config_file }}.phase4_rollback_final"
+            remote_src: true
+
+        # Regenerate from template — this picks up authorizer.class.name from inventory
+        # if the operator has reverted it (non-RBAC ACL two-run workflow).
+        # kraft_migration=true is still set, so migration_mode properties are included
+        # by the template — they are stripped by lineinfile immediately below.
+        - name: Regenerate broker config from template
+          template:
+            src: server.properties.j2
+            dest: "{{ kafka_broker.config_file }}"
+            mode: '640'
+            owner: "{{ kafka_broker_user }}"
+            group: "{{ kafka_broker_group }}"
+
+        - name: Apply secrets protection to broker config
+          include_role:
+            name: common
+            tasks_from: secrets_protection.yml
+          vars:
+            final_properties: "{{ kafka_broker_final_properties }}"
+            encrypt_passwords: "{{ kafka_broker_secrets_protection_encrypt_passwords }}"
+            encrypt_properties: "{{ kafka_broker_secrets_protection_encrypt_properties }}"
+            config_path: "{{ kafka_broker.config_file }}"
+            secrets_file: "{{ kafka_broker_secrets_protection_file }}"
+            secrets_file_owner: "{{ kafka_broker_user }}"
+            secrets_file_group: "{{ kafka_broker_group }}"
+            ca_cert_path: "{{ kafka_broker_ca_cert_path if ssl_enabled | bool else '' }}"
+            handler: "no-op"
+          when:
+            - kafka_broker_secrets_protection_enabled | bool
+            - rbac_enabled | bool or confluent_cli_version is version('3.0.0', '>=')
+
+        # Strip migration-mode and KRaft properties that the template still
+        # includes because kraft_migration=true is set. Safe no-ops if absent.
+        - name: Remove KRaft and migration properties (final cleanup)
+          lineinfile:
+            path: "{{ kafka_broker.config_file }}"
+            state: absent
+            regexp: "^{{ item }}.*"
+          loop:
+            - process\.roles
+            - controller\.listener\.names
+            - controller\.quorum\.voters
+            - controller\.quorum\.bootstrap\.servers
+            - zookeeper\.metadata\.migration\.enable
+            - inter\.broker\.protocol\.version
+            - confluent\.cluster\.link\.metadata\.topic\.enable
+            - node\.id
+
+        # RBAC: ZKtoKraftMigration.yml:117-123 set KRAFT_ACL via lineinfile,
+        # bypassing the template. Revert explicitly — re-running kafka_broker.yml
+        # with kraft_migration=true will then keep it correct via vars/main.yml:548.
+        - name: Revert KRAFT_ACL to ZK_ACL (RBAC clusters)
+          lineinfile:
+            path: "{{ kafka_broker.config_file }}"
+            regexp: '^confluent\.authorizer\.access\.rule\.providers\s*='
+            line: "confluent.authorizer.access.rule.providers=CONFLUENT,ZK_ACL"
+            state: present
+          when: rbac_enabled | bool
+
+        - name: Restart broker and wait
+          include_role:
+            name: kafka_broker
+            tasks_from: restart_and_wait.yml
+
+        - name: Run broker health check after final restart
+          include_role:
+            name: kafka_broker
+            tasks_from: health_check.yml
+
+        - debug:
+            msg: "Broker {{ inventory_hostname }} fully rolled back to ZooKeeper mode"
+      # PURE_DUAL_WRITE: single-run path (Steps 1-5 in one run)
+      # HYBRID_DUAL_WRITE: two-run path — Steps 1-4 completed in first run,
+      #   controllers are stopped, detection now returns HYBRID_DUAL_WRITE.
+      #   Step 5 must still execute to finalize the rollback.
+      when: migration_state in ['PURE_DUAL_WRITE', 'HYBRID_DUAL_WRITE']
+
+#==============================================================================
+# POST-ROLLBACK VERIFICATION (All Phases)
+# Runs after any phase rollback to confirm the cluster is stable in ZK mode.
+#==============================================================================
+- name: Post-Rollback Cluster Verification
+  hosts: kafka_broker
+  gather_facts: false
+  tags:
+    - rollback_phase2
+    - rollback_phase3
+    - rollback_phase4
+
+  tasks:
+    - name: Import variables role
+      import_role:
+        name: variables
+
+    - name: Verify no KRaft-only properties remain in broker config
+      shell: |
+        grep -E '^(process\.roles|zookeeper\.metadata\.migration\.enable)\s*=' \
+          {{ kafka_broker.config_file }} || echo "CLEAN"
+      register: leftover_check
+      changed_when: false
+      check_mode: false
+
+    - name: Warn if KRaft properties still present
+      debug:
+        msg: "WARNING: Unexpected KRaft properties still present: {{ leftover_check.stdout_lines }}"
+      when:
+        - leftover_check.stdout != 'CLEAN'
+        - migration_state in ['HYBRID_DUAL_WRITE', 'PURE_DUAL_WRITE']
+
+    - name: Verify broker.id is set
+      shell: |
+        grep -E '^broker\.id\s*=' {{ kafka_broker.config_file }}
+      register: broker_id_check
+      changed_when: false
+      failed_when: broker_id_check.rc != 0
+
+    - name: Verify zookeeper.connect is set (Phase 3 and 4)
+      shell: |
+        grep -E '^zookeeper\.connect\s*=' {{ kafka_broker.config_file }}
+      register: zk_connect_check
+      changed_when: false
+      failed_when: zk_connect_check.rc != 0
+      when: migration_state in ['HYBRID_DUAL_WRITE', 'PURE_DUAL_WRITE']
+
+    - name: Final health check
+      include_role:
+        name: kafka_broker
+        tasks_from: health_check.yml
+
+- name: Post-Rollback Summary
+  hosts: localhost
+  gather_facts: false
+  tags:
+    - rollback_phase2
+    - rollback_phase3
+    - rollback_phase4
+
+  tasks:
+    - name: Import variables role
+      import_role:
+        name: variables
+
+    - name: Display rollback completion message
+      debug:
+        msg: |
+          ====================================================================
+          ROLLBACK TO ZOOKEEPER COMPLETED SUCCESSFULLY
+          ====================================================================
+          State rolled back: {{ migration_state }}
+
+          REQUIRED NEXT STEPS:
+            1. Update inventory — set kraft_migration: false
+            2. Remove or comment out the kafka_controller host group
+            3. Re-run: ansible-playbook playbooks/kafka_broker.yml
+               (this re-applies ZK-mode config via proper templates and
+                removes any remaining KRaft-specific settings)
+
+          OPTIONAL CLEANUP (if reusing controller hardware):
+            - Remove KRaft metadata dirs:
+              find /var/lib/kafka -type d -name "__cluster_metadata*" -delete
+            - Uninstall controller service on controller nodes
+
+          Configuration backups created:
+          {% if migration_state == 'PREMIGRATION' %}
+            - {{ kafka_controller.config_file }}.phase2_rollback (on each controller)
+          {% elif migration_state == 'HYBRID_DUAL_WRITE' %}
+            - {{ kafka_broker.config_file }}.pre_rollback (on each broker)
+            - {{ kafka_controller.config_file }}.pre_rollback (on each controller)
+          {% elif migration_state == 'PURE_DUAL_WRITE' %}
+            - {{ kafka_broker.config_file }}.phase4_rollback_step1 (after Restart 1)
+            - {{ kafka_broker.config_file }}.phase4_rollback_final (after Restart 3)
+            - {{ kafka_controller.config_file }}.phase4_rollback (on each controller)
+          {% endif %}
+          ====================================================================

--- a/playbooks/tasks/detect_migration_phase.yml
+++ b/playbooks/tasks/detect_migration_phase.yml
@@ -1,0 +1,277 @@
+---
+# Migration Phase Detection
+#
+# Determines the current ZK-to-KRaft migration state using:
+#   Jolokia ZkMigrationState MBean + broker/controller config inspection.
+#
+# kafka-migration-check status is NOT used. As of May 2025 it has known
+# reliability issues (confluentinc/cp-ansible #C047XH0S012).
+#
+# Output Variables:
+#   - migration_state:          PREMIGRATION | HYBRID_DUAL_WRITE | PURE_DUAL_WRITE | FINALIZED
+#   - rollback_allowed:         Boolean
+#   - migration_state_detected: Boolean
+#
+# State definitions:
+#   PREMIGRATION      = Phase 2: Controllers running on KRaft, zookeeper.connect
+#                       still in controller config, no migration flag in broker config.
+#   HYBRID_DUAL_WRITE = Phase 3: ZkMigrationState=1, migration flag in broker config,
+#                       process.roles NOT set on brokers.
+#   PURE_DUAL_WRITE   = Phase 4: ZkMigrationState=1, process.roles=broker set
+#                       (zookeeper.connect removed from broker by ZKtoKraftMigration.yml).
+#   FINALIZED         = Phase 5: ZkMigrationState=3 OR zookeeper.connect removed
+#                       from controller config. IRREVERSIBLE.
+#
+# Phase 3 vs Phase 4 distinction:
+#   Both show ZkMigrationState=1 via Jolokia. Differentiated by broker config:
+#     Phase 3: zookeeper.metadata.migration.enable=true present AND process.roles absent
+#     Phase 4: process.roles=broker present (zookeeper.connect removed by migration)
+
+- name: Initialize migration state detection variables
+  set_fact:
+    migration_state: "UNKNOWN"
+    rollback_allowed: false
+    migration_state_detected: false
+    zk_migration_state: -1
+    jolokia_available: false
+
+# Gather facts so that hostvars are populated for resolve_hostname filter
+- name: Gather facts on controller
+  setup:
+    gather_subset:
+      - '!all'
+      - '!min'
+      - 'os_family'
+  delegate_to: "{{ groups['kafka_controller'][0] }}"
+  delegate_facts: true
+  when: groups['kafka_controller'] | length > 0
+
+- name: Gather facts on broker
+  setup:
+    gather_subset:
+      - '!all'
+      - '!min'
+      - 'os_family'
+  delegate_to: "{{ groups['kafka_broker'][0] }}"
+  delegate_facts: true
+  when: groups['kafka_broker'] | length > 0
+
+#==============================================================================
+# Step 1: Check controller service is running (Jolokia requires running process)
+#==============================================================================
+
+- name: Check if controller service is running
+  shell: systemctl is-active {{ kafka_controller_service_name }}
+  register: controller_status
+  delegate_to: "{{ groups['kafka_controller'][0] }}"
+  failed_when: false
+  changed_when: false
+  when: groups['kafka_controller'] | length > 0
+
+#==============================================================================
+# Step 2: Query Jolokia for ZkMigrationState
+# Uses resolve_hostname filter so FQDN/IP overrides in hostvars are respected.
+# Values: 0=pre-migration, 1=dual-write (Phase 3 OR Phase 4), 3=KRaft-only (Phase 5)
+#==============================================================================
+
+- name: Query Jolokia ZkMigrationState (no auth)
+  uri:
+    url: "{{ 'https' if kafka_controller_jolokia_ssl_enabled | bool else 'http' }}://{{ hostvars[groups['kafka_controller'][0]] | confluent.platform.resolve_hostname }}:{{ kafka_controller_jolokia_port }}/jolokia/read/kafka.controller:type=KafkaController,name=ZkMigrationState"
+    validate_certs: false
+    return_content: true
+    status_code: 200
+    timeout: 10
+  register: jolokia_result
+  delegate_to: localhost
+  failed_when: false
+  changed_when: false
+  when:
+    - groups['kafka_controller'] | length > 0
+    - controller_status.rc is defined
+    - controller_status.rc == 0
+    - jolokia_auth_mode | default('none') == 'none'
+
+- name: Query Jolokia ZkMigrationState (basic auth)
+  uri:
+    url: "{{ 'https' if kafka_controller_jolokia_ssl_enabled | bool else 'http' }}://{{ hostvars[groups['kafka_controller'][0]] | confluent.platform.resolve_hostname }}:{{ kafka_controller_jolokia_port }}/jolokia/read/kafka.controller:type=KafkaController,name=ZkMigrationState"
+    validate_certs: false
+    return_content: true
+    force_basic_auth: true
+    url_username: "{{ jolokia_user }}"
+    url_password: "{{ jolokia_password }}"
+    status_code: 200
+    timeout: 10
+  register: jolokia_result
+  delegate_to: localhost
+  failed_when: false
+  changed_when: false
+  no_log: "{{ mask_secrets | bool }}"
+  when:
+    - groups['kafka_controller'] | length > 0
+    - controller_status.rc is defined
+    - controller_status.rc == 0
+    - jolokia_auth_mode | default('none') == 'basic'
+
+- name: Parse Jolokia ZkMigrationState value
+  set_fact:
+    zk_migration_state: "{{ (jolokia_result.content | from_json).value.Value }}"
+    jolokia_available: true
+  when:
+    - jolokia_result is defined
+    - jolokia_result.status is defined
+    - jolokia_result.status == 200
+
+#==============================================================================
+# Step 3: Inspect config files for phase disambiguation
+#
+# These checks are needed because:
+#   - ZkMigrationState=1 covers both Phase 3 (HYBRID_DUAL_WRITE) and
+#     Phase 4 (PURE_DUAL_WRITE)
+#   - ZkMigrationState may be unavailable if controllers are not yet started
+#     (Phase 2 / PREMIGRATION), requiring config-only detection
+#==============================================================================
+
+- name: Check controller config for zookeeper.connect
+  shell: grep -q "^zookeeper.connect" "{{ hostvars[groups['kafka_controller'][0]]['kafka_controller']['config_file'] | default(kafka_controller.config_file) }}"
+  register: controller_zk_config
+  delegate_to: "{{ groups['kafka_controller'][0] }}"
+  failed_when: false
+  changed_when: false
+  when: groups['kafka_controller'] | length > 0
+
+- name: Check broker config for zookeeper.metadata.migration.enable=true
+  shell: grep -q "^zookeeper.metadata.migration.enable=true" "{{ hostvars[groups['kafka_broker'][0]]['kafka_broker']['config_file'] | default(kafka_broker.config_file) }}"
+  register: broker_migration_flag
+  delegate_to: "{{ groups['kafka_broker'][0] }}"
+  failed_when: false
+  changed_when: false
+  when: groups['kafka_broker'] | length > 0
+
+- name: Read broker config process.roles value
+  shell: grep "^process.roles" "{{ hostvars[groups['kafka_broker'][0]]['kafka_broker']['config_file'] | default(kafka_broker.config_file) }}" | cut -d'=' -f2 | tr -d ' '
+  register: broker_process_roles
+  delegate_to: "{{ groups['kafka_broker'][0] }}"
+  failed_when: false
+  changed_when: false
+  when: groups['kafka_broker'] | length > 0
+
+#==============================================================================
+# Step 4: Determine phase
+#
+# Evaluation order matters — FINALIZED is checked first (irreversible).
+# Then PREMIGRATION (controllers not yet active or ZkMigrationState=0).
+# Then HYBRID_DUAL_WRITE vs PURE_DUAL_WRITE (both have ZkMigrationState=1).
+#==============================================================================
+
+# Phase 5: ZkMigrationState=3 means KRaft is sole source of truth.
+# Also treat loss of zookeeper.connect from controller config as FINALIZED
+# since it indicates the controller was re-provisioned in pure-KRaft mode.
+- name: Determine phase - FINALIZED (Phase 5, irreversible)
+  set_fact:
+    migration_state: "FINALIZED"
+    rollback_allowed: false
+    migration_state_detected: true
+  when:
+    - (zk_migration_state | int) == 3 or
+      (controller_zk_config.rc is defined and controller_zk_config.rc != 0)
+
+# Phase 2: Controllers provisioned but migration not yet activated.
+# ZkMigrationState=0 (or Jolokia unavailable), no migration flag in broker config,
+# and controller still has zookeeper.connect.
+- name: Determine phase - PREMIGRATION (Phase 2)
+  set_fact:
+    migration_state: "PREMIGRATION"
+    rollback_allowed: true
+    migration_state_detected: true
+  when:
+    - migration_state == "UNKNOWN"
+    - controller_zk_config.rc is defined
+    - controller_zk_config.rc == 0
+    - broker_migration_flag.rc is defined
+    - broker_migration_flag.rc != 0
+    - (zk_migration_state | int) == 0 or not jolokia_available | bool
+
+# Phase 3: Dual-write active, brokers still in ZooKeeper mode.
+# Primary signal: ZkMigrationState=1 via Jolokia.
+# Fallback (Jolokia unavailable — e.g. controllers stopped mid-rollback):
+#   config signals alone are unambiguous when migration flag is present and
+#   process.roles is absent. This covers the Phase 4 two-run rollback scenario
+#   where Steps 1-4 have completed (controllers stopped, brokers in hybrid mode)
+#   and the second run needs to proceed to Step 5.
+- name: Determine phase - HYBRID_DUAL_WRITE (Phase 3)
+  set_fact:
+    migration_state: "HYBRID_DUAL_WRITE"
+    rollback_allowed: true
+    migration_state_detected: true
+  when:
+    - migration_state == "UNKNOWN"
+    - (zk_migration_state | int) == 1 or not jolokia_available | bool
+    - broker_migration_flag.rc is defined
+    - broker_migration_flag.rc == 0
+    - broker_process_roles.stdout is defined
+    - broker_process_roles.stdout == "" or broker_process_roles.rc != 0
+
+# Phase 4: Brokers migrated to KRaft, controllers still in dual-write mode.
+# ZkMigrationState=1, process.roles=broker set (migration flag removed by
+# ZKtoKraftMigration.yml lineinfile which also removed zookeeper.connect).
+- name: Determine phase - PURE_DUAL_WRITE (Phase 4)
+  set_fact:
+    migration_state: "PURE_DUAL_WRITE"
+    rollback_allowed: true
+    migration_state_detected: true
+  when:
+    - migration_state == "UNKNOWN"
+    - (zk_migration_state | int) == 1
+    - broker_process_roles.stdout is defined
+    - broker_process_roles.stdout == "broker"
+    - controller_zk_config.rc is defined
+    - controller_zk_config.rc == 0
+
+#==============================================================================
+# Step 5: Final gate and output
+#==============================================================================
+
+- name: Fail if migration state could not be determined
+  fail:
+    msg: |
+      ERROR: Could not determine migration state.
+
+      This may indicate an inconsistent cluster state. Diagnostic information:
+        - Jolokia available: {{ jolokia_available }}
+        - ZkMigrationState (Jolokia): {{ zk_migration_state }}
+        - Controller has zookeeper.connect: {{ 'yes' if controller_zk_config.rc is defined and controller_zk_config.rc == 0 else 'no' }}
+        - Broker process.roles: {{ broker_process_roles.stdout | default('not set') }}
+        - Broker migration flag (zookeeper.metadata.migration.enable=true): {{ 'yes' if broker_migration_flag.rc is defined and broker_migration_flag.rc == 0 else 'no' }}
+
+      Possible causes:
+        - Jolokia not reachable on controllers (set kafka_controller_jolokia_enabled: true)
+        - Controller or broker server.properties not readable
+        - Cluster is in an unexpected intermediate state
+
+      To bypass auto-detection, set migration_state manually in inventory and
+      use --tags rollback_phase2, rollback_phase3, or rollback_phase4.
+  when: not migration_state_detected
+
+- name: Display detected migration state
+  debug:
+    msg: |
+      ======================================================================
+      MIGRATION STATE DETECTED
+      ======================================================================
+      State:              {{ migration_state }}
+      Rollback Allowed:   {{ rollback_allowed }}
+      Detection method:   Jolokia (ZkMigrationState={{ zk_migration_state }}) + config inspection
+
+      {% if migration_state == "PREMIGRATION" %}
+      PREMIGRATION: Controllers provisioned, migration not yet activated.
+      Rollback: Stop controllers only — brokers are untouched.
+      {% elif migration_state == "HYBRID_DUAL_WRITE" %}
+      HYBRID_DUAL_WRITE: Dual-write active, brokers still in ZooKeeper mode.
+      Rollback: One rolling broker restart + ZK znode cleanup + stop controllers.
+      {% elif migration_state == "PURE_DUAL_WRITE" %}
+      PURE_DUAL_WRITE: Brokers migrated to KRaft, controllers in dual-write mode.
+      Rollback: THREE broker restarts + ZK znode cleanup + stop controllers.
+      {% elif migration_state == "FINALIZED" %}
+      FINALIZED: ZooKeeper no longer used. Rollback is IMPOSSIBLE.
+      {% endif %}
+      ======================================================================

--- a/playbooks/validations/kraft_migration_rollback_validations.yml
+++ b/playbooks/validations/kraft_migration_rollback_validations.yml
@@ -1,0 +1,171 @@
+---
+# kraft_migration_rollback_validations.yml
+#
+# Pre-flight validations for the KRaft migration rollback playbook.
+# Run as part of kraft_migration_rollback.yml (imported with tags: always).
+#
+# Key design decisions (informed by full repo analysis):
+#
+# 1. kraft_migration: true MUST remain set in inventory during rollback.
+#    roles/common/tasks/main.yml:26 allows ZK + Controller co-existence ONLY
+#    when kraft_migration|bool is true. Without it, the common role would fail
+#    with "Providing Zookeeper and Controller both are not supported".
+#
+# 2. zookeeper_connect is NOT an operator-supplied variable — it is auto-computed
+#    from the 'zookeeper' inventory group (roles/variables/vars/main.yml:406/424).
+#    The zookeeper group must simply exist in inventory.
+#
+# 3. broker.id is NOT node.id for brokers — roles/variables/vars/main.yml:437-441
+#    shows brokers always use broker.id = index + 1. node.id is only for controllers
+#    (index + 9991). No per-host broker ID mapping is needed.
+#
+# 4. kafka_controller_jolokia_enabled is automatically true when kraft_migration=true
+#    (roles/variables/defaults/main.yml:563: "{{jolokia_enabled or kraft_migration}}").
+
+- name: KRaft Migration Rollback Pre-flight Validations
+  hosts: localhost
+  gather_facts: false
+  any_errors_fatal: true
+
+  tasks:
+    - name: Import variables role
+      import_role:
+        name: variables
+      tags: always
+
+    # ---- Inventory structure checks ----------------------------------------
+
+    - name: Assert kraft_migration is set to true in inventory
+      assert:
+        that:
+          - kraft_migration | bool
+        fail_msg: >-
+          'kraft_migration: true' must be set in your inventory [all:vars] to perform rollback.
+          This flag is required to:
+            (a) allow ZooKeeper and kafka_controller to coexist in the same inventory
+                (roles/common/tasks/main.yml bypasses the ZK+Controller check when
+                kraft_migration=true)
+            (b) correctly compute ZooKeeper connection strings for broker/controller configs
+          Do NOT set kraft_migration: false until AFTER rollback completes.
+      tags: validate
+
+    - name: Assert zookeeper group is present in inventory
+      assert:
+        that:
+          - "'zookeeper' in groups"
+          - "groups['zookeeper'] | length > 0"
+        fail_msg: >-
+          The 'zookeeper' host group must exist in your inventory with at least one host.
+          ZooKeeper must be running and reachable for rollback to succeed.
+      tags: validate
+
+    - name: Assert kafka_controller group is present in inventory
+      assert:
+        that:
+          - "'kafka_controller' in groups"
+          - "groups['kafka_controller'] | length > 0"
+        fail_msg: >-
+          The 'kafka_controller' host group must exist in your inventory.
+          Controllers must be present to detect migration phase and stop them.
+      tags: validate
+
+    - name: Assert kafka_broker group is present in inventory
+      assert:
+        that:
+          - "'kafka_broker' in groups"
+          - "groups['kafka_broker'] | length > 0"
+        fail_msg: "The 'kafka_broker' host group must exist in your inventory."
+      tags: validate
+
+    # ---- ZooKeeper health check --------------------------------------------
+    # No ZK health validation exists anywhere in the migration workflow.
+    # This is the first point where it is enforced before config changes.
+
+    - name: Check ZooKeeper service status on all ZK nodes
+      systemd:
+        name: "{{ zookeeper_service_name }}"
+      register: zk_service_status
+      delegate_to: "{{ item }}"
+      loop: "{{ groups['zookeeper'] }}"
+      tags: validate
+
+    - name: Assert all ZooKeeper services are active
+      assert:
+        that:
+          - item.status.ActiveState == 'active'
+        fail_msg: >-
+          ZooKeeper service is not running on '{{ item.item }}'.
+          All ZooKeeper nodes must be active before rollback can proceed.
+      loop: "{{ zk_service_status.results }}"
+      loop_control:
+        label: "{{ item.item }}"
+      tags: validate
+
+    # ---- Migration phase detection -----------------------------------------
+    # Uses the same Jolokia MBean as ZKtoKraftMigration.yml uses to wait for
+    # phase completion: kafka.controller:type=KafkaController,name=ZkMigrationState
+    # Values: 0=pre-migration, 1=dual-write, 3=kraft-only (irreversible)
+    #
+    # Phase 5 NOTE: ZKtoKraftMigration.yml has Phase 5 entirely commented out
+    # (lines 140-213). This means ZkMigrationState=3 can only be reached via
+    # manual CLI intervention, not through this collection's automation.
+
+    - name: Run migration phase detection
+      include_tasks: ../tasks/detect_migration_phase.yml
+      tags: validate
+
+    - name: Fail if rollback is not possible (FINALIZED state)
+      fail:
+        msg: >-
+          ROLLBACK ABORTED: Migration is in FINALIZED state.
+          ZooKeeper is no longer the source of truth. Rollback is IMPOSSIBLE.
+
+          Note: ZKtoKraftMigration.yml has Phase 5 commented out (lines 140-213).
+          If you reached this state, it was triggered manually. You must proceed
+          with KRaft or restore the entire cluster from backup.
+      when: not rollback_allowed | bool
+      tags: validate
+
+    # ---- Authorizer state check -------------------------------------------
+    # ZKtoKraftMigration.yml (line 120) sets KRAFT_ACL for RBAC during Phase 4
+    # via lineinfile. vars/main.yml:548 auto-computes ZK_ACL when kraft_migration=true,
+    # but the lineinfile bypasses the template. The rollback playbook explicitly
+    # reverts it for PURE_DUAL_WRITE state only.
+
+    - name: Inform about RBAC ACL reversion for PURE_DUAL_WRITE state
+      debug:
+        msg: >-
+          RBAC ACL note: confluent.authorizer.access.rule.providers was set to
+          CONFLUENT,KRAFT_ACL by ZKtoKraftMigration.yml (line 120) via lineinfile.
+          The rollback playbook will explicitly revert it to CONFLUENT,ZK_ACL
+          during Restart 3. After rollback, re-running kafka_broker.yml with
+          kraft_migration=true will keep ZK_ACL via vars/main.yml:548.
+      when:
+        - rbac_enabled | bool
+        - migration_state == 'PURE_DUAL_WRITE'
+      tags: validate
+
+    # ---- Pre-flight summary -----------------------------------------------
+
+    - name: Pre-flight validation passed — display rollback plan
+      debug:
+        msg: |
+          ====================================================================
+          ROLLBACK PRE-FLIGHT PASSED
+          ====================================================================
+          Detected state: {{ migration_state }}
+          Rollback target: ZooKeeper-only mode
+
+          Brokers to revert: {{ groups['kafka_broker'] | join(', ') }}
+          Controllers to stop: {{ groups['kafka_controller'] | join(', ') }}
+          ZooKeeper cluster: {{ groups['zookeeper'] | join(', ') }}
+
+          {% if migration_state == 'PREMIGRATION' %}
+          Rollback complexity: LOW — controllers only, no broker changes needed
+          {% elif migration_state == 'HYBRID_DUAL_WRITE' %}
+          Rollback complexity: MEDIUM — one rolling broker restart
+          {% elif migration_state == 'PURE_DUAL_WRITE' %}
+          Rollback complexity: HIGH — THREE broker restarts per broker required
+          {% endif %}
+          ====================================================================
+      tags: validate


### PR DESCRIPTION
## Summary

- Adds `playbooks/kraft_migration_rollback.yml` — a single-entry-point rollback playbook that auto-detects migration phase (PREMIGRATION / HYBRID_DUAL_WRITE / PURE_DUAL_WRITE) via Jolokia + config inspection and runs the correct rollback steps without requiring manual `--tags` selection
- Adds `playbooks/tasks/detect_migration_phase.yml` — reusable phase detection task file; handles Jolokia-unavailable fallback for mid-rollback re-runs (controllers stopped after Phase 4 Steps 1–4)
- Adds `playbooks/validations/kraft_migration_rollback_validations.yml` — pre-flight checks (ZK health, inventory structure, phase detection, rollback feasibility)
- Integrates rollback as `--tags rollback` entry point in `ZKtoKraftMigration.yml`; `never` tag prevents accidental execution during normal migration runs
- Adds three Molecule scenarios covering full migration → rollback round-trips for all three reversible phases

## What's tested by the Molecule scenarios

| Scenario | State before rollback | Rollback complexity |
|---|---|---|
| `plaintext-rhel-rollback-phase2` | PREMIGRATION — controllers provisioned, brokers untouched | LOW — stop controllers only |
| `plaintext-rhel-rollback-phase3` | HYBRID_DUAL_WRITE — dual-write active, brokers have zookeeper.connect | MEDIUM — 1 rolling broker restart |
| `plaintext-rhel-rollback-phase4` | PURE_DUAL_WRITE — brokers have process.roles=broker, no zookeeper.connect | HIGH — 3 rolling broker restarts |

Each scenario converge mirrors `ZKtoKraftMigration.yml` play order exactly: `migration_precheck` → `kafka_controller` → Jolokia validation → `kafka_broker` serial → wait for ZkMigrationState=1 → [broker KRaft lineinfile + restart for Phase 4] → rollback.

## Usage

```bash
# Auto-detect phase and rollback:
ansible-playbook -i <inventory> playbooks/kraft_migration_rollback.yml

# Or via the migration playbook:
ansible-playbook -i <inventory> playbooks/ZKtoKraftMigration.yml --tags rollback

# Dry run (phase detection only):
ansible-playbook -i <inventory> playbooks/kraft_migration_rollback.yml --tags validate --check
```

## Test plan

- [ ] Run `molecule test -s plaintext-rhel-rollback-phase2`
- [ ] Run `molecule test -s plaintext-rhel-rollback-phase3`
- [ ] Run `molecule test -s plaintext-rhel-rollback-phase4`
- [ ] Verify existing migration scenarios (`plaintext-basic-rhel` with `MIGRATION_CONVERGE`) are unaffected by the `never` tag change on the rollback import

## Related

JIRA: https://confluentinc.atlassian.net/browse/ANSIENG-5796

🤖 Generated with [Claude Code](https://claude.com/claude-code)