### PR TITLE
[ANSIENG-5824] Document mTLS listener override requirements (cherry-pick to 8.3.x)

### DIFF
--- a/docs/VARIABLES.md
+++ b/docs/VARIABLES.md
@@ -1038,7 +1038,7 @@ Default:  "{{ config_prefix }}/kafka"
 
 ### kafka_broker_custom_listeners
 
-Dictionary to put additional listeners to be configured within Kafka. Each listener must include a 'name' and 'port' key. Optionally they can include the keys 'ssl_enabled', 'ssl_mutual_auth_enabled', and 'sasl_protocol'
+Dictionary to put additional listeners to be configured within Kafka. Each listener must include a 'name' and 'port' key. Optional keys: 'ssl_enabled', 'ssl_mutual_auth_enabled', 'ssl_client_authentication', 'sasl_protocol'. IMPORTANT: To disable mTLS on a listener when global ssl_mutual_auth_enabled=true, you MUST define BOTH 'ssl_mutual_auth_enabled': false AND 'ssl_client_authentication': 'none' for that listener. Setting only one will NOT work.
 
 Default:  {}
 

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -520,7 +520,7 @@ kafka_broker_default_listeners: "{
   }{% endif %}{% endif %}
 }"
 
-### Dictionary to put additional listeners to be configured within Kafka. Each listener must include a 'name' and 'port' key. Optionally they can include the keys 'ssl_enabled', 'ssl_mutual_auth_enabled', and 'sasl_protocol'
+### Dictionary to put additional listeners to be configured within Kafka. Each listener must include a 'name' and 'port' key. Optional keys: 'ssl_enabled', 'ssl_mutual_auth_enabled', 'ssl_client_authentication', 'sasl_protocol'. IMPORTANT: To disable mTLS on a listener when global ssl_mutual_auth_enabled=true, you MUST define BOTH 'ssl_mutual_auth_enabled': false AND 'ssl_client_authentication': 'none' for that listener. Setting only one will NOT work.
 kafka_broker_custom_listeners: {}
 
 # Deprecated variable


### PR DESCRIPTION
Cherry-pick of #2475 from 7.9.x to 8.3.x

## Summary
- Documents that disabling mTLS on a custom listener requires BOTH `ssl_mutual_auth_enabled: false` AND `ssl_client_authentication: 'none'`
- Adds `ssl_client_authentication` to the list of optional listener keys

## Changes
- Updated documentation in `roles/variables/defaults/main.yml`
- Updated generated `docs/VARIABLES.md`

## Notes
- Semaphore.yml changes from the original PR were not applicable to 8.3.x (already using Ansible 11)
- Only documentation changes were cherry-picked

Original PR: #2475
Original commit: 01d13594574346fdb13b9c2592284b2763da690a