### PR TITLE
[SETU-2783] [7.9.x] Raise USM catalog snapshot size limit and exporter request timeout

### DIFF
--- a/roles/variables/vars/main.yml
+++ b/roles/variables/vars/main.yml
@@ -390,11 +390,14 @@ kafka_controller_properties:
       confluent.telemetry.exporter._usm.buffer.inflight.submissions.max: 10
       confluent.telemetry.exporter._usm.buffer.pending.batches.max: 80
       confluent.telemetry.exporter._usm.client.base.url: "{{ usm_agent_url }}"
+      confluent.telemetry.exporter._usm.client.request.timeout.ms: 60000
       confluent.telemetry.exporter._usm.events.client.base.url: "{{ usm_agent_url }}"
+      confluent.telemetry.exporter._usm.events.client.request.timeout.ms: 60000
       confluent.catalog.collector.enable: true
       confluent.catalog.collector.destination.topic: catalog-events
       confluent.catalog.collector.full.configs.enable: true
       confluent.catalog.collector.multitenant.topics.enable: false
+      confluent.catalog.collector.max.bytes.per.snapshot: 52428800
       confluent.telemetry.exporter._usm.events.filtering.routes.allowed: catalog-events
       confluent.telemetry.exporter._usm.events.filtering.enabled: true
   usm_agent_telemetry_auth_basic:
@@ -1001,6 +1004,7 @@ kafka_broker_properties:
     properties:
       confluent.telemetry.exporter._usm.enabled: true
       confluent.telemetry.exporter._usm.client.base.url: "{{ usm_agent_url }}"
+      confluent.telemetry.exporter._usm.client.request.timeout.ms: 60000
       confluent.telemetry.exporter._usm.type: http
       confluent.telemetry.exporter._usm.buffer.batch.items.max: 4000
       confluent.telemetry.exporter._usm.buffer.inflight.submissions.max: 10
@@ -1037,10 +1041,12 @@ kafka_broker_properties:
     properties:
       confluent.telemetry.exporter._usm.events.enabled: true
       confluent.telemetry.exporter._usm.events.client.base.url: "{{ usm_agent_url }}"
+      confluent.telemetry.exporter._usm.events.client.request.timeout.ms: 60000
       confluent.catalog.collector.enable: true
       confluent.catalog.collector.destination.topic: catalog-events
       confluent.catalog.collector.full.configs.enable: true
       confluent.catalog.collector.multitenant.topics.enable: false
+      confluent.catalog.collector.max.bytes.per.snapshot: 52428800
       confluent.telemetry.exporter._usm.events.filtering.routes.allowed: catalog-events
       confluent.telemetry.exporter._usm.events.filtering.enabled: true
   usm_agent_telemetry_events_zk_auth_basic:


### PR DESCRIPTION
## Summary
- 7.9.x companion to the master-line PR. 7.9.x still supports ZK mode (master and 8.x are KRaft-only), so this branch needs an additional broker-side change inside the existing `usm_agent_telemetry_events_zk` block.
- Raises `confluent.catalog.collector.max.bytes.per.snapshot` from the 850 KB default to 50 MB so multi-page catalog snapshots stop being dropped by the metadata receiver once topic count crosses ~3k.
- Sets `confluent.telemetry.exporter._usm.client.request.timeout.ms` and `_usm.events.client.request.timeout.ms` to 60 s, aligning the USM HTTP exporter request timeout with the AHC `readTimeout` default of 60 s.

## Per-block changes
- **`kafka_controller_properties.usm_agent_telemetry`** — adds all three keys.
- **`kafka_broker_properties.usm_agent_telemetry`** — adds `_usm.client.request.timeout.ms=60000` unconditionally.
- **`kafka_broker_properties.usm_agent_telemetry_events_zk`** — adds `_usm.events.client.request.timeout.ms=60000` and `catalog.collector.max.bytes.per.snapshot=52428800`. Already gated on `not kraft_enabled or kraft_migration|bool` — this is the ZK-mode-only path where the broker (not the controller) hosts the catalog collector and events exporter.

Gated by the existing `'usm_agent' in groups` check everywhere; non-USM deployments are unchanged.

Jira: [SETU-2783](https://confluentinc.atlassian.net/browse/SETU-2783).
Companions: master cp-ansible PR confluentinc/cp-ansible#2495; CFK confluentinc/confluent-operator#4312.

## Test plan
- Tests skipped on this PR (matches master companion's scope).
- Existing USM-enabled molecule scenarios will pick up the new keys when they run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SETU-2783]: https://confluentinc.atlassian.net/browse/SETU-2783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ