### PR TITLE
Bump default USM agent package version to 1.2.0 (7.9.x)

### DIFF
--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -3056,7 +3056,7 @@ password_encoder_secret: ""
 # USM Agent Variables
 
 ### Version of Confluent USM Agent to install
-confluent_usm_agent_package_version: 1.0.0
+confluent_usm_agent_package_version: 1.2.0
 
 confluent_usm_agent_goarch:
   x86_64: "amd64"


### PR DESCRIPTION
## What
Bump `confluent_usm_agent_package_version` `1.0.0` → `1.2.0` in `roles/variables/defaults/main.yml` on the **7.9.x** line.

## Why
USM Agent 1.2.0 is GA (2026-06-19); validated against CP 7.9.8 in release validation.

## Scope
7.9.x line. 8.1.x raised as a separate PR; 8.2.x / 8.3.x / master pick it up via pint merge-down.

Ref: SETU-3077 (USM Agent 1.2.0 release follow-up, parent SETU-2877)

🤖 Generated with [Claude Code](https://claude.com/claude-code)