### PR TITLE
[SETU-2783] Raise USM catalog snapshot size limit and exporter request timeout

### DIFF
--- a/roles/variables/vars/main.yml
+++ b/roles/variables/vars/main.yml
@@ -497,11 +497,14 @@ kafka_controller_properties:
       confluent.telemetry.exporter._usm.buffer.inflight.submissions.max: 10
       confluent.telemetry.exporter._usm.buffer.pending.batches.max: 80
       confluent.telemetry.exporter._usm.client.base.url: "{{ usm_agent_url }}"
+      confluent.telemetry.exporter._usm.client.request.timeout.ms: 60000
       confluent.telemetry.exporter._usm.events.client.base.url: "{{ usm_agent_url }}"
+      confluent.telemetry.exporter._usm.events.client.request.timeout.ms: 60000
       confluent.catalog.collector.enable: true
       confluent.catalog.collector.destination.topic: catalog-events
       confluent.catalog.collector.full.configs.enable: true
       confluent.catalog.collector.multitenant.topics.enable: false
+      confluent.catalog.collector.max.bytes.per.snapshot: 52428800
       confluent.telemetry.exporter._usm.events.filtering.routes.allowed: catalog-events
       confluent.telemetry.exporter._usm.events.filtering.enabled: true
   usm_agent_telemetry_auth_basic:
@@ -1137,6 +1140,7 @@ kafka_broker_properties:
     properties:
       confluent.telemetry.exporter._usm.enabled: true
       confluent.telemetry.exporter._usm.client.base.url: "{{ usm_agent_url }}"
+      confluent.telemetry.exporter._usm.client.request.timeout.ms: 60000
       confluent.telemetry.exporter._usm.type: http
       confluent.telemetry.exporter._usm.buffer.batch.items.max: 4000
       confluent.telemetry.exporter._usm.buffer.inflight.submissions.max: 10


### PR DESCRIPTION
## Summary
- Raises `confluent.catalog.collector.max.bytes.per.snapshot` from the 850 KB default to 50 MB on the kafka_controller `usm_agent_telemetry` block (KRaft mode hosts the catalog collector on the controller).
- Sets `confluent.telemetry.exporter._usm.client.request.timeout.ms` to 60 s on both controller and broker; sets `_usm.events.client.request.timeout.ms` to 60 s on the controller. The 60 s value aligns the USM HTTP exporter request timeout with the AHC `readTimeout` default of 60 s.
- 8.1.x is KRaft-only, so no ZK-mode broker block here.
- All blocks gated by the existing `'usm_agent' in groups` check; non-USM deployments are unchanged.

Jira: [SETU-2783](https://confluentinc.atlassian.net/browse/SETU-2783). Companion CFK PR: confluentinc/confluent-operator#4312. Master PR: #2495.

## Test plan
- Tests skipped on this PR per scope clarification; molecule scenarios that exercise USM will pick up the new keys when run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SETU-2783]: https://confluentinc.atlassian.net/browse/SETU-2783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ