### PR TITLE
[ubuntu-7.9.x] | Fix secrets molecule scenarios stranded on unsupport…

### DIFF
--- a/molecule/secrets-provided-per-component/molecule.yml
+++ b/molecule/secrets-provided-per-component/molecule.yml
@@ -12,7 +12,7 @@ platforms:
     hostname: ${KRAFT_CONTROLLER:-zookeeper}1.confluent
     groups:
       - ${CONTROLLER_HOSTGROUP:-zookeeper}
-    image: geerlingguy/docker-ubuntu1804-ansible
+    image: geerlingguy/docker-ubuntu2404-ansible
     dockerfile: ../Dockerfile-ubuntu.j2
     command: ""
     volumes:
@@ -25,7 +25,7 @@ platforms:
     hostname: kafka-broker1.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-ubuntu1804-ansible
+    image: geerlingguy/docker-ubuntu2404-ansible
     dockerfile: ../Dockerfile-ubuntu.j2
     command: ""
     volumes:
@@ -38,7 +38,7 @@ platforms:
     hostname: kafka-broker2.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-ubuntu1804-ansible
+    image: geerlingguy/docker-ubuntu2404-ansible
     dockerfile: ../Dockerfile-ubuntu.j2
     command: ""
     volumes:
@@ -51,7 +51,7 @@ platforms:
     hostname: kafka-broker3.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-ubuntu1804-ansible
+    image: geerlingguy/docker-ubuntu2404-ansible
     dockerfile: ../Dockerfile-ubuntu.j2
     command: ""
     volumes:
@@ -64,7 +64,7 @@ platforms:
     hostname: schema-registry1.confluent
     groups:
       - schema_registry
-    image: geerlingguy/docker-ubuntu1804-ansible
+    image: geerlingguy/docker-ubuntu2404-ansible
     dockerfile: ../Dockerfile-ubuntu.j2
     command: ""
     volumes:
@@ -77,7 +77,7 @@ platforms:
     hostname: kafka-connect1.confluent
     groups:
       - kafka_connect
-    image: geerlingguy/docker-ubuntu1804-ansible
+    image: geerlingguy/docker-ubuntu2404-ansible
     dockerfile: ../Dockerfile-ubuntu.j2
     command: ""
     volumes:

--- a/molecule/secrets-upgrade-auto/molecule.yml
+++ b/molecule/secrets-upgrade-auto/molecule.yml
@@ -13,7 +13,7 @@ platforms:
     hostname: ${KRAFT_CONTROLLER:-zookeeper}1.confluent
     groups:
       - ${CONTROLLER_HOSTGROUP:-zookeeper}
-    image: geerlingguy/docker-ubuntu1804-ansible
+    image: geerlingguy/docker-ubuntu2404-ansible
     dockerfile: ../Dockerfile-ubuntu.j2
     command: ""
     volumes:
@@ -26,7 +26,7 @@ platforms:
     hostname: kafka-broker1.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-ubuntu1804-ansible
+    image: geerlingguy/docker-ubuntu2404-ansible
     dockerfile: ../Dockerfile-ubuntu.j2
     command: ""
     volumes:
@@ -39,7 +39,7 @@ platforms:
     hostname: kafka-broker2.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-ubuntu1804-ansible
+    image: geerlingguy/docker-ubuntu2404-ansible
     dockerfile: ../Dockerfile-ubuntu.j2
     command: ""
     volumes:
@@ -52,7 +52,7 @@ platforms:
     hostname: kafka-broker3.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-ubuntu1804-ansible
+    image: geerlingguy/docker-ubuntu2404-ansible
     dockerfile: ../Dockerfile-ubuntu.j2
     command: ""
     volumes:

--- a/molecule/secrets-upgrade-provided/molecule.yml
+++ b/molecule/secrets-upgrade-provided/molecule.yml
@@ -15,7 +15,7 @@ platforms:
     hostname: ${KRAFT_CONTROLLER:-zookeeper}1.confluent
     groups:
       - ${CONTROLLER_HOSTGROUP:-zookeeper}
-    image: geerlingguy/docker-ubuntu1804-ansible
+    image: geerlingguy/docker-ubuntu2404-ansible
     dockerfile: ../Dockerfile-ubuntu.j2
     command: ""
     volumes:
@@ -28,7 +28,7 @@ platforms:
     hostname: kafka-broker1.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-ubuntu1804-ansible
+    image: geerlingguy/docker-ubuntu2404-ansible
     dockerfile: ../Dockerfile-ubuntu.j2
     command: ""
     volumes:
@@ -41,7 +41,7 @@ platforms:
     hostname: kafka-broker2.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-ubuntu1804-ansible
+    image: geerlingguy/docker-ubuntu2404-ansible
     dockerfile: ../Dockerfile-ubuntu.j2
     command: ""
     volumes:
@@ -54,7 +54,7 @@ platforms:
     hostname: kafka-broker3.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-ubuntu1804-ansible
+    image: geerlingguy/docker-ubuntu2404-ansible
     dockerfile: ../Dockerfile-ubuntu.j2
     command: ""
     volumes:


### PR DESCRIPTION
…ed Ubuntu 18.04

The secrets-upgrade-auto, secrets-provided-per-component and secrets-upgrade-provided scenarios still pinned
geerlingguy/docker-ubuntu1804-ansible while the rest of the suite moved to Ubuntu 24.04. Ubuntu 18.04 ships Python 3.6, but this branch's ansible-core requires Python >= 3.7 on managed nodes, so fact gathering fails immediately with "SyntaxError: future feature annotations is not defined". Point these scenarios at geerlingguy/docker-ubuntu2404-ansible (matching mtls-ubuntu); the existing Dockerfile-ubuntu.j2 template, which builds FROM the image var, is unchanged.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
