### PR TITLE
[ANSIENG-5900] Fix Get Java Version to resolve custom_java_path directly under rootless

### DIFF
--- a/roles/common/tasks/debian.yml
+++ b/roles/common/tasks/debian.yml
@@ -252,7 +252,10 @@
   tags: package
 
 - name: Get Java Version
-  command: java -version
+  # custom_java_path isn't on PATH (the alternatives symlink that would put it
+  # there is a privileged, rootless-skipped task) - resolve java directly from
+  # it when set, same as the JVM start scripts' own JAVA_HOME.
+  command: "{{ (custom_java_path ~ '/bin/java') if custom_java_path | default('') | length > 0 else 'java' }} -version"
   register: version_output
   check_mode: false
   changed_when: false

--- a/roles/common/tasks/redhat.yml
+++ b/roles/common/tasks/redhat.yml
@@ -75,7 +75,10 @@
   tags: package
 
 - name: Get Java Version
-  command: java -version
+  # custom_java_path isn't on PATH (the alternatives symlink that would put it
+  # there is a privileged, rootless-skipped task) - resolve java directly from
+  # it when set, same as the JVM start scripts' own JAVA_HOME.
+  command: "{{ (custom_java_path ~ '/bin/java') if custom_java_path | default('') | length > 0 else 'java' }} -version"
   register: version_output
   check_mode: false
   changed_when: false

--- a/roles/common/tasks/ubuntu.yml
+++ b/roles/common/tasks/ubuntu.yml
@@ -152,7 +152,10 @@
   tags: package
 
 - name: Get Java Version
-  command: java -version
+  # custom_java_path isn't on PATH (the alternatives symlink that would put it
+  # there is a privileged, rootless-skipped task) - resolve java directly from
+  # it when set, same as the JVM start scripts' own JAVA_HOME.
+  command: "{{ (custom_java_path ~ '/bin/java') if custom_java_path | default('') | length > 0 else 'java' }} -version"
   register: version_output
   check_mode: false
   changed_when: false


### PR DESCRIPTION
## Summary
- Found via a real `rootless-plain-debian10` CI failure (not a CI-tooling issue): `Get Java Version` (`roles/common/tasks/{debian,ubuntu,redhat}.yml`) ran bare `java -version`, relying on `$PATH`.
- Under a root install with `custom_java_path` set, a privileged `alternatives` task symlinks `/usr/bin/java` there, so bare `java` resolves. That symlink task is `when: not (rootless_enabled | bool)` - skipped under rootless. Java was never on `PATH` at all, so the task failed with "No such file or directory" for every host ~36s into converge, marking them failed and skipping every remaining task (certs, config, systemd units, service start) for the rest of the run.
- Only surfaced now because no prior scenario combined `rootless_enabled` + `custom_java_path` - the RHEL9/Ubuntu2004 rootless scenarios get Java from a real package install baked into their Dockerfiles instead, bypassing `custom_java_path` entirely. Every Debian/Ubuntu Dockerfile in this repo uses the tarball+`custom_java_path` pattern, so this would have hit any Debian-based rootless scenario, not just mine.

## Fix
Resolves java directly from `custom_java_path` when set (`{{ custom_java_path }}/bin/java`, the same source the JVM start scripts' own `JAVA_HOME` already uses), falling back to bare `java` when it's unset - no behavior change for the common case, root or rootless.

## Test plan
- [x] YAML validates, `ansible-playbook --syntax-check` passes
- [ ] Re-run `rootless-plain-debian10` on Semaphore, verify actual verify.txt content (not just the top-level result) to confirm converge completes and services start

🤖 Generated with [Claude Code](https://claude.com/claude-code)