### PR TITLE
[ANSIENG-5881] | Changes for Decoupling CP Ansible Patch Releases from CP Patch Releases

### DIFF
--- a/docs/VARIABLES.md
+++ b/docs/VARIABLES.md
@@ -4,6 +4,14 @@ Below are the supported variables for the role variables
 
 ***
 
+### confluent_package_version
+
+Version of Confluent Platform to install
+
+Default:  ""
+
+***
+
 ### fetch_logs_path
 
 Path on component to store logs collected during fetch_logs playbook

--- a/docs/VARIABLES.md
+++ b/docs/VARIABLES.md
@@ -4,14 +4,6 @@ Below are the supported variables for the role variables
 
 ***
 
-### confluent_package_version
-
-Version of Confluent Platform to install
-
-Default:  7.6.12
-
-***
-
 ### fetch_logs_path
 
 Path on component to store logs collected during fetch_logs playbook

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -1,9 +1,6 @@
 ---
 # Custom filters used in this file are defined in plugins/filter/filters.py
 
-### Version of Confluent Platform to install
-confluent_package_version: 7.6.12
-
 confluent_full_package_version: "{{ confluent_package_version + '-1' }}"
 confluent_package_redhat_suffix: "{{ '-' + confluent_full_package_version if confluent_full_package_version != '' else ''}}"
 confluent_package_debian_suffix: "{{ '=' + confluent_full_package_version if confluent_full_package_version != '' else ''}}"

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -1,6 +1,9 @@
 ---
 # Custom filters used in this file are defined in plugins/filter/filters.py
 
+### Version of Confluent Platform to install
+confluent_package_version: ""
+
 confluent_full_package_version: "{{ confluent_package_version + '-1' }}"
 confluent_package_redhat_suffix: "{{ '-' + confluent_full_package_version if confluent_full_package_version != '' else ''}}"
 confluent_package_debian_suffix: "{{ '=' + confluent_full_package_version if confluent_full_package_version != '' else ''}}"

--- a/roles/variables/tasks/main.yml
+++ b/roles/variables/tasks/main.yml
@@ -1,16 +1,16 @@
 ---
-- name: Assert confluent_package_version is defined
+- name: Assert confluent_package_version is defined and not empty
   assert:
     that:
-      - confluent_package_version is defined
+      - confluent_package_version is defined and confluent_package_version | length > 0
     fail_msg: |
-      ERROR: confluent_package_version is not defined!
+      ERROR: confluent_package_version is not set!
       CP-Ansible no longer defaults confluent_package_version to a specific Confluent Platform version.
       Please set confluent_package_version explicitly in your inventory (e.g. group_vars/all/all.yml) to the
       Confluent Platform version you want to install.
       Refer to the CP-Ansible / Confluent Platform version compatibility matrix:
       https://docs.confluent.io/ansible/current/ansible-requirements.html
-    success_msg: "confluent_package_version is defined as {{ confluent_package_version }}"
+    success_msg: "confluent_package_version is set to {{ confluent_package_version }}"
   tags:
     - validate
     - validate_confluent_package_version

--- a/roles/variables/tasks/main.yml
+++ b/roles/variables/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+- name: Assert confluent_package_version is defined
+  assert:
+    that:
+      - confluent_package_version is defined
+    fail_msg: |
+      ERROR: confluent_package_version is not defined!
+      CP-Ansible no longer defaults confluent_package_version to a specific Confluent Platform version.
+      Please set confluent_package_version explicitly in your inventory (e.g. group_vars/all/all.yml) to the
+      Confluent Platform version you want to install.
+      Refer to the CP-Ansible / Confluent Platform version compatibility matrix:
+      https://docs.confluent.io/ansible/current/ansible-requirements.html
+    success_msg: "confluent_package_version is defined as {{ confluent_package_version }}"
+  tags:
+    - validate
+    - validate_confluent_package_version


### PR DESCRIPTION
Removes the hardcoded `confluent_package_version` default and adds an early validation check requiring it to be set explicitly.

- ANSIENG-5907
- ANSIENG-5908

molecule e2e: https://semaphore.ci.confluent.io/workflows/336fc741-90b2-4a98-8298-6fd4cce44e5d