### PR TITLE
Fix ansible-lint warnings in support bundle playbook and tasks

### DIFF
--- a/playbooks/support_bundle.yml
+++ b/playbooks/support_bundle.yml
@@ -73,6 +73,7 @@
       args:
         executable: "{{ shell_executable }}"
       register: java_version_raw
+      changed_when: false
       ignore_errors: true
 
     - name: Set Java version fact
@@ -85,6 +86,7 @@
       args:
         executable: "{{ shell_executable }}"
       register: memory_stats_raw
+      changed_when: false
       ignore_errors: true
 
     - name: Set memory facts
@@ -318,13 +320,15 @@
         dest: "{{ hostvars['localhost']['bundle_path'] }}/ansible/ansible_playbook.log"
         mode: '0644'
       when: support_bundle_ansible_log_path | length > 0
-      ignore_errors: true
+      # Collect-as-much-as-possible: never fail the bundle (see design)
+      ignore_errors: true  # noqa: ignore-errors
 
     - name: Archive support bundle
       archive:
         path: "{{ hostvars['localhost']['bundle_path'] }}"
         dest: "{{ (support_bundle_output_path | regex_replace('/$', '')) }}/{{ hostvars['localhost']['bundle_name'] }}.tar.gz"
         format: gz
+        mode: '0644'
 
     - name: Get archive file stats
       stat:

--- a/roles/common/tasks/collect_diagnostics.yml
+++ b/roles/common/tasks/collect_diagnostics.yml
@@ -7,6 +7,7 @@
   args:
     executable: "{{ shell_executable }}"
   register: service_status_output
+  changed_when: false
 
 - name: Save service status to file
   copy:
@@ -23,6 +24,7 @@
     journalctl -u {{ service_name }} -n {{ support_bundle_journalctl_lines }} --no-pager > /tmp/journalctl_{{ inventory_hostname }}.log 2>&1 || true
   args:
     executable: "{{ shell_executable }}"
+  changed_when: false
 
 - name: Fetch journalctl logs
   fetch:

--- a/roles/common/tasks/collect_support_bundle.yml
+++ b/roles/common/tasks/collect_support_bundle.yml
@@ -90,6 +90,7 @@
       become: true
       when: support_bundle_skip_configs
       register: config_metadata_output
+      changed_when: false
 
     - name: Save config file metadata to file
       copy:

--- a/roles/common/tasks/sanitize_config_files_local.yml
+++ b/roles/common/tasks/sanitize_config_files_local.yml
@@ -50,7 +50,9 @@
     ansible_become: false
 
 - name: Remove password.properties files
-  shell: find {{ host_bundle_dir }}/configs -name "*password.properties" -type f -delete
+  shell: find {{ host_bundle_dir }}/configs -name "*password.properties" -type f -print -delete
+  register: removed_password_files
+  changed_when: removed_password_files.stdout | length > 0
   delegate_to: localhost
   vars:
     ansible_connection: local

--- a/roles/common/tasks/sanitize_inventory_files_local.yml
+++ b/roles/common/tasks/sanitize_inventory_files_local.yml
@@ -17,7 +17,8 @@
     cmd: "{{ playbook_dir }}/../roles/common/files/sanitize_properties.py {{ hostvars['localhost']['bundle_path'] }}/ansible/inventory_1_raw.yml --type inventory"
     executable: "{{ ansible_python_interpreter }}"
   when: inventory_files_copied.results | default([]) | selectattr('changed', 'equalto', true) | list | length == 0
-  ignore_errors: true
+  # Collect-as-much-as-possible: never fail the bundle (see design)
+  ignore_errors: true  # noqa: ignore-errors
 
 - name: Rename sanitized inventory files
   shell: |
@@ -25,8 +26,12 @@
       if [ -f "$file" ]; then
         base=$(basename "$file" _raw.yml)
         mv "$file" "{{ hostvars['localhost']['bundle_path'] }}/ansible/${base}_sanitized.yml"
+        echo "renamed $file"
       fi
     done
   args:
     executable: "{{ shell_executable }}"
-  ignore_errors: true
+  register: rename_inventory_result
+  changed_when: "'renamed' in rename_inventory_result.stdout"
+  # Collect-as-much-as-possible: never fail the bundle (see design)
+  ignore_errors: true  # noqa: ignore-errors


### PR DESCRIPTION
## Summary

Addresses `no-changed-when`, `ignore-errors`, and `risky-file-permissions` ansible-lint warnings in the support bundle playbook and tasks **without altering collection behavior**.

## Changes

- `changed_when: false` on read-only shell tasks (`java -version`, `free -m`, `systemctl status`, `journalctl`, config metadata `ls`)
- Accurate `changed_when` on the `password.properties` delete and inventory rename tasks (they genuinely mutate)
- Keep `ignore_errors: true` (by design: "collect as much as possible, never fail") and suppress the rule with `# noqa: ignore-errors`
- `mode: '0644'` on the archive task

## Files

- `playbooks/support_bundle.yml`
- `roles/common/tasks/collect_diagnostics.yml`
- `roles/common/tasks/collect_support_bundle.yml`
- `roles/common/tasks/sanitize_config_files_local.yml`
- `roles/common/tasks/sanitize_inventory_files_local.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)