### PR TITLE
[SETU-2783] Raise USM catalog snapshot size limit and exporter request timeout

### DIFF
--- a/molecule/verify_usm_agent.yml
+++ b/molecule/verify_usm_agent.yml
@@ -85,3 +85,55 @@
           - metrics_endpoint_found | default(false)
         fail_msg: "USM Agent v1/metrics endpoint not found in logs or not returning 200 status"
       when: log_file_stat.stat.exists
+
+- name: Verify USM-tuned configs on kafka_controller
+  hosts: kafka_controller
+  gather_facts: false
+  tasks:
+    - name: Get confluent.telemetry.exporter._usm.client.request.timeout.ms from server.properties
+      shell: grep "confluent.telemetry.exporter._usm.client.request.timeout.ms" /etc/kafka/server.properties
+      register: controller_usm_client_timeout_grep
+      changed_when: false
+
+    - name: Assert _usm.client.request.timeout.ms is 60000 on controller
+      assert:
+        that:
+          - "'confluent.telemetry.exporter._usm.client.request.timeout.ms=60000' in controller_usm_client_timeout_grep.stdout"
+        fail_msg: "controller server.properties missing _usm.client.request.timeout.ms=60000, got: {{ controller_usm_client_timeout_grep.stdout }}"
+
+    - name: Get confluent.telemetry.exporter._usm.events.client.request.timeout.ms from server.properties
+      shell: grep "confluent.telemetry.exporter._usm.events.client.request.timeout.ms" /etc/kafka/server.properties
+      register: controller_usm_events_timeout_grep
+      changed_when: false
+
+    - name: Assert _usm.events.client.request.timeout.ms is 60000 on controller
+      assert:
+        that:
+          - "'confluent.telemetry.exporter._usm.events.client.request.timeout.ms=60000' in controller_usm_events_timeout_grep.stdout"
+        fail_msg: "controller server.properties missing _usm.events.client.request.timeout.ms=60000, got: {{ controller_usm_events_timeout_grep.stdout }}"
+
+    - name: Get confluent.catalog.collector.max.bytes.per.snapshot from server.properties
+      shell: grep "confluent.catalog.collector.max.bytes.per.snapshot" /etc/kafka/server.properties
+      register: controller_catalog_max_bytes_grep
+      changed_when: false
+
+    - name: Assert catalog.collector.max.bytes.per.snapshot is 52428800 on controller
+      assert:
+        that:
+          - "'confluent.catalog.collector.max.bytes.per.snapshot=52428800' in controller_catalog_max_bytes_grep.stdout"
+        fail_msg: "controller server.properties missing catalog.collector.max.bytes.per.snapshot=52428800, got: {{ controller_catalog_max_bytes_grep.stdout }}"
+
+- name: Verify USM-tuned configs on kafka_broker
+  hosts: kafka_broker
+  gather_facts: false
+  tasks:
+    - name: Get confluent.telemetry.exporter._usm.client.request.timeout.ms from server.properties
+      shell: grep "confluent.telemetry.exporter._usm.client.request.timeout.ms" /etc/kafka/server.properties
+      register: broker_usm_client_timeout_grep
+      changed_when: false
+
+    - name: Assert _usm.client.request.timeout.ms is 60000 on broker
+      assert:
+        that:
+          - "'confluent.telemetry.exporter._usm.client.request.timeout.ms=60000' in broker_usm_client_timeout_grep.stdout"
+        fail_msg: "broker server.properties missing _usm.client.request.timeout.ms=60000, got: {{ broker_usm_client_timeout_grep.stdout }}"

--- a/roles/variables/vars/main.yml
+++ b/roles/variables/vars/main.yml
@@ -387,11 +387,14 @@ kafka_controller_properties:
       confluent.telemetry.exporter._usm.events.enabled: true
       confluent.telemetry.exporter._usm.type: http
       confluent.telemetry.exporter._usm.client.base.url: "{{ usm_agent_url }}"
+      confluent.telemetry.exporter._usm.client.request.timeout.ms: 60000
       confluent.telemetry.exporter._usm.events.client.base.url: "{{ usm_agent_url }}"
+      confluent.telemetry.exporter._usm.events.client.request.timeout.ms: 60000
       confluent.catalog.collector.enable: true
       confluent.catalog.collector.destination.topic: catalog-events
       confluent.catalog.collector.full.configs.enable: true
       confluent.catalog.collector.multitenant.topics.enable: false
+      confluent.catalog.collector.max.bytes.per.snapshot: 52428800
       confluent.telemetry.exporter._usm.events.filtering.routes.allowed: catalog-events
       confluent.telemetry.exporter._usm.events.filtering.enabled: true
   usm_agent_telemetry_auth_basic:
@@ -990,6 +993,7 @@ kafka_broker_properties:
     properties:
       confluent.telemetry.exporter._usm.enabled: true
       confluent.telemetry.exporter._usm.client.base.url: "{{ usm_agent_url }}"
+      confluent.telemetry.exporter._usm.client.request.timeout.ms: 60000
       confluent.telemetry.exporter._usm.type: http
       confluent.client.topic.metrics.manager: org.apache.kafka.server.metrics.PlatformClientTopicMetricsManager
       confluent.consumer.lag.emitter.enabled: true


### PR DESCRIPTION
## Summary
- Raises `confluent.catalog.collector.max.bytes.per.snapshot` from the 850 KB default to 50 MB on the kafka_controller `usm_agent_telemetry` block (KRaft mode hosts the catalog collector on the controller).
- Sets `confluent.telemetry.exporter._usm.client.request.timeout.ms` to 60 s on both kafka_broker and kafka_controller; sets `_usm.events.client.request.timeout.ms` to 60 s on the controller. The 60 s value aligns the USM HTTP exporter request timeout with the AHC `readTimeout` default of 60 s.
- Gated by the existing `'usm_agent' in groups` check; non-USM deployments are unchanged.

Jira: [SETU-2783](https://confluentinc.atlassian.net/browse/SETU-2783).

## Test plan
- [x] YAML parse check on `roles/variables/vars/main.yml`; all three `usm_agent_telemetry` blocks (controller, broker, connect) load cleanly.
- [x] Verified that the controller block carries all three keys and the broker block carries only the `_usm.client.request.timeout.ms` key (the broker block does not run the events exporter or catalog collector in cp-ansible's KRaft-default layout).
- [ ] Molecule scenario exercising USM-enabled inventory to confirm rendered `/etc/kafka/server.properties` carries the new keys (no scenario currently inventories a `[usm_agent]` group — follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SETU-2783]: https://confluentinc.atlassian.net/browse/SETU-2783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ