### PR TITLE
[76-changelog] | CHANGELOG update for 7.6.11

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,16 @@ Ansible Playbooks for Confluent Platform - Release Notes
 
 .. contents:: Topics
 
+7.6.11
+======
+Notable fixes
+-------------
+- For the list of security and vulnerability issues fixed in this release, see https://support.confluent.io/hc/en-us/sections/360008413952-Security-Advisories-and-Security-Release-Notes
+
+Bug fixes
+-------------
+- Fixed kafka-storage format failures on KRaft clusters with secrets protection enabled — the masterkey is now passed via the CONFLUENT_SECURITY_MASTER_KEY env var (https://github.com/confluentinc/cp-ansible/pull/2477).
+
 7.6.10
 ======
 Notable fixes


### PR DESCRIPTION
## Summary

Adds the `7.6.11` section to `CHANGELOG.rst`, referencing the masterkey fix from #2477.

## Test plan

- [x] CHANGELOG renders correctly