### PR TITLE
[ANSIENG-5900] Rootless: fix custom_java_path PATH resolution + rootless-plain-debian10 /opt check

### DIFF
--- a/molecule/rootless-plain-debian10/verify.yml
+++ b/molecule/rootless-plain-debian10/verify.yml
@@ -46,11 +46,15 @@
         recurse: true
       register: opt_contents
 
-    - name: Assert /opt is empty
+    - name: Assert nothing besides the pre-baked custom_java_path JDK exists under /opt
+      # Dockerfile-debian10-archive.j2 tars a JDK into custom_java_path (/opt/jdk17) at image
+      # build time, before Ansible ever runs - that's not the rootless install writing to /opt.
+      vars:
+        unexpected_opt_files: "{{ opt_contents.files | rejectattr('path', 'match', '^' + custom_java_path + '/') | map(attribute='path') | list }}"
       assert:
         that:
-          - opt_contents.matched == 0
-        fail_msg: "Rootless install wrote to /opt: {{ opt_contents.files | map(attribute='path') | list }}"
+          - unexpected_opt_files | length == 0
+        fail_msg: "Rootless install wrote to /opt outside custom_java_path: {{ unexpected_opt_files }}"
         quiet: true
 
 - name: Verify - SASL_PLAIN configured on kafka_controller

--- a/playbooks/rootless_bootstrap.yml
+++ b/playbooks/rootless_bootstrap.yml
@@ -9,6 +9,9 @@
 # Optional: rootless_enable_linger (default true); rootless_install_packages (default false -
 # installs openssl/rsync/unzip/pip/pyyaml + Java, honoring install_java/custom_java_path);
 # rootless_bootstrap_authorized_keys_src (default: the connecting admin's key).
+# When custom_java_path is set, this also symlinks java/keytool onto /usr/bin (same as the
+# root install's alternatives step) so they resolve on PATH for the deploy and for anyone
+# who SSHes in later - unconditional on rootless_install_packages, always applied.
 
 - name: Rootless bootstrap (privileged, one-time)
   hosts: all
@@ -125,6 +128,26 @@
         - rootless_install_packages | bool
         - ansible_os_family == "Debian"
         - install_java | default((custom_java_path | default('') | length) == 0) | bool
+
+    # custom_java_install.yml's own alternatives tasks are skipped under rootless_enabled
+    # (privileged, write to /usr/bin). Without them, java/keytool are never on PATH anywhere -
+    # not for the deploy itself (keytool-based keystore/truststore tasks, Get Java Version) nor
+    # for an operator who SSHes in later. Do the exact same symlink here instead, once, as root.
+    - name: Java Update Alternatives (custom_java_path, rootless)
+      alternatives:
+        name: java
+        link: /usr/bin/java
+        path: "{{ custom_java_path }}/bin/java"
+        priority: 1
+      when: custom_java_path | default('') | length > 0
+
+    - name: Keytool Update Alternatives (custom_java_path, rootless)
+      alternatives:
+        name: keytool
+        link: /usr/bin/keytool
+        path: "{{ custom_java_path }}/bin/keytool"
+        priority: 1
+      when: custom_java_path | default('') | length > 0
 
     - name: Rootless bootstrap summary
       debug:

--- a/roles/common/tasks/debian.yml
+++ b/roles/common/tasks/debian.yml
@@ -252,10 +252,7 @@
   tags: package
 
 - name: Get Java Version
-  # custom_java_path isn't on PATH (the alternatives symlink that would put it
-  # there is a privileged, rootless-skipped task) - resolve java directly from
-  # it when set, same as the JVM start scripts' own JAVA_HOME.
-  command: "{{ (custom_java_path ~ '/bin/java') if custom_java_path | default('') | length > 0 else 'java' }} -version"
+  command: java -version
   register: version_output
   check_mode: false
   changed_when: false

--- a/roles/common/tasks/redhat.yml
+++ b/roles/common/tasks/redhat.yml
@@ -75,10 +75,7 @@
   tags: package
 
 - name: Get Java Version
-  # custom_java_path isn't on PATH (the alternatives symlink that would put it
-  # there is a privileged, rootless-skipped task) - resolve java directly from
-  # it when set, same as the JVM start scripts' own JAVA_HOME.
-  command: "{{ (custom_java_path ~ '/bin/java') if custom_java_path | default('') | length > 0 else 'java' }} -version"
+  command: java -version
   register: version_output
   check_mode: false
   changed_when: false

--- a/roles/common/tasks/ubuntu.yml
+++ b/roles/common/tasks/ubuntu.yml
@@ -152,10 +152,7 @@
   tags: package
 
 - name: Get Java Version
-  # custom_java_path isn't on PATH (the alternatives symlink that would put it
-  # there is a privileged, rootless-skipped task) - resolve java directly from
-  # it when set, same as the JVM start scripts' own JAVA_HOME.
-  command: "{{ (custom_java_path ~ '/bin/java') if custom_java_path | default('') | length > 0 else 'java' }} -version"
+  command: java -version
   register: version_output
   check_mode: false
   changed_when: false


### PR DESCRIPTION
## Summary
Supersedes the previous `Get Java Version` patch (PR #2610, reverted here) with a better, more customer-correct fix, plus a follow-up test fix - both tested together on the same branch before merging.

- **Real fix**: `custom_java_path` never lands on `PATH` under rootless anywhere - confirmed 8 files across `roles/ssl`, `kafka_broker`, `kafka_controller`, `ksql`, `common` invoke bare `java`/`keytool`. Root's `custom_java_install.yml` already solves this with two `alternatives` tasks (`java`, `keytool` -> `/usr/bin/*`), tagged `privileged` and skipped under `rootless_enabled`. `playbooks/rootless_bootstrap.yml` is the one-time privileged step that already runs as root, so it now does the exact same symlink once - fixes every current and future bare `java`/`keytool` call, and matches real customer expectations (an operator who SSHes in later to run `keytool` themselves gets a working PATH too, not just Ansible's own task execution).
- **Revert**: the narrower `Get Java Version` patch from PR #2610 is reverted - redundant now that bare `java`/`keytool` resolve correctly everywhere via the symlink.
- **Test fix**: `rootless-plain-debian10`'s "Assert /opt is empty" check was a false positive - `Dockerfile-debian10-archive.j2` tars a JDK into `custom_java_path` (`/opt/jdk17`) at image build time, before Ansible runs. Excludes `custom_java_path` from the check instead of asserting `/opt` is fully empty.

## Verification
Both fixes tested together on this branch before opening this PR (not merge-then-test-then-new-PR per fix):
- [x] `rootless-plain-debian10` converge+verify on Semaphore: **passed**, confirmed directly via `verify.txt` content (not just the top-level result) - `failed=0` across all 7 hosts, systemd `--user` units active, processes non-root, SASL_PLAIN property checks, and the kafka_connect plugin/connector deployment all genuinely passing.
- [x] YAML validates, `ansible-playbook --syntax-check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)