### PR TITLE
[80-changelog] | CHANGELOG update for 8.0.5

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,16 @@ Ansible Playbooks for Confluent Platform - Release Notes
 
 .. contents:: Topics
 
+8.0.5
+======
+Notable fixes
+-------------
+- For the list of security and vulnerability issues fixed in this release, see https://support.confluent.io/hc/en-us/sections/360008413952-Security-Advisories-and-Security-Release-Notes
+
+Bug fixes
+-------------
+- Fixed kafka-storage format failures on KRaft clusters with secrets protection enabled — the masterkey is now passed via the CONFLUENT_SECURITY_MASTER_KEY env var (https://github.com/confluentinc/cp-ansible/pull/2477).
+
 8.0.4
 ======
 


### PR DESCRIPTION
## Summary

Adds the `8.0.5` section to `CHANGELOG.rst`, referencing the masterkey fix from #2477.

## Test plan

- [x] CHANGELOG renders correctly