### PR TITLE
Backport: Fix migration preflight masterkey to 7.6.x

### DIFF
--- a/molecule/kraft-rollback-to-hybrid/converge.yml
+++ b/molecule/kraft-rollback-to-hybrid/converge.yml
@@ -17,6 +17,19 @@
   vars:
     repo_root: "{{ playbook_dir }}/../.."
     molecule_inventory: "{{ lookup('env', 'MOLECULE_INVENTORY_FILE') }}"
+    # The nested ansible-playbook sub-runs below start fresh and do NOT inherit
+    # the extra-vars / skip-tags this converge run was invoked with. The on-demand
+    # (Semaphore) pipeline passes confluent_package_version etc. as extra-vars and,
+    # for nightly migration builds, --skip-tags check_confluent_package_version.
+    # Rebuild those from this run's own vars/tags and forward them, otherwise the
+    # sub-runs fall back to role defaults and the version gate fails.
+    _forward_var_names:
+      - confluent_package_version
+      - confluent_full_package_version
+      - confluent_common_repository_baseurl
+      - confluent_package_redhat_suffix
+      - confluent_package_debian_suffix
+    migration_forward_args: "{% for k in _forward_var_names %}{% set v = lookup('vars', k, default='') %}{% if v != '' %}-e {{ k }}='{{ v }}' {% endif %}{% endfor %}{% if ansible_skip_tags | default([]) %}--skip-tags {{ (ansible_skip_tags | default([])) | join(',') }}{% endif %}"
   tasks:
     # Promote the migration-held controllers into the live kafka_controller
     # group so the tagged sub-runs (which read the inventory file fresh) see them.
@@ -33,6 +46,7 @@
         {{ repo_root }}/playbooks/ZKtoKraftMigration.yml
         --tags migrate_to_dual_write
         -e kraft_migration=true
+        {{ migration_forward_args }}
       args:
         chdir: "{{ repo_root }}"
       changed_when: true
@@ -55,6 +69,19 @@
   vars:
     repo_root: "{{ playbook_dir }}/../.."
     molecule_inventory: "{{ lookup('env', 'MOLECULE_INVENTORY_FILE') }}"
+    # The nested ansible-playbook sub-runs below start fresh and do NOT inherit
+    # the extra-vars / skip-tags this converge run was invoked with. The on-demand
+    # (Semaphore) pipeline passes confluent_package_version etc. as extra-vars and,
+    # for nightly migration builds, --skip-tags check_confluent_package_version.
+    # Rebuild those from this run's own vars/tags and forward them, otherwise the
+    # sub-runs fall back to role defaults and the version gate fails.
+    _forward_var_names:
+      - confluent_package_version
+      - confluent_full_package_version
+      - confluent_common_repository_baseurl
+      - confluent_package_redhat_suffix
+      - confluent_package_debian_suffix
+    migration_forward_args: "{% for k in _forward_var_names %}{% set v = lookup('vars', k, default='') %}{% if v != '' %}-e {{ k }}='{{ v }}' {% endif %}{% endfor %}{% if ansible_skip_tags | default([]) %}--skip-tags {{ (ansible_skip_tags | default([])) | join(',') }}{% endif %}"
   tasks:
     # Real rollback with its health checks. The post-rollback controller
     # metadata-quorum probe is correctly skipped on community kafka by
@@ -67,6 +94,7 @@
         {{ repo_root }}/playbooks/KRaftToZKRollback.yml
         --tags rollback_to_hybrid
         -e kraft_migration=true
+        {{ migration_forward_args }}
       args:
         chdir: "{{ repo_root }}"
       changed_when: true

--- a/molecule/kraft-rollback-to-zk/converge.yml
+++ b/molecule/kraft-rollback-to-zk/converge.yml
@@ -13,6 +13,19 @@
   vars:
     repo_root: "{{ playbook_dir }}/../.."
     molecule_inventory: "{{ lookup('env', 'MOLECULE_INVENTORY_FILE') }}"
+    # The nested ansible-playbook sub-runs below start fresh and do NOT inherit
+    # the extra-vars / skip-tags this converge run was invoked with. The on-demand
+    # (Semaphore) pipeline passes confluent_package_version etc. as extra-vars and,
+    # for nightly migration builds, --skip-tags check_confluent_package_version.
+    # Rebuild those from this run's own vars/tags and forward them, otherwise the
+    # sub-runs fall back to role defaults and the version gate fails.
+    _forward_var_names:
+      - confluent_package_version
+      - confluent_full_package_version
+      - confluent_common_repository_baseurl
+      - confluent_package_redhat_suffix
+      - confluent_package_debian_suffix
+    migration_forward_args: "{% for k in _forward_var_names %}{% set v = lookup('vars', k, default='') %}{% if v != '' %}-e {{ k }}='{{ v }}' {% endif %}{% endfor %}{% if ansible_skip_tags | default([]) %}--skip-tags {{ (ansible_skip_tags | default([])) | join(',') }}{% endif %}"
   tasks:
     # Promote the migration-held controllers into the live kafka_controller
     # group so the sub-runs below (which read the inventory file fresh) see them.
@@ -29,6 +42,7 @@
         {{ repo_root }}/playbooks/ZKtoKraftMigration.yml
         --tags migrate_to_dual_write
         -e kraft_migration=true
+        {{ migration_forward_args }}
       args:
         chdir: "{{ repo_root }}"
       changed_when: true
@@ -41,6 +55,7 @@
         {{ repo_root }}/playbooks/KRaftToZKRollback.yml
         --tags rollback_to_premigration
         -e kraft_migration=true
+        {{ migration_forward_args }}
       args:
         chdir: "{{ repo_root }}"
       changed_when: true


### PR DESCRIPTION
Backports #2571 (\"Fix migration preflight masterkey 7.7\", merged into 7.7.x) to 7.6.x.

Split out of #2602, which accidentally carried this change on the rootless
(ANSIENG-5900) branch — see #2604 for the revert removing it from that PR.

## Original description (#2571)
The `kafka-migration-check` preflight only set `KAFKA_OPTS` in its environment.
When secrets protection is enabled, `server.properties` contains encrypted
configs that `SecurePassConfigProvider` resolves via the
`CONFLUENT_SECURITY_MASTER_KEY` environment variable. Without it,
`kafka-migration-check` failed to decrypt the controller config.

Also forwards package extra-vars and skip-tags into the kraft-rollback nested
sub-runs (`kraft-rollback-to-zk` / `kraft-rollback-to-hybrid` converge plays),
since those nested `ansible-playbook` sub-runs start fresh and don't inherit
the parent run's extra-vars/skip-tags.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>