### PR TITLE
[ANSIENG-5844] Support Bundle in CP-Ansible (forward-port of #2481 to 8.3.x)

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,6 +1,7 @@
 [defaults]
 hash_behaviour=merge
-callback_whitelist=profile_tasks
+callbacks_enabled=profile_tasks,confluent.platform.support_bundle_on_failure
+callback_whitelist=profile_tasks,confluent.platform.support_bundle_on_failure
 remote_tmp=~/.ansible/tmp
 collections_paths=~/.ansible/collections:../../../
 

--- a/playbooks/support_bundle.yml
+++ b/playbooks/support_bundle.yml
@@ -1,0 +1,350 @@
+---
+# Support Bundle Collection Playbook
+# Collects comprehensive diagnostic information from Confluent Platform deployment
+# including configs, logs, system info, diagnostics, and SSL metadata
+
+- name: Support Bundle Setup
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  tags: always
+  vars:
+    ansible_become: false
+  tasks:
+    - name: Gather facts without become
+      setup:
+
+    - import_role:
+        name: confluent.platform.variables
+
+    - name: Generate bundle timestamp
+      set_fact:
+        bundle_timestamp: "{{ ansible_date_time.date | regex_replace('-','') }}_{{ ansible_date_time.time | regex_replace(':','') }}"
+
+    - name: Set bundle name
+      set_fact:
+        bundle_name: "support_bundle_{{ bundle_timestamp }}_{{ support_bundle_cluster_name }}"
+        bundle_path: "{{ (support_bundle_output_path | regex_replace('/$', '')) }}/support_bundle_{{ bundle_timestamp }}_{{ support_bundle_cluster_name }}"
+
+    - name: Create bundle directory structure
+      file:
+        path: "{{ bundle_path }}/ansible"
+        state: directory
+        mode: '0755'
+
+    - name: Check inventory file existence
+      stat:
+        path: "{{ item }}"
+      loop: "{{ ansible_inventory_sources }}"
+      when:
+        - item is defined
+        - item | length > 0
+      register: inventory_file_stats
+      ignore_errors: true
+
+    - name: Copy inventory files to bundle
+      copy:
+        src: "{{ item.item }}"
+        dest: "{{ bundle_path }}/ansible/inventory_{{ idx + 1 }}_raw.yml"
+        mode: '0644'
+      loop: "{{ inventory_file_stats.results | default([]) }}"
+      loop_control:
+        index_var: idx
+      when:
+        - item.stat is defined
+        - item.stat.exists
+        - item.stat.isreg
+      ignore_errors: true
+      register: inventory_files_copied
+
+    - name: Sanitize inventory files
+      include_tasks: ../roles/common/tasks/sanitize_inventory_files_local.yml
+
+- name: Import all variables
+  hosts: all
+  tags: always
+  tasks:
+    - import_role:
+        name: confluent.platform.variables
+
+    - name: Gather Java version and memory info
+      shell: |
+        java -version 2>&1 | head -1 || echo "N/A"
+      args:
+        executable: "{{ shell_executable }}"
+      register: java_version_raw
+      ignore_errors: true
+
+    - name: Set Java version fact
+      set_fact:
+        java_version_info: "{{ java_version_raw.stdout | default('N/A') }}"
+
+    - name: Gather memory statistics
+      shell: |
+        free -m | awk 'NR==2{print $2","$3","$4","$7}'
+      args:
+        executable: "{{ shell_executable }}"
+      register: memory_stats_raw
+      ignore_errors: true
+
+    - name: Set memory facts
+      set_fact:
+        memory_total_mb: "{{ memory_stats_raw.stdout.split(',')[0] | default(ansible_memtotal_mb) }}"
+        memory_used_mb: "{{ memory_stats_raw.stdout.split(',')[1] | default('N/A') }}"
+        memory_free_mb: "{{ memory_stats_raw.stdout.split(',')[2] | default('N/A') }}"
+        memory_available_mb: "{{ memory_stats_raw.stdout.split(',')[3] | default('N/A') }}"
+      when: memory_stats_raw is succeeded
+
+- name: Zookeeper Support Bundle
+  hosts: zookeeper
+  gather_facts: true
+  tags: zookeeper
+  ignore_errors: true
+  tasks:
+    - include_role:
+        name: confluent.platform.common
+        tasks_from: collect_support_bundle.yml
+      vars:
+        service_name: "{{ zookeeper_service_name }}"
+        component_name: "zookeeper"
+        component: "{{ zookeeper }}"
+        config_file: "{{ zookeeper.config_file }}"
+        log_dir: "{{ zookeeper_log_dir }}"
+        user: "{{ zookeeper_user }}"
+        group: "{{ zookeeper_group }}"
+
+- name: Kafka Controller Support Bundle
+  hosts: kafka_controller
+  gather_facts: true
+  tags: kafka_controller_support_bundle
+  ignore_errors: true
+  tasks:
+    - include_role:
+        name: confluent.platform.common
+        tasks_from: collect_support_bundle.yml
+      vars:
+        service_name: "{{ kafka_controller_service_name }}"
+        component_name: "kafka_controller"
+        component: "{{ kafka_controller }}"
+        config_file: "{{ kafka_controller.config_file }}"
+        log_dir: "{{ kafka_controller_log_dir }}"
+        user: "{{ kafka_controller_user }}"
+        group: "{{ kafka_controller_group }}"
+
+- name: Kafka Broker Support Bundle
+  hosts: kafka_broker
+  gather_facts: true
+  tags: kafka_broker_support_bundle
+  ignore_errors: true
+  tasks:
+    - include_role:
+        name: confluent.platform.common
+        tasks_from: collect_support_bundle.yml
+      vars:
+        service_name: "{{ kafka_broker_service_name }}"
+        component_name: "kafka_broker"
+        component: "{{ kafka_broker }}"
+        config_file: "{{ kafka_broker.config_file }}"
+        log_dir: "{{ kafka_broker_log_dir }}"
+        user: "{{ kafka_broker_user }}"
+        group: "{{ kafka_broker_group }}"
+
+- name: Schema Registry Support Bundle
+  hosts: schema_registry
+  gather_facts: true
+  tags: schema_registry_support_bundle
+  ignore_errors: true
+  tasks:
+    - include_role:
+        name: confluent.platform.common
+        tasks_from: collect_support_bundle.yml
+      vars:
+        service_name: "{{ schema_registry_service_name }}"
+        component_name: "schema_registry"
+        component: "{{ schema_registry }}"
+        config_file: "{{ schema_registry.config_file }}"
+        log_dir: "{{ schema_registry_log_dir }}"
+        user: "{{ schema_registry_user }}"
+        group: "{{ schema_registry_group }}"
+
+- name: Kafka Connect Support Bundle
+  hosts: kafka_connect
+  gather_facts: true
+  tags: kafka_connect_support_bundle
+  ignore_errors: true
+  tasks:
+    - include_role:
+        name: confluent.platform.common
+        tasks_from: collect_support_bundle.yml
+      vars:
+        service_name: "{{ kafka_connect_service_name }}"
+        component_name: "kafka_connect"
+        component: "{{ kafka_connect }}"
+        config_file: "{{ kafka_connect.config_file }}"
+        log_dir: "{{ kafka_connect_log_dir }}"
+        user: "{{ kafka_connect_user }}"
+        group: "{{ kafka_connect_group }}"
+
+- name: Kafka Connect Replicator Support Bundle
+  hosts: kafka_connect_replicator
+  gather_facts: true
+  tags: kafka_connect_replicator_support_bundle
+  ignore_errors: true
+  tasks:
+    - include_role:
+        name: confluent.platform.common
+        tasks_from: collect_support_bundle.yml
+      vars:
+        service_name: "{{ kafka_connect_replicator_service_name }}"
+        component_name: "kafka_connect_replicator"
+        component: "{{ kafka_connect_replicator }}"
+        config_file: "{{ kafka_connect_replicator.config_file }}"
+        log_dir: "{{ kafka_connect_replicator_log_dir }}"
+        user: "{{ kafka_connect_replicator_user }}"
+        group: "{{ kafka_connect_replicator_group }}"
+
+- name: KSQL Support Bundle
+  hosts: ksql
+  gather_facts: true
+  tags: ksql_support_bundle
+  ignore_errors: true
+  tasks:
+    - include_role:
+        name: confluent.platform.common
+        tasks_from: collect_support_bundle.yml
+      vars:
+        service_name: "{{ ksql_service_name }}"
+        component_name: "ksql"
+        component: "{{ ksql }}"
+        config_file: "{{ ksql.config_file }}"
+        log_dir: "{{ ksql_log_dir }}"
+        user: "{{ ksql_user }}"
+        group: "{{ ksql_group }}"
+
+- name: Kafka Rest Support Bundle
+  hosts: kafka_rest
+  gather_facts: true
+  tags: kafka_rest_support_bundle
+  ignore_errors: true
+  tasks:
+    - include_role:
+        name: confluent.platform.common
+        tasks_from: collect_support_bundle.yml
+      vars:
+        service_name: "{{ kafka_rest_service_name }}"
+        component_name: "kafka_rest"
+        component: "{{ kafka_rest }}"
+        config_file: "{{ kafka_rest.config_file }}"
+        log_dir: "{{ kafka_rest_log_dir }}"
+        user: "{{ kafka_rest_user }}"
+        group: "{{ kafka_rest_group }}"
+
+- name: Control Center Support Bundle
+  hosts: control_center
+  gather_facts: true
+  tags: control_center_support_bundle
+  ignore_errors: true
+  tasks:
+    - include_role:
+        name: confluent.platform.common
+        tasks_from: collect_support_bundle.yml
+      vars:
+        service_name: "{{ control_center_service_name }}"
+        component_name: "control_center"
+        component: "{{ control_center }}"
+        config_file: "{{ control_center.config_file }}"
+        log_dir: "{{ control_center_log_dir }}"
+        user: "{{ control_center_user }}"
+        group: "{{ control_center_group }}"
+
+- name: Control Center Next Gen Support Bundle
+  hosts: control_center_next_gen
+  gather_facts: true
+  tags: control_center_next_gen_support_bundle
+  ignore_errors: true
+  tasks:
+    - include_role:
+        name: confluent.platform.common
+        tasks_from: collect_support_bundle.yml
+      vars:
+        service_name: "{{ control_center_next_gen_service_name }}"
+        component_name: "control_center_next_gen"
+        component: "{{ control_center_next_gen }}"
+        config_file: "{{ control_center_next_gen.config_file }}"
+        log_dir: "{{ control_center_next_gen_log_dir }}"
+        user: "{{ control_center_next_gen_user }}"
+        group: "{{ control_center_next_gen_group }}"
+
+- name: USM Agent Support Bundle
+  hosts: usm_agent
+  gather_facts: true
+  tags: usm_agent_support_bundle
+  ignore_errors: true
+  tasks:
+    - include_role:
+        name: confluent.platform.common
+        tasks_from: collect_support_bundle.yml
+      vars:
+        service_name: "{{ usm_agent_service_name }}"
+        component_name: "usm_agent"
+        component: "{{ usm_agent }}"
+        config_file: "{{ usm_agent.config_file }}"
+        log_dir: "{{ usm_agent.log_dir }}"
+        user: "{{ usm_agent_default_user }}"
+        group: "{{ usm_agent_default_group }}"
+
+- name: Finalize Support Bundle
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  tags: always
+  vars:
+    ansible_become: false
+  tasks:
+    - import_role:
+        name: confluent.platform.variables
+
+    - name: Generate bundle manifest
+      template:
+        src: "{{ playbook_dir }}/../roles/common/templates/bundle_manifest.yml.j2"
+        dest: "{{ hostvars['localhost']['bundle_path'] }}/bundle_manifest.yml"
+        mode: '0644'
+      vars:
+        support_bundle_component_groups: ['zookeeper', 'kafka_controller', 'kafka_broker', 'schema_registry', 'kafka_connect', 'kafka_connect_replicator', 'ksql', 'kafka_rest', 'control_center', 'control_center_next_gen', 'usm_agent']
+
+    - name: Copy Ansible playbook execution log to bundle
+      copy:
+        src: "{{ support_bundle_ansible_log_path }}"
+        dest: "{{ hostvars['localhost']['bundle_path'] }}/ansible/ansible_playbook.log"
+        mode: '0644'
+      when: support_bundle_ansible_log_path | length > 0
+      ignore_errors: true
+
+    - name: Archive support bundle
+      archive:
+        path: "{{ hostvars['localhost']['bundle_path'] }}"
+        dest: "{{ (support_bundle_output_path | regex_replace('/$', '')) }}/{{ hostvars['localhost']['bundle_name'] }}.tar.gz"
+        format: gz
+
+    - name: Get archive file stats
+      stat:
+        path: "{{ (support_bundle_output_path | regex_replace('/$', '')) }}/{{ hostvars['localhost']['bundle_name'] }}.tar.gz"
+      register: bundle_archive_stats
+
+    - name: Display completion message
+      debug:
+        msg: |
+          ========================================
+          Support Bundle Created Successfully
+          ========================================
+          Archive: {{ (support_bundle_output_path | regex_replace('/$', '')) }}/{{ hostvars['localhost']['bundle_name'] }}.tar.gz
+
+          Uncompressed Directory: {{ hostvars['localhost']['bundle_path'] }}
+
+          IMPORTANT:
+          - Review the uncompressed directory contents before sharing
+          - Verify automatic sanitization removed all sensitive data
+          - Manually redact any additional sensitive information if needed
+          - Delete the uncompressed directory after review
+
+          Please upload the .tar.gz file to your support ticket.

--- a/plugins/callback/support_bundle_on_failure.py
+++ b/plugins/callback/support_bundle_on_failure.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+"""Ansible callback plugin to auto-collect support bundle on playbook failure."""
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = '''
+    name: support_bundle_on_failure
+    type: notification
+    short_description: Automatically collect support bundle on playbook failure
+    description:
+        - Triggers support_bundle.yml when any playbook fails
+        - Skips support_bundle.yml itself to prevent recursion
+        - Defaults to true (matches role default in confluent.platform.variables)
+        - "Variable precedence: extra vars (-e) > inventory vars > default (true)"
+    options:
+      support_bundle_auto_collect_on_failure:
+        description: Enable automatic support bundle collection on failure
+        default: True
+        type: bool
+        vars:
+          - name: support_bundle_auto_collect_on_failure
+'''
+
+import os
+import subprocess
+from ansible.plugins.callback import CallbackBase
+from ansible import constants as C
+from ansible import context
+from ansible.utils.display import Display
+
+display = Display()
+
+
+class CallbackModule(CallbackBase):
+    CALLBACK_VERSION = 2.0
+    CALLBACK_TYPE = 'notification'
+    CALLBACK_NAME = 'support_bundle_on_failure'
+    CALLBACK_NEEDS_ENABLED = True
+
+    def __init__(self):
+        super(CallbackModule, self).__init__()
+        self.playbook_name = None
+        self.playbook_dir = None
+        self.play = None
+
+    def v2_playbook_on_start(self, playbook):
+        self.playbook_name = os.path.basename(playbook._file_name)
+        self.playbook_dir = os.path.dirname(os.path.abspath(playbook._file_name))
+
+    def v2_playbook_on_play_start(self, play):
+        # Capture the first play to access variable manager
+        if self.play is None:
+            self.play = play
+
+    def v2_playbook_on_stats(self, stats):
+        # Skip support_bundle.yml itself to prevent recursion
+        if self.playbook_name == 'support_bundle.yml':
+            return
+
+        # Check if there were any failures
+        failed = any(
+            stats.summarize(h).get('failures', 0) > 0 or
+            stats.summarize(h).get('unreachable', 0) > 0
+            for h in stats.processed
+        )
+
+        if not failed:
+            return
+
+        # Get variable value respecting Ansible's variable precedence
+        # Priority: extra vars (-e) > inventory vars > default (true)
+        auto_collect = True  # Default value
+
+        # Read from inventory 'all' group vars (deployment-wide setting)
+        # We check 'all' group specifically because this is a deployment-wide setting
+        # (callbacks run on control node, not per-host)
+        if self.play and hasattr(self.play, '_variable_manager'):
+            try:
+                variable_manager = self.play.get_variable_manager()
+                inventory = variable_manager._inventory
+                all_group = inventory.groups.get('all')
+                if all_group:
+                    group_vars = all_group.get_vars()
+                    if 'support_bundle_auto_collect_on_failure' in group_vars:
+                        value = group_vars['support_bundle_auto_collect_on_failure']
+                        auto_collect = value in [True, 'true', 'True', 'yes', '1', 1]
+            except Exception as e:
+                display.vvv(f"Failed to read variable from inventory: {e}")
+                pass
+
+        # Check for extra vars override (highest precedence)
+        if hasattr(context, 'CLIARGS') and context.CLIARGS:
+            extra_vars = context.CLIARGS.get('extra_vars', ())
+            for ev_str in (extra_vars if isinstance(extra_vars, tuple) else []):
+                if 'support_bundle_auto_collect_on_failure=' in ev_str:
+                    value_str = ev_str.split('=', 1)[1].lower()
+                    auto_collect = value_str not in ('false', 'no', '0', 'off')
+                    break
+
+        if not auto_collect:
+            display.display("\nTo collect diagnostics: ansible-playbook support_bundle.yml", color=C.COLOR_HIGHLIGHT)
+            display.display("Or set: support_bundle_auto_collect_on_failure: true\n", color=C.COLOR_HIGHLIGHT)
+            return
+
+        self._collect_support_bundle()
+
+    def _collect_support_bundle(self):
+        support_bundle_playbook = os.path.join(self.playbook_dir, 'support_bundle.yml')
+        if not os.path.exists(support_bundle_playbook):
+            display.warning("support_bundle.yml not found at: %s" % support_bundle_playbook)
+            return
+
+        collection_root = os.path.dirname(self.playbook_dir)
+        cmd = ['ansible-playbook', support_bundle_playbook]
+
+        # Get inventory and verbosity from CLIARGS
+        if hasattr(context, 'CLIARGS') and context.CLIARGS:
+            inventory = context.CLIARGS.get('inventory')
+            if inventory:
+                # inventory is a tuple of paths - add each with -i
+                for inv_path in (inventory if isinstance(inventory, tuple) else [inventory]):
+                    cmd.extend(['-i', os.path.abspath(str(inv_path))])
+
+            verbosity = context.CLIARGS.get('verbosity', 0)
+            if verbosity > 0:
+                cmd.append('-' + 'v' * verbosity)
+
+        display.vvv("Executing: %s" % ' '.join(cmd))
+        subprocess.run(cmd, cwd=collection_root, check=False)

--- a/roles/common/files/sanitize_properties.py
+++ b/roles/common/files/sanitize_properties.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python
+"""
+Confluent Platform Property File Sanitizer
+
+Sanitizes sensitive data from configuration files while preserving
+non-sensitive metadata like paths, algorithms, and timeout values.
+"""
+
+import re
+import sys
+import argparse
+from pathlib import Path
+
+
+class PropertySanitizer:
+    """Sanitizes Confluent Platform configuration files."""
+
+    # ===== Unified Sensitive Pattern Registry =====
+    # Core sensitive keywords - single source of truth for all file types
+    CORE_SENSITIVE_KEYWORDS = ['password', 'secret', 'key', 'token', 'credential']
+
+    # Exact match patterns (confluent-specific and high-priority)
+    EXACT_SENSITIVE = {
+        'confluent.license',
+        'ldap.java.naming.security.credentials',
+        'confluent.security.master.key',
+        'CONFLUENT_SECURITY_MASTER_KEY',
+    }
+
+    # Additional property-specific suffixes beyond core keywords
+    ADDITIONAL_PROPERTY_SUFFIXES = [
+        '.basic.auth.user.info',
+        '.basic.auth.credentials',
+        '.sasl.jaas.config',
+        '.client.secret',
+        'keystorePassword',  # Jolokia format
+    ]
+
+    # Ansible-specific sensitive variables
+    ANSIBLE_SENSITIVE_VARS = [
+        'ansible_ssh_private_key_file',
+        'ansible_password',
+        'ansible_become_password',
+        'ansible_ssh_pass',
+        'ansible_become_pass',
+    ]
+
+    # Properties that should NOT be sanitized (even if they match sensitive patterns)
+    EXCLUDE_PATTERNS = [
+        r'.*\.path$',                           # File paths
+        r'.*\.location$',                       # File locations
+        r'.*\.algorithm$',                      # Algorithm names (RS256, etc.)
+        r'.*\.provider$',                       # Provider types (BASIC, BEARER)
+        r'.*\.lifetime\.ms$',                   # Timeout values
+        r'.*\.max\.lifetime\.ms$',              # Max lifetime values
+        r'.*\.interval\.ms$',                   # Interval values
+        r'.*\.authentication\.method$',         # Auth method types
+        r'.*\.security\.protocol$',             # Security protocols
+        r'.*\.mechanism$',                      # SASL mechanisms
+        r'.*\.enabled\.mechanisms$',            # Enabled mechanisms list
+        r'.*\.service\.name$',                  # Kerberos service names
+        r'.*\.protocol\.map$',                  # Protocol mappings
+    ]
+
+    def __init__(self):
+        self.exclude_compiled = [re.compile(pattern, re.IGNORECASE) for pattern in self.EXCLUDE_PATTERNS]
+
+    def is_excluded(self, key):
+        """Check if a property key should be excluded from sanitization."""
+        return any(pattern.match(key) for pattern in self.exclude_compiled)
+
+    def is_sensitive(self, key):
+        """Determine if a property key contains sensitive data."""
+        # Check exact matches first
+        if key in self.EXACT_SENSITIVE:
+            return True
+
+        # Check if excluded (takes precedence)
+        if self.is_excluded(key):
+            return False
+
+        key_lower = key.lower()
+
+        # Check core keywords as suffixes (e.g., .password, .secret, .key, .token)
+        for keyword in self.CORE_SENSITIVE_KEYWORDS:
+            if key_lower.endswith(f'.{keyword}'):
+                return True
+
+        # Check additional property-specific suffixes
+        for suffix in self.ADDITIONAL_PROPERTY_SUFFIXES:
+            if key_lower.endswith(suffix.lower()):
+                return True
+
+        return False
+
+    def _sanitize_file_base(self, file_path, line_processor, item_type, in_place=True):
+        """
+        Base method for sanitizing files with common I/O logic.
+
+        Args:
+            file_path: Path to the file to sanitize
+            line_processor: Function(line) -> (processed_line, was_sanitized)
+            item_type: Description of items being sanitized (for logging)
+            in_place: If True, modify file in place; if False, return sanitized content
+
+        Returns:
+            Sanitized content string if in_place=False, else None
+        """
+        path = Path(file_path)
+        if not path.exists():
+            print(f"Warning: File not found: {file_path}", file=sys.stderr)
+            return None
+
+        with open(path, 'r', encoding='utf-8', errors='replace') as f:
+            content = f.readlines()
+
+        lines = []
+        sanitized_count = 0
+
+        # Add sanitization header
+        lines.append("# THIS FILE HAS BEEN SANITIZED - SENSITIVE VALUES REDACTED\n")
+
+        for line in content:
+            # Skip existing sanitization headers
+            if 'THIS FILE HAS BEEN SANITIZED' in line:
+                continue
+
+            # Process line using the provided processor
+            processed_line, was_sanitized = line_processor(line)
+            lines.append(processed_line)
+            if was_sanitized:
+                sanitized_count += 1
+
+        sanitized_content = ''.join(lines)
+
+        if in_place:
+            # Write back to file
+            with open(path, 'w', encoding='utf-8') as f:
+                f.write(sanitized_content)
+            print(f"Sanitized {sanitized_count} {item_type} in {file_path}")
+            return None
+        else:
+            # Return content for dry-run
+            return sanitized_content
+
+    def sanitize_properties_file(self, file_path, in_place=True):
+        """
+        Sanitize a .properties file.
+
+        Args:
+            file_path: Path to the properties file
+            in_place: If True, modify file in place; if False, return sanitized content
+
+        Returns:
+            Sanitized content if in_place=False, else None
+        """
+        def process_properties_line(line):
+            """Process a single line from a .properties file."""
+            # Preserve comments and empty lines
+            if line.strip().startswith('#') or not line.strip():
+                return line, False
+
+            # Parse property line (key=value format)
+            match = re.match(r'^([^=]+)=(.*)', line)
+            if not match:
+                return line, False
+
+            key = match.group(1).strip()
+
+            # Check if this property should be sanitized
+            if self.is_sensitive(key):
+                return f"{key}=***REDACTED***\n", True
+
+            return line, False
+
+        return self._sanitize_file_base(file_path, process_properties_line, "properties", in_place)
+
+    def sanitize_override_file(self, file_path, in_place=True):
+        """
+        Sanitize a systemd override.conf file.
+
+        Args:
+            file_path: Path to the override.conf file
+            in_place: If True, modify file in place; if False, return sanitized content
+        """
+        def process_override_line(line):
+            """Process a single line from an override.conf file."""
+            # Check for Environment= lines with sensitive variables
+            if line.strip().startswith('Environment='):
+                line_upper = line.upper()
+
+                # Check if line contains any core sensitive keyword
+                should_sanitize = any(keyword.upper() in line_upper
+                                      for keyword in self.CORE_SENSITIVE_KEYWORDS)
+
+                # Also check exact sensitive matches
+                should_sanitize = should_sanitize or any(exact in line
+                                                         for exact in self.EXACT_SENSITIVE)
+
+                if should_sanitize:
+                    # Extract variable name and redact value
+                    match = re.match(r'^(Environment=\s*[^=]+=).*', line)
+                    if match:
+                        return f"{match.group(1)}***REDACTED***\n", True
+                    return line, False
+
+                return line, False
+
+            return line, False
+
+        return self._sanitize_file_base(file_path, process_override_line, "environment variables", in_place)
+
+    def sanitize_inventory_file(self, file_path, in_place=True):
+        """
+        Sanitize an Ansible inventory file (YAML format).
+
+        Args:
+            file_path: Path to the inventory file
+            in_place: If True, modify file in place; if False, return sanitized content
+        """
+        def process_inventory_line(line):
+            """Process a single line from an Ansible inventory file."""
+            # Skip comments
+            if line.strip().startswith('#'):
+                return line, False
+
+            # Check for Ansible-specific sensitive variables (exact match)
+            for var in self.ANSIBLE_SENSITIVE_VARS:
+                # Match: ansible_password: value (YAML format)
+                pattern = rf'^(\s*{var}\s*:\s*).*$'
+                match = re.match(pattern, line)
+                if match:
+                    return f"{match.group(1)}***REDACTED***\n", True
+
+            # Check for general sensitive patterns using unified core keywords
+            # But only in YAML value context (after :)
+            if ':' in line:
+                lower_line = line.lower()
+
+                # Build patterns from core keywords (password:, secret:, key:, token:, credential:)
+                sensitive_patterns = [f'{keyword}:' for keyword in self.CORE_SENSITIVE_KEYWORDS]
+
+                # Avoid false positives like 'ssl_key_path' by being more specific
+                if any(pattern in lower_line for pattern in sensitive_patterns):
+                    # Don't sanitize if it's a path/location/algorithm/provider
+                    if not any(exclude in lower_line for exclude in ['_path:', '_location:', '_algorithm:', '_provider:']):
+                        # Extract key and redact value
+                        match = re.match(r'^(\s*[^#:]+:\s*).*$', line)
+                        if match:
+                            return f"{match.group(1)}***REDACTED***\n", True
+
+            # No sanitization needed
+            return line, False
+
+        return self._sanitize_file_base(file_path, process_inventory_line, "variables", in_place)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Sanitize Confluent Platform configuration files'
+    )
+    parser.add_argument('file', help='File to sanitize')
+    parser.add_argument('--type', choices=['properties', 'override', 'inventory'],
+                        help='File type (auto-detected if not specified)')
+    parser.add_argument('--dry-run', action='store_true',
+                        help='Print sanitized output without modifying file')
+
+    args = parser.parse_args()
+
+    # Auto-detect file type if not specified
+    file_path = Path(args.file)
+    file_type = args.type
+
+    if not file_type:
+        if file_path.suffix == '.properties':
+            file_type = 'properties'
+        elif file_path.name == 'override.conf':
+            file_type = 'override'
+        elif file_path.suffix in ['.yml', '.yaml'] or 'inventory' in file_path.name.lower():
+            file_type = 'inventory'
+        else:
+            print(f"Error: Cannot auto-detect file type for {args.file}", file=sys.stderr)
+            sys.exit(1)
+
+    sanitizer = PropertySanitizer()
+
+    # Dispatch to the appropriate sanitization method
+    handlers = {
+        'properties': sanitizer.sanitize_properties_file,
+        'override': sanitizer.sanitize_override_file,
+        'inventory': sanitizer.sanitize_inventory_file,
+    }
+    result = handlers[file_type](args.file, in_place=not args.dry_run)
+
+    if args.dry_run and result:
+        print(result)
+
+
+if __name__ == '__main__':
+    main()

--- a/roles/common/tasks/collect_diagnostics.yml
+++ b/roles/common/tasks/collect_diagnostics.yml
@@ -1,0 +1,36 @@
+---
+# Runtime Diagnostics Collection Task
+# Collects service status and journalctl logs
+
+- name: Get service status
+  shell: systemctl status {{ service_name }} --no-pager -l 2>&1 || true
+  args:
+    executable: "{{ shell_executable }}"
+  register: service_status_output
+
+- name: Save service status to file
+  copy:
+    content: "{{ service_status_output.stdout }}"
+    dest: "{{ host_bundle_dir }}/diagnostics/service_status.txt"
+    mode: '0644'
+  delegate_to: localhost
+  vars:
+    ansible_connection: local
+    ansible_become: false
+
+- name: Collect journalctl logs
+  shell: |
+    journalctl -u {{ service_name }} -n {{ support_bundle_journalctl_lines }} --no-pager > /tmp/journalctl_{{ inventory_hostname }}.log 2>&1 || true
+  args:
+    executable: "{{ shell_executable }}"
+
+- name: Fetch journalctl logs
+  fetch:
+    src: "/tmp/journalctl_{{ inventory_hostname }}.log"
+    dest: "{{ host_bundle_dir }}/diagnostics/journalctl.log"
+    flat: true
+
+- name: Clean up remote journalctl temp file
+  file:
+    path: "/tmp/journalctl_{{ inventory_hostname }}.log"
+    state: absent

--- a/roles/common/tasks/collect_support_bundle.yml
+++ b/roles/common/tasks/collect_support_bundle.yml
@@ -1,0 +1,132 @@
+---
+# Core Support Bundle Collection Task
+# Fetches diagnostic information directly from remote hosts to Ansible controller
+# No remote temporary directories - direct fetch approach per comment #8
+# Directory structure: bundle_path/<component_name>/<hostname>/
+
+- name: Set bundle facts
+  set_fact:
+    host_bundle_dir: "{{ hostvars['localhost']['bundle_path'] }}/{{ component_name }}/{{ inventory_hostname }}"
+  become: false
+
+- name: Create host bundle directories on localhost
+  file:
+    path: "{{ host_bundle_dir }}/{{ item }}"
+    state: directory
+    mode: '0755'
+  delegate_to: localhost
+  vars:
+    ansible_connection: local
+    ansible_become: "{{ ansible_become_localhost }}"
+  loop:
+    - configs
+    - logs
+    - diagnostics
+
+# COLLECT CONFIGURATION FILES
+- name: Collect config files (direct fetch)
+  block:
+    - name: Fetch main config file
+      fetch:
+        src: "{{ config_file }}"
+        dest: "{{ host_bundle_dir }}/configs/"
+        flat: true
+      become: true
+      when: not support_bundle_skip_configs
+
+    - name: Fetch Log4j config file
+      fetch:
+        src: "{{ component.log4j_file }}"
+        dest: "{{ host_bundle_dir }}/configs/"
+        flat: true
+      become: true
+      when:
+        - component.log4j_file is defined
+        - not support_bundle_skip_configs
+
+    - name: Fetch systemd service file
+      fetch:
+        src: "{{ component.systemd_file }}"
+        dest: "{{ host_bundle_dir }}/configs/"
+        flat: true
+      become: true
+      when:
+        - component.systemd_file is defined
+        - not support_bundle_skip_configs
+
+    - name: Fetch systemd override file
+      fetch:
+        src: "{{ component.systemd_override }}"
+        dest: "{{ host_bundle_dir }}/configs/"
+        flat: true
+      become: true
+      when:
+        - component.systemd_override is defined
+        - not support_bundle_skip_configs
+
+    # SANITIZE CONFIG FILES (on localhost after fetch)
+    # Note: Always runs when sanitization enabled, even with secrets_protection,
+    #       because override.conf is not encrypted by secrets protection
+    - name: Sanitize sensitive data from config files
+      include_tasks: sanitize_config_files_local.yml
+      vars:
+        skip_properties_sanitization: "{{ secrets_protection_enabled | default(false) | bool }}"
+      when:
+        - support_bundle_sanitize_configs
+        - not support_bundle_skip_configs
+
+    # COLLECT METADATA ONLY (if skipping configs)
+    - name: Get config file metadata
+      shell: |
+        echo "=== Configuration Files Metadata ==="
+        {% if config_file is defined %}
+        ls -lh {{ config_file }} 2>&1 || echo "{{ config_file }}: Not found"
+        {% endif %}
+        {% if component.log4j_file is defined %}
+        ls -lh {{ component.log4j_file }} 2>&1 || echo "{{ component.log4j_file }}: Not found"
+        {% endif %}
+      args:
+        executable: "{{ shell_executable }}"
+      become: true
+      when: support_bundle_skip_configs
+      register: config_metadata_output
+
+    - name: Save config file metadata to file
+      copy:
+        content: "{{ config_metadata_output.stdout }}"
+        dest: "{{ host_bundle_dir }}/configs/config_files_metadata.txt"
+        mode: '0644'
+      delegate_to: localhost
+      vars:
+        ansible_connection: local
+        ansible_become: false
+      when:
+        - support_bundle_skip_configs
+        - config_metadata_output is defined
+
+# COLLECT LOG FILES
+# Bounded collection to prevent bundle bloat - defaults to *.log files, max 20 most recent
+# Only collect non-empty log files
+- name: Find log files with bounded defaults
+  find:
+    paths: "{{ log_dir }}"
+    recurse: false
+    file_type: file
+    patterns: "{{ support_bundle_log_patterns | default(['*.log']) }}"
+    size: "1"
+    age: "{{ support_bundle_log_age | default(omit) }}"
+  become: true
+  register: log_files_found
+
+- name: Fetch selected log files directly to localhost
+  fetch:
+    src: "{{ item.path }}"
+    dest: "{{ host_bundle_dir }}/logs/"
+    flat: true
+  become: true
+  loop: "{{ (log_files_found.files | default([]) | sort(attribute='mtime', reverse=true))[:(support_bundle_log_max_count | default(20) | int)] }}"
+  when: log_files_found.matched | default(0) > 0
+
+# COLLECT RUNTIME DIAGNOSTICS
+- name: Collect runtime diagnostics
+  include_tasks: collect_diagnostics.yml

--- a/roles/common/tasks/sanitize_config_files_local.yml
+++ b/roles/common/tasks/sanitize_config_files_local.yml
@@ -1,0 +1,57 @@
+---
+# Sanitizes config files: .properties (if not encrypted), override.conf (always)
+# Variable: skip_properties_sanitization - skips .properties if secrets protection enabled
+# Uses script module - automatically finds sanitize_properties.py in roles/common/files/
+
+
+- name: Find .properties files
+  find:
+    paths: "{{ host_bundle_dir }}/configs"
+    patterns: "*.properties"
+  register: properties_files
+  delegate_to: localhost
+  vars:
+    ansible_connection: local
+    ansible_become: false
+  when: not (skip_properties_sanitization | default(false) | bool)
+
+- name: Sanitize .properties files
+  script:
+    cmd: sanitize_properties.py "{{ item.path }}" --type properties
+    executable: "{{ hostvars['localhost']['ansible_python_interpreter'] }}"
+  loop: "{{ properties_files.files | default([]) }}"
+  when:
+    - not (skip_properties_sanitization | default(false) | bool)
+    - properties_files.matched | default(0) > 0
+  delegate_to: localhost
+  vars:
+    ansible_connection: local
+    ansible_become: false
+
+- name: Find override.conf files
+  find:
+    paths: "{{ host_bundle_dir }}/configs"
+    patterns: "override.conf"
+  register: override_files
+  delegate_to: localhost
+  vars:
+    ansible_connection: local
+    ansible_become: false
+
+- name: Sanitize override files
+  script:
+    cmd: sanitize_properties.py "{{ item.path }}" --type override
+    executable: "{{ hostvars['localhost']['ansible_python_interpreter'] }}"
+  loop: "{{ override_files.files | default([]) }}"
+  when: override_files.matched | default(0) > 0
+  delegate_to: localhost
+  vars:
+    ansible_connection: local
+    ansible_become: false
+
+- name: Remove password.properties files
+  shell: find {{ host_bundle_dir }}/configs -name "*password.properties" -type f -delete
+  delegate_to: localhost
+  vars:
+    ansible_connection: local
+    ansible_become: false

--- a/roles/common/tasks/sanitize_inventory_files_local.yml
+++ b/roles/common/tasks/sanitize_inventory_files_local.yml
@@ -1,0 +1,32 @@
+---
+# Sanitizes inventory files collected in the support bundle
+# Called from support_bundle.yml playbook after inventory files are copied
+# Uses script module - automatically finds sanitize_properties.py in roles/common/files/
+
+- name: Sanitize copied inventory files
+  script:
+    cmd: "{{ playbook_dir }}/../roles/common/files/sanitize_properties.py {{ item.dest }} --type inventory"
+    executable: "{{ ansible_python_interpreter }}"
+  loop: "{{ inventory_files_copied.results | default([]) | selectattr('changed', 'equalto', true) | list }}"
+  when: inventory_files_copied.results | default([]) | selectattr('changed', 'equalto', true) | list | length > 0
+  ignore_errors: true
+  register: sanitize_inventory_results
+
+- name: Sanitize generated inventory (if fallback was used)
+  script:
+    cmd: "{{ playbook_dir }}/../roles/common/files/sanitize_properties.py {{ hostvars['localhost']['bundle_path'] }}/ansible/inventory_1_raw.yml --type inventory"
+    executable: "{{ ansible_python_interpreter }}"
+  when: inventory_files_copied.results | default([]) | selectattr('changed', 'equalto', true) | list | length == 0
+  ignore_errors: true
+
+- name: Rename sanitized inventory files
+  shell: |
+    for file in {{ hostvars['localhost']['bundle_path'] }}/ansible/inventory_*_raw.yml; do
+      if [ -f "$file" ]; then
+        base=$(basename "$file" _raw.yml)
+        mv "$file" "{{ hostvars['localhost']['bundle_path'] }}/ansible/${base}_sanitized.yml"
+      fi
+    done
+  args:
+    executable: "{{ shell_executable }}"
+  ignore_errors: true

--- a/roles/common/templates/bundle_manifest.yml.j2
+++ b/roles/common/templates/bundle_manifest.yml.j2
@@ -1,0 +1,47 @@
+support_bundle_info:
+  bundle_name: {{ hostvars['localhost']['bundle_name'] }}
+  timestamp: {{ hostvars['localhost']['bundle_timestamp'] }}
+  cluster_name: {{ support_bundle_cluster_name }}
+  output_path: {{ support_bundle_output_path }}
+  directory_structure: "<component_name>/<hostname>/"
+
+ansible_controller:
+  ansible_version: {{ ansible_version.full }}
+  python_version: {{ ansible_python_version | default('N/A') }}
+  playbook: support_bundle.yml
+  timestamp: {{ ansible_date_time.iso8601 }}
+
+target_nodes_summary:
+{% for host in groups['all'] %}
+  {{ host }}:
+    ansible_version: {{ hostvars[host].ansible_version.full | default('N/A') }}
+    python_version: {{ hostvars[host].ansible_python_version | default('N/A') }}
+    java_version: {{ hostvars[host].java_version_info | default('N/A') }}
+    os_family: {{ hostvars[host].ansible_os_family | default('N/A') }}
+    distribution: {{ hostvars[host].ansible_distribution | default('N/A') }} {{ hostvars[host].ansible_distribution_version | default('') }}
+    kernel: {{ hostvars[host].ansible_kernel | default('N/A') }}
+    architecture: {{ hostvars[host].ansible_architecture | default('N/A') }}
+    memory_total_mb: {{ hostvars[host].memory_total_mb | default(hostvars[host].ansible_memtotal_mb) | default('N/A') }}
+    memory_used_mb: {{ hostvars[host].memory_used_mb | default('N/A') }}
+    memory_free_mb: {{ hostvars[host].memory_free_mb | default('N/A') }}
+    memory_available_mb: {{ hostvars[host].memory_available_mb | default('N/A') }}
+{% endfor %}
+
+inventory_summary:
+  total_hosts: {{ groups['all'] | length }}
+  components:
+{% for component in support_bundle_component_groups %}
+    {{ component }}:
+      count: {{ groups[component] | default([]) | length }}
+      hosts: {{ groups[component] | default([]) | list }}
+{% endfor %}
+
+collection_settings:
+  journalctl_lines: {{ support_bundle_journalctl_lines }}
+  base_path: {{ support_bundle_base_path }}
+  sanitize_configs: {{ support_bundle_sanitize_configs }}
+  skip_configs: {{ support_bundle_skip_configs }}
+  log_patterns: {{ support_bundle_log_patterns | default(['*.log']) }}
+  log_max_count: {{ support_bundle_log_max_count | default(20) }}
+  log_max_size: {{ support_bundle_log_max_size | default('not set') }}
+  log_age: {{ support_bundle_log_age | default('not set') }}

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -24,6 +24,37 @@ mask_secrets: true
 ### Path on component to store logs collected during fetch_logs playbook
 fetch_logs_path: /tmp
 
+### Output path for support bundles on Ansible controller
+support_bundle_output_path: "~/confluent-platform-support-bundles"
+
+### Cluster name to include in support bundle filename
+support_bundle_cluster_name: cp_cluster
+
+### Number of journalctl log lines to collect per service
+support_bundle_journalctl_lines: 0
+
+### Base path on remote hosts for temporary diagnostic files during collection. Log and config files are fetched directly from their original locations.
+support_bundle_base_path: /tmp
+
+### File patterns to collect for logs, bounded defaults for reliability at scale
+support_bundle_log_patterns:
+  - "*.log"
+
+### Maximum number of log files to collect per component, most recent first
+support_bundle_log_max_count: 20
+
+### Whether to sanitize config files before collection. When true, passwords and sensitive values are redacted from config files.
+support_bundle_sanitize_configs: true
+
+### Whether to skip config file collection entirely. When true, only collect metadata about config files, not their contents.
+support_bundle_skip_configs: false
+
+### Whether to automatically collect support bundle when playbooks fail. Default is false and must be explicitly enabled.
+support_bundle_auto_collect_on_failure: true
+
+### Path to Ansible playbook execution log file on Ansible controller. When set, this log file will be included in the support bundle.
+support_bundle_ansible_log_path: ""
+
 ### Boolean to specify the become value for localhost, used when dealing with any file present on localhost/controller.
 ansible_become_localhost: false
 

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -1,4 +1,5 @@
 plugins/modules/kafka_connectors.py validate-modules:missing-gplv3-license
+plugins/callback/support_bundle_on_failure.py validate-modules:missing-gplv3-license
 molecule/certs-create.sh shebang
 molecule/certs-create.sh shellcheck!skip
 molecule/mtls-custombundle-rhel-fips/create_ca_bundle.sh shebang

--- a/tests/sanity/ignore-2.17.txt
+++ b/tests/sanity/ignore-2.17.txt
@@ -1,4 +1,5 @@
 plugins/modules/kafka_connectors.py validate-modules:missing-gplv3-license
+plugins/callback/support_bundle_on_failure.py validate-modules:missing-gplv3-license
 molecule/certs-create.sh shebang
 molecule/certs-create.sh shellcheck!skip
 molecule/mtls-custombundle-rhel-fips/create_ca_bundle.sh shebang

--- a/tests/sanity/ignore-2.18.txt
+++ b/tests/sanity/ignore-2.18.txt
@@ -1,4 +1,5 @@
 plugins/modules/kafka_connectors.py validate-modules:missing-gplv3-license
+plugins/callback/support_bundle_on_failure.py validate-modules:missing-gplv3-license
 molecule/certs-create.sh shebang
 molecule/certs-create.sh shellcheck!skip
 molecule/mtls-custombundle-rhel-fips/create_ca_bundle.sh shebang


### PR DESCRIPTION
## Description

Forward-port of #2481 (**Support Bundle in CP-Ansible — ANSIENG-5844 / ANSIENG-5805**), originally merged to `7.5.x`, onto `8.3.x`.

JIRA: ANSIENG-5844, ANSIENG-5805

Cherry-picked from commit `e1e33acde294a887c10a3130a67b0077b8c77603`.

### What's included
- `playbooks/support_bundle.yml` — manual support bundle collection playbook
- `plugins/callback/support_bundle_on_failure.py` — auto-collect-on-failure callback plugin
- `roles/common/files/sanitize_properties.py` + `roles/common/tasks/collect_*.yml`, `sanitize_*.yml`, `templates/bundle_manifest.yml.j2`
- `roles/variables/defaults/main.yml` — new `support_bundle_*` variables
- `ansible.cfg` — registers the `support_bundle_on_failure` callback
- `tests/sanity/ignore-*.txt` — GPLv3-license sanity ignore for the new callback plugin

### Conflict resolution notes
- The feature files applied cleanly and are identical to the source commit.
- `tests/sanity/ignore-*.txt`: added only the new `plugins/callback/support_bundle_on_failure.py validate-modules:missing-gplv3-license` line, into each ignore file matching the ansible-core version(s) this branch's CI runs.
- `.semaphore/*`: kept this branch's own CI configuration (the incidental CI-env changes bundled into #2481 were specific to the `7.5.x` CI and are not part of the feature).

## Type of change
- [x] New feature (non-breaking change which adds functionality)

🤖 Generated with [Claude Code](https://claude.com/claude-code)