### PR TITLE
[ANSIENG-5900] Remove kraft-rollback masterkey backport from rootless PR

### DIFF
--- a/molecule/kraft-rollback-to-hybrid/converge.yml
+++ b/molecule/kraft-rollback-to-hybrid/converge.yml
@@ -17,19 +17,6 @@
   vars:
     repo_root: "{{ playbook_dir }}/../.."
     molecule_inventory: "{{ lookup('env', 'MOLECULE_INVENTORY_FILE') }}"
-    # The nested ansible-playbook sub-runs below start fresh and do NOT inherit
-    # the extra-vars / skip-tags this converge run was invoked with. The on-demand
-    # (Semaphore) pipeline passes confluent_package_version etc. as extra-vars and,
-    # for nightly migration builds, --skip-tags check_confluent_package_version.
-    # Rebuild those from this run's own vars/tags and forward them, otherwise the
-    # sub-runs fall back to role defaults and the version gate fails.
-    _forward_var_names:
-      - confluent_package_version
-      - confluent_full_package_version
-      - confluent_common_repository_baseurl
-      - confluent_package_redhat_suffix
-      - confluent_package_debian_suffix
-    migration_forward_args: "{% for k in _forward_var_names %}{% set v = lookup('vars', k, default='') %}{% if v != '' %}-e {{ k }}='{{ v }}' {% endif %}{% endfor %}{% if ansible_skip_tags | default([]) %}--skip-tags {{ (ansible_skip_tags | default([])) | join(',') }}{% endif %}"
   tasks:
     # Promote the migration-held controllers into the live kafka_controller
     # group so the tagged sub-runs (which read the inventory file fresh) see them.
@@ -46,7 +33,6 @@
         {{ repo_root }}/playbooks/ZKtoKraftMigration.yml
         --tags migrate_to_dual_write
         -e kraft_migration=true
-        {{ migration_forward_args }}
       args:
         chdir: "{{ repo_root }}"
       changed_when: true
@@ -69,19 +55,6 @@
   vars:
     repo_root: "{{ playbook_dir }}/../.."
     molecule_inventory: "{{ lookup('env', 'MOLECULE_INVENTORY_FILE') }}"
-    # The nested ansible-playbook sub-runs below start fresh and do NOT inherit
-    # the extra-vars / skip-tags this converge run was invoked with. The on-demand
-    # (Semaphore) pipeline passes confluent_package_version etc. as extra-vars and,
-    # for nightly migration builds, --skip-tags check_confluent_package_version.
-    # Rebuild those from this run's own vars/tags and forward them, otherwise the
-    # sub-runs fall back to role defaults and the version gate fails.
-    _forward_var_names:
-      - confluent_package_version
-      - confluent_full_package_version
-      - confluent_common_repository_baseurl
-      - confluent_package_redhat_suffix
-      - confluent_package_debian_suffix
-    migration_forward_args: "{% for k in _forward_var_names %}{% set v = lookup('vars', k, default='') %}{% if v != '' %}-e {{ k }}='{{ v }}' {% endif %}{% endfor %}{% if ansible_skip_tags | default([]) %}--skip-tags {{ (ansible_skip_tags | default([])) | join(',') }}{% endif %}"
   tasks:
     # Real rollback with its health checks. The post-rollback controller
     # metadata-quorum probe is correctly skipped on community kafka by
@@ -94,7 +67,6 @@
         {{ repo_root }}/playbooks/KRaftToZKRollback.yml
         --tags rollback_to_hybrid
         -e kraft_migration=true
-        {{ migration_forward_args }}
       args:
         chdir: "{{ repo_root }}"
       changed_when: true

--- a/molecule/kraft-rollback-to-zk/converge.yml
+++ b/molecule/kraft-rollback-to-zk/converge.yml
@@ -13,19 +13,6 @@
   vars:
     repo_root: "{{ playbook_dir }}/../.."
     molecule_inventory: "{{ lookup('env', 'MOLECULE_INVENTORY_FILE') }}"
-    # The nested ansible-playbook sub-runs below start fresh and do NOT inherit
-    # the extra-vars / skip-tags this converge run was invoked with. The on-demand
-    # (Semaphore) pipeline passes confluent_package_version etc. as extra-vars and,
-    # for nightly migration builds, --skip-tags check_confluent_package_version.
-    # Rebuild those from this run's own vars/tags and forward them, otherwise the
-    # sub-runs fall back to role defaults and the version gate fails.
-    _forward_var_names:
-      - confluent_package_version
-      - confluent_full_package_version
-      - confluent_common_repository_baseurl
-      - confluent_package_redhat_suffix
-      - confluent_package_debian_suffix
-    migration_forward_args: "{% for k in _forward_var_names %}{% set v = lookup('vars', k, default='') %}{% if v != '' %}-e {{ k }}='{{ v }}' {% endif %}{% endfor %}{% if ansible_skip_tags | default([]) %}--skip-tags {{ (ansible_skip_tags | default([])) | join(',') }}{% endif %}"
   tasks:
     # Promote the migration-held controllers into the live kafka_controller
     # group so the sub-runs below (which read the inventory file fresh) see them.
@@ -42,7 +29,6 @@
         {{ repo_root }}/playbooks/ZKtoKraftMigration.yml
         --tags migrate_to_dual_write
         -e kraft_migration=true
-        {{ migration_forward_args }}
       args:
         chdir: "{{ repo_root }}"
       changed_when: true
@@ -55,7 +41,6 @@
         {{ repo_root }}/playbooks/KRaftToZKRollback.yml
         --tags rollback_to_premigration
         -e kraft_migration=true
-        {{ migration_forward_args }}
       args:
         chdir: "{{ repo_root }}"
       changed_when: true


### PR DESCRIPTION
Reverts commit 6e7c3a4f6 (\"Fix migration preflight masterkey 7.7 (#2571)\"), which only
touches `molecule/kraft-rollback-to-hybrid/converge.yml` and
`molecule/kraft-rollback-to-zk/converge.yml`. That change is an unrelated backport of
already-merged PR #2571 to 7.6.x and doesn't belong in #2602 (the rootless/non-root
install work). It's being reopened as its own PR against `7.6.x`.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>