### PR TITLE
[2493-8.0.x] | [ANSIENG-5782] | Cherry-pick #2493 to 8.0.x: validate …

### DIFF
--- a/roles/common/tasks/validate_package_availability.yml
+++ b/roles/common/tasks/validate_package_availability.yml
@@ -1,0 +1,61 @@
+---
+# Probe by BARE package name (no version suffix). apt-cache policy only accepts a
+# package name (pkg=version is apt-get syntax), and yum list with a version-pinned
+# spec is fragile against the repo's dist tag (e.g. -1.el7). The intent here is
+# simply "can this package be obtained from a repo or is it already installed"
+# before we remove the old packages, so the name is sufficient.
+- name: Check Package Availability (RedHat)
+  shell: |
+    yum list available {{ item }} 2>/dev/null || yum list installed {{ item }} 2>/dev/null
+  register: package_availability_check_redhat
+  changed_when: false
+  failed_when: false
+  check_mode: false
+  loop: "{{ validate_packages }}"
+  when:
+    - ansible_os_family == "RedHat"
+    - installation_method == "package"
+  tags:
+    - package
+    - cp_package
+    - validate_package_availability
+
+- name: Check Package Availability (Debian)
+  shell: |
+    apt-cache policy {{ item }} 2>/dev/null | grep -E 'Candidate:' | grep -v 'Candidate: (none)'
+  register: package_availability_check_debian
+  changed_when: false
+  failed_when: false
+  check_mode: false
+  loop: "{{ validate_packages }}"
+  when:
+    - ansible_os_family == "Debian"
+    - installation_method == "package"
+  tags:
+    - package
+    - cp_package
+    - validate_package_availability
+
+# Fail with an explicit list of the missing packages so support does not have to
+# parse raw yum/apt output to find out what is unavailable.
+- name: Fail if Any Package is Unavailable
+  fail:
+    msg: >-
+      Package(s) not available in any repo or installed:
+      {{ unavailable_packages | join(', ') }}. Aborting before removing old
+      packages. Check repo config and Confluent version ({{ confluent_package_version }}).
+  vars:
+    unavailable_packages: >-
+      {{ ((package_availability_check_redhat.results | default([]))
+          + (package_availability_check_debian.results | default([])))
+         | selectattr('rc', 'defined')
+         | selectattr('rc', 'ne', 0)
+         | map(attribute='item')
+         | list }}
+  when:
+    - installation_method == "package"
+    - unavailable_packages | length > 0
+  tags:
+    - package
+    - cp_package
+    - validate_package_availability

--- a/roles/control_center_next_gen/tasks/main.yml
+++ b/roles/control_center_next_gen/tasks/main.yml
@@ -26,6 +26,20 @@
     creates: "{{confluent_control_center_next_gen_binary_base_path}}"
   when: installation_method == "archive"
 
+# Validate package availability BEFORE removing old packages to ensure we don't leave the node in a broken state if new packages aren't available
+- name: Validate Package Availability Before Removing Old Packages
+  include_role:
+    name: common
+    tasks_from: validate_package_availability.yml
+  vars:
+    validate_packages: "{{ control_center_next_gen_packages }}"
+  when: installation_method == "package"
+  tags:
+    - package
+    - cp_package
+    - validate_package_availability
+
+# Only remove old packages after validating new packages are available
 - name: Stop Service and Remove Packages on Version Change
   include_role:
     name: common

--- a/roles/kafka_broker/tasks/main.yml
+++ b/roles/kafka_broker/tasks/main.yml
@@ -42,6 +42,20 @@
       - kafka_broker_final_properties['log.dirs'].split(',')[0] != "/"
     fail_msg: "If you have log.dirs in kafka_broker_custom_properties, make sure it's comma separated directories."
 
+# Validate package availability BEFORE removing old packages to ensure we don't leave the node in a broken state if new packages aren't available
+- name: Validate Package Availability Before Removing Old Packages
+  include_role:
+    name: common
+    tasks_from: validate_package_availability.yml
+  vars:
+    validate_packages: "{{ kafka_broker_packages }}"
+  when: installation_method == "package"
+  tags:
+    - package
+    - cp_package
+    - validate_package_availability
+
+# Only remove old packages after validating new packages are available
 - name: Stop Service and Remove Packages on Version Change
   include_role:
     name: common

--- a/roles/kafka_connect/tasks/main.yml
+++ b/roles/kafka_connect/tasks/main.yml
@@ -26,6 +26,20 @@
     - validate
     - validate_jolokia
 
+# Validate package availability BEFORE removing old packages to ensure we don't leave the node in a broken state if new packages aren't available
+- name: Validate Package Availability Before Removing Old Packages
+  include_role:
+    name: common
+    tasks_from: validate_package_availability.yml
+  vars:
+    validate_packages: "{{ kafka_connect_packages }}"
+  when: installation_method == "package"
+  tags:
+    - package
+    - cp_package
+    - validate_package_availability
+
+# Only remove old packages after validating new packages are available
 - name: Stop Service and Remove Packages on Version Change
   include_role:
     name: common

--- a/roles/kafka_controller/tasks/main.yml
+++ b/roles/kafka_controller/tasks/main.yml
@@ -54,6 +54,20 @@
       - kafka_controller_final_properties['log.dirs'] != "/" and not ',' in kafka_controller_final_properties['log.dirs']
     fail_msg: "If you have log.dirs in kafka_controller_custom_properties, make sure you only provide one directory."
 
+# Validate package availability BEFORE removing old packages to ensure we don't leave the node in a broken state if new packages aren't available
+- name: Validate Package Availability Before Removing Old Packages
+  include_role:
+    name: common
+    tasks_from: validate_package_availability.yml
+  vars:
+    validate_packages: "{{ kafka_controller_packages }}"
+  when: installation_method == "package"
+  tags:
+    - package
+    - cp_package
+    - validate_package_availability
+
+# Only remove old packages after validating new packages are available
 - name: Stop Service and Remove Packages on Version Change
   include_role:
     name: common

--- a/roles/kafka_rest/tasks/main.yml
+++ b/roles/kafka_rest/tasks/main.yml
@@ -26,6 +26,20 @@
     - validate
     - validate_jolokia
 
+# Validate package availability BEFORE removing old packages to ensure we don't leave the node in a broken state if new packages aren't available
+- name: Validate Package Availability Before Removing Old Packages
+  include_role:
+    name: common
+    tasks_from: validate_package_availability.yml
+  vars:
+    validate_packages: "{{ kafka_rest_packages }}"
+  when: installation_method == "package"
+  tags:
+    - package
+    - cp_package
+    - validate_package_availability
+
+# Only remove old packages after validating new packages are available
 - name: Stop Service and Remove Packages on Version Change
   include_role:
     name: common

--- a/roles/ksql/tasks/main.yml
+++ b/roles/ksql/tasks/main.yml
@@ -26,6 +26,20 @@
     - validate
     - validate_jolokia
 
+# Validate package availability BEFORE removing old packages to ensure we don't leave the node in a broken state if new packages aren't available
+- name: Validate Package Availability Before Removing Old Packages
+  include_role:
+    name: common
+    tasks_from: validate_package_availability.yml
+  vars:
+    validate_packages: "{{ ksql_packages }}"
+  when: installation_method == "package"
+  tags:
+    - package
+    - cp_package
+    - validate_package_availability
+
+# Only remove old packages after validating new packages are available
 - name: Stop Service and Remove Packages on Version Change
   include_role:
     name: common

--- a/roles/schema_registry/tasks/main.yml
+++ b/roles/schema_registry/tasks/main.yml
@@ -26,6 +26,20 @@
     - validate
     - validate_jolokia
 
+# Validate package availability BEFORE removing old packages to ensure we don't leave the node in a broken state if new packages aren't available
+- name: Validate Package Availability Before Removing Old Packages
+  include_role:
+    name: common
+    tasks_from: validate_package_availability.yml
+  vars:
+    validate_packages: "{{ schema_registry_packages }}"
+  when: installation_method == "package"
+  tags:
+    - package
+    - cp_package
+    - validate_package_availability
+
+# Only remove old packages after validating new packages are available
 - name: Stop Service and Remove Packages on Version Change
   include_role:
     name: common


### PR DESCRIPTION
…package availability before removing old packages

Cherry-pick of confluentinc/cp-ansible#2493 (merged to 7.6.x, commit 226a59424).

Adds a "Validate Package Availability Before Removing Old Packages" precheck that probes each component's packages by bare name and aborts before removing old packages if the new ones are unavailable, avoiding leaving a node in a broken state during upgrades.

Adapted for 8.0.x (KRaft-only):
- Dropped the ZK->KRaft migration bits (ZKtoKraftMigration.yml, migration_precheck.yml, zookeeper role) which do not exist in 8.0.x.
- Applied the precheck to control_center_next_gen (renamed from control_center).
- Skipped the kraft_migration guard play in all.yml (per request; it references the migration playbook/hosts not present in 8.0.x).

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
