### PR TITLE
[masterkey-7.7.x] | Pass master key to kafka-migration-check prefligh…

### DIFF
--- a/roles/kafka_controller/tasks/main.yml
+++ b/roles/kafka_controller/tasks/main.yml
@@ -510,8 +510,11 @@
     - kraft_migration | bool
     - confluent_server_enabled | bool
     - kafka_controller_migration_preflight_enabled | bool
-  environment:
-    KAFKA_OPTS: "{{ kafka_controller_service_environment_overrides.KAFKA_OPTS | default('') }}"
+  # Secrets-protected server.properties needs the master key to decrypt encrypted
+  # configs when kafka-migration-check parses the controller config file.
+  environment: "{{ {'KAFKA_OPTS': kafka_controller_service_environment_overrides.KAFKA_OPTS | default('')}
+    | combine({'CONFLUENT_SECURITY_MASTER_KEY': existing_masterkey}
+    if kafka_controller_secrets_protection_enabled|bool and existing_masterkey | default('') != '' else {}) }}"
   vars:
     kafka_migration_check_path: "{% if installation_method == 'archive' %}{{ archive_destination_path }}/confluent-{{ confluent_package_version }}/bin/kafka-migration-check{% else %}kafka-migration-check{% endif %}"
 


### PR DESCRIPTION
…t for secrets protection

The "Run kafka-migration-check preflight" task only set KAFKA_OPTS in its environment. When secrets protection is enabled, server.properties contains encrypted configs that SecurePassConfigProvider resolves via the CONFLUENT_SECURITY_MASTER_KEY environment variable. Without it, kafka-migration-check failed to decrypt the controller config:

  ERROR Failed to load master key from environment variable.

Inject CONFLUENT_SECURITY_MASTER_KEY (from existing_masterkey) alongside KAFKA_OPTS when secrets protection is enabled, mirroring the pattern already used in get_meta_properties.yml. Non-secrets migration runs are unaffected.

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

test fix: https://semaphore.ci.confluent.io/workflows/95852f4b-57fa-4293-8922-83446b6fd85f

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
