### PR TITLE
fix(yum): remove async parameter

### DIFF
--- a/roles/common/templates/confluent.repo.j2
+++ b/roles/common/templates/confluent.repo.j2
@@ -1,7 +1,6 @@
 # Maintained by Ansible
 {% for name, repo in confluent_yum_repositories.items() %}
 [{{ name }}]
-async = 1
 baseurl = {{ repo.baseurl }}
 enabled = {{ repo.enabled | int }}
 gpgcheck = {{ repo.gpgcheck | int }}


### PR DESCRIPTION
Async parameter returns this log when running the Ansible role : DEBUG Unknown configuration option: async = 1 in /etc/yum.repos.d/confluent.repo

# Description

When running the Ansible playbook to upgrade to the version 7.9.7, I saw that these logs were visible in /var/log/dnf.log : 
```
2026-06-25T16:02:34+0200 DEBUG Unknown configuration option: async = 1 in /etc/yum.repos.d/confluent.repo
2026-06-25T16:02:34+0200 DEBUG Unknown configuration option: async = 1 in /etc/yum.repos.d/confluent.repo
2026-06-25T16:02:34+0200 DEBUG Unknown configuration option: async = 1 in /etc/yum.repos.d/confluent.repo
2026-06-25T16:02:34+0200 DEBUG Unknown configuration option: async = 1 in /etc/yum.repos.d/confluent.repo
```

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

A test server has been used without the parameter "async = 1".

Logs without async parameter : 

```
2026-06-25T16:10:09+0200 DEBUG repo: downloading from remote: Confluent
2026-06-25T16:10:09+0200 DEBUG Confluent: using metadata from Fri 05 Jun 2026 11:22:23 CEST.
2026-06-25T16:10:09+0200 DEBUG repo: downloading from remote: Confluent.control-center-next-gen
2026-06-25T16:10:09+0200 DEBUG Confluent.control-center-next-gen: using metadata from Fri 19 Jun 2026 09:03:25 CEST.
2026-06-25T16:10:09+0200 DEBUG repo: downloading from remote: Confluent.usm-agent
2026-06-25T16:10:09+0200 DEBUG Confluent.usm-agent: using metadata from Mon 22 Jun 2026 09:20:39 CEST.
```

# Checklist:

- [x] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
