### PR TITLE
[ANSIENG-5875] | Pass sasl.oauthbearer.allowed.files JVM arg for OAuth client-assertion components

### DIFF
--- a/roles/control_center_next_gen/defaults/main.yml
+++ b/roles/control_center_next_gen/defaults/main.yml
@@ -25,11 +25,16 @@ control_center_next_gen_oauth_urls_list: "{{ [oauth_token_uri, oauth_jwks_uri] |
 
 control_center_next_gen_oauth_urls_java_arg: "{% if not whitelist_explicit_oauth_urls|bool %}-Dorg.apache.kafka.sasl.oauthbearer.allowed.urls=*{% else %}-Dorg.apache.kafka.sasl.oauthbearer.allowed.urls={{control_center_next_gen_oauth_urls_list}}{% endif %}"
 
+control_center_next_gen_oauth_files_list: "{{ [control_center_next_gen_oauth_client_assertion_private_key_file_dest_path] | select('!=', 'none') | join(',') }}"
+
+control_center_next_gen_oauth_files_java_arg: "{% if not whitelist_explicit_oauth_files|bool %}-Dorg.apache.kafka.sasl.oauthbearer.allowed.files=*{% else %}-Dorg.apache.kafka.sasl.oauthbearer.allowed.files={{control_center_next_gen_oauth_files_list}}{% endif %}"
+
 control_center_next_gen_java_args:
   - "{% if control_center_next_gen_ssl_enabled|bool %}-Djdk.tls.ephemeralDHKeySize=2048{% endif %}"
   - "{% if control_center_next_gen_authentication_type == 'basic' %}-Djava.security.auth.login.config={{control_center_next_gen.jaas_file}}{% endif %}"
   - "{% if kerberos_client_config_file_dest != '/etc/krb5.conf' %}-Djava.security.krb5.conf={{kerberos_client_config_file_dest}}{% endif %}"
   - "{%  if control_center_next_gen_oauth_urls_list != '' %}{{ control_center_next_gen_oauth_urls_java_arg }}{% endif %}"
+  - "{% if control_center_next_gen_oauth_client_assertion_enabled|bool %}{{ control_center_next_gen_oauth_files_java_arg }}{% endif %}"
 
 ### Custom Java Args to add to the Control Center Next Gen Process
 control_center_next_gen_custom_java_args: ""

--- a/roles/kafka_broker/defaults/main.yml
+++ b/roles/kafka_broker/defaults/main.yml
@@ -26,6 +26,10 @@ kafka_broker_oauth_urls_list: "{{ [oauth_token_uri, oauth_jwks_uri] | select('!=
 
 kafka_broker_oauth_urls_java_arg: "{% if not whitelist_explicit_oauth_urls|bool %}-Dorg.apache.kafka.sasl.oauthbearer.allowed.urls=*{% else %}-Dorg.apache.kafka.sasl.oauthbearer.allowed.urls={{kafka_broker_oauth_urls_list}}{% endif %}"
 
+kafka_broker_oauth_files_list: "{{ [kafka_broker_oauth_client_assertion_private_key_file_dest_path, kafka_broker_sr_oauth_client_assertion_private_key_file_dest_path, oauth_superuser_client_assertion_private_key_file_dest_path] | select('!=', 'none') | join(',') }}"
+
+kafka_broker_oauth_files_java_arg: "{% if not whitelist_explicit_oauth_files|bool %}-Dorg.apache.kafka.sasl.oauthbearer.allowed.files=*{% else %}-Dorg.apache.kafka.sasl.oauthbearer.allowed.files={{kafka_broker_oauth_files_list}}{% endif %}"
+
 kafka_broker_java_args:
   - "{% if kafka_broker_listeners | confluent.platform.ssl_required(ssl_enabled) | bool %}-Djdk.tls.ephemeralDHKeySize=2048{% endif %}"
   - "{% if 'GSSAPI' in kafka_sasl_enabled_mechanisms or (kafka_broker_rest_proxy_enabled and (not rbac_enabled or (rbac_enabled and external_mds_enabled)) and kafka_broker_rest_proxy_authentication_type == 'basic') %}-Djava.security.auth.login.config={{kafka_broker.jaas_file}}{% endif %}"
@@ -33,6 +37,7 @@ kafka_broker_java_args:
   - "{% if kafka_broker_jmxexporter_enabled|bool %}-javaagent:{{jmxexporter_jar_path}}={{kafka_broker_jmxexporter_port}}:{{kafka_broker_jmxexporter_config_path}}{% endif %}"
   - "{% if kerberos_client_config_file_dest != '/etc/krb5.conf' %}-Djava.security.krb5.conf={{kerberos_client_config_file_dest}}{% endif %}"
   - "{% if kafka_broker_oauth_urls_list != '' %}{{ kafka_broker_oauth_urls_java_arg }}{% endif %}"
+  - "{% if kafka_broker_oauth_client_assertion_enabled|bool or oauth_superuser_client_assertion_enabled|bool or schema_registry_oauth_client_assertion_enabled|bool %}{{ kafka_broker_oauth_files_java_arg }}{% endif %}"
 
 ### Custom Java Args to add to the Kafka Process
 kafka_broker_custom_java_args: ""

--- a/roles/kafka_connect/defaults/main.yml
+++ b/roles/kafka_connect/defaults/main.yml
@@ -27,6 +27,10 @@ kafka_connect_oauth_urls_list: "{{ [oauth_token_uri, oauth_jwks_uri] | select('!
 
 kafka_connect_oauth_urls_java_arg: "{% if not whitelist_explicit_oauth_urls|bool %}-Dorg.apache.kafka.sasl.oauthbearer.allowed.urls=*{% else %}-Dorg.apache.kafka.sasl.oauthbearer.allowed.urls={{kafka_connect_oauth_urls_list}}{% endif %}"
 
+kafka_connect_oauth_files_list: "{{ [kafka_connect_oauth_client_assertion_private_key_file_dest_path] | select('!=', 'none') | join(',') }}"
+
+kafka_connect_oauth_files_java_arg: "{% if not whitelist_explicit_oauth_files|bool %}-Dorg.apache.kafka.sasl.oauthbearer.allowed.files=*{% else %}-Dorg.apache.kafka.sasl.oauthbearer.allowed.files={{kafka_connect_oauth_files_list}}{% endif %}"
+
 kafka_connect_java_args:
   - "{% if kafka_connect_ssl_enabled|bool %}-Djdk.tls.ephemeralDHKeySize=2048{% endif %}"
   - "{% if kafka_connect_jolokia_enabled|bool %}-javaagent:{{jolokia_jar_path}}=config={{kafka_connect_jolokia_config}}{% endif %}"
@@ -34,6 +38,7 @@ kafka_connect_java_args:
   - "{% if kafka_connect_authentication_type == 'basic' %}-Djava.security.auth.login.config={{kafka_connect.jaas_file}}{% endif %}"
   - "{% if kerberos_client_config_file_dest != '/etc/krb5.conf' %}-Djava.security.krb5.conf={{kerberos_client_config_file_dest}}{% endif %}"
   - "{% if kafka_connect_oauth_urls_list != '' %}{{ kafka_connect_oauth_urls_java_arg }}{% endif %}"
+  - "{% if kafka_connect_oauth_client_assertion_enabled|bool %}{{ kafka_connect_oauth_files_java_arg }}{% endif %}"
 
 ### Custom Java Args to add to the Connect Process
 kafka_connect_custom_java_args: ""

--- a/roles/kafka_connect_replicator/defaults/main.yml
+++ b/roles/kafka_connect_replicator/defaults/main.yml
@@ -16,11 +16,16 @@ kafka_connect_replicator_oauth_urls_list: "{{ [oauth_token_uri, oauth_jwks_uri] 
 
 kafka_connect_replicator_oauth_urls_java_arg: "{% if not whitelist_explicit_oauth_urls|bool %}-Dorg.apache.kafka.sasl.oauthbearer.allowed.urls=*{% else %}-Dorg.apache.kafka.sasl.oauthbearer.allowed.urls={{kafka_connect_replicator_oauth_urls_list}}{% endif %}"
 
+kafka_connect_replicator_oauth_files_list: "{{ [kafka_connect_replicator_oauth_client_assertion_private_key_file_dest_path, kafka_connect_replicator_producer_oauth_client_assertion_private_key_file_dest_path, kafka_connect_replicator_consumer_oauth_client_assertion_private_key_file_dest_path, kafka_connect_replicator_monitoring_interceptor_oauth_client_assertion_private_key_file_dest_path] | select('!=', 'none') | join(',') }}"
+
+kafka_connect_replicator_oauth_files_java_arg: "{% if not whitelist_explicit_oauth_files|bool %}-Dorg.apache.kafka.sasl.oauthbearer.allowed.files=*{% else %}-Dorg.apache.kafka.sasl.oauthbearer.allowed.files={{kafka_connect_replicator_oauth_files_list}}{% endif %}"
+
 kafka_connect_replicator_java_args:
   - "{% if kafka_connect_replicator_ssl_mutual_auth_enabled| bool %}-Djdk.tls.ephemeralDHKeySize=2048{% endif %}"
   - "{% if kafka_connect_replicator_jolokia_enabled|bool %}-javaagent:{{kafka_connect_replicator_jolokia_jar_path}}=config={{kafka_connect_replicator_jolokia_config}}{% endif %}"
   - "{% if kerberos_client_config_file_dest != '/etc/krb5.conf' %}-Djava.security.krb5.conf={{kerberos_client_config_file_dest}}{% endif %}"
   - "{% if kafka_connect_replicator_oauth_urls_list != '' %}{{ kafka_connect_replicator_oauth_urls_java_arg }}{% endif %}"
+  - "{% if kafka_connect_replicator_oauth_client_assertion_enabled|bool or kafka_connect_replicator_producer_oauth_client_assertion_enabled|bool or kafka_connect_replicator_consumer_oauth_client_assertion_enabled|bool or kafka_connect_replicator_monitoring_interceptor_oauth_client_assertion_enabled|bool %}{{ kafka_connect_replicator_oauth_files_java_arg }}{% endif %}"
 
 ### Custom Java Args to add to the Kafka Connect Replicator Process
 kafka_connect_replicator_custom_java_args: ""

--- a/roles/kafka_controller/defaults/main.yml
+++ b/roles/kafka_controller/defaults/main.yml
@@ -26,6 +26,10 @@ kafka_controller_oauth_urls_list: "{{ [oauth_token_uri, oauth_jwks_uri] | select
 
 kafka_controller_oauth_urls_java_arg: "{% if not whitelist_explicit_oauth_urls|bool %}-Dorg.apache.kafka.sasl.oauthbearer.allowed.urls=*{% else %}-Dorg.apache.kafka.sasl.oauthbearer.allowed.urls={{kafka_controller_oauth_urls_list}}{% endif %}"
 
+kafka_controller_oauth_files_list: "{{ [kafka_controller_oauth_client_assertion_private_key_file_dest_path] | select('!=', 'none') | join(',') }}"
+
+kafka_controller_oauth_files_java_arg: "{% if not whitelist_explicit_oauth_files|bool %}-Dorg.apache.kafka.sasl.oauthbearer.allowed.files=*{% else %}-Dorg.apache.kafka.sasl.oauthbearer.allowed.files={{kafka_controller_oauth_files_list}}{% endif %}"
+
 kafka_controller_java_args:
   - "{% if kafka_controller_listeners | confluent.platform.ssl_required(kafka_controller_ssl_enabled) | bool %}-Djdk.tls.ephemeralDHKeySize=2048{% endif %}"
   - "{% if 'GSSAPI' in kafka_sasl_enabled_mechanisms %}-Djava.security.auth.login.config={{kafka_controller.jaas_file}}{% endif %}"
@@ -33,6 +37,7 @@ kafka_controller_java_args:
   - "{% if kafka_controller_jmxexporter_enabled|bool %}-javaagent:{{jmxexporter_jar_path}}={{kafka_controller_jmxexporter_port}}:{{kafka_controller_jmxexporter_config_path}}{% endif %}"
   - "{% if kerberos_client_config_file_dest != '/etc/krb5.conf' %}-Djava.security.krb5.conf={{kerberos_client_config_file_dest}}{% endif %}"
   - "{% if kafka_controller_oauth_urls_list != ''  %}{{ kafka_controller_oauth_urls_java_arg }}{% endif %}"
+  - "{% if kafka_controller_oauth_client_assertion_enabled|bool %}{{ kafka_controller_oauth_files_java_arg }}{% endif %}"
 
 ### Custom Java Args to add to the Kafka Process
 kafka_controller_custom_java_args: ""

--- a/roles/kafka_rest/defaults/main.yml
+++ b/roles/kafka_rest/defaults/main.yml
@@ -26,6 +26,10 @@ kafka_rest_oauth_urls_list: "{{ [oauth_token_uri, oauth_jwks_uri] | select('!=',
 
 kafka_rest_oauth_urls_java_arg: "{% if not whitelist_explicit_oauth_urls|bool %}-Dorg.apache.kafka.sasl.oauthbearer.allowed.urls=*{% else %}-Dorg.apache.kafka.sasl.oauthbearer.allowed.urls={{kafka_rest_oauth_urls_list}}{% endif %}"
 
+kafka_rest_oauth_files_list: "{{ [kafka_rest_oauth_client_assertion_private_key_file_dest_path] | select('!=', 'none') | join(',') }}"
+
+kafka_rest_oauth_files_java_arg: "{% if not whitelist_explicit_oauth_files|bool %}-Dorg.apache.kafka.sasl.oauthbearer.allowed.files=*{% else %}-Dorg.apache.kafka.sasl.oauthbearer.allowed.files={{kafka_rest_oauth_files_list}}{% endif %}"
+
 kafka_rest_java_args:
   - "{% if kafka_rest_ssl_enabled|bool %}-Djdk.tls.ephemeralDHKeySize=2048{% endif %}"
   - "{% if kafka_rest_jolokia_enabled|bool %}-javaagent:{{jolokia_jar_path}}=config={{kafka_rest_jolokia_config}}{% endif %}"
@@ -33,6 +37,7 @@ kafka_rest_java_args:
   - "{% if kafka_rest_authentication_type == 'basic' %}-Djava.security.auth.login.config={{kafka_rest.jaas_file}}{% endif %}"
   - "{% if kerberos_client_config_file_dest != '/etc/krb5.conf' %}-Djava.security.krb5.conf={{kerberos_client_config_file_dest}}{% endif %}"
   - "{% if kafka_rest_oauth_urls_list != '' %}{{ kafka_rest_oauth_urls_java_arg }}{% endif %}"
+  - "{% if kafka_rest_oauth_client_assertion_enabled|bool %}{{ kafka_rest_oauth_files_java_arg }}{% endif %}"
 
 ### Custom Java Args to add to the Rest Proxy Process
 kafka_rest_custom_java_args: ""

--- a/roles/ksql/defaults/main.yml
+++ b/roles/ksql/defaults/main.yml
@@ -26,6 +26,10 @@ ksql_oauth_urls_list: "{{ [oauth_token_uri, oauth_jwks_uri] | select('!=', 'none
 
 ksql_oauth_urls_java_arg: "{% if not whitelist_explicit_oauth_urls|bool %}-Dorg.apache.kafka.sasl.oauthbearer.allowed.urls=*{% else %}-Dorg.apache.kafka.sasl.oauthbearer.allowed.urls={{ksql_oauth_urls_list}}{% endif %}"
 
+ksql_oauth_files_list: "{{ [ksql_oauth_client_assertion_private_key_file_dest_path] | select('!=', 'none') | join(',') }}"
+
+ksql_oauth_files_java_arg: "{% if not whitelist_explicit_oauth_files|bool %}-Dorg.apache.kafka.sasl.oauthbearer.allowed.files=*{% else %}-Dorg.apache.kafka.sasl.oauthbearer.allowed.files={{ksql_oauth_files_list}}{% endif %}"
+
 ksql_java_args:
   - "{% if ksql_ssl_enabled|bool %}-Djdk.tls.ephemeralDHKeySize=2048{% endif %}"
   - "{% if ksql_jolokia_enabled|bool %}-javaagent:{{jolokia_jar_path}}=config={{ksql_jolokia_config}}{% endif %}"
@@ -33,6 +37,7 @@ ksql_java_args:
   - "{% if ksql_authentication_type == 'basic' %}-Djava.security.auth.login.config={{ksql.jaas_file}}{% endif %}"
   - "{% if kerberos_client_config_file_dest != '/etc/krb5.conf' %}-Djava.security.krb5.conf={{kerberos_client_config_file_dest}}{% endif %}"
   - "{% if ksql_oauth_urls_list != '' %}{{ ksql_oauth_urls_java_arg }}{% endif %}"
+  - "{% if ksql_oauth_client_assertion_enabled|bool %}{{ ksql_oauth_files_java_arg }}{% endif %}"
 
 ### Custom Java Args to add to the ksqlDB Process
 ksql_custom_java_args: ""

--- a/roles/schema_registry/defaults/main.yml
+++ b/roles/schema_registry/defaults/main.yml
@@ -26,6 +26,10 @@ schema_registry_oauth_urls_list: "{{ [oauth_token_uri, oauth_jwks_uri] | select(
 
 schema_registry_oauth_urls_java_arg: "{% if not whitelist_explicit_oauth_urls|bool %}-Dorg.apache.kafka.sasl.oauthbearer.allowed.urls=*{% else %}-Dorg.apache.kafka.sasl.oauthbearer.allowed.urls={{schema_registry_oauth_urls_list}}{% endif %}"
 
+schema_registry_oauth_files_list: "{{ [schema_registry_oauth_client_assertion_private_key_file_dest_path] | select('!=', 'none') | join(',') }}"
+
+schema_registry_oauth_files_java_arg: "{% if not whitelist_explicit_oauth_files|bool %}-Dorg.apache.kafka.sasl.oauthbearer.allowed.files=*{% else %}-Dorg.apache.kafka.sasl.oauthbearer.allowed.files={{schema_registry_oauth_files_list}}{% endif %}"
+
 schema_registry_java_args:
   - "{% if schema_registry_ssl_enabled|bool %}-Djdk.tls.ephemeralDHKeySize=2048{% endif %}"
   - "{% if schema_registry_jolokia_enabled|bool %}-javaagent:{{jolokia_jar_path}}=config={{schema_registry_jolokia_config}}{% endif %}"
@@ -33,6 +37,7 @@ schema_registry_java_args:
   - "{% if schema_registry_authentication_type == 'basic' %}-Djava.security.auth.login.config={{schema_registry.jaas_file}}{% endif %}"
   - "{% if kerberos_client_config_file_dest != '/etc/krb5.conf' %}-Djava.security.krb5.conf={{kerberos_client_config_file_dest}}{% endif %}"
   - "{% if schema_registry_oauth_urls_list != '' %}{{ schema_registry_oauth_urls_java_arg }}{% endif %}"
+  - "{% if schema_registry_oauth_client_assertion_enabled|bool %}{{ schema_registry_oauth_files_java_arg }}{% endif %}"
 
 ### Custom Java Args to add to the Schema Registry Process
 schema_registry_custom_java_args: ""

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -3275,6 +3275,8 @@ kafka_connect_replicator_monitoring_interceptor_oauth_client_assertion_template_
 
 whitelist_explicit_oauth_urls: false
 
+whitelist_explicit_oauth_files: false
+
 
 jolokia_access_control_enabled: false
 


### PR DESCRIPTION
## Summary
- AK 4.3 (CP 8.3.0) enforces a deny-by-default allowlist via `org.apache.kafka.sasl.oauthbearer.allowed.files`. Empty list ⇒ every OAuth client-assertion component (SR first) fails at startup with `Allowed file list: []`.
- Mirrors the existing `_oauth_urls_java_arg` plumbing in 8 component roles (`schema_registry`, `kafka_rest`, `kafka_connect`, `ksql`, `kafka_controller`, `kafka_broker`, `control_center_next_gen`, `kafka_connect_replicator`) plus a global `whitelist_explicit_oauth_files: false` toggle in `roles/variables/defaults/main.yml`.
- Default is permissive (`=*`); flip the global toggle to emit the auto-derived comma-joined list of dest paths each role actually writes. Entry is gated by `<role>_oauth_client_assertion_enabled`, so non-OAuth deployments are unaffected.

Jira: [ANSIENG-5875](https://confluentinc.atlassian.net/browse/ANSIENG-5875)

## Test plan
molecule run - https://semaphore.ci.confluent.io/jobs/2dddfd53-3bd0-48b5-8c3f-2108669af4ed

[ANSIENG-5875]: https://confluentinc.atlassian.net/browse/ANSIENG-5875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ