### PR TITLE
[ANSIENG-5765] | Forward-port cert chain fix to 7.6.x

### DIFF
--- a/molecule/assert_cert_chain.yml
+++ b/molecule/assert_cert_chain.yml
@@ -1,0 +1,42 @@
+---
+### Shared task file for ANSIENG-5765 cert-chain Molecule scenarios.
+### Asserts that {{ chain_service_name }}.chain on the current host:
+###   - exists
+###   - contains exactly expected_chain_cert_count PEM blocks
+###   - is leaf-first (first cert's Subject CN matches the host's inventory name)
+
+- name: Read {{ chain_service_name }}.chain
+  slurp:
+    src: "/var/ssl/private/{{ chain_service_name }}.chain"
+  register: chain_slurp
+
+- name: Count certs in chain
+  set_fact:
+    chain_cert_count: "{{ (chain_slurp['content'] | b64decode).split('-----BEGIN CERTIFICATE-----') | length - 1 }}"
+
+- name: Assert chain has expected number of certs
+  assert:
+    that:
+      - chain_cert_count | int == expected_chain_cert_count | int
+    fail_msg: >-
+      Expected {{ expected_chain_cert_count }} certs in
+      /var/ssl/private/{{ chain_service_name }}.chain on {{ inventory_hostname }},
+      got {{ chain_cert_count }}.
+
+- name: Read first cert's Subject (should match the host's CN)
+  shell: |
+    set -o pipefail
+    awk '/BEGIN CERTIFICATE/,/END CERTIFICATE/' /var/ssl/private/{{ chain_service_name }}.chain \
+      | awk '/BEGIN CERTIFICATE/{n++} n==1' \
+      | openssl x509 -noout -subject
+  args:
+    executable: /bin/bash
+  register: leaf_subject
+  changed_when: false
+
+- name: Assert leaf cert CN matches the host
+  assert:
+    that:
+      - "'CN = ' + inventory_hostname in leaf_subject.stdout or 'CN=' + inventory_hostname in leaf_subject.stdout"
+    fail_msg: >-
+      Leaf cert Subject "{{ leaf_subject.stdout }}" does not match inventory_hostname "{{ inventory_hostname }}".

--- a/molecule/mtls-custom-2tier-rhel/create_certs.sh
+++ b/molecule/mtls-custom-2tier-rhel/create_certs.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Cert generation for ANSIENG-5765 case 1: 2-tier PKI.
+# Produces:
+#   out/caBundle.pem   = Root CA (self-signed) ONLY
+#   out/<host>.crt     = leaf certificate, signed directly by the Root (leaf only, no inline intermediate)
+#   out/<host>.key     = leaf private key
+set -euo pipefail
+
+OUT=out
+HOSTS_FILE="${1:-hosts}"
+
+rm -rf "$OUT" && mkdir -p "$OUT"
+
+# Helper: write a minimal openssl extfile for a leaf cert with SANs.
+write_leaf_ext() {
+    local hostname=$1 fqdn=$2 outfile=$3
+    cat > "$outfile" <<EOF
+basicConstraints = CA:FALSE
+keyUsage = digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth, clientAuth
+subjectAltName = DNS:${hostname},DNS:${fqdn}
+EOF
+}
+
+# 1. Root CA (self-signed).
+openssl req -new -x509 -nodes -days 3650 \
+    -keyout "$OUT/root.key" \
+    -out   "$OUT/root.crt" \
+    -subj '/CN=ANSIENG-5765-Root/O=Confluent/OU=Test'
+
+# 2. Per-host leaf, signed directly by Root.
+while IFS= read -r host || [ -n "$host" ]; do
+    [ -z "$host" ] && continue
+    fqdn="${host}.confluent"
+
+    openssl req -new -nodes \
+        -keyout "$OUT/${host}.key" \
+        -out   "$OUT/${host}.csr" \
+        -subj  "/CN=${host}/O=Confluent/OU=Test"
+
+    write_leaf_ext "$host" "$fqdn" "$OUT/${host}.ext"
+
+    openssl x509 -req -days 3650 -sha256 \
+        -in "$OUT/${host}.csr" \
+        -CA "$OUT/root.crt" -CAkey "$OUT/root.key" -CAcreateserial \
+        -out "$OUT/${host}.crt" \
+        -extfile "$OUT/${host}.ext"
+
+    rm -f "$OUT/${host}.csr" "$OUT/${host}.ext"
+done < "$HOSTS_FILE"
+
+# 3. Assemble CA bundle (Root only for case 1).
+cp "$OUT/root.crt" "$OUT/caBundle.pem"
+
+echo "case 1 cert generation complete:"
+ls -1 "$OUT" | sed 's/^/  /'

--- a/molecule/mtls-custom-2tier-rhel/molecule.yml
+++ b/molecule/mtls-custom-2tier-rhel/molecule.yml
@@ -11,7 +11,7 @@ platforms:
     groups:
       - ${CONTROLLER_HOSTGROUP:-zookeeper}
     image: redhat/ubi9-minimal
-    dockerfile: ../Dockerfile-rhel9-java17.j2
+    dockerfile: ../Dockerfile-rhel-java17.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -24,7 +24,7 @@ platforms:
     groups:
       - kafka_broker
     image: redhat/ubi9-minimal
-    dockerfile: ../Dockerfile-rhel9-java17.j2
+    dockerfile: ../Dockerfile-rhel-java17.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -37,7 +37,7 @@ platforms:
     groups:
       - kafka_broker
     image: redhat/ubi9-minimal
-    dockerfile: ../Dockerfile-rhel9-java17.j2
+    dockerfile: ../Dockerfile-rhel-java17.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -50,7 +50,7 @@ platforms:
     groups:
       - schema_registry
     image: redhat/ubi9-minimal
-    dockerfile: ../Dockerfile-rhel9-java17.j2
+    dockerfile: ../Dockerfile-rhel-java17.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw

--- a/molecule/mtls-custom-2tier-rhel/molecule.yml
+++ b/molecule/mtls-custom-2tier-rhel/molecule.yml
@@ -1,0 +1,73 @@
+---
+### ANSIENG-5765 case 1: 2-tier PKI.
+### CA bundle = Root only. Cert file = leaf only.
+### Expected chain: leaf -> root (2 certs).
+
+driver:
+  name: docker
+platforms:
+  - name: ${KRAFT_CONTROLLER:-zookeeper}1
+    hostname: ${KRAFT_CONTROLLER:-zookeeper}1.confluent
+    groups:
+      - ${CONTROLLER_HOSTGROUP:-zookeeper}
+    image: redhat/ubi9-minimal
+    dockerfile: ../Dockerfile-rhel9-java17.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent
+  - name: kafka-broker1
+    hostname: kafka-broker1.confluent
+    groups:
+      - kafka_broker
+    image: redhat/ubi9-minimal
+    dockerfile: ../Dockerfile-rhel9-java17.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent
+  - name: kafka-broker2
+    hostname: kafka-broker2.confluent
+    groups:
+      - kafka_broker
+    image: redhat/ubi9-minimal
+    dockerfile: ../Dockerfile-rhel9-java17.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent
+  - name: schema-registry1
+    hostname: schema-registry1.confluent
+    groups:
+      - schema_registry
+    image: redhat/ubi9-minimal
+    dockerfile: ../Dockerfile-rhel9-java17.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent
+provisioner:
+  inventory:
+    group_vars:
+      all:
+        scenario_name: mtls-custom-2tier-rhel
+        ssl_enabled: true
+        ssl_mutual_auth_enabled: true
+        ssl_custom_certs: true
+        ssl_ca_cert_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/caBundle.pem"
+        ssl_signed_cert_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}.crt"
+        ssl_key_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}.key"
+        # Number of certs the chain file is expected to contain (leaf -> root).
+        expected_chain_cert_count: 2

--- a/molecule/mtls-custom-2tier-rhel/prepare.yml
+++ b/molecule/mtls-custom-2tier-rhel/prepare.yml
@@ -1,0 +1,51 @@
+---
+### prepare.yml shared shape across all four ANSIENG-5765 cert-chain scenarios.
+### Generates the case-specific cert layout via the scenario's create_certs.sh,
+### then syncs the output back to the molecule scenario directory so that
+### ssl_ca_cert_filepath / ssl_signed_cert_filepath / ssl_key_filepath can
+### lookup() into it.
+
+- name: Generate certs for the cert-chain scenario
+  hosts: kafka_broker[0]
+  gather_facts: true
+  tasks:
+    - name: Install OpenSSL and Rsync
+      package:
+        name:
+          - openssl
+          - rsync
+        state: present
+
+    - name: Create cert generation directory
+      file:
+        path: /var/ssl/private/generation
+        state: directory
+        mode: '755'
+
+    - name: Copy create_certs.sh to host
+      copy:
+        src: create_certs.sh
+        dest: /var/ssl/private/generation/create_certs.sh
+        mode: '755'
+
+    - name: Write hosts file for cert generation
+      copy:
+        content: "{{ groups['all'] | join('\n') }}\n"
+        dest: /var/ssl/private/generation/hosts
+        mode: '644'
+
+    - name: Run cert generation script
+      shell: ./create_certs.sh hosts
+      args:
+        chdir: /var/ssl/private/generation/
+
+    - name: Sync generated certs back to the molecule scenario directory
+      synchronize:
+        src: /var/ssl/private/generation/out/
+        dest: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files"
+        mode: pull
+
+    - name: Cleanup remote cert generation directory
+      file:
+        path: /var/ssl/private/generation
+        state: absent

--- a/molecule/mtls-custom-2tier-rhel/verify.yml
+++ b/molecule/mtls-custom-2tier-rhel/verify.yml
@@ -1,0 +1,32 @@
+---
+### Verifies the cert chain that build_certificate_chain.yml produced.
+###
+### The cluster having come up at all (converge succeeded) is itself end-to-end
+### proof that the chain is correct: mTLS handshakes between broker, controller,
+### and schema_registry would have failed otherwise. These checks add an extra
+### assertion that the chain file has the expected number of certs in
+### leaf-first order for this scenario's input layout.
+
+- name: Verify chain - kafka_controller
+  hosts: kafka_controller:zookeeper
+  gather_facts: false
+  vars:
+    chain_service_name: "{{ 'kafka_controller' if inventory_hostname in groups.get('kafka_controller', []) else 'zookeeper' }}"
+  tasks:
+    - include_tasks: ../assert_cert_chain.yml
+
+- name: Verify chain - kafka_broker
+  hosts: kafka_broker
+  gather_facts: false
+  vars:
+    chain_service_name: kafka_broker
+  tasks:
+    - include_tasks: ../assert_cert_chain.yml
+
+- name: Verify chain - schema_registry
+  hosts: schema_registry
+  gather_facts: false
+  vars:
+    chain_service_name: schema_registry
+  tasks:
+    - include_tasks: ../assert_cert_chain.yml

--- a/molecule/mtls-custom-4tier-bundle-debian/create_certs.sh
+++ b/molecule/mtls-custom-4tier-bundle-debian/create_certs.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Cert generation for ANSIENG-5765 case 7: 4-tier PKI, all CAs in the bundle.
+# Hierarchy: Root -> Int1 -> Int2 -> Leaf
+# Produces:
+#   out/caBundle.pem   = Root + Int1 + Int2 (all CAs concatenated)
+#   out/<host>.crt     = leaf ONLY (no inline intermediates)
+#   out/<host>.key     = leaf private key
+set -euo pipefail
+
+OUT=out
+HOSTS_FILE="${1:-hosts}"
+
+rm -rf "$OUT" && mkdir -p "$OUT"
+
+ca_ext() {
+    cat > "$1" <<EOF
+basicConstraints = critical, CA:TRUE
+keyUsage = critical, keyCertSign, cRLSign
+EOF
+}
+
+leaf_ext() {
+    local hostname=$1 fqdn=$2 outfile=$3
+    cat > "$outfile" <<EOF
+basicConstraints = CA:FALSE
+keyUsage = digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth, clientAuth
+subjectAltName = DNS:${hostname},DNS:${fqdn}
+EOF
+}
+
+# 1. Root CA (self-signed).
+openssl req -new -x509 -nodes -days 3650 \
+    -keyout "$OUT/root.key" \
+    -out   "$OUT/root.crt" \
+    -subj '/CN=ANSIENG-5765-Root/O=Confluent/OU=Test'
+
+# 2. Int1 (signed by Root).
+ca_ext "$OUT/int1.ext"
+openssl req -new -nodes -keyout "$OUT/int1.key" -out "$OUT/int1.csr" \
+    -subj '/CN=ANSIENG-5765-Int1/O=Confluent/OU=Test'
+openssl x509 -req -days 3650 -sha256 \
+    -in "$OUT/int1.csr" \
+    -CA "$OUT/root.crt" -CAkey "$OUT/root.key" -CAcreateserial \
+    -out "$OUT/int1.crt" \
+    -extfile "$OUT/int1.ext"
+
+# 3. Int2 (signed by Int1).
+ca_ext "$OUT/int2.ext"
+openssl req -new -nodes -keyout "$OUT/int2.key" -out "$OUT/int2.csr" \
+    -subj '/CN=ANSIENG-5765-Int2/O=Confluent/OU=Test'
+openssl x509 -req -days 3650 -sha256 \
+    -in "$OUT/int2.csr" \
+    -CA "$OUT/int1.crt" -CAkey "$OUT/int1.key" -CAcreateserial \
+    -out "$OUT/int2.crt" \
+    -extfile "$OUT/int2.ext"
+
+# 4. Per-host leaf, signed by Int2.
+while IFS= read -r host || [ -n "$host" ]; do
+    [ -z "$host" ] && continue
+    fqdn="${host}.confluent"
+
+    openssl req -new -nodes \
+        -keyout "$OUT/${host}.key" \
+        -out   "$OUT/${host}.csr" \
+        -subj  "/CN=${host}/O=Confluent/OU=Test"
+
+    leaf_ext "$host" "$fqdn" "$OUT/${host}.ext"
+
+    openssl x509 -req -days 3650 -sha256 \
+        -in "$OUT/${host}.csr" \
+        -CA "$OUT/int2.crt" -CAkey "$OUT/int2.key" -CAcreateserial \
+        -out "$OUT/${host}.crt" \
+        -extfile "$OUT/${host}.ext"
+
+    rm -f "$OUT/${host}.csr" "$OUT/${host}.ext"
+done < "$HOSTS_FILE"
+
+# 5. Assemble CA bundle: Root + Int1 + Int2 (case 7).
+cat "$OUT/root.crt" "$OUT/int1.crt" "$OUT/int2.crt" > "$OUT/caBundle.pem"
+
+# Cleanup CA scratch files we don't need to sync back.
+rm -f "$OUT"/int*.csr "$OUT"/int*.ext "$OUT"/*.srl
+
+echo "case 7 cert generation complete:"
+ls -1 "$OUT" | sed 's/^/  /'

--- a/molecule/mtls-custom-4tier-bundle-debian/molecule.yml
+++ b/molecule/mtls-custom-4tier-bundle-debian/molecule.yml
@@ -11,8 +11,8 @@ platforms:
     hostname: ${KRAFT_CONTROLLER:-zookeeper}1.confluent
     groups:
       - ${CONTROLLER_HOSTGROUP:-zookeeper}
-    image: geerlingguy/docker-debian9-ansible
-    dockerfile: ../Dockerfile-debian-java11.j2
+    image: geerlingguy/docker-debian10-ansible
+    dockerfile: ../Dockerfile-debian10-java11.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -24,8 +24,8 @@ platforms:
     hostname: kafka-broker1.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-debian9-ansible
-    dockerfile: ../Dockerfile-debian-java11.j2
+    image: geerlingguy/docker-debian10-ansible
+    dockerfile: ../Dockerfile-debian10-java11.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -37,8 +37,8 @@ platforms:
     hostname: kafka-broker2.confluent
     groups:
       - kafka_broker
-    image: geerlingguy/docker-debian9-ansible
-    dockerfile: ../Dockerfile-debian-java11.j2
+    image: geerlingguy/docker-debian10-ansible
+    dockerfile: ../Dockerfile-debian10-java11.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -50,8 +50,8 @@ platforms:
     hostname: schema-registry1.confluent
     groups:
       - schema_registry
-    image: geerlingguy/docker-debian9-ansible
-    dockerfile: ../Dockerfile-debian-java11.j2
+    image: geerlingguy/docker-debian10-ansible
+    dockerfile: ../Dockerfile-debian10-java11.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw

--- a/molecule/mtls-custom-4tier-bundle-debian/molecule.yml
+++ b/molecule/mtls-custom-4tier-bundle-debian/molecule.yml
@@ -1,0 +1,74 @@
+---
+### ANSIENG-5765 case 7 on Debian.
+### Same cert layout as mtls-custom-4tier-bundle-rhel (Root + Int1 + Int2 in the
+### bundle, leaf-only cert file) but exercises the chain task on a Debian host
+### to confirm the shell logic is OS-agnostic.
+
+driver:
+  name: docker
+platforms:
+  - name: ${KRAFT_CONTROLLER:-zookeeper}1
+    hostname: ${KRAFT_CONTROLLER:-zookeeper}1.confluent
+    groups:
+      - ${CONTROLLER_HOSTGROUP:-zookeeper}
+    image: geerlingguy/docker-debian9-ansible
+    dockerfile: ../Dockerfile-debian-java11.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent
+  - name: kafka-broker1
+    hostname: kafka-broker1.confluent
+    groups:
+      - kafka_broker
+    image: geerlingguy/docker-debian9-ansible
+    dockerfile: ../Dockerfile-debian-java11.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent
+  - name: kafka-broker2
+    hostname: kafka-broker2.confluent
+    groups:
+      - kafka_broker
+    image: geerlingguy/docker-debian9-ansible
+    dockerfile: ../Dockerfile-debian-java11.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent
+  - name: schema-registry1
+    hostname: schema-registry1.confluent
+    groups:
+      - schema_registry
+    image: geerlingguy/docker-debian9-ansible
+    dockerfile: ../Dockerfile-debian-java11.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent
+provisioner:
+  inventory:
+    group_vars:
+      all:
+        scenario_name: mtls-custom-4tier-bundle-debian
+        ssl_enabled: true
+        ssl_mutual_auth_enabled: true
+        ssl_custom_certs: true
+        ssl_ca_cert_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/caBundle.pem"
+        ssl_signed_cert_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}.crt"
+        ssl_key_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}.key"
+        expected_chain_cert_count: 4
+        debian_java_package_name: openjdk-11-jdk

--- a/molecule/mtls-custom-4tier-bundle-debian/prepare.yml
+++ b/molecule/mtls-custom-4tier-bundle-debian/prepare.yml
@@ -1,0 +1,48 @@
+---
+### Shared prepare for ANSIENG-5765 cert-chain scenarios.
+### See molecule/mtls-custom-2tier-rhel/prepare.yml for rationale.
+
+- name: Generate certs for the cert-chain scenario
+  hosts: kafka_broker[0]
+  gather_facts: true
+  tasks:
+    - name: Install OpenSSL and Rsync
+      package:
+        name:
+          - openssl
+          - rsync
+        state: present
+
+    - name: Create cert generation directory
+      file:
+        path: /var/ssl/private/generation
+        state: directory
+        mode: '755'
+
+    - name: Copy create_certs.sh to host
+      copy:
+        src: create_certs.sh
+        dest: /var/ssl/private/generation/create_certs.sh
+        mode: '755'
+
+    - name: Write hosts file for cert generation
+      copy:
+        content: "{{ groups['all'] | join('\n') }}\n"
+        dest: /var/ssl/private/generation/hosts
+        mode: '644'
+
+    - name: Run cert generation script
+      shell: ./create_certs.sh hosts
+      args:
+        chdir: /var/ssl/private/generation/
+
+    - name: Sync generated certs back to the molecule scenario directory
+      synchronize:
+        src: /var/ssl/private/generation/out/
+        dest: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files"
+        mode: pull
+
+    - name: Cleanup remote cert generation directory
+      file:
+        path: /var/ssl/private/generation
+        state: absent

--- a/molecule/mtls-custom-4tier-bundle-debian/verify.yml
+++ b/molecule/mtls-custom-4tier-bundle-debian/verify.yml
@@ -1,0 +1,32 @@
+---
+### Verifies the cert chain that build_certificate_chain.yml produced.
+###
+### The cluster having come up at all (converge succeeded) is itself end-to-end
+### proof that the chain is correct: mTLS handshakes between broker, controller,
+### and schema_registry would have failed otherwise. These checks add an extra
+### assertion that the chain file has the expected number of certs in
+### leaf-first order for this scenario's input layout.
+
+- name: Verify chain - kafka_controller
+  hosts: kafka_controller:zookeeper
+  gather_facts: false
+  vars:
+    chain_service_name: "{{ 'kafka_controller' if inventory_hostname in groups.get('kafka_controller', []) else 'zookeeper' }}"
+  tasks:
+    - include_tasks: ../assert_cert_chain.yml
+
+- name: Verify chain - kafka_broker
+  hosts: kafka_broker
+  gather_facts: false
+  vars:
+    chain_service_name: kafka_broker
+  tasks:
+    - include_tasks: ../assert_cert_chain.yml
+
+- name: Verify chain - schema_registry
+  hosts: schema_registry
+  gather_facts: false
+  vars:
+    chain_service_name: schema_registry
+  tasks:
+    - include_tasks: ../assert_cert_chain.yml

--- a/molecule/mtls-custom-4tier-bundle-rhel/create_certs.sh
+++ b/molecule/mtls-custom-4tier-bundle-rhel/create_certs.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Cert generation for ANSIENG-5765 case 7: 4-tier PKI, all CAs in the bundle.
+# Hierarchy: Root -> Int1 -> Int2 -> Leaf
+# Produces:
+#   out/caBundle.pem   = Root + Int1 + Int2 (all CAs concatenated)
+#   out/<host>.crt     = leaf ONLY (no inline intermediates)
+#   out/<host>.key     = leaf private key
+set -euo pipefail
+
+OUT=out
+HOSTS_FILE="${1:-hosts}"
+
+rm -rf "$OUT" && mkdir -p "$OUT"
+
+ca_ext() {
+    cat > "$1" <<EOF
+basicConstraints = critical, CA:TRUE
+keyUsage = critical, keyCertSign, cRLSign
+EOF
+}
+
+leaf_ext() {
+    local hostname=$1 fqdn=$2 outfile=$3
+    cat > "$outfile" <<EOF
+basicConstraints = CA:FALSE
+keyUsage = digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth, clientAuth
+subjectAltName = DNS:${hostname},DNS:${fqdn}
+EOF
+}
+
+# 1. Root CA (self-signed).
+openssl req -new -x509 -nodes -days 3650 \
+    -keyout "$OUT/root.key" \
+    -out   "$OUT/root.crt" \
+    -subj '/CN=ANSIENG-5765-Root/O=Confluent/OU=Test'
+
+# 2. Int1 (signed by Root).
+ca_ext "$OUT/int1.ext"
+openssl req -new -nodes -keyout "$OUT/int1.key" -out "$OUT/int1.csr" \
+    -subj '/CN=ANSIENG-5765-Int1/O=Confluent/OU=Test'
+openssl x509 -req -days 3650 -sha256 \
+    -in "$OUT/int1.csr" \
+    -CA "$OUT/root.crt" -CAkey "$OUT/root.key" -CAcreateserial \
+    -out "$OUT/int1.crt" \
+    -extfile "$OUT/int1.ext"
+
+# 3. Int2 (signed by Int1).
+ca_ext "$OUT/int2.ext"
+openssl req -new -nodes -keyout "$OUT/int2.key" -out "$OUT/int2.csr" \
+    -subj '/CN=ANSIENG-5765-Int2/O=Confluent/OU=Test'
+openssl x509 -req -days 3650 -sha256 \
+    -in "$OUT/int2.csr" \
+    -CA "$OUT/int1.crt" -CAkey "$OUT/int1.key" -CAcreateserial \
+    -out "$OUT/int2.crt" \
+    -extfile "$OUT/int2.ext"
+
+# 4. Per-host leaf, signed by Int2.
+while IFS= read -r host || [ -n "$host" ]; do
+    [ -z "$host" ] && continue
+    fqdn="${host}.confluent"
+
+    openssl req -new -nodes \
+        -keyout "$OUT/${host}.key" \
+        -out   "$OUT/${host}.csr" \
+        -subj  "/CN=${host}/O=Confluent/OU=Test"
+
+    leaf_ext "$host" "$fqdn" "$OUT/${host}.ext"
+
+    openssl x509 -req -days 3650 -sha256 \
+        -in "$OUT/${host}.csr" \
+        -CA "$OUT/int2.crt" -CAkey "$OUT/int2.key" -CAcreateserial \
+        -out "$OUT/${host}.crt" \
+        -extfile "$OUT/${host}.ext"
+
+    rm -f "$OUT/${host}.csr" "$OUT/${host}.ext"
+done < "$HOSTS_FILE"
+
+# 5. Assemble CA bundle: Root + Int1 + Int2 (case 7).
+cat "$OUT/root.crt" "$OUT/int1.crt" "$OUT/int2.crt" > "$OUT/caBundle.pem"
+
+# Cleanup CA scratch files we don't need to sync back.
+rm -f "$OUT"/int*.csr "$OUT"/int*.ext "$OUT"/*.srl
+
+echo "case 7 cert generation complete:"
+ls -1 "$OUT" | sed 's/^/  /'

--- a/molecule/mtls-custom-4tier-bundle-rhel/molecule.yml
+++ b/molecule/mtls-custom-4tier-bundle-rhel/molecule.yml
@@ -1,0 +1,74 @@
+---
+### ANSIENG-5765 case 7: 4-tier PKI, all CAs in the bundle.
+### CA bundle = Root + Int1 + Int2. Cert file = leaf only (no inline intermediates).
+### This is the hardest enterprise PKI layout: was broken in the per-CA-loop
+### implementation; the fix gives openssl the whole bundle in one verify call.
+### Expected chain: leaf -> int2 -> int1 -> root (4 certs).
+
+driver:
+  name: docker
+platforms:
+  - name: ${KRAFT_CONTROLLER:-zookeeper}1
+    hostname: ${KRAFT_CONTROLLER:-zookeeper}1.confluent
+    groups:
+      - ${CONTROLLER_HOSTGROUP:-zookeeper}
+    image: redhat/ubi9-minimal
+    dockerfile: ../Dockerfile-rhel9-java17.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent
+  - name: kafka-broker1
+    hostname: kafka-broker1.confluent
+    groups:
+      - kafka_broker
+    image: redhat/ubi9-minimal
+    dockerfile: ../Dockerfile-rhel9-java17.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent
+  - name: kafka-broker2
+    hostname: kafka-broker2.confluent
+    groups:
+      - kafka_broker
+    image: redhat/ubi9-minimal
+    dockerfile: ../Dockerfile-rhel9-java17.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent
+  - name: schema-registry1
+    hostname: schema-registry1.confluent
+    groups:
+      - schema_registry
+    image: redhat/ubi9-minimal
+    dockerfile: ../Dockerfile-rhel9-java17.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent
+provisioner:
+  inventory:
+    group_vars:
+      all:
+        scenario_name: mtls-custom-4tier-bundle-rhel
+        ssl_enabled: true
+        ssl_mutual_auth_enabled: true
+        ssl_custom_certs: true
+        ssl_ca_cert_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/caBundle.pem"
+        ssl_signed_cert_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}.crt"
+        ssl_key_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}.key"
+        expected_chain_cert_count: 4

--- a/molecule/mtls-custom-4tier-bundle-rhel/molecule.yml
+++ b/molecule/mtls-custom-4tier-bundle-rhel/molecule.yml
@@ -13,7 +13,7 @@ platforms:
     groups:
       - ${CONTROLLER_HOSTGROUP:-zookeeper}
     image: redhat/ubi9-minimal
-    dockerfile: ../Dockerfile-rhel9-java17.j2
+    dockerfile: ../Dockerfile-rhel-java17.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -26,7 +26,7 @@ platforms:
     groups:
       - kafka_broker
     image: redhat/ubi9-minimal
-    dockerfile: ../Dockerfile-rhel9-java17.j2
+    dockerfile: ../Dockerfile-rhel-java17.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -39,7 +39,7 @@ platforms:
     groups:
       - kafka_broker
     image: redhat/ubi9-minimal
-    dockerfile: ../Dockerfile-rhel9-java17.j2
+    dockerfile: ../Dockerfile-rhel-java17.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -52,7 +52,7 @@ platforms:
     groups:
       - schema_registry
     image: redhat/ubi9-minimal
-    dockerfile: ../Dockerfile-rhel9-java17.j2
+    dockerfile: ../Dockerfile-rhel-java17.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw

--- a/molecule/mtls-custom-4tier-bundle-rhel/prepare.yml
+++ b/molecule/mtls-custom-4tier-bundle-rhel/prepare.yml
@@ -1,0 +1,48 @@
+---
+### Shared prepare for ANSIENG-5765 cert-chain scenarios.
+### See molecule/mtls-custom-2tier-rhel/prepare.yml for rationale.
+
+- name: Generate certs for the cert-chain scenario
+  hosts: kafka_broker[0]
+  gather_facts: true
+  tasks:
+    - name: Install OpenSSL and Rsync
+      package:
+        name:
+          - openssl
+          - rsync
+        state: present
+
+    - name: Create cert generation directory
+      file:
+        path: /var/ssl/private/generation
+        state: directory
+        mode: '755'
+
+    - name: Copy create_certs.sh to host
+      copy:
+        src: create_certs.sh
+        dest: /var/ssl/private/generation/create_certs.sh
+        mode: '755'
+
+    - name: Write hosts file for cert generation
+      copy:
+        content: "{{ groups['all'] | join('\n') }}\n"
+        dest: /var/ssl/private/generation/hosts
+        mode: '644'
+
+    - name: Run cert generation script
+      shell: ./create_certs.sh hosts
+      args:
+        chdir: /var/ssl/private/generation/
+
+    - name: Sync generated certs back to the molecule scenario directory
+      synchronize:
+        src: /var/ssl/private/generation/out/
+        dest: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files"
+        mode: pull
+
+    - name: Cleanup remote cert generation directory
+      file:
+        path: /var/ssl/private/generation
+        state: absent

--- a/molecule/mtls-custom-4tier-bundle-rhel/verify.yml
+++ b/molecule/mtls-custom-4tier-bundle-rhel/verify.yml
@@ -1,0 +1,32 @@
+---
+### Verifies the cert chain that build_certificate_chain.yml produced.
+###
+### The cluster having come up at all (converge succeeded) is itself end-to-end
+### proof that the chain is correct: mTLS handshakes between broker, controller,
+### and schema_registry would have failed otherwise. These checks add an extra
+### assertion that the chain file has the expected number of certs in
+### leaf-first order for this scenario's input layout.
+
+- name: Verify chain - kafka_controller
+  hosts: kafka_controller:zookeeper
+  gather_facts: false
+  vars:
+    chain_service_name: "{{ 'kafka_controller' if inventory_hostname in groups.get('kafka_controller', []) else 'zookeeper' }}"
+  tasks:
+    - include_tasks: ../assert_cert_chain.yml
+
+- name: Verify chain - kafka_broker
+  hosts: kafka_broker
+  gather_facts: false
+  vars:
+    chain_service_name: kafka_broker
+  tasks:
+    - include_tasks: ../assert_cert_chain.yml
+
+- name: Verify chain - schema_registry
+  hosts: schema_registry
+  gather_facts: false
+  vars:
+    chain_service_name: schema_registry
+  tasks:
+    - include_tasks: ../assert_cert_chain.yml

--- a/molecule/mtls-custom-4tier-inline-rhel/create_certs.sh
+++ b/molecule/mtls-custom-4tier-inline-rhel/create_certs.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# Cert generation for ANSIENG-5765 case 9: 4-tier PKI, full chain inlined in cert file.
+# Hierarchy: Root -> Int1 -> Int2 -> Leaf
+# Produces:
+#   out/caBundle.pem   = Root ONLY
+#   out/<host>.crt     = leaf + Int2 + Int1 concatenated (whole chain in one file)
+#   out/<host>.key     = leaf private key
+set -euo pipefail
+
+OUT=out
+HOSTS_FILE="${1:-hosts}"
+
+rm -rf "$OUT" && mkdir -p "$OUT"
+
+ca_ext() {
+    cat > "$1" <<EOF
+basicConstraints = critical, CA:TRUE
+keyUsage = critical, keyCertSign, cRLSign
+EOF
+}
+
+leaf_ext() {
+    local hostname=$1 fqdn=$2 outfile=$3
+    cat > "$outfile" <<EOF
+basicConstraints = CA:FALSE
+keyUsage = digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth, clientAuth
+subjectAltName = DNS:${hostname},DNS:${fqdn}
+EOF
+}
+
+# 1. Root CA (self-signed).
+openssl req -new -x509 -nodes -days 3650 \
+    -keyout "$OUT/root.key" \
+    -out   "$OUT/root.crt" \
+    -subj '/CN=ANSIENG-5765-Root/O=Confluent/OU=Test'
+
+# 2. Int1 (signed by Root).
+ca_ext "$OUT/int1.ext"
+openssl req -new -nodes -keyout "$OUT/int1.key" -out "$OUT/int1.csr" \
+    -subj '/CN=ANSIENG-5765-Int1/O=Confluent/OU=Test'
+openssl x509 -req -days 3650 -sha256 \
+    -in "$OUT/int1.csr" \
+    -CA "$OUT/root.crt" -CAkey "$OUT/root.key" -CAcreateserial \
+    -out "$OUT/int1.crt" \
+    -extfile "$OUT/int1.ext"
+
+# 3. Int2 (signed by Int1).
+ca_ext "$OUT/int2.ext"
+openssl req -new -nodes -keyout "$OUT/int2.key" -out "$OUT/int2.csr" \
+    -subj '/CN=ANSIENG-5765-Int2/O=Confluent/OU=Test'
+openssl x509 -req -days 3650 -sha256 \
+    -in "$OUT/int2.csr" \
+    -CA "$OUT/int1.crt" -CAkey "$OUT/int1.key" -CAcreateserial \
+    -out "$OUT/int2.crt" \
+    -extfile "$OUT/int2.ext"
+
+# 4. Per-host leaf, signed by Int2. Inline the whole chain into <host>.crt.
+while IFS= read -r host || [ -n "$host" ]; do
+    [ -z "$host" ] && continue
+    fqdn="${host}.confluent"
+
+    openssl req -new -nodes \
+        -keyout "$OUT/${host}.key" \
+        -out   "$OUT/${host}.csr" \
+        -subj  "/CN=${host}/O=Confluent/OU=Test"
+
+    leaf_ext "$host" "$fqdn" "$OUT/${host}.ext"
+
+    openssl x509 -req -days 3650 -sha256 \
+        -in "$OUT/${host}.csr" \
+        -CA "$OUT/int2.crt" -CAkey "$OUT/int2.key" -CAcreateserial \
+        -out "$OUT/${host}.leaf-only.crt" \
+        -extfile "$OUT/${host}.ext"
+
+    # Inline the chain: leaf + Int2 + Int1 (no root in cert file).
+    cat "$OUT/${host}.leaf-only.crt" "$OUT/int2.crt" "$OUT/int1.crt" > "$OUT/${host}.crt"
+
+    rm -f "$OUT/${host}.csr" "$OUT/${host}.ext" "$OUT/${host}.leaf-only.crt"
+done < "$HOSTS_FILE"
+
+# 5. CA bundle: Root ONLY (case 9).
+cp "$OUT/root.crt" "$OUT/caBundle.pem"
+
+# Cleanup CA scratch files.
+rm -f "$OUT"/int*.csr "$OUT"/int*.ext "$OUT"/*.srl
+
+echo "case 9 cert generation complete:"
+ls -1 "$OUT" | sed 's/^/  /'

--- a/molecule/mtls-custom-4tier-inline-rhel/molecule.yml
+++ b/molecule/mtls-custom-4tier-inline-rhel/molecule.yml
@@ -14,7 +14,7 @@ platforms:
     groups:
       - ${CONTROLLER_HOSTGROUP:-zookeeper}
     image: redhat/ubi9-minimal
-    dockerfile: ../Dockerfile-rhel9-java17.j2
+    dockerfile: ../Dockerfile-rhel-java17.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -27,7 +27,7 @@ platforms:
     groups:
       - kafka_broker
     image: redhat/ubi9-minimal
-    dockerfile: ../Dockerfile-rhel9-java17.j2
+    dockerfile: ../Dockerfile-rhel-java17.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -40,7 +40,7 @@ platforms:
     groups:
       - kafka_broker
     image: redhat/ubi9-minimal
-    dockerfile: ../Dockerfile-rhel9-java17.j2
+    dockerfile: ../Dockerfile-rhel-java17.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -53,7 +53,7 @@ platforms:
     groups:
       - schema_registry
     image: redhat/ubi9-minimal
-    dockerfile: ../Dockerfile-rhel9-java17.j2
+    dockerfile: ../Dockerfile-rhel-java17.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw

--- a/molecule/mtls-custom-4tier-inline-rhel/molecule.yml
+++ b/molecule/mtls-custom-4tier-inline-rhel/molecule.yml
@@ -1,0 +1,75 @@
+---
+### ANSIENG-5765 case 9: 4-tier PKI, full chain inlined in the cert file.
+### CA bundle = Root only. Cert file = leaf + Int2 + Int1 (the user pasted the
+### whole chain into one file). The fix detects the leaf via topology rather
+### than by "last cert" and walks the issuer/subject relationships to emit the
+### correct order.
+### Expected chain: leaf -> int2 -> int1 -> root (4 certs).
+
+driver:
+  name: docker
+platforms:
+  - name: ${KRAFT_CONTROLLER:-zookeeper}1
+    hostname: ${KRAFT_CONTROLLER:-zookeeper}1.confluent
+    groups:
+      - ${CONTROLLER_HOSTGROUP:-zookeeper}
+    image: redhat/ubi9-minimal
+    dockerfile: ../Dockerfile-rhel9-java17.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent
+  - name: kafka-broker1
+    hostname: kafka-broker1.confluent
+    groups:
+      - kafka_broker
+    image: redhat/ubi9-minimal
+    dockerfile: ../Dockerfile-rhel9-java17.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent
+  - name: kafka-broker2
+    hostname: kafka-broker2.confluent
+    groups:
+      - kafka_broker
+    image: redhat/ubi9-minimal
+    dockerfile: ../Dockerfile-rhel9-java17.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent
+  - name: schema-registry1
+    hostname: schema-registry1.confluent
+    groups:
+      - schema_registry
+    image: redhat/ubi9-minimal
+    dockerfile: ../Dockerfile-rhel9-java17.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent
+provisioner:
+  inventory:
+    group_vars:
+      all:
+        scenario_name: mtls-custom-4tier-inline-rhel
+        ssl_enabled: true
+        ssl_mutual_auth_enabled: true
+        ssl_custom_certs: true
+        ssl_ca_cert_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/caBundle.pem"
+        ssl_signed_cert_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}.crt"
+        ssl_key_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}.key"
+        expected_chain_cert_count: 4

--- a/molecule/mtls-custom-4tier-inline-rhel/prepare.yml
+++ b/molecule/mtls-custom-4tier-inline-rhel/prepare.yml
@@ -1,0 +1,51 @@
+---
+### prepare.yml shared shape across all four ANSIENG-5765 cert-chain scenarios.
+### Generates the case-specific cert layout via the scenario's create_certs.sh,
+### then syncs the output back to the molecule scenario directory so that
+### ssl_ca_cert_filepath / ssl_signed_cert_filepath / ssl_key_filepath can
+### lookup() into it.
+
+- name: Generate certs for the cert-chain scenario
+  hosts: kafka_broker[0]
+  gather_facts: true
+  tasks:
+    - name: Install OpenSSL and Rsync
+      package:
+        name:
+          - openssl
+          - rsync
+        state: present
+
+    - name: Create cert generation directory
+      file:
+        path: /var/ssl/private/generation
+        state: directory
+        mode: '755'
+
+    - name: Copy create_certs.sh to host
+      copy:
+        src: create_certs.sh
+        dest: /var/ssl/private/generation/create_certs.sh
+        mode: '755'
+
+    - name: Write hosts file for cert generation
+      copy:
+        content: "{{ groups['all'] | join('\n') }}\n"
+        dest: /var/ssl/private/generation/hosts
+        mode: '644'
+
+    - name: Run cert generation script
+      shell: ./create_certs.sh hosts
+      args:
+        chdir: /var/ssl/private/generation/
+
+    - name: Sync generated certs back to the molecule scenario directory
+      synchronize:
+        src: /var/ssl/private/generation/out/
+        dest: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files"
+        mode: pull
+
+    - name: Cleanup remote cert generation directory
+      file:
+        path: /var/ssl/private/generation
+        state: absent

--- a/molecule/mtls-custom-4tier-inline-rhel/verify.yml
+++ b/molecule/mtls-custom-4tier-inline-rhel/verify.yml
@@ -1,0 +1,32 @@
+---
+### Verifies the cert chain that build_certificate_chain.yml produced.
+###
+### The cluster having come up at all (converge succeeded) is itself end-to-end
+### proof that the chain is correct: mTLS handshakes between broker, controller,
+### and schema_registry would have failed otherwise. These checks add an extra
+### assertion that the chain file has the expected number of certs in
+### leaf-first order for this scenario's input layout.
+
+- name: Verify chain - kafka_controller
+  hosts: kafka_controller:zookeeper
+  gather_facts: false
+  vars:
+    chain_service_name: "{{ 'kafka_controller' if inventory_hostname in groups.get('kafka_controller', []) else 'zookeeper' }}"
+  tasks:
+    - include_tasks: ../assert_cert_chain.yml
+
+- name: Verify chain - kafka_broker
+  hosts: kafka_broker
+  gather_facts: false
+  vars:
+    chain_service_name: kafka_broker
+  tasks:
+    - include_tasks: ../assert_cert_chain.yml
+
+- name: Verify chain - schema_registry
+  hosts: schema_registry
+  gather_facts: false
+  vars:
+    chain_service_name: schema_registry
+  tasks:
+    - include_tasks: ../assert_cert_chain.yml

--- a/molecule/mtls-custom-partial-rhel/create_certs.sh
+++ b/molecule/mtls-custom-partial-rhel/create_certs.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# Cert generation for ANSIENG-5765 case 10: 4-tier PKI, partial chain.
+# Hierarchy: Root -> Int1 -> Int2 -> Leaf, but the Root is intentionally omitted
+# from the CA bundle (DoD-style partial chain).
+# Produces:
+#   out/caBundle.pem   = Int1 + Int2 (NO root)
+#   out/<host>.crt     = leaf ONLY (no inline intermediates)
+#   out/<host>.key     = leaf private key
+set -euo pipefail
+
+OUT=out
+HOSTS_FILE="${1:-hosts}"
+
+rm -rf "$OUT" && mkdir -p "$OUT"
+
+ca_ext() {
+    cat > "$1" <<EOF
+basicConstraints = critical, CA:TRUE
+keyUsage = critical, keyCertSign, cRLSign
+EOF
+}
+
+leaf_ext() {
+    local hostname=$1 fqdn=$2 outfile=$3
+    cat > "$outfile" <<EOF
+basicConstraints = CA:FALSE
+keyUsage = digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth, clientAuth
+subjectAltName = DNS:${hostname},DNS:${fqdn}
+EOF
+}
+
+# 1. Root CA (self-signed) — generated but NOT shipped in the bundle.
+openssl req -new -x509 -nodes -days 3650 \
+    -keyout "$OUT/root.key" \
+    -out   "$OUT/root.crt" \
+    -subj '/CN=ANSIENG-5765-Root/O=Confluent/OU=Test'
+
+# 2. Int1 (signed by Root).
+ca_ext "$OUT/int1.ext"
+openssl req -new -nodes -keyout "$OUT/int1.key" -out "$OUT/int1.csr" \
+    -subj '/CN=ANSIENG-5765-Int1/O=Confluent/OU=Test'
+openssl x509 -req -days 3650 -sha256 \
+    -in "$OUT/int1.csr" \
+    -CA "$OUT/root.crt" -CAkey "$OUT/root.key" -CAcreateserial \
+    -out "$OUT/int1.crt" \
+    -extfile "$OUT/int1.ext"
+
+# 3. Int2 (signed by Int1).
+ca_ext "$OUT/int2.ext"
+openssl req -new -nodes -keyout "$OUT/int2.key" -out "$OUT/int2.csr" \
+    -subj '/CN=ANSIENG-5765-Int2/O=Confluent/OU=Test'
+openssl x509 -req -days 3650 -sha256 \
+    -in "$OUT/int2.csr" \
+    -CA "$OUT/int1.crt" -CAkey "$OUT/int1.key" -CAcreateserial \
+    -out "$OUT/int2.crt" \
+    -extfile "$OUT/int2.ext"
+
+# 4. Per-host leaf, signed by Int2.
+while IFS= read -r host || [ -n "$host" ]; do
+    [ -z "$host" ] && continue
+    fqdn="${host}.confluent"
+
+    openssl req -new -nodes \
+        -keyout "$OUT/${host}.key" \
+        -out   "$OUT/${host}.csr" \
+        -subj  "/CN=${host}/O=Confluent/OU=Test"
+
+    leaf_ext "$host" "$fqdn" "$OUT/${host}.ext"
+
+    openssl x509 -req -days 3650 -sha256 \
+        -in "$OUT/${host}.csr" \
+        -CA "$OUT/int2.crt" -CAkey "$OUT/int2.key" -CAcreateserial \
+        -out "$OUT/${host}.crt" \
+        -extfile "$OUT/${host}.ext"
+
+    rm -f "$OUT/${host}.csr" "$OUT/${host}.ext"
+done < "$HOSTS_FILE"
+
+# 5. CA bundle: Int1 + Int2 ONLY. Root is deliberately omitted (partial chain).
+cat "$OUT/int1.crt" "$OUT/int2.crt" > "$OUT/caBundle.pem"
+
+# Remove the root from the output entirely so it cannot leak into the install.
+rm -f "$OUT"/root.crt "$OUT"/root.key
+rm -f "$OUT"/int*.csr "$OUT"/int*.ext "$OUT"/*.srl
+
+echo "case 10 cert generation complete (no root):"
+ls -1 "$OUT" | sed 's/^/  /'

--- a/molecule/mtls-custom-partial-rhel/molecule.yml
+++ b/molecule/mtls-custom-partial-rhel/molecule.yml
@@ -14,7 +14,7 @@ platforms:
     groups:
       - ${CONTROLLER_HOSTGROUP:-zookeeper}
     image: redhat/ubi9-minimal
-    dockerfile: ../Dockerfile-rhel9-java17.j2
+    dockerfile: ../Dockerfile-rhel-java17.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -27,7 +27,7 @@ platforms:
     groups:
       - kafka_broker
     image: redhat/ubi9-minimal
-    dockerfile: ../Dockerfile-rhel9-java17.j2
+    dockerfile: ../Dockerfile-rhel-java17.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -40,7 +40,7 @@ platforms:
     groups:
       - kafka_broker
     image: redhat/ubi9-minimal
-    dockerfile: ../Dockerfile-rhel9-java17.j2
+    dockerfile: ../Dockerfile-rhel-java17.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
@@ -53,7 +53,7 @@ platforms:
     groups:
       - schema_registry
     image: redhat/ubi9-minimal
-    dockerfile: ../Dockerfile-rhel9-java17.j2
+    dockerfile: ../Dockerfile-rhel-java17.j2
     command: ""
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw

--- a/molecule/mtls-custom-partial-rhel/molecule.yml
+++ b/molecule/mtls-custom-partial-rhel/molecule.yml
@@ -1,0 +1,76 @@
+---
+### ANSIENG-5765 case 10: 4-tier PKI, partial chain (no root in the bundle).
+### CA bundle = Int1 + Int2 only (root deliberately omitted, mirroring DoD-style
+### partial chains). Cert file = leaf only.
+### The fix's `-partial_chain` flag is the key piece: openssl is allowed to
+### stop at a trusted intermediate instead of insisting on a self-signed root.
+### Expected chain: leaf -> int2 -> int1 (3 certs; walk stops at top intermediate).
+
+driver:
+  name: docker
+platforms:
+  - name: ${KRAFT_CONTROLLER:-zookeeper}1
+    hostname: ${KRAFT_CONTROLLER:-zookeeper}1.confluent
+    groups:
+      - ${CONTROLLER_HOSTGROUP:-zookeeper}
+    image: redhat/ubi9-minimal
+    dockerfile: ../Dockerfile-rhel9-java17.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent
+  - name: kafka-broker1
+    hostname: kafka-broker1.confluent
+    groups:
+      - kafka_broker
+    image: redhat/ubi9-minimal
+    dockerfile: ../Dockerfile-rhel9-java17.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent
+  - name: kafka-broker2
+    hostname: kafka-broker2.confluent
+    groups:
+      - kafka_broker
+    image: redhat/ubi9-minimal
+    dockerfile: ../Dockerfile-rhel9-java17.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent
+  - name: schema-registry1
+    hostname: schema-registry1.confluent
+    groups:
+      - schema_registry
+    image: redhat/ubi9-minimal
+    dockerfile: ../Dockerfile-rhel9-java17.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent
+provisioner:
+  inventory:
+    group_vars:
+      all:
+        scenario_name: mtls-custom-partial-rhel
+        ssl_enabled: true
+        ssl_mutual_auth_enabled: true
+        ssl_custom_certs: true
+        ssl_ca_cert_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/caBundle.pem"
+        ssl_signed_cert_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}.crt"
+        ssl_key_filepath: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files/{{inventory_hostname}}.key"
+        # Partial chain stops at the top intermediate, so 3 certs not 4.
+        expected_chain_cert_count: 3

--- a/molecule/mtls-custom-partial-rhel/prepare.yml
+++ b/molecule/mtls-custom-partial-rhel/prepare.yml
@@ -1,0 +1,51 @@
+---
+### prepare.yml shared shape across all four ANSIENG-5765 cert-chain scenarios.
+### Generates the case-specific cert layout via the scenario's create_certs.sh,
+### then syncs the output back to the molecule scenario directory so that
+### ssl_ca_cert_filepath / ssl_signed_cert_filepath / ssl_key_filepath can
+### lookup() into it.
+
+- name: Generate certs for the cert-chain scenario
+  hosts: kafka_broker[0]
+  gather_facts: true
+  tasks:
+    - name: Install OpenSSL and Rsync
+      package:
+        name:
+          - openssl
+          - rsync
+        state: present
+
+    - name: Create cert generation directory
+      file:
+        path: /var/ssl/private/generation
+        state: directory
+        mode: '755'
+
+    - name: Copy create_certs.sh to host
+      copy:
+        src: create_certs.sh
+        dest: /var/ssl/private/generation/create_certs.sh
+        mode: '755'
+
+    - name: Write hosts file for cert generation
+      copy:
+        content: "{{ groups['all'] | join('\n') }}\n"
+        dest: /var/ssl/private/generation/hosts
+        mode: '644'
+
+    - name: Run cert generation script
+      shell: ./create_certs.sh hosts
+      args:
+        chdir: /var/ssl/private/generation/
+
+    - name: Sync generated certs back to the molecule scenario directory
+      synchronize:
+        src: /var/ssl/private/generation/out/
+        dest: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files"
+        mode: pull
+
+    - name: Cleanup remote cert generation directory
+      file:
+        path: /var/ssl/private/generation
+        state: absent

--- a/molecule/mtls-custom-partial-rhel/verify.yml
+++ b/molecule/mtls-custom-partial-rhel/verify.yml
@@ -1,0 +1,32 @@
+---
+### Verifies the cert chain that build_certificate_chain.yml produced.
+###
+### The cluster having come up at all (converge succeeded) is itself end-to-end
+### proof that the chain is correct: mTLS handshakes between broker, controller,
+### and schema_registry would have failed otherwise. These checks add an extra
+### assertion that the chain file has the expected number of certs in
+### leaf-first order for this scenario's input layout.
+
+- name: Verify chain - kafka_controller
+  hosts: kafka_controller:zookeeper
+  gather_facts: false
+  vars:
+    chain_service_name: "{{ 'kafka_controller' if inventory_hostname in groups.get('kafka_controller', []) else 'zookeeper' }}"
+  tasks:
+    - include_tasks: ../assert_cert_chain.yml
+
+- name: Verify chain - kafka_broker
+  hosts: kafka_broker
+  gather_facts: false
+  vars:
+    chain_service_name: kafka_broker
+  tasks:
+    - include_tasks: ../assert_cert_chain.yml
+
+- name: Verify chain - schema_registry
+  hosts: schema_registry
+  gather_facts: false
+  vars:
+    chain_service_name: schema_registry
+  tasks:
+    - include_tasks: ../assert_cert_chain.yml

--- a/roles/ssl/tasks/build_certificate_chain.yml
+++ b/roles/ssl/tasks/build_certificate_chain.yml
@@ -1,94 +1,159 @@
 ---
 # Certificate Chain Building Tasks
-# ------------------------------
-# These tasks build a proper certificate chain by:
-# 1. Creating a temporary directory for processing
-# 2. Splitting a CA bundle into individual certificates
-# 3. Extracting certificates from the signed cert
-# 4. Building a validated certificate chain by finding which CA signed the cert
-# 5. Cleaning up temporary files
+# --------------------------------
+# Inputs:
+#   - ca_cert_path: PEM file containing one or more trusted CA certificates
+#     (root and/or intermediate, in any order).
+#   - cert_path: PEM file containing the signed server certificate.
+#     May be leaf-only or include any subset of intermediates and/or the root,
+#     in any order.
+#
+# Output:
+#   - {{ ssl_file_dir_final }}/{{ service_name }}.chain — properly ordered
+#     "leaf -> intermediate(s) -> root" chain. For partial chains where no
+#     self-signed root is available, the walk stops at the topmost cert that
+#     has a known parent in the trust pool.
+#
+# Algorithm:
+#   1. Split both ca_cert_path and cert_path into individual cert files.
+#   2. Identify the leaf in cert_path: the cert whose Subject is not the
+#      Issuer of any other cert in cert_path (handles arbitrary input order).
+#   3. Use the non-leaf certs from cert_path as -untrusted bridges and run a
+#      single `openssl verify -CAfile <bundle> -untrusted <bridges>
+#      -partial_chain <leaf>`. This validates the chain cryptographically and
+#      handles DoD-style partial chains via -partial_chain.
+#   4. Walk Issuer -> Subject across the union of all certs (cert_path +
+#      ca_cert_path), starting from the leaf, to emit the ordered chain.
+#      OpenSSL has already proven the chain is valid; the walk only sorts
+#      the certs into output order.
 
-# Creates a temporary directory that will be automatically deleted when the playbook ends
-# Example: Creates a directory like /tmp/ansible.individual_certs.XXXXXXXX/
 - name: Create temp directory for individual certificates
   tempfile:
     state: directory
-    suffix: individual_certs
+    suffix: cert_chain
   register: temp_dir
 
-# Splits a CA certificate bundle into individual certificate files
-# This is necessary because a CA bundle can contain multiple certificates
-#
-# Sample certificate bundle format:
-# -----BEGIN CERTIFICATE-----
-# MIIDSjCCAjKgAwIBAgIQRK+wgNajJ7qJMDmGLvhAazANBgkqhkiG9w0BAQUFADA/
-# MSQwIgYDVQQKExtEaWdpdGFsIFNpZ25hdHVyZSBUcnVzdCBDby4xFzAVBgNVBAMT
-# (more base64 encoded certificate data)
-# -----END CERTIFICATE-----
-# -----BEGIN CERTIFICATE-----
-# MIIE0zCCA7ugAwIBAgIQGNrRniZ96LtKIVjNzGs7SjANBgkqhkiG9w0BAQUFADCB
-# yjELMAkGA1UEBhMCVVMxFzAVBgNVBAoTDlZlcmlTaWduLCBJbmMuMR8wHQYDVQQL
-# (more base64 encoded certificate data)
-# -----END CERTIFICATE-----
-#
-# Example: If ca_cert_path contains 3 certificates like above, this creates:
-#   /tmp/ansible.individual_certs.XXXXXXXX/ca.1.pem
-#   /tmp/ansible.individual_certs.XXXXXXXX/ca.2.pem
-#   /tmp/ansible.individual_certs.XXXXXXXX/ca.3.pem
-- name: Split CA Cert Bundle into Individual Certificates
+- name: Build and Verify Certificate Chain
   shell: |
-    awk 'BEGIN {n=0} /BEGIN CERTIFICATE/{n++} {print > "{{ temp_dir.path }}/ca." n ".pem"}' {{ ca_cert_path }}
-  changed_when: false
+    set -euo pipefail
 
-# Extracts the last (end-entity) certificate from the signed certificate bundle
-# For multi-cert bundles, we need the last certificate to verify against the CA
-# Example: If cert_path contains a chain with 2 certificates, this creates:
-#   /tmp/ansible.individual_certs.XXXXXXXX/signed.last.pem
-# containing only the last certificate in the chain
-- name: Split Signed Cert Bundle - Extract Last Certificate
-  shell: |
-    awk '
-      # Store each certificate (including newlines) in a variable
-      /BEGIN CERTIFICATE/,/END CERTIFICATE/ {
-        cert = cert $0 "\n"
-      }
-      # When we reach the end of a certificate, store it as the last one and reset
-      /END CERTIFICATE/ {
-        last_cert = cert
-        cert = ""
-      }
-      # At the end, print only the last certificate we found
-      END {
-        print last_cert
-      }' {{ cert_path }} > "{{ temp_dir.path }}/signed.last.pem"
-  changed_when: false
+    TEMP_DIR='{{ temp_dir.path }}'
+    CA_CERT_PATH='{{ ca_cert_path }}'
+    CERT_PATH='{{ cert_path }}'
+    OUTPUT_CHAIN='{{ ssl_file_dir_final }}/{{ service_name }}.chain'
 
-# Verifies which CA certificate can validate the end-entity certificate
-# and builds a complete certificate chain by concatenating them
-# Example: If ca.2.pem successfully validates signed.last.pem, this creates:
-#   /path/to/ssl_dir/servicename.chain
-# containing the full certificate + CA certificate chain
-- name: Verify and Build Certificate Chain
-  shell: |
-    # Try each CA certificate to find one that can verify our certificate
-    for ca_file in {{ temp_dir.path }}/ca.*.pem; do
-      # Attempt to verify the certificate using this CA
-      if openssl verify -CAfile "$ca_file" "{{ temp_dir.path }}/signed.last.pem"; then
-        # When we find a match, create the chain by concatenating the cert and CA
-        cat {{ cert_path }} "$ca_file" > "{{ ssl_file_dir_final }}/{{ service_name }}.chain"
-        echo "Chain completed with: $ca_file"
-        exit 0  # Success, no need to check other CAs
+    # 1. Split both input files into individual cert files. The `n>0` gate
+    #    drops any leading lines (whitespace, comments, BOM) before the first
+    #    BEGIN CERTIFICATE marker so the glob does not pick up junk files.
+    awk 'BEGIN{n=0} /BEGIN CERTIFICATE/{n++} n>0 {print > ("'"$TEMP_DIR"'/cert."n".pem")}' "$CERT_PATH"
+    awk 'BEGIN{n=0} /BEGIN CERTIFICATE/{n++} n>0 {print > ("'"$TEMP_DIR"'/ca."n".pem")}'   "$CA_CERT_PATH"
+
+    cert_files=( "$TEMP_DIR"/cert.*.pem )
+    ca_files=(   "$TEMP_DIR"/ca.*.pem )
+    if [ ! -e "${cert_files[0]}" ]; then
+      echo "ERROR: no certificates found in cert_path ($CERT_PATH)" >&2
+      exit 1
+    fi
+    if [ ! -e "${ca_files[0]}" ]; then
+      echo "ERROR: no certificates found in ca_cert_path ($CA_CERT_PATH)" >&2
+      exit 1
+    fi
+
+    subj_of() { openssl x509 -in "$1" -noout -subject -nameopt RFC2253 | sed 's/^subject=//'; }
+    iss_of()  { openssl x509 -in "$1" -noout -issuer  -nameopt RFC2253 | sed 's/^issuer=//';  }
+
+    # 2. Identify the leaf in cert_path:
+    #    the cert whose Subject is NOT the Issuer of any other cert in cert_path.
+    LEAF=""
+    for f in "${cert_files[@]}"; do
+      f_subj=$(subj_of "$f")
+      is_parent=false
+      for g in "${cert_files[@]}"; do
+        [ "$g" = "$f" ] && continue
+        if [ "$(iss_of "$g")" = "$f_subj" ]; then
+          is_parent=true
+          break
+        fi
+      done
+      if ! $is_parent; then
+        LEAF="$f"
+        break
       fi
     done
-    # If we get here, no CA could verify the certificate
-    echo "No valid CA found to complete the chain" >&2
-    exit 1  # Failure
-  register: chain_result
-  failed_when: chain_result.rc != 0
-  changed_when: chain_result.rc == 0
+    if [ -z "$LEAF" ]; then
+      echo "ERROR: could not identify leaf certificate in cert_path ($CERT_PATH)" >&2
+      exit 1
+    fi
 
-# Removes the temporary directory and all its contents
-# Example: Deletes /tmp/ansible.individual_certs.XXXXXXXX/ and all files inside
+    # 3. Collect non-leaf certs from cert_path as bridging intermediates.
+    BRIDGES="$TEMP_DIR/bridges.pem"
+    : > "$BRIDGES"
+    for f in "${cert_files[@]}"; do
+      [ "$f" = "$LEAF" ] && continue
+      cat "$f" >> "$BRIDGES"
+    done
+
+    # 4. Verify the chain. -partial_chain permits stopping at a trusted
+    #    intermediate (DoD/enterprise PKI without root in the bundle).
+    if [ -s "$BRIDGES" ]; then
+      openssl verify -CAfile "$CA_CERT_PATH" -untrusted "$BRIDGES" -partial_chain "$LEAF" >&2
+    else
+      openssl verify -CAfile "$CA_CERT_PATH" -partial_chain "$LEAF" >&2
+    fi
+
+    # 5. Walk Issuer -> Subject across all available certs to emit the chain
+    #    in leaf -> intermediate(s) -> root order. Dedupe by Subject (one cert
+    #    per Subject DN) using a file as the seen-set: this is robust to
+    #    Subject DNs that happen to contain unusual characters which would
+    #    collide with an in-memory delimiter.
+    pool=( "${cert_files[@]}" "${ca_files[@]}" )
+
+    SEEN="$TEMP_DIR/seen.txt"
+    : > "$SEEN"
+    : > "$OUTPUT_CHAIN"
+    current="$LEAF"
+    safety=0
+    while [ -n "$current" ]; do
+      safety=$((safety + 1))
+      if [ "$safety" -gt 32 ]; then
+        echo "ERROR: chain walk exceeded 32 hops, aborting (possible cycle)" >&2
+        exit 1
+      fi
+
+      c_subj=$(subj_of "$current")
+      c_iss=$(iss_of "$current")
+
+      if ! grep -Fxq -- "$c_subj" "$SEEN"; then
+        cat "$current" >> "$OUTPUT_CHAIN"
+        printf '%s\n' "$c_subj" >> "$SEEN"
+      fi
+
+      # Self-signed -> a trust anchor, stop walking.
+      if [ "$c_subj" = "$c_iss" ]; then
+        break
+      fi
+
+      # Find parent in the pool (Subject == Issuer of current cert).
+      parent=""
+      for f in "${pool[@]}"; do
+        [ "$f" = "$current" ] && continue
+        if [ "$(subj_of "$f")" = "$c_iss" ]; then
+          parent="$f"
+          break
+        fi
+      done
+
+      # No parent found -> partial chain, stop here.
+      [ -z "$parent" ] && break
+      current="$parent"
+    done
+
+    echo "Chain written to $OUTPUT_CHAIN" >&2
+  args:
+    executable: "{{ shell_executable }}"
+  register: build_chain_result
+  changed_when: build_chain_result.rc == 0
+
 - name: Cleanup Temp Directory
   file:
     path: "{{ temp_dir.path }}"


### PR DESCRIPTION
Forward-port of [#2550](https://github.com/confluentinc/cp-ansible/pull/2550) from `7.5.x`.

## Summary

- Cherry-picks the squash merge that fixed `roles/ssl/tasks/build_certificate_chain.yml` for multi-tier PKI and partial-chain (DoD) cert layouts. See [Confluence](https://confluentinc.atlassian.net/wiki/spaces/OAAC/pages/5331747706) for the full bug analysis.
- Adjusts the 5 new Molecule scenarios' images to match 7.6.x conventions:
  - RHEL (4 scenarios): `redhat/ubi9-minimal` + `Dockerfile-rhel-java17.j2`
  - Debian (1 scenario): `geerlingguy/docker-debian10-ansible` + `Dockerfile-debian10-java11.j2`

## Test plan

- [ ] `molecule test -s mtls-custom-2tier-rhel`
- [ ] `molecule test -s mtls-custom-4tier-bundle-rhel`
- [ ] `molecule test -s mtls-custom-4tier-inline-rhel`
- [ ] `molecule test -s mtls-custom-partial-rhel`
- [ ] `molecule test -s mtls-custom-4tier-bundle-debian`

🤖 Generated with [Claude Code](https://claude.com/claude-code)