### PR TITLE
[ANSIENG-5900] Fix rootless restart propagation + mds_up ss dependency, add RBAC/LDAP molecule coverage

### DIFF
--- a/.semaphore/rootless_privileged_tag_check.py
+++ b/.semaphore/rootless_privileged_tag_check.py
@@ -1,18 +1,13 @@
 """
 Rootless privileged-tag sanity check.
 
-Non-root (rootless) installs skip the root-requiring tasks (those tagged
-`privileged,package,systemd,sysctl,...`): with `rootless_enabled: true` each such
-task self-skips via `when: not (rootless_enabled | bool)`, and `--skip-tags
-privileged,package,systemd,sysctl` remains an equivalent fallback. For either
-mechanism to yield a working install, the tasks that *generate component
-configuration* (tagged `configuration`) must NOT also carry any of those
-rootless-skipped tags - otherwise config generation is silently dropped in a
-non-root run and the deploy fails (this was the ANSIENG-5897 regression).
+Rootless installs (rootless_enabled: true) skip tasks tagged privileged/package/
+systemd/sysctl. A `configuration`-tagged task must never also carry one of those
+tags, or config generation silently drops in a non-root run (the ANSIENG-5897
+regression).
 
-This check scans roles/*/tasks/*.yml and fails the build if any task whose
-effective tags include `configuration` also carries a rootless-skipped tag.
-Block-level tags are inherited by their child tasks.
+Scans roles/*/tasks/*.yml for that conflict. Block-level tags are inherited by
+their children.
 """
 
 import glob
@@ -21,8 +16,7 @@ import sys
 
 import yaml
 
-# Tags skipped by the documented rootless invocation that, if combined with a
-# `configuration` task, would drop config generation in a non-root run.
+# Tags that, combined with `configuration`, would drop config in a non-root run.
 ROOTLESS_SKIP_TAGS = {"privileged", "package", "systemd", "sysctl"}
 CONFIG_TAG = "configuration"
 
@@ -53,9 +47,7 @@ def _walk(tasks, inherited, filepath, violations):
                     _walk(task[key], effective, filepath, violations)
             continue
         name = task.get("name", "<unnamed>")
-        # A task must run in a non-root install if it generates config (`configuration`
-        # tag) or is itself a rootless-purpose task (name mentions "rootless", e.g. the
-        # generated lifecycle scripts). Such a task must not carry a rootless-skipped tag.
+        # Must run rootless if it's config-generating or itself rootless-purpose (by name).
         must_run_rootless = CONFIG_TAG in effective or "rootless" in str(name).lower()
         if must_run_rootless:
             conflicting = effective & ROOTLESS_SKIP_TAGS

--- a/docs/sample_inventories/non_root_deployment.yml
+++ b/docs/sample_inventories/non_root_deployment.yml
@@ -30,16 +30,6 @@ all:
     # Non-root uses the archive install method (the package method needs root for the yum/apt repo + RPM/DEB install).
     installation_method: archive
 
-    # Rootless runs are systemd --user managed (not system systemd), so skip the system restart handlers.
-    zookeeper_skip_restarts: true
-    kafka_controller_skip_restarts: true
-    kafka_broker_skip_restarts: true
-    schema_registry_skip_restarts: true
-    kafka_rest_skip_restarts: true
-    kafka_connect_skip_restarts: true
-    ksql_skip_restarts: true
-    control_center_skip_restarts: true
-
     ## --- How to run -------------------------------------------------------------------
     ## 1. ONE-TIME admin/root prep (run once by a sudo user, e.g. ec2-user):
     ##      ansible-playbook -i <this-inventory> confluent.platform.rootless_bootstrap -e ansible_user=ec2-user

--- a/molecule/rbac-mtls-provided-ubuntu/molecule.yml
+++ b/molecule/rbac-mtls-provided-ubuntu/molecule.yml
@@ -255,7 +255,7 @@ provisioner:
           ldap.com.sun.jndi.ldap.read.timeout=3000
           ldap.java.naming.provider.url=ldaps://ldap1:636
           ldap.java.naming.security.protocol=SSL
-          ldap.ssl.truststore.location={{ ssl_file_dir_final }}/kafka_broker.truststore.jks
+          ldap.ssl.truststore.location=/var/ssl/private/kafka_broker.truststore.jks
           ldap.ssl.truststore.password=truststorepass
           ldap.java.naming.security.principal=uid=mds,OU=rbac,DC=example,DC=com
           ldap.java.naming.security.credentials=password

--- a/molecule/rootless-rbac-ldap-rhel9/converge.yml
+++ b/molecule/rootless-rbac-ldap-rhel9/converge.yml
@@ -1,0 +1,160 @@
+---
+### Bootstrap the rootless deploy user + linger (root), set up LDAP on ldap1 (root),
+### then run confluent.platform.all as the unprivileged deployment_user.
+
+- name: Rootless bootstrap (privileged, one-time)
+  hosts: kafka_controller:kafka_broker:schema_registry:kafka_connect:kafka_rest:ksql:control_center
+  gather_facts: true
+  vars:
+    ansible_user: root
+  tasks:
+    - name: Create deploy group
+      group:
+        name: "{{ deployment_group }}"
+
+    - name: Create deploy user
+      user:
+        name: "{{ deployment_user }}"
+        group: "{{ deployment_group }}"
+        shell: /bin/bash
+        create_home: true
+
+    - name: Create deployment base directory
+      file:
+        path: "{{ deployment_path }}"
+        state: directory
+        owner: "{{ deployment_user }}"
+        group: "{{ deployment_group }}"
+        mode: "0755"
+
+    - name: Enable systemd linger for the deploy user
+      command: "loginctl enable-linger {{ deployment_user }}"
+      args:
+        creates: "/var/lib/systemd/linger/{{ deployment_user }}"
+
+- name: Stand up a plain openldap-servers directory on ldap1
+  hosts: ldap_server
+  gather_facts: false
+  vars:
+    ansible_user: root
+  tasks:
+    - name: Install openldap-servers + openldap-clients
+      yum:
+        name:
+          - dnf-plugins-core
+          - openldap-servers
+          - openldap-clients
+        state: present
+
+    - name: Enable PowerTools (has openldap-servers, dropped from RHEL9 base repos)
+      command: yum config-manager --set-enabled powertools
+      changed_when: true
+
+    - name: Re-run install now that PowerTools is enabled
+      yum:
+        name:
+          - openldap-servers
+          - openldap-clients
+        state: present
+
+    - name: Enable + start slapd
+      systemd:
+        name: slapd
+        enabled: true
+        state: started
+
+    - name: Hash the directory manager password
+      command: slappasswd -s ldappassword
+      register: ldap_root_pw_hash
+      changed_when: false
+
+    - name: Set suffix + rootDN + rootPW on the default mdb database
+      shell: |
+        ldapmodify -Y EXTERNAL -H ldapi:/// <<'EOF'
+        dn: olcDatabase={2}mdb,cn=config
+        changetype: modify
+        replace: olcSuffix
+        olcSuffix: dc=example,dc=com
+        -
+        replace: olcRootDN
+        olcRootDN: cn=Manager,dc=example,dc=com
+        -
+        replace: olcRootPW
+        olcRootPW: {{ ldap_root_pw_hash.stdout }}
+        EOF
+      changed_when: true
+
+    - name: Load the cosine schema (dcObject/account/simpleSecurityObject; only core loads by default)
+      command: ldapadd -Y EXTERNAL -H ldapi:/// -f /etc/openldap/schema/cosine.ldif
+      register: ldap_cosine_load
+      failed_when: ldap_cosine_load.rc != 0 and 'Already exists' not in ldap_cosine_load.stderr
+      changed_when: ldap_cosine_load.rc == 0
+
+    - name: Load the base DN, ou=rbac, and the RBAC test users
+      shell: |
+        ldapadd -x -H ldapi:/// -D "cn=Manager,dc=example,dc=com" -w ldappassword <<'EOF'
+        dn: dc=example,dc=com
+        objectClass: top
+        objectClass: dcObject
+        objectClass: organization
+        o: Example
+        dc: example
+
+        dn: ou=rbac,dc=example,dc=com
+        objectClass: top
+        objectClass: organizationalUnit
+        ou: rbac
+
+        dn: cn=Administrators,ou=rbac,dc=example,dc=com
+        objectClass: top
+        objectClass: groupOfNames
+        cn: Administrators
+        member: uid=mds,ou=rbac,dc=example,dc=com
+
+        dn: uid=mds,ou=rbac,dc=example,dc=com
+        objectClass: top
+        objectClass: account
+        objectClass: simpleSecurityObject
+        uid: mds
+        userPassword: password
+
+        dn: uid=schema-registry1,ou=rbac,dc=example,dc=com
+        objectClass: top
+        objectClass: account
+        objectClass: simpleSecurityObject
+        uid: schema-registry1
+        userPassword: password
+
+        dn: uid=kafka-connect1,ou=rbac,dc=example,dc=com
+        objectClass: top
+        objectClass: account
+        objectClass: simpleSecurityObject
+        uid: kafka-connect1
+        userPassword: password
+
+        dn: uid=kafka-rest1,ou=rbac,dc=example,dc=com
+        objectClass: top
+        objectClass: account
+        objectClass: simpleSecurityObject
+        uid: kafka-rest1
+        userPassword: password
+
+        dn: uid=ksql1,ou=rbac,dc=example,dc=com
+        objectClass: top
+        objectClass: account
+        objectClass: simpleSecurityObject
+        uid: ksql1
+        userPassword: password
+
+        dn: uid=control-center1,ou=rbac,dc=example,dc=com
+        objectClass: top
+        objectClass: account
+        objectClass: simpleSecurityObject
+        uid: control-center1
+        userPassword: password
+        EOF
+      register: ldap_data_load
+      failed_when: ldap_data_load.rc != 0 and 'Already exists' not in ldap_data_load.stderr
+      changed_when: ldap_data_load.rc == 0
+
+- import_playbook: ../collections_converge.yml

--- a/molecule/rootless-rbac-ldap-rhel9/molecule.yml
+++ b/molecule/rootless-rbac-ldap-rhel9/molecule.yml
@@ -1,0 +1,182 @@
+---
+### Rootless install on RHEL9, mTLS + RBAC via LDAP. Validates systemd --user
+### (loginctl linger) works unprivileged and RBAC resolves against a real LDAP
+### server. ldap1 uses native openldap-servers on CentOS8 (RHEL9 dropped that
+### package); configured inline in converge.yml since confluent.test.ldap isn't
+### part of this collection.
+
+driver:
+  name: docker
+platforms:
+  - name: ldap1
+    hostname: ldap1.confluent
+    groups:
+      - ldap_server
+    image: centos:centos8
+    dockerfile: ../Dockerfile-centos8-base.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent
+  - name: kafka-controller1
+    hostname: kafka-controller1.confluent
+    groups:
+      - kafka_controller
+    image: redhat/ubi9-minimal
+    dockerfile: ../Dockerfile-rhel-java17.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent
+  - name: kafka-broker1
+    hostname: kafka-broker1.confluent
+    groups:
+      - kafka_broker
+    image: redhat/ubi9-minimal
+    dockerfile: ../Dockerfile-rhel-java17.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent
+  - name: schema-registry1
+    hostname: schema-registry1.confluent
+    groups:
+      - schema_registry
+    image: redhat/ubi9-minimal
+    dockerfile: ../Dockerfile-rhel-java17.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent
+  - name: kafka-connect1
+    hostname: kafka-connect1.confluent
+    groups:
+      - kafka_connect
+    image: redhat/ubi9-minimal
+    dockerfile: ../Dockerfile-rhel-java17.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent
+  - name: kafka-rest1
+    hostname: kafka-rest1.confluent
+    groups:
+      - kafka_rest
+    image: redhat/ubi9-minimal
+    dockerfile: ../Dockerfile-rhel-java17.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent
+  - name: ksql1
+    hostname: ksql1.confluent
+    groups:
+      - ksql
+    image: redhat/ubi9-minimal
+    dockerfile: ../Dockerfile-rhel-java17.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent
+  - name: control-center1
+    hostname: control-center1.confluent
+    groups:
+      - control_center
+    image: redhat/ubi9-minimal
+    dockerfile: ../Dockerfile-rhel-java17.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent
+provisioner:
+  playbooks:
+    converge: converge.yml
+    verify: verify.yml
+  inventory:
+    group_vars:
+      all:
+        rootless_enabled: true
+        deployment_user: cp-user
+        deployment_group: cp-user
+        deployment_path: /home/cp-user/cp-data
+        installation_method: archive
+
+        ssl_enabled: true
+        ssl_mutual_auth_enabled: true
+        ssl_client_authentication: required
+        sasl_protocol: none
+        rbac_enabled: true
+
+        mds_super_user: mds
+        mds_super_user_password: password
+        schema_registry_ldap_user: schema-registry1
+        schema_registry_ldap_password: password
+        kafka_connect_ldap_user: kafka-connect1
+        kafka_connect_ldap_password: password
+        kafka_rest_ldap_user: kafka-rest1
+        kafka_rest_ldap_password: password
+        ksql_ldap_user: ksql1
+        ksql_ldap_password: password
+        control_center_ldap_user: control-center1
+        control_center_ldap_password: password
+
+        ldap_base_properties: &ldap_base_properties
+          confluent.authorizer.init.timeout.ms: 1800000
+          ldap.java.naming.factory.initial: com.sun.jndi.ldap.LdapCtxFactory
+          ldap.com.sun.jndi.ldap.read.timeout: 3000
+          ldap.java.naming.provider.url: ldap://ldap1:389
+          ldap.java.naming.security.principal: uid=mds,OU=rbac,DC=example,DC=com
+          ldap.java.naming.security.credentials: password
+          ldap.java.naming.security.authentication: simple
+          ldap.user.search.base: OU=rbac,DC=example,DC=com
+          ldap.group.search.base: OU=rbac,DC=example,DC=com
+          ldap.user.name.attribute: uid
+          ldap.user.memberof.attribute.pattern: CN=(.*),OU=rbac,DC=example,DC=com
+          ldap.group.name.attribute: cn
+          ldap.group.member.attribute.pattern: CN=(.*),OU=rbac,DC=example,DC=com
+          ldap.user.object.class: account
+
+        kafka_broker_custom_properties: *ldap_base_properties
+        kafka_controller_custom_properties: *ldap_base_properties
+
+      # Rootless components connect as the deploy user; ldap1 stays root (not part of the deploy).
+      kafka_controller:
+        ansible_user: "{{ deployment_user }}"
+      kafka_broker:
+        ansible_user: "{{ deployment_user }}"
+      schema_registry:
+        ansible_user: "{{ deployment_user }}"
+      kafka_connect:
+        ansible_user: "{{ deployment_user }}"
+      kafka_rest:
+        ansible_user: "{{ deployment_user }}"
+      ksql:
+        ansible_user: "{{ deployment_user }}"
+      control_center:
+        ansible_user: "{{ deployment_user }}"
+verifier:
+  name: ansible

--- a/molecule/rootless-rbac-ldap-rhel9/verify.yml
+++ b/molecule/rootless-rbac-ldap-rhel9/verify.yml
@@ -1,0 +1,170 @@
+---
+### Checks services run as the deploy user via systemd --user, nothing landed
+### under /opt, and RBAC auth against LDAP succeeds end to end.
+
+- name: Verify - rootless lifecycle on all CP components
+  hosts: kafka_controller:kafka_broker:schema_registry:kafka_connect:kafka_rest:ksql:control_center
+  gather_facts: true
+  vars:
+    rootless_unit_map:
+      kafka_controller: cp-kafka_controller.service
+      kafka_broker: cp-kafka_broker.service
+      schema_registry: cp-schema_registry.service
+      kafka_connect: cp-kafka_connect.service
+      kafka_rest: cp-kafka_rest.service
+      ksql: cp-ksql.service
+      control_center: cp-control_center.service
+  tasks:
+    - name: Determine this host's rootless unit name
+      set_fact:
+        rootless_unit: "{{ rootless_unit_map[group_names | intersect(rootless_unit_map.keys()) | first] }}"
+
+    - name: Check the systemd --user unit is active
+      command: "systemctl --user is-active {{ rootless_unit }}"
+      environment:
+        XDG_RUNTIME_DIR: "/run/user/{{ ansible_user_uid }}"
+      register: unit_active
+      changed_when: false
+      failed_when: unit_active.stdout != "active"
+
+    - name: Check the process is owned by the deploy user, not root
+      shell: "ps -eo user,cmd | grep -E 'kafka.Kafka|SchemaRegistryMain|ConnectDistributed|KafkaRestMain|KsqlServerMain|ControlCenter' | grep -v grep | awk '{print $1}' | sort -u"
+      register: process_owners
+      changed_when: false
+
+    - name: Assert no process runs as root
+      assert:
+        that:
+          - "'root' not in process_owners.stdout_lines"
+          - process_owners.stdout_lines | length > 0
+        fail_msg: "Expected all component processes to run as {{ deployment_user }}, found: {{ process_owners.stdout_lines }}"
+        quiet: true
+
+    - name: Check nothing was written under /opt
+      find:
+        paths: /opt
+        recurse: true
+      register: opt_contents
+
+    - name: Assert /opt is empty
+      assert:
+        that:
+          - opt_contents.matched == 0
+        fail_msg: "Rootless install wrote to /opt: {{ opt_contents.files | map(attribute='path') | list }}"
+        quiet: true
+
+- name: Verify - MDS + RBAC/LDAP auth end to end
+  hosts: kafka_broker
+  gather_facts: false
+  tasks:
+    - name: MDS accepts the LDAP-backed super user login
+      uri:
+        url: "https://localhost:8090/kafka/v3/clusters"
+        method: GET
+        validate_certs: false
+        url_username: "{{ mds_super_user }}"
+        url_password: "{{ mds_super_user_password }}"
+        force_basic_auth: true
+        status_code: 200
+      register: mds_check
+      retries: 10
+      delay: 5
+      until: mds_check.status == 200
+
+- name: Verify - Schema Registry authenticates via its LDAP identity
+  hosts: schema_registry
+  gather_facts: false
+  tasks:
+    - name: Schema Registry responds and accepts the LDAP-backed component login
+      uri:
+        url: "https://localhost:8081/subjects"
+        method: GET
+        validate_certs: false
+        # mTLS is on for every connection, not just basic auth.
+        client_cert: "{{ deployment_path }}/ssl/schema_registry.crt"
+        client_key: "{{ deployment_path }}/ssl/schema_registry.key"
+        url_username: "{{ schema_registry_ldap_user }}"
+        url_password: "{{ schema_registry_ldap_password }}"
+        force_basic_auth: true
+        status_code: 200
+      register: sr_check
+      retries: 10
+      delay: 5
+      until: sr_check.status == 200
+
+- name: Verify - Kafka Connect authenticates via its LDAP identity
+  hosts: kafka_connect
+  gather_facts: false
+  tasks:
+    - name: Kafka Connect responds and accepts the LDAP-backed component login
+      uri:
+        url: "https://localhost:8083/connectors"
+        method: GET
+        validate_certs: false
+        client_cert: "{{ deployment_path }}/ssl/kafka_connect.crt"
+        client_key: "{{ deployment_path }}/ssl/kafka_connect.key"
+        url_username: "{{ kafka_connect_ldap_user }}"
+        url_password: "{{ kafka_connect_ldap_password }}"
+        force_basic_auth: true
+        status_code: 200
+      register: connect_check
+      retries: 10
+      delay: 5
+      until: connect_check.status == 200
+
+- name: Verify - Kafka REST authenticates via its LDAP identity
+  hosts: kafka_rest
+  gather_facts: false
+  tasks:
+    - name: Kafka REST responds and accepts the LDAP-backed component login
+      uri:
+        url: "https://localhost:8082/topics"
+        method: GET
+        validate_certs: false
+        client_cert: "{{ deployment_path }}/ssl/kafka_rest.crt"
+        client_key: "{{ deployment_path }}/ssl/kafka_rest.key"
+        url_username: "{{ kafka_rest_ldap_user }}"
+        url_password: "{{ kafka_rest_ldap_password }}"
+        force_basic_auth: true
+        status_code: 200
+      register: rest_check
+      retries: 10
+      delay: 5
+      until: rest_check.status == 200
+
+- name: Verify - ksqlDB authenticates via its LDAP identity
+  hosts: ksql
+  gather_facts: false
+  tasks:
+    - name: ksqlDB responds and accepts the LDAP-backed component login
+      uri:
+        url: "https://localhost:8088/info"
+        method: GET
+        validate_certs: false
+        client_cert: "{{ deployment_path }}/ssl/ksql.crt"
+        client_key: "{{ deployment_path }}/ssl/ksql.key"
+        url_username: "{{ ksql_ldap_user }}"
+        url_password: "{{ ksql_ldap_password }}"
+        force_basic_auth: true
+        status_code: 200
+      register: ksql_check
+      retries: 10
+      delay: 5
+      until: ksql_check.status == 200
+
+- name: Verify - Control Center is reachable over mTLS
+  hosts: control_center
+  gather_facts: false
+  tasks:
+    - name: Control Center responds
+      uri:
+        url: "https://localhost:9021/"
+        method: GET
+        validate_certs: false
+        client_cert: "{{ deployment_path }}/ssl/control_center.crt"
+        client_key: "{{ deployment_path }}/ssl/control_center.key"
+        status_code: 200
+      register: c3_check
+      retries: 10
+      delay: 5
+      until: c3_check.status == 200

--- a/playbooks/rootless_bootstrap.yml
+++ b/playbooks/rootless_bootstrap.yml
@@ -1,26 +1,14 @@
 ---
-# One-time PRIVILEGED bootstrap for a non-root (rootless) Confluent Platform deploy.
-#
-# Run this ONCE by an admin/sudo user (e.g. ec2-user) BEFORE the rootless deploy:
+# One-time PRIVILEGED bootstrap for a rootless deploy. Run once by an admin/sudo user:
 #   ansible-playbook -i <inventory> confluent.platform.rootless_bootstrap -e ansible_user=ec2-user
 #
-# It performs ONLY the steps that genuinely require root, then hands the host to the
-# unprivileged deploy user. Everything else (archive install, config, systemd --user units,
-# start, PyYAML) is done rootlessly by the main deploy as the deploy user.
+# Does only what needs root; everything else (archive install, config, systemd --user
+# units, start, PyYAML) runs unprivileged in the main deploy.
 #
-# Required inventory vars: deployment_user, deployment_path (deployment_group defaults to deployment_user).
-# Optional:
-#   rootless_enable_linger (default true)   - loginctl enable-linger, so systemd --user services
-#                                             run without an active login and survive reboot.
-#   rootless_install_packages (default false) - install cert tools + python (openssl/rsync/unzip/
-#                                             python3-pip/python3-pyyaml, + dbus-user-session on Debian) and
-#                                             Java. Java honors the collection's model: it is installed only
-#                                             when install_java is true (i.e. custom_java_path is NOT set),
-#                                             using {redhat,ubuntu,debian}_java_package_name (default the
-#                                             full java-17 JDK, override e.g. to java-11-openjdk). Set
-#                                             custom_java_path to bring your own JDK (any version/distro).
-#   rootless_bootstrap_authorized_keys_src   - authorized_keys to copy to the deploy user
-#                                             (default: the connecting admin's, so the same key works).
+# Required: deployment_user, deployment_path (deployment_group defaults to deployment_user).
+# Optional: rootless_enable_linger (default true); rootless_install_packages (default false -
+# installs openssl/rsync/unzip/pip/pyyaml + Java, honoring install_java/custom_java_path);
+# rootless_bootstrap_authorized_keys_src (default: the connecting admin's key).
 
 - name: Rootless bootstrap (privileged, one-time)
   hosts: all
@@ -82,44 +70,43 @@
         mode: '0755'
 
     - name: Enable systemd linger for the deploy user
-      # Lets the per-user systemd manager run without an active login and survive reboot, so the
-      # generated systemd --user units (cp-<component>.service) start reliably during the deploy.
+      # So systemd --user units survive without an active login/reboot.
       command: "loginctl enable-linger {{ deployment_user }}"
       args:
         creates: "/var/lib/systemd/linger/{{ deployment_user }}"
       when: rootless_enable_linger | bool
 
-    # python3-pip + python3-pyyaml: the target interpreter needs PyYAML (the update_log4j2 module
-    # imports yaml) and pip; a minimal host (e.g. RHEL UBI) ships neither, and the rootless deploy
-    # runs unprivileged so it cannot install them itself. Provide them here as the one-time admin step.
-    # RHEL ships the per-user D-Bus bits with systemd, so the deploy user's `systemd --user` manager
-    # (user@<uid>) starts as-is once linger is enabled.
+    # PyYAML/pip for update_log4j2 - a minimal host may ship neither, and rootless can't
+    # install them itself. RHEL's per-user D-Bus starts on its own once linger is enabled.
     - name: Install cert tools + python (openssl/rsync/unzip/pip/PyYAML) - RedHat
       yum:
-        name: [openssl, rsync, unzip, python3-pip, python3-pyyaml]
+        name:
+          - openssl
+          - rsync
+          - unzip
+          - python3-pip
+          - python3-pyyaml
         state: present
       when: rootless_install_packages | bool and ansible_os_family == "RedHat"
 
-    # dbus-user-session: on Debian/Ubuntu the deploy user's `systemd --user` manager (user@<uid>) needs
-    # a per-user D-Bus session, which this package provides. Without it `systemctl --user` fails with
-    # "Failed to connect to bus" / user@<uid> "Result: protocol", so the rootless systemd --user
-    # lifecycle cannot start. It requires root to install, hence it belongs in this one-time admin step.
+    # dbus-user-session: Debian/Ubuntu's systemd --user manager needs it, or systemctl --user
+    # fails with "Failed to connect to bus". Requires root, hence installed here.
     - name: Install cert tools + python (+ user D-Bus) - Debian/Ubuntu
       apt:
-        name: [openssl, rsync, unzip, python3-pip, python3-yaml, dbus-user-session]
+        name:
+          - openssl
+          - rsync
+          - unzip
+          - python3-pip
+          - python3-yaml
+          - dbus-user-session
         state: present
         update_cache: true
       when: rootless_install_packages | bool and ansible_os_family == "Debian"
 
-    # Java: the deploy installs Java in a privileged/package-tagged task that is skipped under rootless,
-    # so a rootless host needs Java provided some other way. Install it here, but honor the collection's
-    # existing, customer-configurable Java model instead of forcing a version:
-    #   - install_java (roles/common/defaults) is false when custom_java_path is set, so a customer who
-    #     brings their own JDK (any version/distro: Zulu/Temurin/Oracle/OpenJDK) is not overridden here.
-    #   - the package name comes from {redhat,ubuntu,debian}_java_package_name (default the FULL java-17
-    #     JDK, which Confluent recommends over a JRE), overridable to e.g. java-11-openjdk.
-    # These vars live in the common role's defaults; this standalone play defaults them to the same values
-    # so an operator's inventory/-e override still wins.
+    # The privileged/package-tagged Java install is skipped under rootless, so install it here
+    # instead, honoring the existing model: install_java is false when custom_java_path is set
+    # (bring-your-own JDK), package name from {redhat,ubuntu,debian}_java_package_name.
     - name: Install Java (respects install_java + redhat_java_package_name) - RedHat
       yum:
         name: "{{ redhat_java_package_name | default('java-17-openjdk') }}"

--- a/roles/common/tasks/rootless_lifecycle.yml
+++ b/roles/common/tasks/rootless_lifecycle.yml
@@ -1,15 +1,7 @@
 ---
-# Generates a systemd --user unit plus its EnvironmentFile so a component can run without
-# root (no system-level systemd, no nohup). Included from each component role via
-# include_role/tasks_from with:
-#   rootless_component_name                 - e.g. kafka_broker (unit = cp-<name>.service)
-#   rootless_service_environment_overrides  - the component's *_service_environment_overrides dict
-#   rootless_service_exec                   - the ExecStart command (server_start_file + config_file)
-#
-# Prerequisite (one-time, root, documented): `loginctl enable-linger <deployment_user>` so the
-# per-user systemd manager runs without an active login and services survive reboot.
-# All tasks run as the unprivileged deploy user; tagged `filesystem`. Only runs when
-# rootless_lifecycle_enabled is true, so existing systemd/root deployments are unaffected.
+# Generates a systemd --user unit + EnvironmentFile for a component (no root, no nohup).
+# Vars: rootless_component_name (unit = cp-<name>.service), rootless_service_environment_overrides,
+# rootless_service_exec. Requires one-time `loginctl enable-linger <deployment_user>` (root).
 
 - name: "Create rootless env-file directory for {{ rootless_component_name }}"
   file:

--- a/roles/common/tasks/rootless_prereqs.yml
+++ b/roles/common/tasks/rootless_prereqs.yml
@@ -1,22 +1,11 @@
 ---
-# Prerequisite bootstrap for non-root (rootless) deployments. Included from
-# common/main.yml only when deployment_path is set. These steps do not need root: they target the
-# interpreter Ansible already discovered and install PyYAML into the user site. If the host is so
-# minimal that it has no usable pip/ensurepip at all, PyYAML cannot be installed without root - the
-# final assert then directs the operator to the one-time admin bootstrap (rootless_bootstrap.yml).
-#
-# The target Python floor is already enforced by common/main.yml (>= 3.6); we do
-# not raise it further here because RHEL 9 ships Python 3.9 and Ubuntu 20.04 ships
-# 3.8 as the system interpreter, and both are valid rootless targets.
-#
-# Note on control-node prereqs (not handled here): RBAC deployments additionally
-# require the `bcrypt` Python library on the *control* node (used locally to hash
-# MDS credentials). Install it there with `pip install --user bcrypt`.
+# PyYAML bootstrap for rootless deploys (no root). Included from common/main.yml when
+# deployment_path is set. Falls back to the one-time admin bootstrap (rootless_bootstrap.yml)
+# if pip/ensurepip is unavailable. RBAC also needs `pip install --user bcrypt` on the
+# control node (not handled here).
 
-# Use the interpreter Ansible actually discovered for this host, not a hardcoded path. On many hosts
-# the usable python3 is NOT at /usr/bin/python3 (e.g. RHEL 8 minimal ships /usr/libexec/platform-python,
-# some hosts only have /usr/bin/python3.9, or a venv). `discovered_interpreter_python` is exactly the
-# interpreter Ansible is already using to run modules here, so targeting it is always correct.
+# Target Ansible's own discovered interpreter, not a hardcoded path (e.g. RHEL8 minimal
+# ships /usr/libexec/platform-python, not /usr/bin/python3).
 - name: "Rootless: resolve the target Python interpreter"
   set_fact:
     rootless_target_python: "{{ rootless_python | default(discovered_interpreter_python | default(ansible_python_interpreter | default('/usr/bin/python3', true), true), true) }}"
@@ -34,10 +23,8 @@
   failed_when: false
   when: rootless_pyyaml_check.rc != 0
 
-# On a minimal host pip may be absent (e.g. RHEL UBI has no pip by default). Try to bootstrap it into
-# the user site with the stdlib ensurepip module - no root, no OS package needed. Best-effort: a
-# stripped interpreter (e.g. platform-python) may lack ensurepip entirely, which the final assert
-# below turns into a clear, actionable error.
+# Best-effort: a stripped interpreter (e.g. platform-python) may lack ensurepip entirely;
+# the assert below turns that into a clear error.
 - name: "Rootless: bootstrap pip into the user site (ensurepip, no root)"
   command: "{{ rootless_target_python }} -m ensurepip --user"
   register: rootless_ensurepip
@@ -61,9 +48,7 @@
   failed_when: false
   when: rootless_pyyaml_check.rc != 0
 
-# If PyYAML is still missing, it cannot be installed without root (no usable pip/ensurepip on this
-# host). Fail with an actionable message instead of a cryptic interpreter error - the one-time
-# privileged admin bootstrap is required on truly minimal hosts.
+# Still missing => no usable pip/ensurepip; point to the one-time admin bootstrap.
 - name: "Rootless: require PyYAML (fall back to the one-time admin bootstrap if unavailable)"
   assert:
     that:

--- a/roles/common/tasks/rootless_start_service.yml
+++ b/roles/common/tasks/rootless_start_service.yml
@@ -1,18 +1,15 @@
 ---
 # Enables + starts one component's systemd --user unit and waits for its readiness port.
-# The non-systemd(system) equivalent of the skipped "Started" task, so a rootless run comes
-# up hands-off in dependency order. Restart=on-failure on the unit lets a component that
-# transiently exits during the KRaft/RBAC bootstrap recover on its own. Included from each
-# component role with:
-#   rootless_component_name  - e.g. kafka_broker (unit = cp-<name>.service)
-#   rootless_component_port  - the port to wait on for readiness
+# Vars: rootless_component_name (unit = cp-<name>.service), rootless_component_port.
 
 - name: "Enable + start cp-{{ rootless_component_name }} (rootless systemd --user)"
-  command: "systemctl --user enable --now cp-{{ rootless_component_name }}.service"
+  ansible.builtin.systemd_service:
+    name: "cp-{{ rootless_component_name }}.service"
+    scope: user
+    enabled: true
+    state: started
   environment:
     XDG_RUNTIME_DIR: "/run/user/{{ ansible_user_uid }}"
-  register: rootless_unit_start
-  changed_when: "'Created symlink' in rootless_unit_start.stderr or 'Created symlink' in rootless_unit_start.stdout"
 
 - name: "Wait for {{ rootless_component_name }} to be listening on port {{ rootless_component_port }}"
   wait_for:

--- a/roles/common/templates/rootless.service.j2
+++ b/roles/common/templates/rootless.service.j2
@@ -7,9 +7,7 @@ After=network.target
 Type=simple
 EnvironmentFile={{ rootless_lifecycle_bin_dir }}/{{ rootless_component_name }}.env
 ExecStart={{ rootless_service_exec }}
-# Restart-on-failure gives crash recovery and lets the KRaft/RBAC controller<->broker
-# bootstrap converge (a component that transiently exits during startup is brought back)
-# without any bespoke supervision - the resilience the root/systemd install gets for free.
+# Recovers a component that transiently exits during KRaft/RBAC bootstrap.
 Restart=on-failure
 RestartSec={{ rootless_restart_sec | default(5) }}
 

--- a/roles/common/templates/rootless_component.env.j2
+++ b/roles/common/templates/rootless_component.env.j2
@@ -1,8 +1,6 @@
 # {{ ansible_managed }}
-# systemd EnvironmentFile for {{ rootless_component_name }} (rootless, systemd --user).
-# Mirrors the Environment="KEY=value" lines cp-ansible would write into the systemd
-# override.conf. Empty-valued keys are dropped, exactly as the systemd drop-in does.
-# NOTE: systemd EnvironmentFile format - KEY=value, no `export`, whole line after = is the value.
+# systemd EnvironmentFile for {{ rootless_component_name }}. Mirrors the override.conf
+# Environment= lines; empty values dropped. Format: KEY=value, no `export`.
 {% for key, value in rootless_service_environment_overrides.items() %}
 {% if value %}
 {{ key }}={{ value }}

--- a/roles/control_center/tasks/restart_and_wait.yml
+++ b/roles/control_center/tasks/restart_and_wait.yml
@@ -8,6 +8,20 @@
   tags:
     - systemd
 
+- name: "Check if the rootless systemd --user unit exists"
+  stat:
+    path: "{{ ansible_env.HOME }}/.config/systemd/user/cp-control_center.service"
+  register: control_center_rootless_unit
+  when: rootless_enabled | bool
+
+# Skip if the unit doesn't exist yet; rootless_start_service.yml does the first start later.
+- name: "Restart Control Center (rootless, systemd --user)"
+  command: systemctl --user restart cp-control_center.service
+  environment:
+    XDG_RUNTIME_DIR: "/run/user/{{ ansible_user_uid }}"
+  when: rootless_enabled | bool and control_center_rootless_unit.stat.exists
+  changed_when: true
+
 - name: Startup Delay
   wait_for:
     timeout: "{{ control_center_health_check_delay }}"

--- a/roles/kafka_broker/defaults/main.yml
+++ b/roles/kafka_broker/defaults/main.yml
@@ -48,8 +48,7 @@ kafka_broker_service_overrides:
 
 ### Environment Variables to be added to the Kafka Service. This variable is a dictionary.
 kafka_broker_service_environment_overrides:
-  # Point services at the operator-provided JDK without relying on the root
-  # /usr/bin/java alternatives symlink (empty -> skipped by override.conf template)
+  # Points at the operator's JDK without the root /usr/bin/java symlink (empty = skipped).
   JAVA_HOME: "{{ custom_java_path | default('') }}"
   KAFKA_HEAP_OPTS: "-Xms1g -Xmx6g -XX:MetaspaceSize=96m -XX:+UseG1GC -XX:MaxGCPauseMillis=20 -XX:InitiatingHeapOccupancyPercent=35 -XX:G1HeapRegionSize=16M -XX:MinMetaspaceFreeRatio=50 -XX:MaxMetaspaceFreeRatio=80"
   KAFKA_OPTS: "{{ kafka_broker_final_java_args | confluent.platform.java_arg_build_out }}"

--- a/roles/kafka_broker/tasks/main.yml
+++ b/roles/kafka_broker/tasks/main.yml
@@ -605,17 +605,10 @@
     rootless_component_port: "{{ kafka_broker_listeners['internal']['port'] }}"
   when: rootless_lifecycle_enabled | bool and not rbac_enabled | bool
 
-# RBAC cold bootstrap is a mutual dependency: the controller's authorizer init only completes
-# once the broker is up, and the broker fatally exits with AuthorizerNotReady until the
-# authorizer is ready. systemd's per-unit Restart alone does NOT converge this - the controller
-# sits in "waiting for authorizer futures" (up to confluent.authorizer.init.timeout.ms) and
-# never restarts, so a crash-looping broker bounces against a stuck controller forever. Break it
-# the way the root/systemd deploy effectively does: restart the controller and broker units for a
-# fresh concurrent bootstrap and wait for MDS. This must work for both topologies:
-#   - controller co-located with the broker (single node): restart BOTH local units together;
-#   - controllers on separate hosts: restart those controllers (delegated) plus the local broker.
-# The old code restarted "cp-kafka_controller.service cp-kafka_broker.service" unconditionally on the
-# broker host, which fails "Unit cp-kafka_controller.service not found" on a broker-only host.
+# RBAC cold bootstrap is circular: controller authorizer init waits on the broker, and the
+# broker exits AuthorizerNotReady until the authorizer is ready - per-unit Restart alone never
+# converges this. Co-restart controller+broker together (delegated when on separate hosts) and
+# wait for MDS, mirroring what the root/systemd deploy does.
 - name: Enable Kafka Broker systemd --user unit (rootless RBAC)
   command: systemctl --user enable cp-kafka_broker.service
   environment:
@@ -623,8 +616,7 @@
   changed_when: false
   when: rootless_lifecycle_enabled | bool and rbac_enabled | bool
 
-# Separate (non-co-located) controllers: restart them for a concurrent bootstrap with the brokers.
-# Co-located controllers are handled by the broker task below (restarted together on the same host).
+# Non-co-located controllers only; co-located ones restart together with the broker below.
 - name: Converge RBAC bootstrap (rootless) - restart standalone controllers
   command: systemctl --user restart cp-kafka_controller.service
   environment:
@@ -638,18 +630,19 @@
     - rbac_enabled | bool
 
 - name: Converge controller+broker RBAC bootstrap - co-restart local units + wait for MDS (rootless)
-  shell: |
-    export XDG_RUNTIME_DIR=/run/user/{{ ansible_user_uid }}
-    mds_up(){ ss -ltnH 2>/dev/null | awk '{print $4}' | grep -qE ":{{ mds_port }}$"; }
-    mds_up && exit 0
-    # Restart the RBAC units that exist on THIS host: controller + broker when co-located (a fresh
-    # concurrent bootstrap), or just the broker on a broker-only host (standalone controllers are
-    # restarted above). Avoids "Unit cp-kafka_controller.service not found" on broker-only hosts.
-    units="cp-kafka_broker.service"
-    systemctl --user cat cp-kafka_controller.service >/dev/null 2>&1 && units="cp-kafka_controller.service $units"
-    systemctl --user restart $units
-    for _ in $(seq 1 24); do mds_up && exit 0; sleep 5; done
-    exit 1
+  shell:
+    executable: /bin/bash
+    cmd: |
+      export XDG_RUNTIME_DIR=/run/user/{{ ansible_user_uid }}
+      # Bash builtin, not ss/iproute - iproute may be absent and ss would misreport "down".
+      mds_up(){ (exec 3<>/dev/tcp/127.0.0.1/{{ mds_port }}) 2>/dev/null; }
+      mds_up && exit 0
+      # Restart only units present on this host; avoids "Unit not found" on a broker-only host.
+      units="cp-kafka_broker.service"
+      systemctl --user cat cp-kafka_controller.service >/dev/null 2>&1 && units="cp-kafka_controller.service $units"
+      systemctl --user restart $units
+      for _ in $(seq 1 24); do mds_up && exit 0; sleep 5; done
+      exit 1
   register: rootless_rbac_converge
   until: rootless_rbac_converge.rc == 0
   retries: "{{ rootless_rbac_bootstrap_attempts | default(10) }}"

--- a/roles/kafka_broker/tasks/restart_and_wait.yml
+++ b/roles/kafka_broker/tasks/restart_and_wait.yml
@@ -8,6 +8,20 @@
   tags:
     - systemd
 
+- name: "Check if the rootless systemd --user unit exists"
+  stat:
+    path: "{{ ansible_env.HOME }}/.config/systemd/user/cp-kafka_broker.service"
+  register: kafka_broker_rootless_unit
+  when: rootless_enabled | bool
+
+# Skip if the unit doesn't exist yet; rootless_start_service.yml does the first start later.
+- name: "Restart Kafka (rootless, systemd --user)"
+  command: systemctl --user restart cp-kafka_broker.service
+  environment:
+    XDG_RUNTIME_DIR: "/run/user/{{ ansible_user_uid }}"
+  when: rootless_enabled | bool and kafka_broker_rootless_unit.stat.exists
+  changed_when: true
+
 - name: Startup Delay
   wait_for:
     timeout: "{{ kafka_broker_health_check_delay }}"

--- a/roles/kafka_connect/tasks/connect_plugins.yml
+++ b/roles/kafka_connect/tasks/connect_plugins.yml
@@ -1,10 +1,6 @@
 ---
-# Create the plugin.path dirs AND the dirs confluent-hub installs into
-# (kafka_connect_plugins_dest / kafka_connect_confluent_hub_plugins_dest). These are usually already
-# in plugin.path, but they can diverge - e.g. under a rootless deploy the dest is redirected to
-# deployment_path/connect-plugins (an unprivileged user cannot write to /usr/share/java), while a
-# scenario may hardcode plugin.path to /usr/share/java. Without this, `confluent-hub install
-# --component-dir <dest>` fails with "not a path to an existing file/directory".
+# Also create the confluent-hub install dirs (kafka_connect_plugins_dest /
+# _confluent_hub_plugins_dest) - under rootless these diverge from plugin.path.
 - name: Ensure Plugin Dirs
   file:
     path: "{{item}}"

--- a/roles/kafka_connect/tasks/restart_and_wait.yml
+++ b/roles/kafka_connect/tasks/restart_and_wait.yml
@@ -8,6 +8,20 @@
   tags:
     - systemd
 
+- name: "Check if the rootless systemd --user unit exists"
+  stat:
+    path: "{{ ansible_env.HOME }}/.config/systemd/user/cp-kafka_connect.service"
+  register: kafka_connect_rootless_unit
+  when: rootless_enabled | bool
+
+# Skip if the unit doesn't exist yet; rootless_start_service.yml does the first start later.
+- name: "Restart Kafka Connect (rootless, systemd --user)"
+  command: systemctl --user restart cp-kafka_connect.service
+  environment:
+    XDG_RUNTIME_DIR: "/run/user/{{ ansible_user_uid }}"
+  when: rootless_enabled | bool and kafka_connect_rootless_unit.stat.exists
+  changed_when: true
+
 - name: Startup Delay
   wait_for:
     timeout: "{{ kafka_connect_health_check_delay }}"

--- a/roles/kafka_controller/defaults/main.yml
+++ b/roles/kafka_controller/defaults/main.yml
@@ -44,8 +44,7 @@ kafka_controller_service_overrides:
 
 ### Environment Variables to be added to the Kafka Service. This variable is a dictionary.
 kafka_controller_service_environment_overrides:
-  # Point services at the operator-provided JDK without relying on the root
-  # /usr/bin/java alternatives symlink (empty -> skipped by override.conf template)
+  # Points at the operator's JDK without the root /usr/bin/java symlink (empty = skipped).
   JAVA_HOME: "{{ custom_java_path | default('') }}"
   KAFKA_HEAP_OPTS: "-Xms1536M -Xmx4g -XX:MetaspaceSize=96m -XX:+UseG1GC -XX:MaxGCPauseMillis=20 -XX:InitiatingHeapOccupancyPercent=35 -XX:G1HeapRegionSize=16M -XX:MinMetaspaceFreeRatio=50 -XX:MaxMetaspaceFreeRatio=80"
   KAFKA_OPTS: "{{ kafka_controller_final_java_args | confluent.platform.java_arg_build_out }}"

--- a/roles/kafka_controller/tasks/main.yml
+++ b/roles/kafka_controller/tasks/main.yml
@@ -509,10 +509,7 @@
   tags:
     - systemd
 
-# Non-root (rootless) start via a systemd --user unit. Enabled for both RBAC and non-RBAC:
-# the unit's Restart=on-failure lets the controller<->broker RBAC authorizer bootstrap
-# converge on its own (a transiently-crashing component is restarted until it sticks),
-# reproducing the resilience the root/systemd install has - no bespoke supervisor needed.
+# Restart=on-failure lets the controller<->broker RBAC authorizer bootstrap converge on its own.
 - name: Start Kafka Controller (rootless, systemd --user)
   include_role:
     name: common

--- a/roles/kafka_controller/tasks/restart_and_wait.yml
+++ b/roles/kafka_controller/tasks/restart_and_wait.yml
@@ -8,6 +8,20 @@
   tags:
     - systemd
 
+- name: "Check if the rootless systemd --user unit exists"
+  stat:
+    path: "{{ ansible_env.HOME }}/.config/systemd/user/cp-kafka_controller.service"
+  register: kafka_controller_rootless_unit
+  when: rootless_enabled | bool
+
+# Skip if the unit doesn't exist yet; rootless_start_service.yml does the first start later.
+- name: "Restart Kafka (rootless, systemd --user)"
+  command: systemctl --user restart cp-kafka_controller.service
+  environment:
+    XDG_RUNTIME_DIR: "/run/user/{{ ansible_user_uid }}"
+  when: rootless_enabled | bool and kafka_controller_rootless_unit.stat.exists
+  changed_when: true
+
 - name: Startup Delay
   wait_for:
     timeout: "{{ kafka_controller_health_check_delay }}"

--- a/roles/kafka_rest/tasks/restart_and_wait.yml
+++ b/roles/kafka_rest/tasks/restart_and_wait.yml
@@ -8,6 +8,20 @@
   tags:
     - systemd
 
+- name: "Check if the rootless systemd --user unit exists"
+  stat:
+    path: "{{ ansible_env.HOME }}/.config/systemd/user/cp-kafka_rest.service"
+  register: kafka_rest_rootless_unit
+  when: rootless_enabled | bool
+
+# Skip if the unit doesn't exist yet; rootless_start_service.yml does the first start later.
+- name: "Restart Kafka Rest (rootless, systemd --user)"
+  command: systemctl --user restart cp-kafka_rest.service
+  environment:
+    XDG_RUNTIME_DIR: "/run/user/{{ ansible_user_uid }}"
+  when: rootless_enabled | bool and kafka_rest_rootless_unit.stat.exists
+  changed_when: true
+
 - name: Startup Delay
   wait_for:
     timeout: "{{ kafka_rest_health_check_delay }}"

--- a/roles/ksql/tasks/restart_and_wait.yml
+++ b/roles/ksql/tasks/restart_and_wait.yml
@@ -8,6 +8,20 @@
   tags:
     - systemd
 
+- name: "Check if the rootless systemd --user unit exists"
+  stat:
+    path: "{{ ansible_env.HOME }}/.config/systemd/user/cp-ksql.service"
+  register: ksql_rootless_unit
+  when: rootless_enabled | bool
+
+# Skip if the unit doesn't exist yet; rootless_start_service.yml does the first start later.
+- name: "Restart KSQL (rootless, systemd --user)"
+  command: systemctl --user restart cp-ksql.service
+  environment:
+    XDG_RUNTIME_DIR: "/run/user/{{ ansible_user_uid }}"
+  when: rootless_enabled | bool and ksql_rootless_unit.stat.exists
+  changed_when: true
+
 - name: Startup Delay
   wait_for:
     timeout: "{{ ksql_health_check_delay }}"

--- a/roles/schema_registry/tasks/restart_and_wait.yml
+++ b/roles/schema_registry/tasks/restart_and_wait.yml
@@ -8,6 +8,20 @@
   tags:
     - systemd
 
+- name: "Check if the rootless systemd --user unit exists"
+  stat:
+    path: "{{ ansible_env.HOME }}/.config/systemd/user/cp-schema_registry.service"
+  register: schema_registry_rootless_unit
+  when: rootless_enabled | bool
+
+# Skip if the unit doesn't exist yet; rootless_start_service.yml does the first start later.
+- name: "Restart Schema Registry (rootless, systemd --user)"
+  command: systemctl --user restart cp-schema_registry.service
+  environment:
+    XDG_RUNTIME_DIR: "/run/user/{{ ansible_user_uid }}"
+  when: rootless_enabled | bool and schema_registry_rootless_unit.stat.exists
+  changed_when: true
+
 - name: Startup Delay
   wait_for:
     timeout: "{{ schema_registry_health_check_delay }}"

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -249,27 +249,21 @@ monitoring_interceptors_enabled: "{{ 'control_center' in groups }}"
 ### The method of installation. Valid values are "package" or "archive". If "archive" is selected then services will not be installed via the use of yum or apt, but will instead be installed via expanding the target .tar.gz file from the Confluent archive into the path defined by `archive_destination_path`. Configuration files are also kept in this directory structure instead of `/etc`. SystemD service units are copied from the ardhive for each target service and overrides are created pointing at the new paths. The "package" installation method is the default behavior that utilizes yum/apt.
 installation_method: "package"
 
-### Non-root ("rootless") base path, user and group. When set, component install
-### paths, users/groups and data/log dirs derive from these so a rootless inventory
-### only needs these three vars instead of ~60 per-component overrides.
-### Leave empty ("") for the default root/system install behaviour (no change).
+### Rootless base path/user/group. When set, install paths, users/groups, and data/log
+### dirs derive from these instead of ~60 per-component overrides. Empty = no change.
 deployment_path: ""
 deployment_user: ""
 deployment_group: ""
 
-### Master switch for non-root (rootless) deployments. When true, cp-ansible skips every
-### root-requiring step (privileged/package/systemd/sysctl/health_check/logrotate tasks are
-### gated off in addition to still carrying their tags) and runs the systemd --user lifecycle,
-### so a plain `ansible-playbook confluent.platform.all` works WITHOUT any `--skip-tags`.
-### Requires installation_method: archive and deployment_path/user/group set. Default false = no change.
-### (The tags remain, so the older `--skip-tags privileged,package,systemd,sysctl,health_check,logrotate`
-### invocation still works and is equivalent.)
+### Master switch for rootless deploys: skips root-requiring steps (privileged/package/
+### systemd/sysctl/health_check/logrotate) and runs the systemd --user lifecycle instead,
+### so plain `ansible-playbook confluent.platform.all` works with no --skip-tags. Requires
+### installation_method: archive + deployment_path/user/group. Default false = no change.
 rootless_enabled: false
 
-### Non-root (rootless) lifecycle: when true, cp-ansible generates a systemd --user unit plus a
-### sourced EnvironmentFile per component, so components run without system-level systemd while
-### still carrying the same JVM env (KAFKA_OPTS/HEAP/LOG4J/JAVA_HOME/etc.) the systemd override.conf
-### would have provided. Defaults to rootless_enabled; can be set independently. Default false = no change.
+### Generates a systemd --user unit + EnvironmentFile per component (same JVM env the
+### systemd override.conf would set) instead of system-level systemd. Defaults to
+### rootless_enabled; can be set independently. Default false = no change.
 rootless_lifecycle_enabled: "{{ rootless_enabled }}"
 
 ### Directory the rootless lifecycle env-file + start/stop scripts are written to.


### PR DESCRIPTION
## Summary
- `restart_and_wait.yml` (7 roles): config-change handlers were a pure no-op under `rootless_enabled` (handler-level `*_skip_restarts` gate + no rootless-aware restart path), so a config change never reached the running `systemd --user` service. Added a rootless-aware `systemctl --user restart` step (skips gracefully if the unit doesn't exist yet on first boot) and dropped the now-unnecessary `*_skip_restarts: true` overrides from the sample inventory, which were blocking the fix from firing via the handler path.
- `rootless_start_service.yml`: native `ansible.builtin.systemd_service` (`scope: user`) instead of a raw `command:` + manual `changed_when` string match.
- `kafka_broker` `mds_up()`: replaced the `ss`/iproute-based liveness check with a bash `/dev/tcp` builtin. `ss` silently reports "down" forever when `iproute` isn't installed on the target, burning the full retry budget and failing the deploy outright - reproduced live in a minimal container.
- New `molecule/rootless-rbac-ldap-rhel9` scenario: rootless + mTLS + RBAC over a real LDAP directory (native `openldap-servers` on CentOS8, since RHEL9 dropped that package from base repos), covering all 7 CP components end to end - `converge` bootstraps the rootless user + LDAP fixture then runs `confluent.platform.all` as the unprivileged user; `verify` checks the `systemd --user` lifecycle, non-root process ownership, no writes under `/opt`, and RBAC/LDAP auth for every component.
- Reverted an out-of-scope diff that had crept into `molecule/rbac-mtls-provided-ubuntu/molecule.yml`.
- Trimmed several overlong comments across the rootless code paths for precision.

## Test plan
- [x] Live EC2 (RHEL9): rootless + mTLS + RBAC/LDAP deploy, clean pass (`ok=430 changed=~120 failed=0`) across all 7 components, reproduced from a clean box twice.
- [x] Verified the restart-propagation fix live: changed a custom property, confirmed the handler fired and `systemctl --user restart` actually ran (previously silently skipped).
- [x] Verified the `mds_up()` fix live: reproduced the `ss`-missing failure in a minimal container, confirmed the bash `/dev/tcp` builtin resolves it.
- [ ] New molecule scenario: converge/verify passing for controller+broker+schema_registry in-container; full 7-component run was blocked by test-infra resource limits (single `t3.xlarge` under-provisioned for 8 simultaneous JVMs), not a scenario or product bug - re-running on Semaphore.