### PR TITLE
ANSIENG-5796: KRaft → ZooKeeper migration rollback

### DIFF
--- a/molecule/kraft-rollback-to-hybrid/converge.yml
+++ b/molecule/kraft-rollback-to-hybrid/converge.yml
@@ -55,65 +55,23 @@
   vars:
     repo_root: "{{ playbook_dir }}/../.."
     molecule_inventory: "{{ lookup('env', 'MOLECULE_INVENTORY_FILE') }}"
-    controller_host: "{{ (groups['kafka_controller'] | default([]) + groups['kafka_controller_migration'] | default([])) | first }}"
   tasks:
-    # Run the real rollback WITH its health checks (the post-rollback controller
-    # quorum probe included). If it fails, capture the controller's actual state
-    # before failing, so we can tell a real rollback bug from an unhealthy/down
-    # controller rather than guessing.
-    - block:
-        - name: Partial rollback to hybrid (--tags rollback_to_hybrid)
-          command: >-
-            ansible-playbook
-            -i {{ molecule_inventory }}
-            {{ repo_root }}/playbooks/KRaftToZKRollback.yml
-            --tags rollback_to_hybrid
-            -e kraft_migration=true
-          args:
-            chdir: "{{ repo_root }}"
-          changed_when: true
-          register: rollback_run
+    # Real rollback with its health checks. The post-rollback controller
+    # metadata-quorum probe is correctly skipped on community kafka by
+    # KRaftToZKRollback.yml's confluent_server_enabled guard, so nothing to skip
+    # here. verify.yml asserts the hybrid end state.
+    - name: Partial rollback to hybrid (--tags rollback_to_hybrid)
+      command: >-
+        ansible-playbook
+        -i {{ molecule_inventory }}
+        {{ repo_root }}/playbooks/KRaftToZKRollback.yml
+        --tags rollback_to_hybrid
+        -e kraft_migration=true
+      args:
+        chdir: "{{ repo_root }}"
+      changed_when: true
+      register: rollback_run
 
-        - name: Show rollback output
-          debug:
-            var: rollback_run.stdout_lines
-
-      rescue:
-        - name: Show rollback output (failed run)
-          debug:
-            var: rollback_run.stdout_lines | default(['<no stdout captured>'])
-
-        - name: Capture controller service status
-          shell: "systemctl status {{ kafka_controller_service_name | default('confluent-kcontroller') }} --no-pager -l || true"
-          delegate_to: "{{ controller_host }}"
-          changed_when: false
-          register: ctrl_status
-
-        - name: Capture controller listening sockets (expect :9093)
-          shell: "ss -ltnp || netstat -ltnp || true"
-          delegate_to: "{{ controller_host }}"
-          changed_when: false
-          register: ctrl_ports
-
-        - name: Capture recent controller logs
-          shell: "journalctl -u {{ kafka_controller_service_name | default('confluent-kcontroller') }} --no-pager -n 120 || true"
-          delegate_to: "{{ controller_host }}"
-          changed_when: false
-          register: ctrl_logs
-
-        - name: Dump controller diagnostics
-          debug:
-            msg: |
-              ===== controller systemctl status =====
-              {{ ctrl_status.stdout }}
-              ===== listening sockets (look for :9093) =====
-              {{ ctrl_ports.stdout }}
-              ===== last 120 controller log lines =====
-              {{ ctrl_logs.stdout }}
-
-        - name: Fail after capturing diagnostics
-          fail:
-            msg: >-
-              rollback_to_hybrid sub-run failed. Controller diagnostics captured
-              above (is confluent-kcontroller active? listening on :9093? any
-              errors/OOM in the log?).
+    - name: Show rollback output
+      debug:
+        var: rollback_run.stdout_lines

--- a/molecule/kraft-rollback-to-hybrid/converge.yml
+++ b/molecule/kraft-rollback-to-hybrid/converge.yml
@@ -1,0 +1,65 @@
+---
+# Scenario 2 — PURE_DUAL_WRITE → hybrid (the hard one).
+#
+# Orchestrates: (deploy already done in prepare) → forward to HYBRID_DUAL_WRITE
+# → push brokers to PURE_DUAL_WRITE (broker-migration plays only, no controller
+# changes / no finalize) → partial rollback to hybrid.
+#
+# The forward step and the final rollback invoke the real entry playbooks with
+# the real customer tags. The intermediate PURE step uses a local replay of the
+# broker-migration plays because no single tag isolates them from the
+# controller-finalize plays. No changes to the main playbooks are required.
+
+- name: Activate KRaft controllers in the inventory
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Promote kafka_controller_migration → kafka_controller
+      lineinfile:
+        path: "{{ inventory_dir }}/ansible_inventory.yml"
+        regexp: "kafka_controller_migration:"
+        line: "kafka_controller:"
+
+- name: Forward to PURE_DUAL_WRITE, then partial rollback to hybrid
+  hosts: localhost
+  gather_facts: false
+  vars:
+    repo_root: "{{ playbook_dir }}/../.."
+    molecule_inventory: "{{ inventory_dir }}/ansible_inventory.yml"
+  tasks:
+    - name: Forward-migrate to HYBRID_DUAL_WRITE (--tags migrate_to_dual_write)
+      command: >-
+        ansible-playbook
+        -i {{ molecule_inventory }}
+        {{ repo_root }}/playbooks/ZKtoKraftMigration.yml
+        --tags migrate_to_dual_write
+        -e kraft_migration=true
+      args:
+        chdir: "{{ repo_root }}"
+      changed_when: true
+
+    - name: Push brokers to PURE_DUAL_WRITE (broker-migration plays only)
+      command: >-
+        ansible-playbook
+        -i {{ molecule_inventory }}
+        {{ playbook_dir }}/migrate_brokers_to_kraft.yml
+        -e kraft_migration=true
+      args:
+        chdir: "{{ repo_root }}"
+      changed_when: true
+
+    - name: Partial rollback to hybrid (--tags rollback_to_hybrid)
+      command: >-
+        ansible-playbook
+        -i {{ molecule_inventory }}
+        {{ repo_root }}/playbooks/KRaftToZKRollback.yml
+        --tags rollback_to_hybrid
+        -e kraft_migration=true
+      args:
+        chdir: "{{ repo_root }}"
+      changed_when: true
+      register: rollback_run
+
+    - name: Show rollback output
+      debug:
+        var: rollback_run.stdout_lines

--- a/molecule/kraft-rollback-to-hybrid/converge.yml
+++ b/molecule/kraft-rollback-to-hybrid/converge.yml
@@ -1,17 +1,17 @@
 ---
 # Scenario 2 — PURE_DUAL_WRITE → hybrid (the hard one).
 #
-# Orchestrates: (deploy already done in prepare) → forward to HYBRID_DUAL_WRITE
-# → push brokers to PURE_DUAL_WRITE (broker-migration plays only, no controller
-# changes / no finalize) → partial rollback to hybrid.
+# deploy (prepare) → forward to HYBRID_DUAL_WRITE → push brokers to
+# PURE_DUAL_WRITE → partial rollback to hybrid.
 #
-# The forward step and the final rollback invoke the real entry playbooks with
-# the real customer tags, against molecule's own generated inventory
-# (MOLECULE_INVENTORY_FILE). The intermediate PURE step uses a local replay of
-# the broker-migration plays because no single tag isolates them from the
-# controller-finalize plays. No changes to the main playbooks are required.
+# Steps that depend on --tags (forward migrate, rollback) run the real entry
+# playbooks as a tagged sub-run, because import_playbook applies tags additively
+# and cannot scope execution to a tag subset. The PURE step has no tag
+# dependency (it is a standalone replay of just the broker-migration plays), so
+# it is imported directly: in-process on molecule's own connection, with output
+# visible inline.
 
-- name: Forward to PURE_DUAL_WRITE, then partial rollback to hybrid
+- name: Promote controllers and migrate forward to HYBRID_DUAL_WRITE
   hosts: localhost
   gather_facts: false
   vars:
@@ -19,7 +19,7 @@
     molecule_inventory: "{{ lookup('env', 'MOLECULE_INVENTORY_FILE') }}"
   tasks:
     # Promote the migration-held controllers into the live kafka_controller
-    # group so the sub-runs below (which read the inventory file fresh) see them.
+    # group so the tagged sub-runs (which read the inventory file fresh) see them.
     - name: Promote kafka_controller_migration → kafka_controller
       lineinfile:
         path: "{{ molecule_inventory }}"
@@ -36,29 +36,84 @@
       args:
         chdir: "{{ repo_root }}"
       changed_when: true
+      register: forward_migrate
 
-    - name: Push brokers to PURE_DUAL_WRITE (broker-migration plays only)
-      command: >-
-        ansible-playbook
-        -i {{ molecule_inventory }}
-        {{ playbook_dir }}/migrate_brokers_to_kraft.yml
-        -e kraft_migration=true
-      args:
-        chdir: "{{ repo_root }}"
-      changed_when: true
-
-    - name: Partial rollback to hybrid (--tags rollback_to_hybrid)
-      command: >-
-        ansible-playbook
-        -i {{ molecule_inventory }}
-        {{ repo_root }}/playbooks/KRaftToZKRollback.yml
-        --tags rollback_to_hybrid
-        -e kraft_migration=true
-      args:
-        chdir: "{{ repo_root }}"
-      changed_when: true
-      register: rollback_run
-
-    - name: Show rollback output
+    - name: Show forward-migration output
       debug:
-        var: rollback_run.stdout_lines
+        var: forward_migrate.stdout_lines
+
+# Push brokers HYBRID_DUAL_WRITE → PURE_DUAL_WRITE. Replays only the
+# broker-migration plays (no controller finalize), so there is no tag
+# dependency and it can be imported directly.
+- import_playbook: migrate_brokers_to_kraft.yml
+  vars:
+    kraft_migration: true
+
+- name: Partial rollback to hybrid
+  hosts: localhost
+  gather_facts: false
+  vars:
+    repo_root: "{{ playbook_dir }}/../.."
+    molecule_inventory: "{{ lookup('env', 'MOLECULE_INVENTORY_FILE') }}"
+    controller_host: "{{ (groups['kafka_controller'] | default([]) + groups['kafka_controller_migration'] | default([])) | first }}"
+  tasks:
+    # Run the real rollback WITH its health checks (the post-rollback controller
+    # quorum probe included). If it fails, capture the controller's actual state
+    # before failing, so we can tell a real rollback bug from an unhealthy/down
+    # controller rather than guessing.
+    - block:
+        - name: Partial rollback to hybrid (--tags rollback_to_hybrid)
+          command: >-
+            ansible-playbook
+            -i {{ molecule_inventory }}
+            {{ repo_root }}/playbooks/KRaftToZKRollback.yml
+            --tags rollback_to_hybrid
+            -e kraft_migration=true
+          args:
+            chdir: "{{ repo_root }}"
+          changed_when: true
+          register: rollback_run
+
+        - name: Show rollback output
+          debug:
+            var: rollback_run.stdout_lines
+
+      rescue:
+        - name: Show rollback output (failed run)
+          debug:
+            var: rollback_run.stdout_lines | default(['<no stdout captured>'])
+
+        - name: Capture controller service status
+          shell: "systemctl status {{ kafka_controller_service_name | default('confluent-kcontroller') }} --no-pager -l || true"
+          delegate_to: "{{ controller_host }}"
+          changed_when: false
+          register: ctrl_status
+
+        - name: Capture controller listening sockets (expect :9093)
+          shell: "ss -ltnp || netstat -ltnp || true"
+          delegate_to: "{{ controller_host }}"
+          changed_when: false
+          register: ctrl_ports
+
+        - name: Capture recent controller logs
+          shell: "journalctl -u {{ kafka_controller_service_name | default('confluent-kcontroller') }} --no-pager -n 120 || true"
+          delegate_to: "{{ controller_host }}"
+          changed_when: false
+          register: ctrl_logs
+
+        - name: Dump controller diagnostics
+          debug:
+            msg: |
+              ===== controller systemctl status =====
+              {{ ctrl_status.stdout }}
+              ===== listening sockets (look for :9093) =====
+              {{ ctrl_ports.stdout }}
+              ===== last 120 controller log lines =====
+              {{ ctrl_logs.stdout }}
+
+        - name: Fail after capturing diagnostics
+          fail:
+            msg: >-
+              rollback_to_hybrid sub-run failed. Controller diagnostics captured
+              above (is confluent-kcontroller active? listening on :9093? any
+              errors/OOM in the log?).

--- a/molecule/kraft-rollback-to-hybrid/converge.yml
+++ b/molecule/kraft-rollback-to-hybrid/converge.yml
@@ -6,27 +6,26 @@
 # changes / no finalize) → partial rollback to hybrid.
 #
 # The forward step and the final rollback invoke the real entry playbooks with
-# the real customer tags. The intermediate PURE step uses a local replay of the
-# broker-migration plays because no single tag isolates them from the
+# the real customer tags, against molecule's own generated inventory
+# (MOLECULE_INVENTORY_FILE). The intermediate PURE step uses a local replay of
+# the broker-migration plays because no single tag isolates them from the
 # controller-finalize plays. No changes to the main playbooks are required.
-
-- name: Activate KRaft controllers in the inventory
-  hosts: localhost
-  gather_facts: false
-  tasks:
-    - name: Promote kafka_controller_migration → kafka_controller
-      lineinfile:
-        path: "{{ inventory_dir }}/ansible_inventory.yml"
-        regexp: "kafka_controller_migration:"
-        line: "kafka_controller:"
 
 - name: Forward to PURE_DUAL_WRITE, then partial rollback to hybrid
   hosts: localhost
   gather_facts: false
   vars:
     repo_root: "{{ playbook_dir }}/../.."
-    molecule_inventory: "{{ inventory_dir }}/ansible_inventory.yml"
+    molecule_inventory: "{{ lookup('env', 'MOLECULE_INVENTORY_FILE') }}"
   tasks:
+    # Promote the migration-held controllers into the live kafka_controller
+    # group so the sub-runs below (which read the inventory file fresh) see them.
+    - name: Promote kafka_controller_migration → kafka_controller
+      lineinfile:
+        path: "{{ molecule_inventory }}"
+        regexp: "kafka_controller_migration:"
+        line: "kafka_controller:"
+
     - name: Forward-migrate to HYBRID_DUAL_WRITE (--tags migrate_to_dual_write)
       command: >-
         ansible-playbook

--- a/molecule/kraft-rollback-to-hybrid/migrate_brokers_to_kraft.yml
+++ b/molecule/kraft-rollback-to-hybrid/migrate_brokers_to_kraft.yml
@@ -1,0 +1,60 @@
+---
+# Molecule-only helper. Replays just the broker-migration plays from
+# playbooks/ZKtoKraftMigration.yml ("Migrate Brokers to Kraft" + "Restart Kafka
+# Broker", lines 86-138 of that file). Run against a HYBRID_DUAL_WRITE cluster,
+# these plays add process.roles=broker and restart the brokers, advancing them
+# to PURE_DUAL_WRITE *without* touching the controllers or finalizing the
+# migration. Kept here (not in the main playbooks) so production code is
+# unchanged. Keep in sync with ZKtoKraftMigration.yml if those plays change.
+
+- name: Migrate Brokers to Kraft
+  hosts: kafka_broker
+  gather_facts: true
+  any_errors_fatal: true
+  tasks:
+    - import_role:
+        name: variables
+
+    - name: Remove Zookeeper configs from Broker
+      lineinfile:
+        path: "{{ kafka_broker.config_file }}"
+        state: absent
+        regexp: "^{{ item }}*"
+      loop:
+        - zookeeper
+        - inter.broker.protocol.version
+
+    - name: Reconfigure ZK Brokers as KRaft brokers
+      lineinfile:
+        path: "{{ kafka_broker.config_file }}"
+        line: process.roles=broker
+
+    - name: Check if Cluster has RBAC enabled
+      lineinfile:
+        path: "{{ kafka_broker.config_file }}"
+        regexp: 'confluent.authorizer.access.rule.providers(.*)$'
+        state: absent
+      register: auth_present
+      when: rbac_enabled|bool
+
+    - name: Replace ZK_ACL with KRAFT_ACL
+      lineinfile:
+        path: "{{ kafka_broker.config_file }}"
+        line: confluent.authorizer.access.rule.providers=CONFLUENT,KRAFT_ACL
+      when:
+        - rbac_enabled|bool
+        - auth_present.found
+
+- name: Restart Kafka Broker
+  hosts: kafka_broker
+  gather_facts: true
+  serial: '1'
+  any_errors_fatal: true
+  tasks:
+    - include_role:
+        name: kafka_broker
+        tasks_from: restart_and_wait.yml
+    - include_role:
+        name: kafka_broker
+        tasks_from: health_check.yml
+      tags: health_check

--- a/molecule/kraft-rollback-to-hybrid/molecule.yml
+++ b/molecule/kraft-rollback-to-hybrid/molecule.yml
@@ -1,0 +1,62 @@
+---
+### KRaft → ZooKeeper rollback e2e (ANSIENG-5796) — Scenario 2.
+### PURE_DUAL_WRITE → hybrid (partial rollback; controllers stay active).
+###
+### Dedicated hosts: one ZooKeeper, one Kafka broker, one KRaft controller
+### (1 controller / 1 broker / 1 zookeeper — the topology the feature was
+### manually validated on). prepare.yml deploys ZooKeeper + broker; the
+### controller is held in kafka_controller_migration and is NOT deployed until
+### converge.yml promotes it. SASL PLAIN, community edition.
+
+driver:
+  name: docker
+platforms:
+  - name: zookeeper1
+    hostname: zookeeper1.confluent
+    groups:
+      - zookeeper
+    image: redhat/ubi8-minimal
+    dockerfile: ../Dockerfile-rhel-java17.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent
+  - name: kafka-broker1
+    hostname: kafka-broker1.confluent
+    groups:
+      - kafka_broker
+    image: redhat/ubi8-minimal
+    dockerfile: ../Dockerfile-rhel-java17.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent
+  - name: kafka-controller1
+    hostname: kafka-controller1.confluent
+    groups:
+      - kafka_controller_migration
+    image: redhat/ubi8-minimal
+    dockerfile: ../Dockerfile-rhel-java17.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent
+provisioner:
+  playbooks:
+    prepare: ./prepare.yml
+    converge: ./converge.yml
+    verify: ./verify.yml
+  inventory:
+    group_vars:
+      all:
+        sasl_protocol: plain
+        confluent_server_enabled: false

--- a/molecule/kraft-rollback-to-hybrid/molecule.yml
+++ b/molecule/kraft-rollback-to-hybrid/molecule.yml
@@ -59,4 +59,4 @@ provisioner:
     group_vars:
       all:
         sasl_protocol: plain
-        confluent_server_enabled: false
+        # confluent_server_enabled: false

--- a/molecule/kraft-rollback-to-hybrid/molecule.yml
+++ b/molecule/kraft-rollback-to-hybrid/molecule.yml
@@ -2,15 +2,28 @@
 ### KRaft → ZooKeeper rollback e2e (ANSIENG-5796) — Scenario 2.
 ### PURE_DUAL_WRITE → hybrid (partial rollback; controllers stay active).
 ###
-### Dedicated hosts: one ZooKeeper, one Kafka broker, one KRaft controller
-### (1 controller / 1 broker / 1 zookeeper — the topology the feature was
-### manually validated on). prepare.yml deploys ZooKeeper + broker; the
-### controller is held in kafka_controller_migration and is NOT deployed until
-### converge.yml promotes it. SASL PLAIN, community edition.
+### RBAC + mTLS (mirrors rbac-mtls-rhel8), trimmed to the rollback component
+### set: one OpenLDAP, one ZooKeeper, one broker (also hosts MDS), one KRaft
+### controller held in kafka_controller_migration until converge promotes it.
+### NOTE: ssl_enabled puts ZooKeeper on TLS (port 2182) — the rollback's ZK
+### cleanup is TLS-aware for this reason.
 
 driver:
   name: docker
 platforms:
+  - name: ldap1
+    hostname: ldap1.confluent
+    groups:
+      - ldap_server
+    image: centos:centos8
+    dockerfile: ../Dockerfile-centos8-base.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent
   - name: zookeeper1
     hostname: zookeeper1.confluent
     groups:
@@ -58,5 +71,43 @@ provisioner:
   inventory:
     group_vars:
       all:
-        sasl_protocol: plain
-        # confluent_server_enabled: false
+        ssl_enabled: true
+        ssl_mutual_auth_enabled: true
+
+        rbac_enabled: true
+        rbac_super_users:
+          - User:C=US,ST=Ca,L=PaloAlto,O=CONFLUENT,OU=TEST,CN=kafka_broker
+          - User:C=US,ST=Ca,L=PaloAlto,O=CONFLUENT,OU=TEST,CN=kafka_controller
+          - User:CN=kafka_controller,OU=QE IT,O=CONFLUENT,L=PaloAlto,ST=Ca,C=US
+          - User:CN=kafka_broker,OU=QE IT,O=CONFLUENT,L=PaloAlto,ST=Ca,C=US
+
+        mds_super_user: mds
+        mds_super_user_password: password
+
+        kafka_broker_custom_properties:
+          ldap.java.naming.factory.initial: com.sun.jndi.ldap.LdapCtxFactory
+          ldap.com.sun.jndi.ldap.read.timeout: 3000
+          ldap.java.naming.provider.url: ldap://ldap1:389
+          ldap.java.naming.security.principal: uid=mds,OU=rbac,DC=example,DC=com
+          ldap.java.naming.security.credentials: password
+          ldap.java.naming.security.authentication: simple
+          ldap.user.search.base: OU=rbac,DC=example,DC=com
+          ldap.group.search.base: OU=rbac,DC=example,DC=com
+          ldap.user.name.attribute: uid
+          ldap.user.memberof.attribute.pattern: CN=(.*),OU=rbac,DC=example,DC=com
+          ldap.group.name.attribute: cn
+          ldap.group.member.attribute.pattern: CN=(.*),OU=rbac,DC=example,DC=com
+          ldap.user.object.class: account
+
+      ldap_server:
+        ldaps_enabled: false
+        ldaps_custom_certs: false
+        ldap_admin_password: ldppassword
+        ldap_rbac_group: rbac
+        ldap_dc: example
+        ldap_dc_extension: com
+        ldap_users:
+          - username: "{{ mds_super_user }}"
+            password: "{{ mds_super_user_password }}"
+            uid: 9993
+            guid: 93

--- a/molecule/kraft-rollback-to-hybrid/prepare.yml
+++ b/molecule/kraft-rollback-to-hybrid/prepare.yml
@@ -1,8 +1,15 @@
 ---
-# Stand up the initial ZooKeeper-based cluster. The KRaft controllers live in
-# kafka_controller_migration (not kafka_controller), so confluent.platform.all
-# deploys ZooKeeper + brokers only and the all.yml kraft_migration guard stays
-# happy (kraft_migration is not set here — it is passed only to the migration /
-# rollback sub-runs in converge.yml).
-- name: Deploy ZooKeeper-based cluster
+# Install OpenLDAP first (MDS identity backend for RBAC), then stand up the
+# initial ZooKeeper-based cluster with RBAC + mTLS. The KRaft controllers stay
+# in kafka_controller_migration (not kafka_controller), so confluent.platform.all
+# deploys ZooKeeper + broker (+ MDS) only and the all.yml kraft_migration guard
+# stays happy — kraft_migration is passed only to the migration/rollback sub-runs
+# in converge.yml.
+- name: Install and configure OpenLDAP
+  hosts: ldap_server
+  tasks:
+    - import_role:
+        name: confluent.test.ldap
+
+- name: Deploy ZooKeeper-based cluster (RBAC + mTLS)
   import_playbook: confluent.platform.all

--- a/molecule/kraft-rollback-to-hybrid/prepare.yml
+++ b/molecule/kraft-rollback-to-hybrid/prepare.yml
@@ -1,0 +1,8 @@
+---
+# Stand up the initial ZooKeeper-based cluster. The KRaft controllers live in
+# kafka_controller_migration (not kafka_controller), so confluent.platform.all
+# deploys ZooKeeper + brokers only and the all.yml kraft_migration guard stays
+# happy (kraft_migration is not set here — it is passed only to the migration /
+# rollback sub-runs in converge.yml).
+- name: Deploy ZooKeeper-based cluster
+  import_playbook: confluent.platform.all

--- a/molecule/kraft-rollback-to-hybrid/verify.yml
+++ b/molecule/kraft-rollback-to-hybrid/verify.yml
@@ -54,11 +54,11 @@
         success_msg: "Controller {{ inventory_hostname }} is still active"
 
 # Confirm the post-rollback state with the rollback feature's own detection
-# utility (JMX ZkMigrationState primary, broker-config fallback) — the same
-# signal a real re-run would see — rather than a hand-rolled MBean read.
+# utility (JMX ZkMigrationState primary, broker process.roles for PURE vs HYBRID)
+# — the same signal a real re-run would see — rather than a hand-rolled MBean read.
 - name: Verify - migration utility detects HYBRID_DUAL_WRITE
   hosts: localhost
-  gather_facts: false
+  gather_facts: true  # detection resolves kafka_broker.config_file, which needs ansible_os_family
   tasks:
     - import_role:
         name: variables

--- a/molecule/kraft-rollback-to-hybrid/verify.yml
+++ b/molecule/kraft-rollback-to-hybrid/verify.yml
@@ -1,0 +1,51 @@
+---
+### Verifies Scenario 2: partial rollback landed the cluster back in hybrid mode.
+### - Brokers: hybrid (migration flag present, no process.roles), ZK restored.
+### - Controllers: still active (only the brokers were reverted).
+
+- name: Verify - brokers reverted to hybrid mode
+  hosts: kafka_broker
+  gather_facts: false
+  tasks:
+    - import_role:
+        name: variables
+
+    - name: Read broker server.properties
+      slurp:
+        src: "{{ kafka_broker.config_file }}"
+      register: broker_cfg
+
+    - name: Assert broker is in hybrid (ZK + migration) mode, not pure KRaft
+      vars:
+        cfg: "{{ broker_cfg.content | b64decode }}"
+      assert:
+        that:
+          - cfg is search('(?m)^zookeeper.metadata.migration.enable=true')
+          - cfg is search('(?m)^zookeeper.connect=')
+          - cfg is not search('(?m)^process.roles')
+        fail_msg: >-
+          Broker {{ inventory_hostname }} is not in hybrid mode after a partial
+          rollback (expected migration flag + zookeeper.connect, no process.roles).
+        success_msg: "Broker {{ inventory_hostname }} is back in hybrid mode"
+
+- name: Verify - controllers remain active
+  hosts: kafka_controller
+  gather_facts: false
+  tasks:
+    - import_role:
+        name: variables
+
+    - name: Get controller service state
+      systemd:
+        name: "{{ kafka_controller_service_name }}"
+      register: ctrl_svc
+      failed_when: false
+
+    - name: Assert controller is still active
+      assert:
+        that:
+          - ctrl_svc.status.ActiveState == 'active'
+        fail_msg: >-
+          Controller {{ inventory_hostname }} was stopped during a partial
+          rollback to hybrid; it should stay active.
+        success_msg: "Controller {{ inventory_hostname }} is still active"

--- a/molecule/kraft-rollback-to-hybrid/verify.yml
+++ b/molecule/kraft-rollback-to-hybrid/verify.yml
@@ -5,7 +5,7 @@
 
 - name: Verify - brokers reverted to hybrid mode
   hosts: kafka_broker
-  gather_facts: false
+  gather_facts: true
   tasks:
     - import_role:
         name: variables
@@ -28,9 +28,12 @@
           rollback (expected migration flag + zookeeper.connect, no process.roles).
         success_msg: "Broker {{ inventory_hostname }} is back in hybrid mode"
 
+# Match either group name: converge renames kafka_controller_migration →
+# kafka_controller in the inventory file, but molecule may regenerate the
+# inventory before verify. Targeting both avoids a no-hosts-matched false pass.
 - name: Verify - controllers remain active
-  hosts: kafka_controller
-  gather_facts: false
+  hosts: kafka_controller:kafka_controller_migration
+  gather_facts: true
   tasks:
     - import_role:
         name: variables

--- a/molecule/kraft-rollback-to-hybrid/verify.yml
+++ b/molecule/kraft-rollback-to-hybrid/verify.yml
@@ -52,3 +52,29 @@
           Controller {{ inventory_hostname }} was stopped during a partial
           rollback to hybrid; it should stay active.
         success_msg: "Controller {{ inventory_hostname }} is still active"
+
+    # Confirm via JMX that the controller is still in dual-write (migration)
+    - name: Query controller ZkMigrationState via Jolokia
+      uri:
+        url: "{{ 'https' if kafka_controller_jolokia_ssl_enabled | bool else 'http' }}://localhost:{{ kafka_controller_jolokia_port }}/jolokia/read/kafka.controller:type=KafkaController,name=ZkMigrationState"
+        validate_certs: false
+        return_content: true
+        status_code: 200
+        force_basic_auth: "{{ jolokia_auth_mode == 'basic' }}"
+        url_username: "{{ jolokia_user if jolokia_auth_mode == 'basic' else omit }}"
+        url_password: "{{ jolokia_password if jolokia_auth_mode == 'basic' else omit }}"
+      register: zk_migration_state
+      retries: 5
+      delay: 6
+      until: zk_migration_state.status | default(0) == 200
+
+    - name: Assert controller is still in dual-write (migration) mode
+      assert:
+        that:
+          - (zk_migration_state.content | from_json).value.Value | int == 1
+        fail_msg: >-
+          Controller ZkMigrationState is
+          {{ (zk_migration_state.content | from_json).value.Value }}, expected 1
+          (dual-write). The controller left migration mode or finalized during a
+          partial rollback to hybrid.
+        success_msg: "Controller is in dual-write migration mode (ZkMigrationState=1)"

--- a/molecule/kraft-rollback-to-hybrid/verify.yml
+++ b/molecule/kraft-rollback-to-hybrid/verify.yml
@@ -53,28 +53,35 @@
           rollback to hybrid; it should stay active.
         success_msg: "Controller {{ inventory_hostname }} is still active"
 
-    # Confirm via JMX that the controller is still in dual-write (migration)
-    - name: Query controller ZkMigrationState via Jolokia
-      uri:
-        url: "{{ 'https' if kafka_controller_jolokia_ssl_enabled | bool else 'http' }}://localhost:{{ kafka_controller_jolokia_port }}/jolokia/read/kafka.controller:type=KafkaController,name=ZkMigrationState"
-        validate_certs: false
-        return_content: true
-        status_code: 200
-        force_basic_auth: "{{ jolokia_auth_mode == 'basic' }}"
-        url_username: "{{ jolokia_user if jolokia_auth_mode == 'basic' else omit }}"
-        url_password: "{{ jolokia_password if jolokia_auth_mode == 'basic' else omit }}"
-      register: zk_migration_state
-      retries: 5
-      delay: 6
-      until: zk_migration_state.status | default(0) == 200
+# Confirm the post-rollback state with the rollback feature's own detection
+# utility (JMX ZkMigrationState primary, broker-config fallback) — the same
+# signal a real re-run would see — rather than a hand-rolled MBean read.
+- name: Verify - migration utility detects HYBRID_DUAL_WRITE
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - import_role:
+        name: variables
 
-    - name: Assert controller is still in dual-write (migration) mode
+    # detect_migration_phase.yml delegates to groups['kafka_controller'][0], but
+    # molecule regenerates the inventory before verify so the converge-time
+    # rename is gone. Re-promote the controllers in-memory (connection hostvars
+    # are preserved since the host already exists in kafka_controller_migration).
+    - name: Re-activate kafka_controller group for detection
+      add_host:
+        name: "{{ item }}"
+        groups: kafka_controller
+      loop: "{{ groups['kafka_controller_migration'] | default([]) }}"
+      changed_when: false
+
+    - name: Detect migration state (migration utility)
+      include_tasks: ../../playbooks/tasks/detect_migration_phase.yml
+
+    - name: Assert cluster is in HYBRID_DUAL_WRITE after partial rollback
       assert:
         that:
-          - (zk_migration_state.content | from_json).value.Value | int == 1
+          - migration_state == "HYBRID_DUAL_WRITE"
         fail_msg: >-
-          Controller ZkMigrationState is
-          {{ (zk_migration_state.content | from_json).value.Value }}, expected 1
-          (dual-write). The controller left migration mode or finalized during a
-          partial rollback to hybrid.
-        success_msg: "Controller is in dual-write migration mode (ZkMigrationState=1)"
+          Migration utility detected '{{ migration_state }}', expected
+          HYBRID_DUAL_WRITE after a partial rollback to hybrid.
+        success_msg: "Migration utility detected HYBRID_DUAL_WRITE"

--- a/molecule/kraft-rollback-to-zk/converge.yml
+++ b/molecule/kraft-rollback-to-zk/converge.yml
@@ -1,0 +1,60 @@
+---
+# Scenario 1 — HYBRID_DUAL_WRITE → premigration.
+#
+# Orchestrates: (deploy already done in prepare) → migrate forward to
+# HYBRID_DUAL_WRITE → roll back to pre-migration. Both the forward and the
+# rollback steps invoke the real entry playbooks with the real customer tags,
+# so there is zero divergence from production behaviour and no changes to the
+# main playbooks or Semaphore infra are required.
+
+- name: Activate KRaft controllers in the inventory
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    # Promote the migration-held controllers into the live kafka_controller
+    # group so the forward-migration / rollback sub-runs (which read the
+    # inventory file fresh) can see them.
+    - name: Promote kafka_controller_migration → kafka_controller
+      lineinfile:
+        path: "{{ inventory_dir }}/ansible_inventory.yml"
+        regexp: "kafka_controller_migration:"
+        line: "kafka_controller:"
+
+- name: Migrate forward to HYBRID_DUAL_WRITE, then roll back to pre-migration
+  hosts: localhost
+  gather_facts: false
+  vars:
+    repo_root: "{{ playbook_dir }}/../.."
+    molecule_inventory: "{{ inventory_dir }}/ansible_inventory.yml"
+  tasks:
+    - name: Forward-migrate to HYBRID_DUAL_WRITE (--tags migrate_to_dual_write)
+      command: >-
+        ansible-playbook
+        -i {{ molecule_inventory }}
+        {{ repo_root }}/playbooks/ZKtoKraftMigration.yml
+        --tags migrate_to_dual_write
+        -e kraft_migration=true
+      args:
+        chdir: "{{ repo_root }}"
+      changed_when: true
+      register: forward_migrate
+
+    - name: Roll back to pre-migration (--tags rollback_to_premigration)
+      command: >-
+        ansible-playbook
+        -i {{ molecule_inventory }}
+        {{ repo_root }}/playbooks/KRaftToZKRollback.yml
+        --tags rollback_to_premigration
+        -e kraft_migration=true
+      args:
+        chdir: "{{ repo_root }}"
+      changed_when: true
+      register: rollback_run
+
+    - name: Show forward-migration output
+      debug:
+        var: forward_migrate.stdout_lines
+
+    - name: Show rollback output
+      debug:
+        var: rollback_run.stdout_lines

--- a/molecule/kraft-rollback-to-zk/converge.yml
+++ b/molecule/kraft-rollback-to-zk/converge.yml
@@ -2,31 +2,26 @@
 # Scenario 1 — HYBRID_DUAL_WRITE → premigration.
 #
 # Orchestrates: (deploy already done in prepare) → migrate forward to
-# HYBRID_DUAL_WRITE → roll back to pre-migration. Both the forward and the
-# rollback steps invoke the real entry playbooks with the real customer tags,
-# so there is zero divergence from production behaviour and no changes to the
-# main playbooks or Semaphore infra are required.
-
-- name: Activate KRaft controllers in the inventory
-  hosts: localhost
-  gather_facts: false
-  tasks:
-    # Promote the migration-held controllers into the live kafka_controller
-    # group so the forward-migration / rollback sub-runs (which read the
-    # inventory file fresh) can see them.
-    - name: Promote kafka_controller_migration → kafka_controller
-      lineinfile:
-        path: "{{ inventory_dir }}/ansible_inventory.yml"
-        regexp: "kafka_controller_migration:"
-        line: "kafka_controller:"
+# HYBRID_DUAL_WRITE → roll back to pre-migration. Both steps invoke the real
+# entry playbooks with the real customer tags, against molecule's own generated
+# inventory (MOLECULE_INVENTORY_FILE), so there is zero divergence from
+# production behaviour and no changes to the main playbooks / Semaphore infra.
 
 - name: Migrate forward to HYBRID_DUAL_WRITE, then roll back to pre-migration
   hosts: localhost
   gather_facts: false
   vars:
     repo_root: "{{ playbook_dir }}/../.."
-    molecule_inventory: "{{ inventory_dir }}/ansible_inventory.yml"
+    molecule_inventory: "{{ lookup('env', 'MOLECULE_INVENTORY_FILE') }}"
   tasks:
+    # Promote the migration-held controllers into the live kafka_controller
+    # group so the sub-runs below (which read the inventory file fresh) see them.
+    - name: Promote kafka_controller_migration → kafka_controller
+      lineinfile:
+        path: "{{ molecule_inventory }}"
+        regexp: "kafka_controller_migration:"
+        line: "kafka_controller:"
+
     - name: Forward-migrate to HYBRID_DUAL_WRITE (--tags migrate_to_dual_write)
       command: >-
         ansible-playbook

--- a/molecule/kraft-rollback-to-zk/molecule.yml
+++ b/molecule/kraft-rollback-to-zk/molecule.yml
@@ -1,0 +1,62 @@
+---
+### KRaft → ZooKeeper rollback e2e (ANSIENG-5796) — Scenario 1.
+### HYBRID_DUAL_WRITE → premigration (full rollback to pure ZooKeeper).
+###
+### Dedicated hosts: one ZooKeeper, one Kafka broker, one KRaft controller
+### (1 controller / 1 broker / 1 zookeeper — the topology the feature was
+### manually validated on). prepare.yml deploys ZooKeeper + broker; the
+### controller is held in kafka_controller_migration and is NOT deployed until
+### converge.yml promotes it. SASL PLAIN, community edition.
+
+driver:
+  name: docker
+platforms:
+  - name: zookeeper1
+    hostname: zookeeper1.confluent
+    groups:
+      - zookeeper
+    image: redhat/ubi8-minimal
+    dockerfile: ../Dockerfile-rhel-java17.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent
+  - name: kafka-broker1
+    hostname: kafka-broker1.confluent
+    groups:
+      - kafka_broker
+    image: redhat/ubi8-minimal
+    dockerfile: ../Dockerfile-rhel-java17.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent
+  - name: kafka-controller1
+    hostname: kafka-controller1.confluent
+    groups:
+      - kafka_controller_migration
+    image: redhat/ubi8-minimal
+    dockerfile: ../Dockerfile-rhel-java17.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent
+provisioner:
+  playbooks:
+    prepare: ./prepare.yml
+    converge: ./converge.yml
+    verify: ./verify.yml
+  inventory:
+    group_vars:
+      all:
+        sasl_protocol: plain
+        confluent_server_enabled: false

--- a/molecule/kraft-rollback-to-zk/molecule.yml
+++ b/molecule/kraft-rollback-to-zk/molecule.yml
@@ -2,15 +2,28 @@
 ### KRaft → ZooKeeper rollback e2e (ANSIENG-5796) — Scenario 1.
 ### HYBRID_DUAL_WRITE → premigration (full rollback to pure ZooKeeper).
 ###
-### Dedicated hosts: one ZooKeeper, one Kafka broker, one KRaft controller
-### (1 controller / 1 broker / 1 zookeeper — the topology the feature was
-### manually validated on). prepare.yml deploys ZooKeeper + broker; the
-### controller is held in kafka_controller_migration and is NOT deployed until
-### converge.yml promotes it. SASL PLAIN, community edition.
+### RBAC + mTLS (mirrors rbac-mtls-rhel8), trimmed to the rollback component
+### set: one OpenLDAP, one ZooKeeper, one broker (also hosts MDS), one KRaft
+### controller held in kafka_controller_migration until converge promotes it.
+### NOTE: ssl_enabled puts ZooKeeper on TLS (port 2182) — the rollback's ZK
+### cleanup is TLS-aware for this reason.
 
 driver:
   name: docker
 platforms:
+  - name: ldap1
+    hostname: ldap1.confluent
+    groups:
+      - ldap_server
+    image: centos:centos8
+    dockerfile: ../Dockerfile-centos8-base.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent
   - name: zookeeper1
     hostname: zookeeper1.confluent
     groups:
@@ -58,5 +71,43 @@ provisioner:
   inventory:
     group_vars:
       all:
-        sasl_protocol: plain
-        confluent_server_enabled: false
+        ssl_enabled: true
+        ssl_mutual_auth_enabled: true
+
+        rbac_enabled: true
+        rbac_super_users:
+          - User:C=US,ST=Ca,L=PaloAlto,O=CONFLUENT,OU=TEST,CN=kafka_broker
+          - User:C=US,ST=Ca,L=PaloAlto,O=CONFLUENT,OU=TEST,CN=kafka_controller
+          - User:CN=kafka_controller,OU=QE IT,O=CONFLUENT,L=PaloAlto,ST=Ca,C=US
+          - User:CN=kafka_broker,OU=QE IT,O=CONFLUENT,L=PaloAlto,ST=Ca,C=US
+
+        mds_super_user: mds
+        mds_super_user_password: password
+
+        kafka_broker_custom_properties:
+          ldap.java.naming.factory.initial: com.sun.jndi.ldap.LdapCtxFactory
+          ldap.com.sun.jndi.ldap.read.timeout: 3000
+          ldap.java.naming.provider.url: ldap://ldap1:389
+          ldap.java.naming.security.principal: uid=mds,OU=rbac,DC=example,DC=com
+          ldap.java.naming.security.credentials: password
+          ldap.java.naming.security.authentication: simple
+          ldap.user.search.base: OU=rbac,DC=example,DC=com
+          ldap.group.search.base: OU=rbac,DC=example,DC=com
+          ldap.user.name.attribute: uid
+          ldap.user.memberof.attribute.pattern: CN=(.*),OU=rbac,DC=example,DC=com
+          ldap.group.name.attribute: cn
+          ldap.group.member.attribute.pattern: CN=(.*),OU=rbac,DC=example,DC=com
+          ldap.user.object.class: account
+
+      ldap_server:
+        ldaps_enabled: false
+        ldaps_custom_certs: false
+        ldap_admin_password: ldppassword
+        ldap_rbac_group: rbac
+        ldap_dc: example
+        ldap_dc_extension: com
+        ldap_users:
+          - username: "{{ mds_super_user }}"
+            password: "{{ mds_super_user_password }}"
+            uid: 9993
+            guid: 93

--- a/molecule/kraft-rollback-to-zk/prepare.yml
+++ b/molecule/kraft-rollback-to-zk/prepare.yml
@@ -1,8 +1,15 @@
 ---
-# Stand up the initial ZooKeeper-based cluster. The KRaft controllers live in
-# kafka_controller_migration (not kafka_controller), so confluent.platform.all
-# deploys ZooKeeper + brokers only and the all.yml kraft_migration guard stays
-# happy (kraft_migration is not set here — it is passed only to the migration /
-# rollback sub-runs in converge.yml).
-- name: Deploy ZooKeeper-based cluster
+# Install OpenLDAP first (MDS identity backend for RBAC), then stand up the
+# initial ZooKeeper-based cluster with RBAC + mTLS. The KRaft controllers stay
+# in kafka_controller_migration (not kafka_controller), so confluent.platform.all
+# deploys ZooKeeper + broker (+ MDS) only and the all.yml kraft_migration guard
+# stays happy — kraft_migration is passed only to the migration/rollback sub-runs
+# in converge.yml.
+- name: Install and configure OpenLDAP
+  hosts: ldap_server
+  tasks:
+    - import_role:
+        name: confluent.test.ldap
+
+- name: Deploy ZooKeeper-based cluster (RBAC + mTLS)
   import_playbook: confluent.platform.all

--- a/molecule/kraft-rollback-to-zk/prepare.yml
+++ b/molecule/kraft-rollback-to-zk/prepare.yml
@@ -1,0 +1,8 @@
+---
+# Stand up the initial ZooKeeper-based cluster. The KRaft controllers live in
+# kafka_controller_migration (not kafka_controller), so confluent.platform.all
+# deploys ZooKeeper + brokers only and the all.yml kraft_migration guard stays
+# happy (kraft_migration is not set here — it is passed only to the migration /
+# rollback sub-runs in converge.yml).
+- name: Deploy ZooKeeper-based cluster
+  import_playbook: confluent.platform.all

--- a/molecule/kraft-rollback-to-zk/verify.yml
+++ b/molecule/kraft-rollback-to-zk/verify.yml
@@ -1,0 +1,88 @@
+---
+### Verifies Scenario 1: full rollback landed the cluster in pure ZooKeeper.
+### - Brokers: KRaft/migration properties gone, zookeeper.connect present.
+### - Controllers: service stopped, __cluster_metadata removed.
+### - ZooKeeper: /migration znode removed.
+
+- name: Verify - brokers are in pure ZooKeeper mode
+  hosts: kafka_broker
+  gather_facts: false
+  tasks:
+    - import_role:
+        name: variables
+
+    - name: Read broker server.properties
+      slurp:
+        src: "{{ kafka_broker.config_file }}"
+      register: broker_cfg
+
+    - name: Assert KRaft/migration properties removed and ZooKeeper restored
+      vars:
+        cfg: "{{ broker_cfg.content | b64decode }}"
+      assert:
+        that:
+          - cfg is not search('(?m)^process.roles')
+          - cfg is not search('(?m)^controller.quorum.voters')
+          - cfg is not search('(?m)^controller.listener.names')
+          - cfg is not search('(?m)^zookeeper.metadata.migration.enable')
+          - cfg is search('(?m)^zookeeper.connect=')
+        fail_msg: >-
+          Broker {{ inventory_hostname }} still carries KRaft/migration
+          properties after a full rollback.
+        success_msg: "Broker {{ inventory_hostname }} is in pure ZooKeeper mode"
+
+- name: Verify - controllers are deprovisioned
+  hosts: kafka_controller
+  gather_facts: false
+  tasks:
+    - import_role:
+        name: variables
+
+    - name: Get controller service state
+      systemd:
+        name: "{{ kafka_controller_service_name }}"
+      register: ctrl_svc
+      failed_when: false
+
+    - name: Assert controller is not active
+      assert:
+        that:
+          - ctrl_svc.status.ActiveState != 'active'
+        fail_msg: "Controller {{ inventory_hostname }} is still active after full rollback"
+        success_msg: "Controller {{ inventory_hostname }} is stopped"
+
+    - name: Look for leftover __cluster_metadata directories
+      find:
+        paths: "{{ kafka_controller_final_properties['log.dirs'] }}"
+        patterns: "__cluster_metadata*"
+        file_type: directory
+      register: ctrl_meta
+
+    - name: Assert __cluster_metadata removed from controller
+      assert:
+        that:
+          - ctrl_meta.files | length == 0
+        fail_msg: "Controller {{ inventory_hostname }} still has __cluster_metadata directories"
+
+- name: Verify - ZooKeeper migration state cleaned
+  hosts: zookeeper[0]
+  gather_facts: false
+  tasks:
+    - import_role:
+        name: variables
+
+    - name: Query /migration znode
+      shell: |
+        echo "get /migration" | {{ zk_cli }} localhost:{{ zookeeper_client_port }}
+      vars:
+        zk_cli: "{% if installation_method == 'archive' %}{{ archive_destination_path }}/confluent-{{ confluent_package_version }}/bin/zookeeper-shell{% else %}/usr/bin/zookeeper-shell{% endif %}"
+      register: zk_migration
+      changed_when: false
+      failed_when: false
+
+    - name: Assert /migration znode no longer exists
+      assert:
+        that:
+          - zk_migration.rc != 0
+        fail_msg: "/migration znode still present after full rollback"
+        success_msg: "/migration znode removed"

--- a/molecule/kraft-rollback-to-zk/verify.yml
+++ b/molecule/kraft-rollback-to-zk/verify.yml
@@ -56,7 +56,7 @@
 
     - name: Look for leftover __cluster_metadata directories
       find:
-        paths: "{{ kafka_controller_final_properties['log.dirs'] }}"
+        paths: /var/lib/controller/data
         patterns: "__cluster_metadata*"
         file_type: directory
       register: ctrl_meta

--- a/molecule/kraft-rollback-to-zk/verify.yml
+++ b/molecule/kraft-rollback-to-zk/verify.yml
@@ -74,18 +74,28 @@
     - import_role:
         name: variables
 
-    - name: Query /migration znode
-      shell: |
-        echo "get /migration" | {{ zk_cli }} localhost:{{ zookeeper_client_port }}
+    # TLS-aware: under RBAC/mTLS ZooKeeper runs with TLS (port 2182), and the
+    # client config lives on the broker, so query via the broker like the
+    # rollback does. Assert on the actual "Node does not exist" output rather
+    # than rc — a failed/again-plaintext connection also exits non-zero and would
+    # otherwise false-pass as "znode removed".
+    - name: Query /migration znode (TLS-aware, via broker client config)
+      shell: >
+        echo "get /migration" |
+        {{ zk_cli }} {{ groups['zookeeper'][0] }}:{{ zookeeper_client_port }}
+        {% if zookeeper_ssl_enabled | bool %}-zk-tls-config-file {{ kafka_broker.zookeeper_tls_client_config_file if kafka_broker_secrets_protection_enabled | bool else kafka_broker.config_file }}{% endif %}
       vars:
         zk_cli: "{% if installation_method == 'archive' %}{{ archive_destination_path }}/confluent-{{ confluent_package_version }}/bin/zookeeper-shell{% else %}/usr/bin/zookeeper-shell{% endif %}"
       register: zk_migration
       changed_when: false
       failed_when: false
+      delegate_to: "{{ groups['kafka_broker'][0] }}"
 
     - name: Assert /migration znode no longer exists
       assert:
         that:
-          - zk_migration.rc != 0
-        fail_msg: "/migration znode still present after full rollback"
+          - "'Node does not exist' in (zk_migration.stdout + zk_migration.stderr)"
+        fail_msg: >-
+          /migration znode still present (or ZooKeeper unreachable) after full
+          rollback. Output: {{ zk_migration.stdout }} {{ zk_migration.stderr }}
         success_msg: "/migration znode removed"

--- a/molecule/kraft-rollback-to-zk/verify.yml
+++ b/molecule/kraft-rollback-to-zk/verify.yml
@@ -6,7 +6,7 @@
 
 - name: Verify - brokers are in pure ZooKeeper mode
   hosts: kafka_broker
-  gather_facts: false
+  gather_facts: true
   tasks:
     - import_role:
         name: variables
@@ -31,9 +31,12 @@
           properties after a full rollback.
         success_msg: "Broker {{ inventory_hostname }} is in pure ZooKeeper mode"
 
+# Match either group name: converge renames kafka_controller_migration →
+# kafka_controller in the inventory file, but molecule may regenerate the
+# inventory before verify. Targeting both avoids a no-hosts-matched false pass.
 - name: Verify - controllers are deprovisioned
-  hosts: kafka_controller
-  gather_facts: false
+  hosts: kafka_controller:kafka_controller_migration
+  gather_facts: true
   tasks:
     - import_role:
         name: variables
@@ -66,7 +69,7 @@
 
 - name: Verify - ZooKeeper migration state cleaned
   hosts: zookeeper[0]
-  gather_facts: false
+  gather_facts: true
   tasks:
     - import_role:
         name: variables

--- a/molecule/kraft_migration_guard_inventory.yml
+++ b/molecule/kraft_migration_guard_inventory.yml
@@ -1,0 +1,15 @@
+---
+# Inventory for the all.yml kraft_migration guard test (ANSIENG-5782, review #8).
+# kraft_migration is intentionally set ONLY at group scope (kafka_broker:vars),
+# NOT under all:vars, to reproduce the customer scenario the reviewer flagged.
+all:
+  hosts:
+    localhost:
+      ansible_connection: local
+  children:
+    kafka_broker:
+      hosts:
+        broker1:
+          ansible_connection: local
+      vars:
+        kraft_migration: true

--- a/molecule/kraft_migration_guard_test.yml
+++ b/molecule/kraft_migration_guard_test.yml
@@ -1,0 +1,44 @@
+---
+# Test for the all.yml "Validate Playbook Selection" guard (ANSIENG-5782, review #8).
+#
+# all.yml runs its guard across the managed host groups with any_errors_fatal,
+# evaluating:
+#     kraft_migration | default(false) | bool
+# This must fire (and abort the whole run) when kraft_migration is enabled at ANY
+# scope, including a *group* scope such as [kafka_broker:vars] — the customer
+# scenario the reviewer flagged. The old localhost-only guard missed that case
+# because group/host vars never apply to localhost.
+#
+# Run with:
+#   ansible-playbook -i molecule/kraft_migration_guard_inventory.yml \
+#       molecule/kraft_migration_guard_test.yml
+#
+# Expected: the play below fails fast on the group host (broker1) and the
+# "should not run" play never executes.
+
+# Mirrors the real all.yml guard: same host pattern style + any_errors_fatal.
+- name: Validate Playbook Selection (mirror of all.yml guard)
+  hosts: kafka_broker:localhost
+  gather_facts: false
+  any_errors_fatal: true
+  tasks:
+    - name: Fail if kraft_migration flag is enabled
+      fail:
+        msg: "kraft_migration flag is enabled on {{ inventory_hostname }}. Guard correctly detected the group-scoped flag and is aborting the run."
+      when: kraft_migration | default(false) | bool
+
+# If the guard works, any_errors_fatal aborts before this play whenever the flag
+# is set. Reaching this play *with the flag still set* means the guard failed to
+# block the run. Runs on the group host (which can see the group-scoped flag) and
+# only fails when kraft_migration is actually enabled, so a clean inventory passes.
+- name: Regression sentinel - must not run while kraft_migration is set
+  hosts: kafka_broker
+  gather_facts: false
+  tasks:
+    - name: Fail because the guard did not block the run
+      fail:
+        msg: >-
+          REGRESSION: the all.yml guard did not abort with a group-scoped
+          kraft_migration flag. Review the guard's host pattern and
+          any_errors_fatal in playbooks/all.yml (ANSIENG-5782, review #8).
+      when: kraft_migration | default(false) | bool

--- a/playbooks/KRaftToZKRollback.yml
+++ b/playbooks/KRaftToZKRollback.yml
@@ -3,26 +3,9 @@
 # live in rollback/rollback.yml. FINALIZED state is non-recoverable.
 # Docs: https://docs.confluent.io/platform/current/installation/migrate-zk-kraft.html#reverting-to-zk-mode
 
-# Resolve each broker's server.properties path via its own variables role and
-# expose it as a hostvar, so the localhost-run detection reads the real path.
-- name: Resolve broker config path for migration-state detection
-  hosts: kafka_broker
-  gather_facts: true
-  any_errors_fatal: true
-  tags:
-    - rollback_to_hybrid
-    - rollback_to_premigration
-  tasks:
-    - import_role:
-        name: variables
-
-    - name: Set broker_config_path fact
-      set_fact:
-        broker_config_path: "{{ kafka_broker.config_file }}"
-
 - name: Pre-Rollback Checks and Validation
   hosts: localhost
-  gather_facts: false
+  gather_facts: true  # detection resolves kafka_broker.config_file, which needs ansible_os_family
   any_errors_fatal: true
   tags:
     - rollback_to_hybrid

--- a/playbooks/KRaftToZKRollback.yml
+++ b/playbooks/KRaftToZKRollback.yml
@@ -78,7 +78,10 @@
         name: kafka_controller
         tasks_from: health_check.yml
       tags: health_check
-      when: "'rollback_to_hybrid' in ansible_run_tags"
+      when:
+        - "'rollback_to_hybrid' in ansible_run_tags"
+        - confluent_server_enabled | bool
+        - kafka_controller_health_checks_enabled | bool
 
 - name: Rollback Complete
   hosts: localhost

--- a/playbooks/KRaftToZKRollback.yml
+++ b/playbooks/KRaftToZKRollback.yml
@@ -3,6 +3,23 @@
 # live in rollback/rollback.yml. FINALIZED state is non-recoverable.
 # Docs: https://docs.confluent.io/platform/current/installation/migrate-zk-kraft.html#reverting-to-zk-mode
 
+# Resolve each broker's server.properties path via its own variables role and
+# expose it as a hostvar, so the localhost-run detection reads the real path.
+- name: Resolve broker config path for migration-state detection
+  hosts: kafka_broker
+  gather_facts: false
+  any_errors_fatal: true
+  tags:
+    - rollback_to_hybrid
+    - rollback_to_premigration
+  tasks:
+    - import_role:
+        name: variables
+
+    - name: Set broker_config_path fact
+      set_fact:
+        broker_config_path: "{{ kafka_broker.config_file }}"
+
 - name: Pre-Rollback Checks and Validation
   hosts: localhost
   gather_facts: false
@@ -100,6 +117,11 @@
           {% if 'rollback_to_premigration' in ansible_run_tags %}
           ROLLBACK TO ZOOKEEPER COMPLETED SUCCESSFULLY
           Cluster is now operating in pure ZooKeeper mode.
+
+          IMPORTANT: Remove the kafka_controller hosts and the kraft_migration
+          flag from your inventory before running all.yml again. Otherwise the
+          controllers will be redeployed as migration-mode KRaft controllers
+          against a cluster that has already rolled back to ZooKeeper.
           {% else %}
           PARTIAL ROLLBACK COMPLETED
           Brokers reverted to hybrid mode; KRaft controllers remain active.

--- a/playbooks/KRaftToZKRollback.yml
+++ b/playbooks/KRaftToZKRollback.yml
@@ -7,7 +7,7 @@
 # expose it as a hostvar, so the localhost-run detection reads the real path.
 - name: Resolve broker config path for migration-state detection
   hosts: kafka_broker
-  gather_facts: false
+  gather_facts: true
   any_errors_fatal: true
   tags:
     - rollback_to_hybrid

--- a/playbooks/KRaftToZKRollback.yml
+++ b/playbooks/KRaftToZKRollback.yml
@@ -1,0 +1,106 @@
+---
+# Revert from KRaft migration back to ZooKeeper. Tag and workflow details
+# live in rollback/rollback.yml. FINALIZED state is non-recoverable.
+# Docs: https://docs.confluent.io/platform/current/installation/migrate-zk-kraft.html#reverting-to-zk-mode
+
+- name: Pre-Rollback Checks and Validation
+  hosts: localhost
+  gather_facts: false
+  any_errors_fatal: true
+  tags:
+    - rollback_to_hybrid
+    - rollback_to_premigration
+  tasks:
+    - import_role:
+        name: variables
+
+    - name: Execute all pre-rollback checks
+      include_tasks: tasks/pre_rollback_checks.yml
+
+- name: Propagate Migration State to All Hosts
+  hosts: kafka_controller:kafka_broker:zookeeper
+  gather_facts: false
+  any_errors_fatal: true
+  tags:
+    - rollback_to_hybrid
+    - rollback_to_premigration
+  tasks:
+    - name: Set migration_state fact on all hosts
+      set_fact:
+        migration_state: "{{ hostvars['localhost']['migration_state'] }}"
+
+- import_playbook: rollback/rollback.yml
+
+- name: Post-Rollback ZooKeeper Health Check
+  hosts: zookeeper
+  gather_facts: true
+  tags:
+    - rollback_to_hybrid
+    - rollback_to_premigration
+  tasks:
+    - import_role:
+        name: variables
+
+    - name: Zookeeper Health Check
+      include_role:
+        name: zookeeper
+        tasks_from: health_check.yml
+      tags: health_check
+
+- name: Post-Rollback Broker Health Check
+  hosts: kafka_broker
+  gather_facts: true
+  tags:
+    - rollback_to_hybrid
+    - rollback_to_premigration
+  tasks:
+    - import_role:
+        name: variables
+
+    - name: Kafka Broker Health Check
+      include_role:
+        name: kafka_broker
+        tasks_from: health_check.yml
+      tags: health_check
+
+- name: Post-Rollback Controller Health Check
+  hosts: kafka_controller
+  gather_facts: true
+  tags:
+    - rollback_to_hybrid
+    - rollback_to_premigration
+  tasks:
+    - import_role:
+        name: variables
+
+    - name: Kafka Controller Health Check
+      include_role:
+        name: kafka_controller
+        tasks_from: health_check.yml
+      tags: health_check
+      when: "'rollback_to_hybrid' in ansible_run_tags"
+
+- name: Rollback Complete
+  hosts: localhost
+  connection: local
+  gather_facts: true
+  become: false
+  tags:
+    - rollback_to_hybrid
+    - rollback_to_premigration
+  vars:
+    ansible_become: false
+  tasks:
+    - name: Print rollback completion summary
+      debug:
+        msg: |
+          {% if 'rollback_to_premigration' in ansible_run_tags %}
+          ROLLBACK TO ZOOKEEPER COMPLETED SUCCESSFULLY
+          Cluster is now operating in pure ZooKeeper mode.
+          {% else %}
+          PARTIAL ROLLBACK COMPLETED
+          Brokers reverted to hybrid mode; KRaft controllers remain active.
+          Cluster state: HYBRID_DUAL_WRITE.
+          To continue rollback to pure ZooKeeper: --tags rollback_to_premigration
+          To re-migrate forward to KRaft:        --tags migrate_to_kraft
+          {% endif %}

--- a/playbooks/ZKtoKraftMigration.yml
+++ b/playbooks/ZKtoKraftMigration.yml
@@ -213,8 +213,8 @@
     - debug:
         msg: "Migration from Zookeeper to Kraft has completed, you may shut down your Zookeeper. Please remove Zookeeper section and migration flag from your inventory file."
 
-# Rollback path — only runs when one of the rollback_to_* tags is explicitly passed.
-# The `never` tag prevents this subtree from running during forward migration or
+# Rollback path: the `never` tag keeps this from running during forward
+# migration; it runs only with --tags rollback_to_hybrid or rollback_to_premigration.
 - import_playbook: KRaftToZKRollback.yml
   tags:
     - never

--- a/playbooks/ZKtoKraftMigration.yml
+++ b/playbooks/ZKtoKraftMigration.yml
@@ -212,3 +212,9 @@
   tasks:
     - debug:
         msg: "Migration from Zookeeper to Kraft has completed, you may shut down your Zookeeper. Please remove Zookeeper section and migration flag from your inventory file."
+
+# Rollback path — only runs when one of the rollback_to_* tags is explicitly passed.
+# The `never` tag prevents this subtree from running during forward migration or
+- import_playbook: KRaftToZKRollback.yml
+  tags:
+    - never

--- a/playbooks/rollback/rollback.yml
+++ b/playbooks/rollback/rollback.yml
@@ -175,7 +175,7 @@
         - name: Delete /controller znode (allows a broker to become ZK controller)
           shell: >
             echo "deleteall /controller" |
-            {{ zookeeper_cli_path }} {{ zk_endpoint }} {{ zk_tls_args }}
+            {{ zk_jaas_opts }} {{ zookeeper_cli_path }} {{ zk_endpoint }} {{ zk_tls_args }}
           register: delete_controller
           changed_when: "'Node does not exist' not in (delete_controller.stdout + delete_controller.stderr)"
           failed_when:
@@ -186,7 +186,7 @@
         - name: Verify /migration state (per official docs)
           shell: >
             echo "get /migration" |
-            {{ zookeeper_cli_path }} {{ zk_endpoint }} {{ zk_tls_args }}
+            {{ zk_jaas_opts }} {{ zookeeper_cli_path }} {{ zk_endpoint }} {{ zk_tls_args }}
           register: get_migration
           changed_when: false
           failed_when:
@@ -197,7 +197,7 @@
         - name: Delete /migration znode
           shell: >
             echo "delete /migration" |
-            {{ zookeeper_cli_path }} {{ zk_endpoint }} {{ zk_tls_args }}
+            {{ zk_jaas_opts }} {{ zookeeper_cli_path }} {{ zk_endpoint }} {{ zk_tls_args }}
           register: delete_migration
           changed_when: "'Node does not exist' not in (delete_migration.stdout + delete_migration.stderr)"
           failed_when:
@@ -211,6 +211,8 @@
         zookeeper_cli_path: "{% if installation_method == 'archive' %}{{ archive_destination_path }}/confluent-{{ confluent_package_version }}/bin/zookeeper-shell{% else %}/usr/bin/zookeeper-shell{% endif %}"
         zk_endpoint: "{{ groups['zookeeper'][0] }}:{{ zookeeper_client_port }}"
         zk_tls_args: "{% if zookeeper_ssl_enabled | bool %}-zk-tls-config-file {{ kafka_broker.zookeeper_tls_client_config_file if kafka_broker_secrets_protection_enabled | bool else kafka_broker.config_file }}{% endif %}"
+        # When ZooKeeper requires SASL auth (kerberos/digest → zookeeper.set.acl=true),
+        zk_jaas_opts: "{% if kafka_broker_final_properties['zookeeper.set.acl'] | default('false') | lower == 'true' %}KAFKA_OPTS='-Djava.security.auth.login.config={{ kafka_broker.jaas_file }}'{% endif %}"
       when: migration_state in ["HYBRID_DUAL_WRITE", "PURE_DUAL_WRITE"]
 
 - name: Clean broker metadata logs

--- a/playbooks/rollback/rollback.yml
+++ b/playbooks/rollback/rollback.yml
@@ -346,7 +346,6 @@
             - node.id
             - controller.listener.names
             - controller.quorum.voters
-            - controller.quorum.bootstrap.servers
             - zookeeper.metadata.migration.enable
             - confluent.cluster.link.metadata.topic.enable
 

--- a/playbooks/rollback/rollback.yml
+++ b/playbooks/rollback/rollback.yml
@@ -280,16 +280,13 @@
             - controller.quorum.voters
             - controller.quorum.bootstrap.servers
             - zookeeper.metadata.migration.enable
-            - inter.broker.protocol.version
             - confluent.cluster.link.metadata.topic.enable
 
-        - name: Ensure zookeeper.connect is present
-          lineinfile:
-            path: "{{ kafka_broker.config_file }}"
-            line: "zookeeper.connect={{ zookeeper_connect_string }}"
-            regexp: "^zookeeper.connect=.*"
-          vars:
-            zookeeper_connect_string: "{% for host in groups['zookeeper'] %}{{ host }}:{{ zookeeper_client_port }}{% if not loop.last %},{% endif %}{% endfor %}/{{ kafka_broker_default_final_properties['zookeeper.chroot'] | default('') }}"
+        # zookeeper.connect is rendered correctly by regenerate_config.yml above
+        # (variables role, vars/main.yml) using the confluent.platform.resolve_hostnames
+        # filter and the zookeeper_chroot variable. We deliberately do NOT rewrite it
+        # here: a hand-built string skipped the filter, mishandled the chroot, and
+        # could overwrite a correct value with an inconsistent one.
 
         - name: Restore ZK_ACL for RBAC (if RBAC enabled)
           lineinfile:

--- a/playbooks/rollback/rollback.yml
+++ b/playbooks/rollback/rollback.yml
@@ -57,6 +57,21 @@
           set_fact:
             broker_id: "{{ broker_id_extracted.stdout }}"
 
+        # RBAC: the bare template renders super.users as only "User:<mds>". The
+        # broker/controller cert principals (rbac_super_users) are normally
+        # injected by roles/kafka_broker/tasks/rbac.yml during deploy, which
+        # regenerate_config.yml does NOT run. Without them the broker's mTLS
+        # principal is not a super user, and on restart MDS is denied access to
+        # _confluent-metadata-auth (TopicAuthorizationException) and never starts.
+        # Rebuild super.users here so the regenerated config keeps it (matches
+        # how CFK regenerates the full kafka config on rollback).
+        - name: Rebuild RBAC super.users before regenerating config
+          set_fact:
+            kafka_broker_final_properties: "{{ kafka_broker_final_properties | combine({'super.users': (rbac_super_users + (kafka_broker_final_properties['super.users'] | default('')).split(';') + ['User:' + (mds_super_user | default('mds'))]) | difference(['']) | unique | join(';')}) }}"
+          when:
+            - rbac_enabled | bool
+            - rbac_super_users | length > 0
+
         - name: Regenerate server.properties (variables role renders hybrid mode)
           include_role:
             name: kafka_broker
@@ -260,6 +275,19 @@
         - name: Set broker_id fact for template
           set_fact:
             broker_id: "{{ broker_id_extracted.stdout }}"
+
+        # RBAC: regenerate_config.yml renders super.users as only "User:<mds>",
+        # dropping the cert principals that roles/kafka_broker/tasks/rbac.yml
+        # injects during deploy. Without them the broker's mTLS principal is not
+        # a super user and MDS is denied access to _confluent-metadata-auth on
+        # restart. Rebuild super.users before regenerating (see the hybrid-revert
+        # play above for the full explanation).
+        - name: Rebuild RBAC super.users before regenerating config
+          set_fact:
+            kafka_broker_final_properties: "{{ kafka_broker_final_properties | combine({'super.users': (rbac_super_users + (kafka_broker_final_properties['super.users'] | default('')).split(';') + ['User:' + (mds_super_user | default('mds'))]) | difference(['']) | unique | join(';')}) }}"
+          when:
+            - rbac_enabled | bool
+            - rbac_super_users | length > 0
 
         - name: Regenerate server.properties (picks up any operator inventory edits)
           include_role:

--- a/playbooks/rollback/rollback.yml
+++ b/playbooks/rollback/rollback.yml
@@ -36,11 +36,19 @@
     - import_role:
         name: variables
 
+    # Revert only brokers still on KRaft; skip any already on hybrid (an
+    # interrupted rollback can leave a mix) so they are not restarted needlessly.
+    - name: Check whether this broker is still on KRaft
+      shell: grep -q "^process.roles" "{{ kafka_broker.config_file }}"
+      register: this_broker_on_kraft
+      failed_when: false
+      changed_when: false
+
     - block:
         - name: Backup current broker configuration
           copy:
             src: "{{ kafka_broker.config_file }}"
-            dest: "{{ kafka_broker.config_file }}.before_hybrid_revert"
+            dest: "{{ kafka_broker.config_file }}.before_hybrid_revert.{{ ansible_date_time.iso8601_basic_short }}"
             remote_src: true
 
         - name: Extract broker ID (from node.id if present, otherwise broker.id)
@@ -107,7 +115,16 @@
 
         - debug:
             msg: "Broker {{ inventory_hostname }} reverted to hybrid mode"
-      when: migration_state == "PURE_DUAL_WRITE"
+      when:
+        - migration_state == "PURE_DUAL_WRITE"
+        - this_broker_on_kraft.rc == 0
+
+    - name: Note brokers already in hybrid mode (revert skipped)
+      debug:
+        msg: "Broker {{ inventory_hostname }} is already in hybrid mode; revert skipped"
+      when:
+        - migration_state == "PURE_DUAL_WRITE"
+        - this_broker_on_kraft.rc != 0
 
 - name: Deprovision KRaft controllers
   hosts: kafka_controller
@@ -123,7 +140,7 @@
         - name: Backup controller configuration
           copy:
             src: "{{ kafka_controller.config_file }}"
-            dest: "{{ kafka_controller.config_file }}.before_controller_stop"
+            dest: "{{ kafka_controller.config_file }}.before_controller_stop.{{ ansible_date_time.iso8601_basic_short }}"
             remote_src: true
           failed_when: false
 
@@ -152,7 +169,11 @@
           when: controller_metadata_dirs.files | length > 0
 
         - debug:
-            msg: "Controller {{ inventory_hostname }} stopped, disabled, metadata cleaned"
+            msg: >-
+              Controller {{ inventory_hostname }} stopped, disabled, metadata cleaned.
+              IMPORTANT: remove this controller host from the inventory before
+              re-running all.yml, otherwise it will be redeployed as a
+              migration-mode KRaft controller against a rolled-back cluster.
       when: migration_state in ["PREMIGRATION", "HYBRID_DUAL_WRITE", "PURE_DUAL_WRITE"]
 
 - name: Clean ZooKeeper migration state
@@ -170,8 +191,9 @@
         # (zookeeper_ssl_enabled, e.g. RBAC/mTLS clusters use port 2182). The
         # TLS client config lives on the broker (kafka_broker config), so these
         # run delegated to a broker and connect to the ZK node — mirroring
-        # roles/common/tasks/rbac_setup.yml. failed_when is tightened so a real
-        # connection error fails instead of being silently swallowed.
+        # roles/common/tasks/rbac_setup.yml. failed_when fails only on a real
+        # error: a non-zero rc that is not the benign "Node does not exist"
+        # (expected when the znode is already gone on a re-run).
         - name: Delete /controller znode (allows a broker to become ZK controller)
           shell: >
             echo "deleteall /controller" |
@@ -261,7 +283,7 @@
         - name: Backup broker configuration before final changes
           copy:
             src: "{{ kafka_broker.config_file }}"
-            dest: "{{ kafka_broker.config_file }}.before_pure_zk_revert"
+            dest: "{{ kafka_broker.config_file }}.before_pure_zk_revert.{{ ansible_date_time.iso8601_basic_short }}"
             remote_src: true
 
         - name: Extract broker ID

--- a/playbooks/rollback/rollback.yml
+++ b/playbooks/rollback/rollback.yml
@@ -1,0 +1,316 @@
+---
+# Unified KRaft → ZooKeeper rollback playbook
+#
+# Five plays, each gated by detected migration_state so that any play that
+# doesn't apply to the current state no-ops cleanly. Two CLI tags control
+# how far the rollback goes:
+#
+#   --tags rollback_to_hybrid
+#     Only meaningful from PURE_DUAL_WRITE. Reverts brokers from KRaft back
+#     to hybrid mode. KRaft controller stays active.
+#
+#   --tags rollback_to_premigration
+#     Full unwind to pure ZooKeeper. From PURE_DUAL_WRITE this runs all five
+#     plays; from HYBRID_DUAL_WRITE it skips the first; from PREMIGRATION
+#     only the controller-deprovision play runs.
+#
+# When state is PURE_DUAL_WRITE the operator MUST pass one of the two tags
+# explicitly (enforced by pre_rollback_checks.yml).
+#
+# Non-RBAC ACL clusters (using authorizer.class.name instead of RBAC providers)
+# need a two-run workflow:
+#   1. --tags rollback_to_hybrid  → moves cluster to HYBRID_DUAL_WRITE
+#   2. Edit inventory to restore the ZK authorizer class
+#   3. --tags rollback_to_premigration  → final broker restart picks up
+#                                          the inventory edit via template regen
+
+- name: Revert brokers to hybrid mode (template regen)
+  hosts: kafka_broker
+  gather_facts: true
+  serial: '1'
+  any_errors_fatal: true
+  tags:
+    - rollback_to_hybrid
+    - rollback_to_premigration
+  tasks:
+    - import_role:
+        name: variables
+
+    - block:
+        - name: Backup current broker configuration
+          copy:
+            src: "{{ kafka_broker.config_file }}"
+            dest: "{{ kafka_broker.config_file }}.before_hybrid_revert"
+            remote_src: true
+
+        - name: Extract broker ID (from node.id if present, otherwise broker.id)
+          shell: |
+            if grep -q "^node.id" "{{ kafka_broker.config_file }}"; then
+              grep "^node.id" "{{ kafka_broker.config_file }}" | cut -d'=' -f2 | tr -d ' '
+            else
+              grep "^broker.id" "{{ kafka_broker.config_file }}" | cut -d'=' -f2 | tr -d ' '
+            fi
+          register: broker_id_extracted
+          changed_when: false
+
+        - name: Set broker_id fact for template
+          set_fact:
+            broker_id: "{{ broker_id_extracted.stdout }}"
+
+        - name: Regenerate server.properties (variables role renders hybrid mode)
+          include_role:
+            name: kafka_broker
+            tasks_from: regenerate_config.yml
+
+        - name: Create Kafka Broker Config with Secrets Protection
+          include_role:
+            name: common
+            tasks_from: secrets_protection.yml
+          vars:
+            final_properties: "{{ kafka_broker_final_properties }}"
+            encrypt_passwords: "{{ kafka_broker_secrets_protection_encrypt_passwords }}"
+            encrypt_properties: "{{ kafka_broker_secrets_protection_encrypt_properties }}"
+            config_path: "{{ kafka_broker.config_file }}"
+            secrets_file: "{{ kafka_broker_secrets_protection_file }}"
+            secrets_file_owner: "{{ kafka_broker_user }}"
+            secrets_file_group: "{{ kafka_broker_group }}"
+            ca_cert_path: "{{ kafka_broker_ca_cert_path if ssl_enabled|bool else '' }}"
+            handler: "no-op"
+          when:
+            - kafka_broker_secrets_protection_enabled|bool
+            - rbac_enabled|bool or confluent_cli_version is version('3.0.0', '>=')
+
+        - name: Restart broker and wait
+          include_role:
+            name: kafka_broker
+            tasks_from: restart_and_wait.yml
+
+        - name: Run broker health check
+          include_role:
+            name: kafka_broker
+            tasks_from: health_check.yml
+
+        - debug:
+            msg: "Broker {{ inventory_hostname }} reverted to hybrid mode"
+      when: migration_state == "PURE_DUAL_WRITE"
+
+- name: Deprovision KRaft controllers
+  hosts: kafka_controller
+  gather_facts: true
+  any_errors_fatal: true
+  tags:
+    - rollback_to_premigration
+  tasks:
+    - import_role:
+        name: variables
+
+    - block:
+        - name: Backup controller configuration
+          copy:
+            src: "{{ kafka_controller.config_file }}"
+            dest: "{{ kafka_controller.config_file }}.before_controller_stop"
+            remote_src: true
+          failed_when: false
+
+        - name: Stop Kafka Controller service
+          systemd:
+            name: "{{ kafka_controller_service_name }}"
+            state: stopped
+
+        - name: Disable Kafka Controller service
+          systemd:
+            name: "{{ kafka_controller_service_name }}"
+            enabled: false
+
+        - name: Find __cluster_metadata directories on controller
+          find:
+            paths: "{{ kafka_controller_final_properties['log.dirs'] }}"
+            patterns: "__cluster_metadata*"
+            file_type: directory
+          register: controller_metadata_dirs
+
+        - name: Delete __cluster_metadata directories from controller
+          file:
+            path: "{{ item.path }}"
+            state: absent
+          loop: "{{ controller_metadata_dirs.files }}"
+          when: controller_metadata_dirs.files | length > 0
+
+        - debug:
+            msg: "Controller {{ inventory_hostname }} stopped, disabled, metadata cleaned"
+      when: migration_state in ["PREMIGRATION", "HYBRID_DUAL_WRITE", "PURE_DUAL_WRITE"]
+
+- name: Clean ZooKeeper migration state
+  hosts: zookeeper[0]
+  gather_facts: true
+  any_errors_fatal: true
+  tags:
+    - rollback_to_premigration
+  tasks:
+    - import_role:
+        name: variables
+
+    - block:
+        - name: Delete /controller znode (allows a broker to become ZK controller)
+          shell: |
+            echo "deleteall /controller" | {{ zookeeper_cli_path }} localhost:{{ zookeeper_client_port }}
+          register: delete_controller
+          failed_when: false
+          changed_when: "'Node does not exist' not in delete_controller.stderr"
+          vars:
+            zookeeper_cli_path: "{% if installation_method == 'archive' %}{{ archive_destination_path }}/confluent-{{ confluent_package_version }}/bin/zookeeper-shell{% else %}/usr/bin/zookeeper-shell{% endif %}"
+
+        - name: Verify /migration state (per official docs)
+          shell: |
+            echo "get /migration" | {{ zookeeper_cli_path }} localhost:{{ zookeeper_client_port }}
+          register: get_migration
+          failed_when: false
+          changed_when: false
+          vars:
+            zookeeper_cli_path: "{% if installation_method == 'archive' %}{{ archive_destination_path }}/confluent-{{ confluent_package_version }}/bin/zookeeper-shell{% else %}/usr/bin/zookeeper-shell{% endif %}"
+
+        - name: Delete /migration znode
+          shell: |
+            echo "delete /migration" | {{ zookeeper_cli_path }} localhost:{{ zookeeper_client_port }}
+          register: delete_migration
+          failed_when: false
+          changed_when: "'Node does not exist' not in delete_migration.stderr"
+          vars:
+            zookeeper_cli_path: "{% if installation_method == 'archive' %}{{ archive_destination_path }}/confluent-{{ confluent_package_version }}/bin/zookeeper-shell{% else %}/usr/bin/zookeeper-shell{% endif %}"
+
+        - debug:
+            msg: "ZooKeeper migration state cleaned"
+      when: migration_state in ["HYBRID_DUAL_WRITE", "PURE_DUAL_WRITE"]
+
+- name: Clean broker metadata logs
+  hosts: kafka_broker
+  gather_facts: true
+  any_errors_fatal: true
+  tags:
+    - rollback_to_premigration
+  tasks:
+    - import_role:
+        name: variables
+
+    - block:
+        - name: Find __cluster_metadata directories on broker
+          find:
+            paths: "{{ kafka_broker_final_properties['log.dirs'].split(',') }}"
+            patterns: "__cluster_metadata*"
+            file_type: directory
+          register: broker_metadata_dirs
+
+        - name: Delete __cluster_metadata directories on broker
+          file:
+            path: "{{ item.path }}"
+            state: absent
+          loop: "{{ broker_metadata_dirs.files }}"
+          when: broker_metadata_dirs.files | length > 0
+
+        - debug:
+            msg: "Metadata logs cleaned on {{ inventory_hostname }}"
+      when: migration_state in ["HYBRID_DUAL_WRITE", "PURE_DUAL_WRITE"]
+
+# Template regen runs before lineinfile so any inventory edits the operator
+# made between rollback_to_hybrid and rollback_to_premigration are picked up.
+- name: Final broker rolling restart to pure ZK
+  hosts: kafka_broker
+  gather_facts: true
+  serial: '1'
+  any_errors_fatal: true
+  tags:
+    - rollback_to_premigration
+  tasks:
+    - import_role:
+        name: variables
+
+    - block:
+        - name: Backup broker configuration before final changes
+          copy:
+            src: "{{ kafka_broker.config_file }}"
+            dest: "{{ kafka_broker.config_file }}.before_pure_zk_revert"
+            remote_src: true
+
+        - name: Extract broker ID
+          shell: |
+            if grep -q "^node.id" "{{ kafka_broker.config_file }}"; then
+              grep "^node.id" "{{ kafka_broker.config_file }}" | cut -d'=' -f2 | tr -d ' '
+            else
+              grep "^broker.id" "{{ kafka_broker.config_file }}" | cut -d'=' -f2 | tr -d ' '
+            fi
+          register: broker_id_extracted
+          changed_when: false
+
+        - name: Set broker_id fact for template
+          set_fact:
+            broker_id: "{{ broker_id_extracted.stdout }}"
+
+        - name: Regenerate server.properties (picks up any operator inventory edits)
+          include_role:
+            name: kafka_broker
+            tasks_from: regenerate_config.yml
+
+        - name: Create Kafka Broker Config with Secrets Protection
+          include_role:
+            name: common
+            tasks_from: secrets_protection.yml
+          vars:
+            final_properties: "{{ kafka_broker_final_properties }}"
+            encrypt_passwords: "{{ kafka_broker_secrets_protection_encrypt_passwords }}"
+            encrypt_properties: "{{ kafka_broker_secrets_protection_encrypt_properties }}"
+            config_path: "{{ kafka_broker.config_file }}"
+            secrets_file: "{{ kafka_broker_secrets_protection_file }}"
+            secrets_file_owner: "{{ kafka_broker_user }}"
+            secrets_file_group: "{{ kafka_broker_group }}"
+            ca_cert_path: "{{ kafka_broker_ca_cert_path if ssl_enabled|bool else '' }}"
+            handler: "no-op"
+          when:
+            - kafka_broker_secrets_protection_enabled|bool
+            - rbac_enabled|bool or confluent_cli_version is version('3.0.0', '>=')
+
+        - name: Remove ALL KRaft and migration properties
+          lineinfile:
+            path: "{{ kafka_broker.config_file }}"
+            state: absent
+            regexp: "^{{ item }}.*"
+          loop:
+            - process.roles
+            - node.id
+            - controller.listener.names
+            - controller.quorum.voters
+            - controller.quorum.bootstrap.servers
+            - zookeeper.metadata.migration.enable
+            - inter.broker.protocol.version
+            - confluent.cluster.link.metadata.topic.enable
+
+        - name: Ensure zookeeper.connect is present
+          lineinfile:
+            path: "{{ kafka_broker.config_file }}"
+            line: "zookeeper.connect={{ zookeeper_connect_string }}"
+            regexp: "^zookeeper.connect=.*"
+          vars:
+            zookeeper_connect_string: "{% for host in groups['zookeeper'] %}{{ host }}:{{ zookeeper_client_port }}{% if not loop.last %},{% endif %}{% endfor %}/{{ kafka_broker_default_final_properties['zookeeper.chroot'] | default('') }}"
+
+        - name: Restore ZK_ACL for RBAC (if RBAC enabled)
+          lineinfile:
+            path: "{{ kafka_broker.config_file }}"
+            regexp: "^confluent.authorizer.access.rule.providers=.*"
+            line: "confluent.authorizer.access.rule.providers=CONFLUENT,ZK_ACL"
+          when: rbac_enabled | bool
+          # For non-RBAC ACL clusters using authorizer.class.name, restore it
+          # in inventory between --tags rollback_to_hybrid and --tags rollback_to_premigration
+          # runs. The template regeneration above picks up the inventory change.
+
+        - name: Restart broker and wait
+          include_role:
+            name: kafka_broker
+            tasks_from: restart_and_wait.yml
+
+        - name: Run broker health check
+          include_role:
+            name: kafka_broker
+            tasks_from: health_check.yml
+
+        - debug:
+            msg: "Broker {{ inventory_hostname }} rolled back to pure ZooKeeper"
+      when: migration_state in ["HYBRID_DUAL_WRITE", "PURE_DUAL_WRITE"]

--- a/playbooks/rollback/rollback.yml
+++ b/playbooks/rollback/rollback.yml
@@ -151,35 +151,51 @@
         name: variables
 
     - block:
+        # zookeeper-shell needs TLS client config when ZooKeeper runs with TLS
+        # (zookeeper_ssl_enabled, e.g. RBAC/mTLS clusters use port 2182). The
+        # TLS client config lives on the broker (kafka_broker config), so these
+        # run delegated to a broker and connect to the ZK node — mirroring
+        # roles/common/tasks/rbac_setup.yml. failed_when is tightened so a real
+        # connection error fails instead of being silently swallowed.
         - name: Delete /controller znode (allows a broker to become ZK controller)
-          shell: |
-            echo "deleteall /controller" | {{ zookeeper_cli_path }} localhost:{{ zookeeper_client_port }}
+          shell: >
+            echo "deleteall /controller" |
+            {{ zookeeper_cli_path }} {{ zk_endpoint }} {{ zk_tls_args }}
           register: delete_controller
-          failed_when: false
-          changed_when: "'Node does not exist' not in delete_controller.stderr"
-          vars:
-            zookeeper_cli_path: "{% if installation_method == 'archive' %}{{ archive_destination_path }}/confluent-{{ confluent_package_version }}/bin/zookeeper-shell{% else %}/usr/bin/zookeeper-shell{% endif %}"
+          changed_when: "'Node does not exist' not in (delete_controller.stdout + delete_controller.stderr)"
+          failed_when:
+            - delete_controller.rc != 0
+            - "'Node does not exist' not in (delete_controller.stdout + delete_controller.stderr)"
+          delegate_to: "{{ groups['kafka_broker'][0] }}"
 
         - name: Verify /migration state (per official docs)
-          shell: |
-            echo "get /migration" | {{ zookeeper_cli_path }} localhost:{{ zookeeper_client_port }}
+          shell: >
+            echo "get /migration" |
+            {{ zookeeper_cli_path }} {{ zk_endpoint }} {{ zk_tls_args }}
           register: get_migration
-          failed_when: false
           changed_when: false
-          vars:
-            zookeeper_cli_path: "{% if installation_method == 'archive' %}{{ archive_destination_path }}/confluent-{{ confluent_package_version }}/bin/zookeeper-shell{% else %}/usr/bin/zookeeper-shell{% endif %}"
+          failed_when:
+            - get_migration.rc != 0
+            - "'Node does not exist' not in (get_migration.stdout + get_migration.stderr)"
+          delegate_to: "{{ groups['kafka_broker'][0] }}"
 
         - name: Delete /migration znode
-          shell: |
-            echo "delete /migration" | {{ zookeeper_cli_path }} localhost:{{ zookeeper_client_port }}
+          shell: >
+            echo "delete /migration" |
+            {{ zookeeper_cli_path }} {{ zk_endpoint }} {{ zk_tls_args }}
           register: delete_migration
-          failed_when: false
-          changed_when: "'Node does not exist' not in delete_migration.stderr"
-          vars:
-            zookeeper_cli_path: "{% if installation_method == 'archive' %}{{ archive_destination_path }}/confluent-{{ confluent_package_version }}/bin/zookeeper-shell{% else %}/usr/bin/zookeeper-shell{% endif %}"
+          changed_when: "'Node does not exist' not in (delete_migration.stdout + delete_migration.stderr)"
+          failed_when:
+            - delete_migration.rc != 0
+            - "'Node does not exist' not in (delete_migration.stdout + delete_migration.stderr)"
+          delegate_to: "{{ groups['kafka_broker'][0] }}"
 
         - debug:
             msg: "ZooKeeper migration state cleaned"
+      vars:
+        zookeeper_cli_path: "{% if installation_method == 'archive' %}{{ archive_destination_path }}/confluent-{{ confluent_package_version }}/bin/zookeeper-shell{% else %}/usr/bin/zookeeper-shell{% endif %}"
+        zk_endpoint: "{{ groups['zookeeper'][0] }}:{{ zookeeper_client_port }}"
+        zk_tls_args: "{% if zookeeper_ssl_enabled | bool %}-zk-tls-config-file {{ kafka_broker.zookeeper_tls_client_config_file if kafka_broker_secrets_protection_enabled | bool else kafka_broker.config_file }}{% endif %}"
       when: migration_state in ["HYBRID_DUAL_WRITE", "PURE_DUAL_WRITE"]
 
 - name: Clean broker metadata logs

--- a/playbooks/tasks/detect_migration_phase.yml
+++ b/playbooks/tasks/detect_migration_phase.yml
@@ -1,0 +1,136 @@
+---
+# Sets migration_state to PREMIGRATION | HYBRID_DUAL_WRITE | PURE_DUAL_WRITE | FINALIZED
+# using JMX (ZkMigrationState MBean) with broker-config fallback. Hard-fails on
+# UNKNOWN or FINALIZED.
+#
+# JMX enum: 0=None, 1=Migration, 2=PreMigration, 3=PostMigration
+# Terminal states (FINALIZED, PREMIGRATION) require JMX; dual-write states
+# accept config signals as backup.
+
+- name: Initialize migration state detection variables
+  set_fact:
+    migration_state: "UNKNOWN"
+    zk_migration_state: -1
+
+- name: Gather facts on controller
+  setup:
+    gather_subset: ['!all', '!min', 'os_family']
+  delegate_to: "{{ groups['kafka_controller'][0] }}"
+  delegate_facts: true
+  when: groups['kafka_controller'] | length > 0
+
+- name: Gather facts on broker
+  setup:
+    gather_subset: ['!all', '!min', 'os_family']
+  delegate_to: "{{ groups['kafka_broker'][0] }}"
+  delegate_facts: true
+  when: groups['kafka_broker'] | length > 0
+
+- name: Check if controllers are running
+  shell: systemctl is-active {{ kafka_controller_service_name }}
+  register: controller_status
+  delegate_to: "{{ groups['kafka_controller'][0] }}"
+  failed_when: false
+  changed_when: false
+  when: (groups['kafka_controller'] | length > 0)
+
+- name: Query Jolokia for ZkMigrationState
+  uri:
+    url: "{{ 'https' if kafka_controller_jolokia_ssl_enabled|bool else 'http' }}://localhost:{{ kafka_controller_jolokia_port }}/jolokia/read/kafka.controller:type=KafkaController,name=ZkMigrationState"
+    validate_certs: false
+    return_content: true
+    status_code: 200
+    timeout: 10
+    force_basic_auth: "{{ use_basic_auth }}"
+    url_username: "{{ jolokia_user if use_basic_auth else omit }}"
+    url_password: "{{ jolokia_password if use_basic_auth else omit }}"
+  register: jolokia_response
+  delegate_to: "{{ groups['kafka_controller'][0] }}"
+  failed_when: false
+  changed_when: false
+  when:
+    - groups['kafka_controller'] | length > 0
+    - controller_status.rc | default(1) == 0
+  vars:
+    use_basic_auth: "{{ jolokia_auth_mode == 'basic' }}"
+
+- name: Parse Jolokia response
+  set_fact:
+    zk_migration_state: "{{ (jolokia_response.content | from_json).value.Value }}"
+  when:
+    - jolokia_response.status | default(0) == 200
+
+- name: Compute broker server.properties path
+  set_fact:
+    broker_config_path: "{% if hostvars[broker_host].installation_method | default(installation_method) == 'archive' %}{{ hostvars[broker_host].archive_destination_path | default(archive_destination_path) }}/confluent-{{ hostvars[broker_host].confluent_package_version | default(confluent_package_version) }}/etc/kafka/server.properties{% else %}/etc/kafka/server.properties{% endif %}"
+  vars:
+    broker_host: "{{ groups['kafka_broker'][0] }}"
+  when: groups['kafka_broker'] | length > 0
+
+- name: Check broker config for process.roles
+  shell: grep "^process.roles" "{{ broker_config_path }}" | cut -d'=' -f2 | tr -d ' '
+  register: broker_process_roles
+  delegate_to: "{{ groups['kafka_broker'][0] }}"
+  failed_when: false
+  changed_when: false
+
+- name: Check broker config for migration flag
+  shell: grep -q "^zookeeper.metadata.migration.enable=true" "{{ broker_config_path }}"
+  register: broker_migration_flag
+  delegate_to: "{{ groups['kafka_broker'][0] }}"
+  failed_when: false
+  changed_when: false
+
+- name: Determine migration phase from collected signals
+  set_fact:
+    migration_state: >-
+      {%- set zks = zk_migration_state | int -%}
+      {#- Terminal states require JMX to confirm; dual-write states accept config signals as backup -#}
+      {%- if zks == 3 -%}
+      FINALIZED
+      {%- elif broker_process_roles.stdout | default('') == 'broker' -%}
+      PURE_DUAL_WRITE
+      {%- elif zks == 1 or broker_migration_flag.rc | default(1) == 0 -%}
+      HYBRID_DUAL_WRITE
+      {%- elif zks in [0, 2] -%}
+      PREMIGRATION
+      {%- else -%}
+      UNKNOWN
+      {%- endif -%}
+
+- name: Fail if phase could not be determined
+  fail:
+    msg: "ERROR: Could not determine migration phase."
+  when: migration_state == "UNKNOWN"
+
+- name: Display detected migration state
+  debug:
+    msg: |
+      MIGRATION STATE: {{ migration_state }}
+
+      {% if migration_state == "PREMIGRATION" %}
+      PREMIGRATION State:
+        - KRaft controllers are running but migration not started
+        - Brokers still fully on ZooKeeper
+        - Rollback: Simple controller shutdown
+      {% elif migration_state == "HYBRID_DUAL_WRITE" %}
+      HYBRID_DUAL_WRITE State:
+        - KRaft controller is active, writing to both ZK and KRaft
+        - Some brokers still in ZooKeeper mode
+        - Rollback: Standard 4-step rollback procedure
+      {% elif migration_state == "PURE_DUAL_WRITE" %}
+      PURE_DUAL_WRITE State:
+        - All brokers migrated to KRaft mode
+        - Controllers still writing to both ZK and KRaft (dual-write)
+        - Rollback: Multi-restart rollback procedure
+      {% elif migration_state == "FINALIZED" %}
+      FINALIZED State:
+        - Migration complete, metadata only in KRaft
+        - Rollback NOT POSSIBLE
+      {% endif %}
+
+- name: Fail if rollback not possible
+  fail:
+    msg: |
+      ERROR: Rollback is NOT possible - migration already finalized (FINALIZED state).
+  when: migration_state == "FINALIZED"

--- a/playbooks/tasks/detect_migration_phase.yml
+++ b/playbooks/tasks/detect_migration_phase.yml
@@ -9,20 +9,6 @@
     migration_state: "UNKNOWN"
     zk_migration_state: -1
 
-- name: Gather facts on controller
-  setup:
-    gather_subset: ['!all', '!min', 'os_family']
-  delegate_to: "{{ groups['kafka_controller'][0] }}"
-  delegate_facts: true
-  when: groups['kafka_controller'] | length > 0
-
-- name: Gather facts on broker
-  setup:
-    gather_subset: ['!all', '!min', 'os_family']
-  delegate_to: "{{ groups['kafka_broker'][0] }}"
-  delegate_facts: true
-  when: groups['kafka_broker'] | length > 0
-
 - name: Check if controllers are running
   shell: systemctl is-active {{ kafka_controller_service_name }}
   register: controller_status
@@ -58,8 +44,10 @@
     - jolokia_response.status | default(0) == 200
 
 # Any broker still on KRaft => PURE_DUAL_WRITE (JMX can't tell PURE from HYBRID).
+# The calling play gathers facts so kafka_broker.config_file (its dict references
+# ansible_os_family) resolves here.
 - name: Check process.roles on every broker
-  shell: grep -q "^process.roles" "{{ hostvars[item].broker_config_path | default(kafka_broker.config_file) }}"
+  shell: grep -q "^process.roles" "{{ kafka_broker.config_file }}"
   register: broker_process_roles_all
   delegate_to: "{{ item }}"
   loop: "{{ groups['kafka_broker'] | default([]) }}"

--- a/playbooks/tasks/detect_migration_phase.yml
+++ b/playbooks/tasks/detect_migration_phase.yml
@@ -1,11 +1,8 @@
 ---
-# Sets migration_state to PREMIGRATION | HYBRID_DUAL_WRITE | PURE_DUAL_WRITE | FINALIZED
-# using JMX (ZkMigrationState MBean) with broker-config fallback. Hard-fails on
-# UNKNOWN or FINALIZED.
-#
-# JMX enum: 0=None, 1=Migration, 2=PreMigration, 3=PostMigration
-# Terminal states (FINALIZED, PREMIGRATION) require JMX; dual-write states
-# accept config signals as backup.
+# Sets migration_state: PREMIGRATION | HYBRID_DUAL_WRITE | PURE_DUAL_WRITE | FINALIZED.
+# FINALIZED/HYBRID/PREMIGRATION come from the controller's JMX ZkMigrationState
+# (0=None, 1=Migration, 2=PreMigration, 3=PostMigration); PURE is read from broker
+# process.roles, since JMX can't tell PURE from HYBRID. Hard-fails on UNKNOWN/FINALIZED.
 
 - name: Initialize migration state detection variables
   set_fact:
@@ -60,37 +57,29 @@
   when:
     - jolokia_response.status | default(0) == 200
 
-- name: Compute broker server.properties path
+# Any broker still on KRaft => PURE_DUAL_WRITE (JMX can't tell PURE from HYBRID).
+- name: Check process.roles on every broker
+  shell: grep -q "^process.roles" "{{ hostvars[item].broker_config_path | default(kafka_broker.config_file) }}"
+  register: broker_process_roles_all
+  delegate_to: "{{ item }}"
+  loop: "{{ groups['kafka_broker'] | default([]) }}"
+  failed_when: false
+  changed_when: false
+
+- name: Aggregate broker signal (any broker on KRaft => PURE)
   set_fact:
-    broker_config_path: "{% if hostvars[broker_host].installation_method | default(installation_method) == 'archive' %}{{ hostvars[broker_host].archive_destination_path | default(archive_destination_path) }}/confluent-{{ hostvars[broker_host].confluent_package_version | default(confluent_package_version) }}/etc/kafka/server.properties{% else %}/etc/kafka/server.properties{% endif %}"
-  vars:
-    broker_host: "{{ groups['kafka_broker'][0] }}"
-  when: groups['kafka_broker'] | length > 0
-
-- name: Check broker config for process.roles
-  shell: grep "^process.roles" "{{ broker_config_path }}" | cut -d'=' -f2 | tr -d ' '
-  register: broker_process_roles
-  delegate_to: "{{ groups['kafka_broker'][0] }}"
-  failed_when: false
-  changed_when: false
-
-- name: Check broker config for migration flag
-  shell: grep -q "^zookeeper.metadata.migration.enable=true" "{{ broker_config_path }}"
-  register: broker_migration_flag
-  delegate_to: "{{ groups['kafka_broker'][0] }}"
-  failed_when: false
-  changed_when: false
+    any_broker_on_kraft: "{{ broker_process_roles_all.results | default([]) | selectattr('rc', 'defined') | selectattr('rc', 'equalto', 0) | list | length > 0 }}"
 
 - name: Determine migration phase from collected signals
   set_fact:
     migration_state: >-
       {%- set zks = zk_migration_state | int -%}
-      {#- Terminal states require JMX to confirm; dual-write states accept config signals as backup -#}
+      {#- process.roles distinguishes PURE from HYBRID (JMX can't); FINALIZED/HYBRID/PREMIGRATION come from JMX. -#}
       {%- if zks == 3 -%}
       FINALIZED
-      {%- elif broker_process_roles.stdout | default('') == 'broker' -%}
+      {%- elif any_broker_on_kraft | bool -%}
       PURE_DUAL_WRITE
-      {%- elif zks == 1 or broker_migration_flag.rc | default(1) == 0 -%}
+      {%- elif zks == 1 -%}
       HYBRID_DUAL_WRITE
       {%- elif zks in [0, 2] -%}
       PREMIGRATION

--- a/playbooks/tasks/pre_rollback_checks.yml
+++ b/playbooks/tasks/pre_rollback_checks.yml
@@ -41,9 +41,9 @@
       ERROR: PURE_DUAL_WRITE state requires explicit tag selection.
 
       Options:
-        --tags rollback_to_hybrid          → revert brokers to hybrid mode
+        --tags rollback_to_hybrid          -> revert brokers to hybrid mode
                                               (KRaft controller stays active)
-        --tags rollback_to_premigration   → full rollback to pure ZooKeeper
+        --tags rollback_to_premigration   -> full rollback to pure ZooKeeper
 
       Re-run with one of the tags above.
   when:
@@ -64,4 +64,4 @@
     - "'rollback_to_premigration' not in ansible_run_tags"
 
 - debug:
-    msg: "✓ Pre-rollback checks passed. Ready to execute {{ migration_state }} rollback."
+    msg: "Pre-rollback checks passed. Ready to execute {{ migration_state }} rollback."

--- a/playbooks/tasks/pre_rollback_checks.yml
+++ b/playbooks/tasks/pre_rollback_checks.yml
@@ -1,0 +1,67 @@
+---
+- name: Verify kraft_migration flag is enabled
+  fail:
+    msg: "ERROR: kraft_migration flag is not enabled in inventory. Cannot perform rollback."
+  when: not (kraft_migration | default(false) | bool)
+
+- name: Check ZooKeeper group exists in inventory
+  fail:
+    msg: "ERROR: ZooKeeper hosts not found in inventory. Cannot rollback without ZooKeeper."
+  when: not (('zookeeper' in groups.keys() and groups['zookeeper'] | length > 0) | bool)
+
+- name: Check Kafka Controller group exists
+  fail:
+    msg: "ERROR: Kafka Controller hosts not found in inventory. No controllers to rollback."
+  when: not (('kafka_controller' in groups.keys() and groups['kafka_controller'] | length > 0) | bool)
+
+- name: Check ZooKeeper service status on all nodes
+  systemd:
+    name: "{{ zookeeper_service_name }}"
+  register: zk_status
+  delegate_to: "{{ item }}"
+  loop: "{{ groups['zookeeper'] }}"
+
+- name: Verify all ZooKeeper services are running
+  fail:
+    msg: "ERROR: ZooKeeper service is not running on {{ item.item }}. Cannot perform rollback."
+  when: item.status.ActiveState != 'active'
+  loop: "{{ zk_status.results }}"
+  loop_control:
+    label: "{{ item.item }}"
+
+- debug:
+    msg: "All ZooKeeper nodes are healthy and accessible"
+
+- name: Run migration state detection
+  include_tasks: detect_migration_phase.yml
+
+- name: Require explicit rollback tag for PURE_DUAL_WRITE state
+  fail:
+    msg: |
+      ERROR: PURE_DUAL_WRITE state requires explicit tag selection.
+
+      Options:
+        --tags rollback_to_hybrid          → revert brokers to hybrid mode
+                                              (KRaft controller stays active)
+        --tags rollback_to_premigration   → full rollback to pure ZooKeeper
+
+      Re-run with one of the tags above.
+  when:
+    - migration_state == "PURE_DUAL_WRITE"
+    - "'rollback_to_hybrid' not in ansible_run_tags"
+    - "'rollback_to_premigration' not in ansible_run_tags"
+
+- name: Fail if rollback_to_hybrid specified for non-PURE_DUAL_WRITE state
+  fail:
+    msg: |
+      ERROR: --tags rollback_to_hybrid is only applicable for PURE_DUAL_WRITE state.
+      Current state: {{ migration_state }}
+
+      For {{ migration_state }}, use --tags rollback_to_premigration instead.
+  when:
+    - migration_state != "PURE_DUAL_WRITE"
+    - "'rollback_to_hybrid' in ansible_run_tags"
+    - "'rollback_to_premigration' not in ansible_run_tags"
+
+- debug:
+    msg: "✓ Pre-rollback checks passed. Ready to execute {{ migration_state }} rollback."

--- a/roles/kafka_broker/tasks/regenerate_config.yml
+++ b/roles/kafka_broker/tasks/regenerate_config.yml
@@ -1,0 +1,8 @@
+---
+- name: Regenerate server.properties from template
+  template:
+    src: server.properties.j2
+    dest: "{{ kafka_broker.config_file }}"
+    mode: '640'
+    owner: "{{ kafka_broker_user }}"
+    group: "{{ kafka_broker_group }}"


### PR DESCRIPTION
## Summary

Introduces a KRaft → ZooKeeper rollback path for clusters mid-migration. The rollback is integrated into the existing `ZKtoKraftMigration.yml` entry point and driven by CLI tags, so operators have a single playbook for the full migration lifecycle.

The previous structure had three phase-specific rollback files (`phase2_rollback.yml`, `phase3_rollback.yml`, `phase4_rollback.yml`) with significant duplication. They've been consolidated into a single `rollback/rollback.yml` whose stages are gated by the cluster's detected migration state.

Detection uses JMX (Jolokia `ZkMigrationState` MBean) as the primary signal with broker-config inspection as a fallback when JMX is unreachable. This matches the approach CFK (Confluent Operator) uses for the same problem.

## User-facing change

Two new CLI tags on `ZKtoKraftMigration.yml`:

| Tag | What it does | When to use |
|---|---|---|
| `--tags rollback_to_hybrid` | Reverts brokers from KRaft to hybrid mode; KRaft controllers stay active | When the cluster is in PURE_DUAL_WRITE and you want a partial rollback |
| `--tags rollback_to_premigration` | Full unwind to pure ZooKeeper | Any pre-FINALIZED state |

Pre-rollback flow:
- Auto-detects current state (PREMIGRATION / HYBRID_DUAL_WRITE / PURE_DUAL_WRITE / FINALIZED)
- Hard-blocks rollback when state is FINALIZED (per the docs, non-recoverable)
- For PURE_DUAL_WRITE, requires the operator to explicitly choose between `rollback_to_hybrid` and `rollback_to_premigration` (no implicit default)

Standalone `KRaftToZKRollback.yml` continues to work for users who prefer the dedicated entry point.

## Testing done

Manual end-to-end runs against a fresh 3-node test cluster (1 controller / 1 broker / 1 zookeeper). Each phase was migrated forward then rolled back via the new tags. Full `ansible-playbook` output captured as testing artifacts:

📎 **Rollback test run logs**: https://gist.github.com/ishikaa-p/d7e9ebb1daf53f65a08c14ba987def12

| Scenario | Initial state | Tag invoked | Expected stages | Outcome |
|---|---|---|---|---|
| Phase 2 rollback | PREMIGRATION | `rollback_to_premigration` | Deprovision controllers only | ✓ |
| Phase 3 rollback | HYBRID_DUAL_WRITE | `rollback_to_premigration` | Full 4-stage rollback (B+C+D+E) | ✓ |
| Phase 4 partial rollback | PURE_DUAL_WRITE | `rollback_to_hybrid` | Stage A only (broker template regen) | ✓ |
| Phase 4 continued rollback | HYBRID_DUAL_WRITE | `rollback_to_premigration` | Stages B+C+D+E (Stage A correctly skipped) | ✓ |
| FINALIZED rollback attempt | FINALIZED | any | Hard-fail at pre-flight | ✓ |

Detection paths verified independently:
- Primary (JMX/Jolokia) on PURE_DUAL_WRITE, HYBRID_DUAL_WRITE, FINALIZED clusters
- Config-fallback (broker `process.roles` + migration flag + controller config) by simulating JMX-unreachable

Post-rollback verification (via the role-defined `health_check.yml` tasks for ZK, broker, and controller) ran cleanly in all test scenarios.

## Molecule test details

Two new Molecule scenarios drive the real entry playbooks with the real customer tags against Molecule's own generated inventory — no divergence from production behaviour.

| Scenario | Path | Forward → Rollback | Asserts |
|---|---|---|---|
| Full rollback | `molecule/kraft-rollback-to-zk` | HYBRID_DUAL_WRITE → premigration | Brokers: KRaft/migration props removed, `zookeeper.connect` restored, no `process.roles` · Controllers: service stopped + `__cluster_metadata` removed · ZooKeeper: `/migration` znode gone |
| Partial rollback | `molecule/kraft-rollback-to-hybrid` | PURE_DUAL_WRITE → hybrid | Brokers: back in hybrid (`zookeeper.metadata.migration.enable=true`, no `process.roles`) · Controllers: stay active · Detection: reports `HYBRID_DUAL_WRITE` |

Both reuse the role-defined `health_check.yml` tasks (ZK / broker / controller) plus `assert` checks on `server.properties`.

### CI runs
- **Newly added KRaft rollback tests**: https://semaphore.ci.confluent.io/workflows/4713c586-568c-44e1-a78e-2babcc909e1d
- **General migration tests**: https://semaphore.ci.confluent.io/workflows/77dda32f-8f33-4daf-a8b7-70cac5e529bc/summary?report_id=63a7566e-bb24-3b6d-a18c-7af5cdce63f5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
