### PR TITLE
Fix ansible-lint warnings in KRaft rollback playbook and migration-phase detection

### DIFF
--- a/playbooks/rollback/rollback.yml
+++ b/playbooks/rollback/rollback.yml
@@ -39,7 +39,7 @@
     # Revert only brokers still on KRaft; skip any already on hybrid (an
     # interrupted rollback can leave a mix) so they are not restarted needlessly.
     - name: Check whether this broker is still on KRaft
-      shell: grep -q "^process.roles" "{{ kafka_broker.config_file }}"
+      command: grep -q "^process.roles" "{{ kafka_broker.config_file }}"
       register: this_broker_on_kraft
       failed_when: false
       changed_when: false
@@ -50,6 +50,7 @@
             src: "{{ kafka_broker.config_file }}"
             dest: "{{ kafka_broker.config_file }}.before_hybrid_revert.{{ ansible_date_time.iso8601_basic_short }}"
             remote_src: true
+            mode: preserve
 
         - name: Extract broker ID (from node.id if present, otherwise broker.id)
           shell: |
@@ -142,6 +143,7 @@
             src: "{{ kafka_controller.config_file }}"
             dest: "{{ kafka_controller.config_file }}.before_controller_stop.{{ ansible_date_time.iso8601_basic_short }}"
             remote_src: true
+            mode: preserve
           failed_when: false
 
         - name: Stop Kafka Controller service
@@ -285,6 +287,7 @@
             src: "{{ kafka_broker.config_file }}"
             dest: "{{ kafka_broker.config_file }}.before_pure_zk_revert.{{ ansible_date_time.iso8601_basic_short }}"
             remote_src: true
+            mode: preserve
 
         - name: Extract broker ID
           shell: |

--- a/playbooks/tasks/detect_migration_phase.yml
+++ b/playbooks/tasks/detect_migration_phase.yml
@@ -9,8 +9,8 @@
     migration_state: "UNKNOWN"
     zk_migration_state: -1
 
-- name: Check if controllers are running
-  shell: systemctl is-active {{ kafka_controller_service_name }}
+- name: Check if controllers are running  # noqa: command-instead-of-module
+  command: systemctl is-active {{ kafka_controller_service_name }}
   register: controller_status
   delegate_to: "{{ groups['kafka_controller'][0] }}"
   failed_when: false
@@ -47,7 +47,7 @@
 # The calling play gathers facts so kafka_broker.config_file (its dict references
 # ansible_os_family) resolves here.
 - name: Check process.roles on every broker
-  shell: grep -q "^process.roles" "{{ kafka_broker.config_file }}"
+  command: grep -q "^process.roles" "{{ kafka_broker.config_file }}"
   register: broker_process_roles_all
   delegate_to: "{{ item }}"
   loop: "{{ groups['kafka_broker'] | default([]) }}"


### PR DESCRIPTION
## What

Resolves the ansible-lint sanity-check warnings reported on `7.6.x` for the KRaft → ZooKeeper rollback playbook and migration-phase detection task.

### `playbooks/tasks/detect_migration_phase.yml`
- `Check if controllers are running`: `shell` → `command` (fixes `command-instead-of-shell`), plus `# noqa: command-instead-of-module` — `systemctl is-active` is a read-only status query the `systemd` module can't replicate without side effects. Matches the existing precedent in `roles/common/tasks/validate_package_availability.yml`.
- `Check process.roles on every broker`: `shell` → `command` (`grep -q "pattern" file` needs no shell features).

### `playbooks/rollback/rollback.yml`
- `Check whether this broker is still on KRaft`: `shell` → `command`.
- The three config backup `copy` tasks (`before_hybrid_revert`, `before_controller_stop`, `before_pure_zk_revert`): added `mode: preserve` (fixes `risky-file-permissions`) — preserves the source config file's permissions on the backup copy.

## Why
These sanity fixes are required from 7.6.x.

## Testing
- YAML parses cleanly for both files.
- Behavior is unchanged: the `shell`→`command` swaps target invocations with no shell features, and `mode: preserve` keeps the backup's permissions identical to the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)