### PR TITLE
Bump CP Version to 7.5.15

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -15,3 +15,4 @@ skip_list:
   - key-order
   - fqcn[action]
   - package-latest
+  - risky-shell-pipe

--- a/.bumpversion-ansible.cfg
+++ b/.bumpversion-ansible.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 7.5.14
+current_version = 7.5.15
 commit = true
 message = Bump cp-ansible Version: {current_version} → {new_version}
 tag = false

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 7.5.14
+current_version = 7.5.15
 commit = true
 message = Bump CP Version: {current_version} → {new_version}
 tag = false

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,16 @@ Ansible Playbooks for Confluent Platform - Release Notes
 
 .. contents:: Topics
 
+v7.5.15
+======
+Notable fixes
+-------------
+- For the list of security and vulnerability issues fixed in this release, see https://support.confluent.io/hc/en-us/sections/360008413952-Security-Advisories-and-Security-Release-Notes
+- Removed redundant double restart for kafka broker and kafka controller.
+- Fixed the security.properties copy task so the file is correctly copied to the Ansible host.
+- Fixed kafka-storage format failures on KRaft clusters with secrets protection enabled - the master key is now passed to the format step via the CONFLUENT_SECURITY_MASTER_KEY environment variable.
+- Fixed custom certificate chain building for multi-tier and partial-chain PKIs - chains now assemble correctly for root + intermediate bundles and DoD-style partial chains.
+
 v7.5.14
 ======
 Notable fixes

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,14 @@ Ansible Playbooks for Confluent Platform - Release Notes
 
 v7.5.15
 ======
+New features
+-------------
+- Support bundle generation for CP-Ansible playbook runs.
+
+Notable enhancements
+-------------
+- Introduced Confluent CLI v3.0.0 preflight assertion.
+
 Notable fixes
 -------------
 - For the list of security and vulnerability issues fixed in this release, see https://support.confluent.io/hc/en-us/sections/360008413952-Security-Advisories-and-Security-Release-Notes

--- a/README.md
+++ b/README.md
@@ -52,12 +52,12 @@ Ansible Playbooks for Confluent Platform (Confluent Ansible) offers a simplified
 
 ## Testing
 
-CP-Ansible's tests use the [Molecule](https://ansible.readthedocs.io/projects/molecule/) framework, and it is strongly advised to test this way before submitting a Pull Request. Please refer to the [HOW_TO_TEST.md](https://github.com/confluentinc/cp-ansible/blob/7.5.14-post/docs/HOW_TO_TEST.md)
+CP-Ansible's tests use the [Molecule](https://ansible.readthedocs.io/projects/molecule/) framework, and it is strongly advised to test this way before submitting a Pull Request. Please refer to the [HOW_TO_TEST.md](https://github.com/confluentinc/cp-ansible/blob/7.5.15-post/docs/HOW_TO_TEST.md)
 
 
 ## Contributing
 
-If you would like to contribute to the CP-Ansible project, please refer to the [CONTRIBUTE.md](https://github.com/confluentinc/cp-ansible/blob/7.5.14-post/docs/CONTRIBUTING.md)
+If you would like to contribute to the CP-Ansible project, please refer to the [CONTRIBUTE.md](https://github.com/confluentinc/cp-ansible/blob/7.5.15-post/docs/CONTRIBUTING.md)
 
 ## Support
 
@@ -69,4 +69,4 @@ This [page](https://docs.confluent.io/ansible/current/ansible-release-notes.html
 
 ## License
 
-[Apache 2.0](https://github.com/confluentinc/cp-ansible/blob/7.5.14-post/LICENSE.md)
+[Apache 2.0](https://github.com/confluentinc/cp-ansible/blob/7.5.15-post/LICENSE.md)

--- a/docs/MOLECULE_SCENARIOS.md
+++ b/docs/MOLECULE_SCENARIOS.md
@@ -414,6 +414,164 @@ Validates that Control Center Can connect to each KSQL cluster
 
 ***
 
+### molecule/mtls-custom-2tier-rhel
+
+#### Scenario mtls-custom-2tier-rhel test's the following:
+
+ANSIENG-5765 case 1: 2-tier PKI.
+
+CA bundle = Root only. Cert file = leaf only.
+
+Expected chain: leaf -> root (2 certs).
+
+#### Scenario mtls-custom-2tier-rhel verify test's the following:
+
+Verifies the cert chain that build_certificate_chain.yml produced.
+
+
+
+The cluster having come up at all (converge succeeded) is itself end-to-end
+
+proof that the chain is correct: mTLS handshakes between broker, controller,
+
+and schema_registry would have failed otherwise. These checks add an extra
+
+assertion that the chain file has the expected number of certs in
+
+leaf-first order for this scenario's input layout.
+
+***
+
+### molecule/mtls-custom-4tier-bundle-debian
+
+#### Scenario mtls-custom-4tier-bundle-debian test's the following:
+
+ANSIENG-5765 case 7 on Debian.
+
+Same cert layout as mtls-custom-4tier-bundle-rhel (Root + Int1 + Int2 in the
+
+bundle, leaf-only cert file) but exercises the chain task on a Debian host
+
+to confirm the shell logic is OS-agnostic.
+
+#### Scenario mtls-custom-4tier-bundle-debian verify test's the following:
+
+Verifies the cert chain that build_certificate_chain.yml produced.
+
+
+
+The cluster having come up at all (converge succeeded) is itself end-to-end
+
+proof that the chain is correct: mTLS handshakes between broker, controller,
+
+and schema_registry would have failed otherwise. These checks add an extra
+
+assertion that the chain file has the expected number of certs in
+
+leaf-first order for this scenario's input layout.
+
+***
+
+### molecule/mtls-custom-4tier-bundle-rhel
+
+#### Scenario mtls-custom-4tier-bundle-rhel test's the following:
+
+ANSIENG-5765 case 7: 4-tier PKI, all CAs in the bundle.
+
+CA bundle = Root + Int1 + Int2. Cert file = leaf only (no inline intermediates).
+
+This is the hardest enterprise PKI layout: was broken in the per-CA-loop
+
+implementation; the fix gives openssl the whole bundle in one verify call.
+
+Expected chain: leaf -> int2 -> int1 -> root (4 certs).
+
+#### Scenario mtls-custom-4tier-bundle-rhel verify test's the following:
+
+Verifies the cert chain that build_certificate_chain.yml produced.
+
+
+
+The cluster having come up at all (converge succeeded) is itself end-to-end
+
+proof that the chain is correct: mTLS handshakes between broker, controller,
+
+and schema_registry would have failed otherwise. These checks add an extra
+
+assertion that the chain file has the expected number of certs in
+
+leaf-first order for this scenario's input layout.
+
+***
+
+### molecule/mtls-custom-4tier-inline-rhel
+
+#### Scenario mtls-custom-4tier-inline-rhel test's the following:
+
+ANSIENG-5765 case 9: 4-tier PKI, full chain inlined in the cert file.
+
+CA bundle = Root only. Cert file = leaf + Int2 + Int1 (the user pasted the
+
+whole chain into one file). The fix detects the leaf via topology rather
+
+than by "last cert" and walks the issuer/subject relationships to emit the
+
+correct order.
+
+Expected chain: leaf -> int2 -> int1 -> root (4 certs).
+
+#### Scenario mtls-custom-4tier-inline-rhel verify test's the following:
+
+Verifies the cert chain that build_certificate_chain.yml produced.
+
+
+
+The cluster having come up at all (converge succeeded) is itself end-to-end
+
+proof that the chain is correct: mTLS handshakes between broker, controller,
+
+and schema_registry would have failed otherwise. These checks add an extra
+
+assertion that the chain file has the expected number of certs in
+
+leaf-first order for this scenario's input layout.
+
+***
+
+### molecule/mtls-custom-partial-rhel
+
+#### Scenario mtls-custom-partial-rhel test's the following:
+
+ANSIENG-5765 case 10: 4-tier PKI, partial chain (no root in the bundle).
+
+CA bundle = Int1 + Int2 only (root deliberately omitted, mirroring DoD-style
+
+partial chains). Cert file = leaf only.
+
+The fix's `-partial_chain` flag is the key piece: openssl is allowed to
+
+stop at a trusted intermediate instead of insisting on a self-signed root.
+
+Expected chain: leaf -> int2 -> int1 (3 certs; walk stops at top intermediate).
+
+#### Scenario mtls-custom-partial-rhel verify test's the following:
+
+Verifies the cert chain that build_certificate_chain.yml produced.
+
+
+
+The cluster having come up at all (converge succeeded) is itself end-to-end
+
+proof that the chain is correct: mTLS handshakes between broker, controller,
+
+and schema_registry would have failed otherwise. These checks add an extra
+
+assertion that the chain file has the expected number of certs in
+
+leaf-first order for this scenario's input layout.
+
+***
+
 ### molecule/mtls-custombundle-rhel-fips
 
 #### Scenario mtls-custombundle-rhel-fips test's the following:
@@ -1273,6 +1431,80 @@ SCRAM enabled.
 #### Scenario scram-rhel verify test's the following:
 
 Validates that SCRAM is enabled on all components.
+
+***
+
+### molecule/secrets-provided-per-component
+
+#### Scenario secrets-provided-per-component test's the following:
+
+Each CP component group gets its own customer-provided master key +
+
+security.properties pair via inventory group_vars (kafka_broker,
+
+schema_registry). kafka_connect has secrets protection disabled to cover
+
+the per-component opt-out. kafka_controller has no customer pair and
+
+regenerates its own key. Verify asserts every component has a distinct key.
+
+#### Scenario secrets-provided-per-component verify test's the following:
+
+Asserts each secrets-enabled component carries its own distinct master
+
+key, and that kafka_connect (per-component opt-out) runs plaintext.
+
+***
+
+### molecule/secrets-upgrade-auto
+
+#### Scenario secrets-upgrade-auto test's the following:
+
+Auto-Generated Master Key Test.
+
+First converge runs with regenerate_masterkey: true to auto-generate a master key.
+
+Second converge runs with regenerate_masterkey: false to confirm the key persists
+
+and that encrypted properties remain valid (regression coverage for ANSIENG-5857
+
+/ ANSIENG-5784: security.properties was not deployed on subsequent runs when
+
+regenerate_masterkey was false, and properties drifted on serial re-runs).
+
+#### Scenario secrets-upgrade-auto verify test's the following:
+
+Asserts every broker carries the same non-empty master key
+
+and that secrets protection took effect.
+
+***
+
+### molecule/secrets-upgrade-provided
+
+#### Scenario secrets-upgrade-provided test's the following:
+
+Customer-Provided Master Key Test.
+
+Simulates the workflow where a customer generates the master key and
+
+security.properties out-of-band and supplies them to cp-ansible via
+
+`secrets_protection_masterkey` and `secrets_protection_security_file`
+
+with `regenerate_masterkey: false`. The converge.yml stages bootstrap
+
+artifacts at a custom path so we can prove the explicit path is honored
+
+(regression coverage for ANSIENG-5857: the security.properties copy was
+
+being skipped when regenerate_masterkey was false on a fresh host).
+
+#### Scenario secrets-upgrade-provided verify test's the following:
+
+Asserts the customer-supplied master key reached every component
+
+(controller + all brokers) and that secrets protection took effect.
 
 ***
 

--- a/docs/VARIABLES.md
+++ b/docs/VARIABLES.md
@@ -8,7 +8,7 @@ Below are the supported variables for the role variables
 
 Version of Confluent Platform to install
 
-Default:  7.5.14
+Default:  7.5.15
 
 ***
 

--- a/docs/VARIABLES.md
+++ b/docs/VARIABLES.md
@@ -20,6 +20,86 @@ Default:  /tmp
 
 ***
 
+### support_bundle_output_path
+
+Output path for support bundles on Ansible controller
+
+Default:  "~/confluent-platform-support-bundles"
+
+***
+
+### support_bundle_cluster_name
+
+Cluster name to include in support bundle filename
+
+Default:  cp_cluster
+
+***
+
+### support_bundle_journalctl_lines
+
+Number of journalctl log lines to collect per service
+
+Default:  0
+
+***
+
+### support_bundle_base_path
+
+Base path on remote hosts for temporary diagnostic files during collection. Log and config files are fetched directly from their original locations.
+
+Default:  /tmp
+
+***
+
+### support_bundle_log_patterns
+
+File patterns to collect for logs, bounded defaults for reliability at scale
+
+Default: 
+
+***
+
+### support_bundle_log_max_count
+
+Maximum number of log files to collect per component, most recent first
+
+Default:  20
+
+***
+
+### support_bundle_sanitize_configs
+
+Whether to sanitize config files before collection. When true, passwords and sensitive values are redacted from config files.
+
+Default:  true
+
+***
+
+### support_bundle_skip_configs
+
+Whether to skip config file collection entirely. When true, only collect metadata about config files, not their contents.
+
+Default:  false
+
+***
+
+### support_bundle_auto_collect_on_failure
+
+Whether to automatically collect support bundle when playbooks fail. Default is false and must be explicitly enabled.
+
+Default:  true
+
+***
+
+### support_bundle_ansible_log_path
+
+Path to Ansible playbook execution log file on Ansible controller. When set, this log file will be included in the support bundle.
+
+Default:  ""
+
+***
+
 ### ansible_become_localhost
 
 Boolean to specify the become value for localhost, used when dealing with any file present on localhost/controller.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: confluent
 name: platform
-version: 7.5.14
+version: 7.5.15
 readme: README.md
 authors:
   - Confluent Ansible Community

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -2,7 +2,7 @@
 # Custom filters used in this file are defined in plugins/filter/filters.py
 
 ### Version of Confluent Platform to install
-confluent_package_version: 7.5.14
+confluent_package_version: 7.5.15
 
 confluent_full_package_version: "{{ confluent_package_version + '-1' }}"
 confluent_package_redhat_suffix: "{{ '-' + confluent_full_package_version if confluent_full_package_version != '' else ''}}"

--- a/roles/variables/vars/main.yml
+++ b/roles/variables/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-confluent_ansible_branch: 7.5.14-post
+confluent_ansible_branch: 7.5.15-post
 
 systemd_base_dir: "{{'/lib/systemd/system' if ansible_os_family == 'Debian' else '/usr/lib/systemd/system'}}"
 

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -3,6 +3,16 @@ plugins/modules/kafka_connectors.py pylint:ansible-format-automatic-specificatio
 plugins/modules/kafka_connectors.py validate-modules:missing-gplv3-license
 molecule/certs-create.sh shebang
 molecule/certs-create.sh shellcheck!skip
+molecule/mtls-custom-2tier-rhel/create_certs.sh shebang
+molecule/mtls-custom-2tier-rhel/create_certs.sh shellcheck!skip
+molecule/mtls-custom-4tier-bundle-debian/create_certs.sh shebang
+molecule/mtls-custom-4tier-bundle-debian/create_certs.sh shellcheck!skip
+molecule/mtls-custom-4tier-bundle-rhel/create_certs.sh shebang
+molecule/mtls-custom-4tier-bundle-rhel/create_certs.sh shellcheck!skip
+molecule/mtls-custom-4tier-inline-rhel/create_certs.sh shebang
+molecule/mtls-custom-4tier-inline-rhel/create_certs.sh shellcheck!skip
+molecule/mtls-custom-partial-rhel/create_certs.sh shebang
+molecule/mtls-custom-partial-rhel/create_certs.sh shellcheck!skip
 molecule/mtls-custombundle-rhel-fips/create_ca_bundle.sh shebang
 molecule/mtls-custombundle-rhel-fips/create_ca_bundle.sh shellcheck!skip
 test_roles/confluent.test.kerberos/files/create_admin.sh shebang

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -3,6 +3,16 @@ plugins/modules/kafka_connectors.py pylint:ansible-format-automatic-specificatio
 plugins/modules/kafka_connectors.py validate-modules:missing-gplv3-license
 molecule/certs-create.sh shebang
 molecule/certs-create.sh shellcheck!skip
+molecule/mtls-custom-2tier-rhel/create_certs.sh shebang
+molecule/mtls-custom-2tier-rhel/create_certs.sh shellcheck!skip
+molecule/mtls-custom-4tier-bundle-debian/create_certs.sh shebang
+molecule/mtls-custom-4tier-bundle-debian/create_certs.sh shellcheck!skip
+molecule/mtls-custom-4tier-bundle-rhel/create_certs.sh shebang
+molecule/mtls-custom-4tier-bundle-rhel/create_certs.sh shellcheck!skip
+molecule/mtls-custom-4tier-inline-rhel/create_certs.sh shebang
+molecule/mtls-custom-4tier-inline-rhel/create_certs.sh shellcheck!skip
+molecule/mtls-custom-partial-rhel/create_certs.sh shebang
+molecule/mtls-custom-partial-rhel/create_certs.sh shellcheck!skip
 molecule/mtls-custombundle-rhel-fips/create_ca_bundle.sh shebang
 molecule/mtls-custombundle-rhel-fips/create_ca_bundle.sh shellcheck!skip
 test_roles/confluent.test.kerberos/files/create_admin.sh shebang

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -2,6 +2,16 @@ Jenkinsfile.disabled shebang
 plugins/modules/kafka_connectors.py validate-modules:missing-gplv3-license
 molecule/certs-create.sh shebang
 molecule/certs-create.sh shellcheck!skip
+molecule/mtls-custom-2tier-rhel/create_certs.sh shebang
+molecule/mtls-custom-2tier-rhel/create_certs.sh shellcheck!skip
+molecule/mtls-custom-4tier-bundle-debian/create_certs.sh shebang
+molecule/mtls-custom-4tier-bundle-debian/create_certs.sh shellcheck!skip
+molecule/mtls-custom-4tier-bundle-rhel/create_certs.sh shebang
+molecule/mtls-custom-4tier-bundle-rhel/create_certs.sh shellcheck!skip
+molecule/mtls-custom-4tier-inline-rhel/create_certs.sh shebang
+molecule/mtls-custom-4tier-inline-rhel/create_certs.sh shellcheck!skip
+molecule/mtls-custom-partial-rhel/create_certs.sh shebang
+molecule/mtls-custom-partial-rhel/create_certs.sh shellcheck!skip
 molecule/mtls-custombundle-rhel-fips/create_ca_bundle.sh shebang
 molecule/mtls-custombundle-rhel-fips/create_ca_bundle.sh shellcheck!skip
 test_roles/confluent.test.kerberos/files/create_admin.sh shebang

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -2,6 +2,16 @@ Jenkinsfile.disabled shebang
 plugins/modules/kafka_connectors.py validate-modules:missing-gplv3-license
 molecule/certs-create.sh shebang
 molecule/certs-create.sh shellcheck!skip
+molecule/mtls-custom-2tier-rhel/create_certs.sh shebang
+molecule/mtls-custom-2tier-rhel/create_certs.sh shellcheck!skip
+molecule/mtls-custom-4tier-bundle-debian/create_certs.sh shebang
+molecule/mtls-custom-4tier-bundle-debian/create_certs.sh shellcheck!skip
+molecule/mtls-custom-4tier-bundle-rhel/create_certs.sh shebang
+molecule/mtls-custom-4tier-bundle-rhel/create_certs.sh shellcheck!skip
+molecule/mtls-custom-4tier-inline-rhel/create_certs.sh shebang
+molecule/mtls-custom-4tier-inline-rhel/create_certs.sh shellcheck!skip
+molecule/mtls-custom-partial-rhel/create_certs.sh shebang
+molecule/mtls-custom-partial-rhel/create_certs.sh shellcheck!skip
 molecule/mtls-custombundle-rhel-fips/create_ca_bundle.sh shebang
 molecule/mtls-custombundle-rhel-fips/create_ca_bundle.sh shellcheck!skip
 test_roles/confluent.test.kerberos/files/create_admin.sh shebang

--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -2,6 +2,16 @@ Jenkinsfile.disabled shebang
 plugins/modules/kafka_connectors.py validate-modules:missing-gplv3-license
 molecule/certs-create.sh shebang
 molecule/certs-create.sh shellcheck!skip
+molecule/mtls-custom-2tier-rhel/create_certs.sh shebang
+molecule/mtls-custom-2tier-rhel/create_certs.sh shellcheck!skip
+molecule/mtls-custom-4tier-bundle-debian/create_certs.sh shebang
+molecule/mtls-custom-4tier-bundle-debian/create_certs.sh shellcheck!skip
+molecule/mtls-custom-4tier-bundle-rhel/create_certs.sh shebang
+molecule/mtls-custom-4tier-bundle-rhel/create_certs.sh shellcheck!skip
+molecule/mtls-custom-4tier-inline-rhel/create_certs.sh shebang
+molecule/mtls-custom-4tier-inline-rhel/create_certs.sh shellcheck!skip
+molecule/mtls-custom-partial-rhel/create_certs.sh shebang
+molecule/mtls-custom-partial-rhel/create_certs.sh shellcheck!skip
 molecule/mtls-custombundle-rhel-fips/create_ca_bundle.sh shebang
 molecule/mtls-custombundle-rhel-fips/create_ca_bundle.sh shellcheck!skip
 test_roles/confluent.test.kerberos/files/create_admin.sh shebang

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -37,6 +37,16 @@ docs/doc.py pylint!skip
 docs/molecule_doc.py pylint!skip
 molecule/certs-create.sh shebang
 molecule/certs-create.sh shellcheck!skip
+molecule/mtls-custom-2tier-rhel/create_certs.sh shebang
+molecule/mtls-custom-2tier-rhel/create_certs.sh shellcheck!skip
+molecule/mtls-custom-4tier-bundle-debian/create_certs.sh shebang
+molecule/mtls-custom-4tier-bundle-debian/create_certs.sh shellcheck!skip
+molecule/mtls-custom-4tier-bundle-rhel/create_certs.sh shebang
+molecule/mtls-custom-4tier-bundle-rhel/create_certs.sh shellcheck!skip
+molecule/mtls-custom-4tier-inline-rhel/create_certs.sh shebang
+molecule/mtls-custom-4tier-inline-rhel/create_certs.sh shellcheck!skip
+molecule/mtls-custom-partial-rhel/create_certs.sh shebang
+molecule/mtls-custom-partial-rhel/create_certs.sh shellcheck!skip
 molecule/mtls-custombundle-rhel-fips/create_ca_bundle.sh shebang
 molecule/mtls-custombundle-rhel-fips/create_ca_bundle.sh shellcheck!skip
 plugins/modules/kafka_connectors.py validate-modules:missing-gplv3-license

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -3,6 +3,16 @@ plugins/modules/kafka_connectors.py pylint:ansible-format-automatic-specificatio
 plugins/modules/kafka_connectors.py validate-modules:missing-gplv3-license
 molecule/certs-create.sh shebang
 molecule/certs-create.sh shellcheck!skip
+molecule/mtls-custom-2tier-rhel/create_certs.sh shebang
+molecule/mtls-custom-2tier-rhel/create_certs.sh shellcheck!skip
+molecule/mtls-custom-4tier-bundle-debian/create_certs.sh shebang
+molecule/mtls-custom-4tier-bundle-debian/create_certs.sh shellcheck!skip
+molecule/mtls-custom-4tier-bundle-rhel/create_certs.sh shebang
+molecule/mtls-custom-4tier-bundle-rhel/create_certs.sh shellcheck!skip
+molecule/mtls-custom-4tier-inline-rhel/create_certs.sh shebang
+molecule/mtls-custom-4tier-inline-rhel/create_certs.sh shellcheck!skip
+molecule/mtls-custom-partial-rhel/create_certs.sh shebang
+molecule/mtls-custom-partial-rhel/create_certs.sh shellcheck!skip
 molecule/mtls-custombundle-rhel-fips/create_ca_bundle.sh shebang
 molecule/mtls-custombundle-rhel-fips/create_ca_bundle.sh shellcheck!skip
 test_roles/confluent.test.kerberos/files/create_admin.sh shebang


### PR DESCRIPTION
Release `7.5.15` for the `7.5.x` line.

- Bump CP version to `7.5.15` (CP + cp-ansible version bumps, `galaxy.yml`, defaults/vars)
- Regenerate `docs/VARIABLES.md` / `docs/MOLECULE_SCENARIOS.md`
- Update `README.md` `blob/<ver>-post` GitHub URLs to `7.5.15-post`

🤖 Generated with [Claude Code](https://claude.com/claude-code)