### PR TITLE
Fix class name for JAAS login module in Jetty 12

### DIFF
--- a/roles/control_center_next_gen/templates/jaas.conf.j2
+++ b/roles/control_center_next_gen/templates/jaas.conf.j2
@@ -1,5 +1,5 @@
 ControlCenter {
-  org.eclipse.jetty.jaas.spi.PropertyFileLoginModule required
+  org.eclipse.jetty.security.jaas.spi.PropertyFileLoginModule required
   file="{{control_center_next_gen.password_file}}"
   debug="false";
 };


### PR DESCRIPTION
# Description

C3 Next Gen uses Jetty 12, and the PropertyFileLoginModule class has changed to: https://github.com/jetty/jetty.project/blob/jetty-12.1.x/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/jaas/spi/PropertyFileLoginModule.java

Before, on Jetty 11 and previous, it was located at https://github.com/jetty/jetty.project/blob/jetty-11.0.x/jetty-jaas/src/main/java/org/eclipse/jetty/jaas/spi/PropertyFileLoginModule.java

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

TBD

# Checklist:

- [ ] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
