### PR TITLE
[7.8.x] Pass master key to kafka-storage formatted-check on controller

### DIFF
--- a/roles/kafka_controller/tasks/get_meta_properties.yml
+++ b/roles/kafka_controller/tasks/get_meta_properties.yml
@@ -1,9 +1,21 @@
 ---
+- name: Get existing master key from override.conf
+  include_role:
+    name: common
+    tasks_from: get_masterkey.yml
+  vars:
+    systemd_override_path: "{{ kafka_controller.systemd_override }}"
+  when: kafka_controller_secrets_protection_enabled|bool
+  tags:
+    - get_existing_masterkey_from_override_conf
+
 - name: Check if Data Directories are Formatted
   command: "{{ binary_base_path }}/bin/kafka-storage info -c {{ kafka_controller.config_file }}"
+  environment: "{{ {'CONFLUENT_SECURITY_MASTER_KEY': existing_masterkey} if kafka_controller_secrets_protection_enabled|bool and existing_masterkey | default('') != '' else {} }}"
   ignore_errors: true
   failed_when: false
   changed_when: false
+  no_log: "{{mask_secrets|bool}}"
   register: formatted
 
 - name: Get ClusterId
@@ -21,16 +33,6 @@
   delegate_to: "{{ groups.kafka_broker[0] }}"
   register: zoo_cluster
   when: kraft_migration|bool
-
-- name: Get existing master key from override.conf
-  include_role:
-    name: common
-    tasks_from: get_masterkey.yml
-  vars:
-    systemd_override_path: "{{ kafka_controller.systemd_override }}"
-  when: kafka_controller_secrets_protection_enabled|bool
-  tags:
-    - get_existing_masterkey_from_override_conf
 
 - name: Format Data Directory and Add Scram Credentials
   shell: |


### PR DESCRIPTION
## Problem
The `Check if Data Directories are Formatted` task in `kafka_controller/get_meta_properties.yml` ran `kafka-storage info` **without** `CONFLUENT_SECURITY_MASTER_KEY`.

With secrets protection enabled, the controller's `server.properties` holds `${securepass:...}` references. On a re-converge against an already-formatted node, `info` couldn't read the encrypted config and exited non-zero, so the play treated the directory as unformatted and re-ran `kafka-storage format` with a freshly generated random cluster id — failing with:

```
RuntimeException: Invalid cluster.id in: .../meta.properties.
Expected <new-id>, but read <existing-id>
```

This surfaced in the `secrets-upgrade-auto` molecule scenario (fails on the second secrets-protected pass against an already-formatted controller).

## Fix
- Fetch the existing master key (`get_masterkey.yml`) **before** the formatted-check.
- Pass the same `environment:` (master key) the format task already uses to the `Check if Data Directories are Formatted` task, plus `no_log`.

Now `kafka-storage info` succeeds on an already-formatted, secrets-protected node, correctly reports the directory as formatted, and the format step is skipped on re-runs.

## Forward-merge
Verified this branch pint-merges cleanly through **7.9.x → 8.0.x → 8.1.x → 8.2.x → 8.3.x**. The 7.9→8.0 boundary auto-drops `kraft_migration` correctly; all other hops are identical-file no-ops. The SCRAM `--add-scram` `shell:` block is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)