### PR TITLE
[ANSIENG-5900] Add kafka_connect plugin + connector coverage to rootless-scram-debian10

### DIFF
--- a/molecule/rootless-scram-debian10/molecule.yml
+++ b/molecule/rootless-scram-debian10/molecule.yml
@@ -118,6 +118,20 @@ provisioner:
         ssl_enabled: true
         sasl_protocol: scram
 
+        kafka_connect_confluent_hub_plugins:
+          - jcustenborder/kafka-connect-spooldir:2.0.43
+
+        kafka_connect_custom_properties:
+          plugin.path: "{{ binary_base_path }}/share/java/connect_plugins,{{ binary_base_path }}/share/filestream-connectors,{{ kafka_connect_confluent_hub_plugins_dest }}"
+
+        kafka_connect_connectors:
+          - name: sample-connector-1
+            config:
+              connector.class: "FileStreamSourceConnector"
+              tasks.max: "1"
+              file: "{{ deployment_path }}/confluent/etc/kafka/connect-distributed.properties"
+              topic: "test_topic"
+
       # Rootless components connect as the deploy user.
       kafka_controller:
         ansible_user: "{{ deployment_user }}"

--- a/molecule/rootless-scram-debian10/verify.yml
+++ b/molecule/rootless-scram-debian10/verify.yml
@@ -113,6 +113,31 @@
         property: security.protocol
         expected_value: SASL_PLAINTEXT
 
+- name: Verify - kafka_connect plugin + connector deployed (rootless)
+  hosts: kafka_connect
+  gather_facts: false
+  tasks:
+    - name: Get Connectors on connect cluster1
+      uri:
+        url: "https://localhost:8083/connectors"
+        validate_certs: false
+      register: connectors
+
+    - name: Assert Connector Created
+      assert:
+        that:
+          - connectors.json[0] == "sample-connector-1"
+        fail_msg: "Connector not created"
+
+    - name: Wait for Connector tasks to return Running
+      uri:
+        url: "https://localhost:8083/connectors/sample-connector-1/status"
+        validate_certs: false
+      register: connector_status_response
+      until: connector_status_response.json.tasks[0].state == 'RUNNING'
+      retries: 10
+      delay: 5
+
 - name: Verify - SASL_SCRAM configured on control_center
   hosts: control_center
   gather_facts: false


### PR DESCRIPTION
## Summary
- Deploys the same confluent-hub plugin `archive-plain-ubuntu2004` already validates (`jcustenborder/kafka-connect-spooldir:2.0.43`) and a `FileStreamSourceConnector` via `kafka_connect_connectors` in the rootless SCRAM/Debian10 scenario.
- Verified with the same connector-check pattern `archive-plain-ubuntu2004/verify.yml` uses (`GET /connectors`, poll `/connectors/.../status` until `RUNNING`).
- No product code changes: confirmed `roles/kafka_connect/tasks/connect_plugins.yml` and `deploy_connectors.yml` have zero `privileged`/`package` tags and zero `not rootless` guards - already fully rootless-safe. `binary_base_path` is already deployment_path-aware for archive installs, so `plugin.path` resolves correctly under rootless with no changes.

**Intentionally out of scope**: `kafka_connect_replicator` + Kerberos coverage. Checked and both have real rootless gaps - `kafka_connect_replicator` has no systemd `--user` start path at all (every systemd task is guarded `when: not rootless_enabled` with no rootless counterpart), and `roles/kerberos/tasks/main.yml` unconditionally skips keytab deployment under `rootless_enabled` collection-wide (plus every `*_keytab_path` default hardcodes `/etc/security/keytabs/...`, not deployment_path-aware). These are real product bugs, not test-writing gaps - tracked separately, not fixed here.

## Test plan
- [x] `ansible-playbook --syntax-check` passes on `converge.yml`
- [x] YAML validates on `molecule.yml`/`verify.yml`
- [ ] Semaphore run to confirm the connector actually reaches RUNNING state under rootless

🤖 Generated with [Claude Code](https://claude.com/claude-code)