### PR TITLE
Release 8.1.5: version bump, docs, and changelog

### DIFF
--- a/.bumpversion-ansible.cfg
+++ b/.bumpversion-ansible.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 8.1.4
+current_version = 8.1.5
 commit = true
 message = Bump cp-ansible Version: {current_version} → {new_version}
 tag = false

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 8.1.4
+current_version = 8.1.5
 commit = true
 message = Bump CP Version: {current_version} → {new_version}
 tag = false

--- a/.semaphore/sanity_tests.sh
+++ b/.semaphore/sanity_tests.sh
@@ -53,7 +53,7 @@ pip install pylint
 pip install "ansible==$ANSIBLE_VERSION.*"
 pip install yamllint
 pip install galaxy-importer
-pip install setuptools
+pip install "setuptools<81"
 
 python --version
 ansible --version

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,20 @@ Ansible Playbooks for Confluent Platform - Release Notes
 
 .. contents:: Topics
 
+8.1.5
+======
+New features
+-------------
+- N/A
+
+Notable enhancements
+-------------
+- This release adds protection against Common Vulnerabilites and Exposures found in Confluent Platform. More info: https://docs.confluent.io/platform/8.1/release-notes/index.html#cp-release-8-1-5
+
+Notable Fixes
+-------------
+- N/A
+
 v8.1.4
 ======
 New features

--- a/README.md
+++ b/README.md
@@ -51,12 +51,12 @@ Ansible Playbooks for Confluent Platform (Confluent Ansible) offers a simplified
 
 ## Testing
 
-CP-Ansible's tests use the [Molecule](https://ansible.readthedocs.io/projects/molecule/) framework, and it is strongly advised to test this way before submitting a Pull Request. Please refer to the [HOW_TO_TEST.md](https://github.com/confluentinc/cp-ansible/blob/8.1.4-post/docs/HOW_TO_TEST.md)
+CP-Ansible's tests use the [Molecule](https://ansible.readthedocs.io/projects/molecule/) framework, and it is strongly advised to test this way before submitting a Pull Request. Please refer to the [HOW_TO_TEST.md](https://github.com/confluentinc/cp-ansible/blob/8.1.5-post/docs/HOW_TO_TEST.md)
 
 
 ## Contributing
 
-If you would like to contribute to the CP-Ansible project, please refer to the [CONTRIBUTE.md](https://github.com/confluentinc/cp-ansible/blob/8.1.4-post/docs/CONTRIBUTING.md)
+If you would like to contribute to the CP-Ansible project, please refer to the [CONTRIBUTE.md](https://github.com/confluentinc/cp-ansible/blob/8.1.5-post/docs/CONTRIBUTING.md)
 
 ## Support
 
@@ -68,4 +68,4 @@ This [page](https://docs.confluent.io/ansible/current/ansible-release-notes.html
 
 ## License
 
-[Apache 2.0](https://github.com/confluentinc/cp-ansible/blob/8.1.4-post/LICENSE.md)
+[Apache 2.0](https://github.com/confluentinc/cp-ansible/blob/8.1.5-post/LICENSE.md)

--- a/docs/MOLECULE_SCENARIOS.md
+++ b/docs/MOLECULE_SCENARIOS.md
@@ -134,13 +134,15 @@ Validates that TLS is configured properly.
 
 #### Scenario broker-scale-up test's the following:
 
+Tests scale-up of the Kafka broker cluster.
+
+Brings up a 3-broker cluster in the create/prepare phase, then adds 2 more
+
+brokers (broker4, broker5) in the converge phase and verifies they join.
+
 Installation of Confluent Platform on RHEL8.
 
 MTLS enabled.
-
-Installs Three unique Kafka Connect Clusters with unique connectors.
-
-Installs two unique KSQL Clusters.
 
 USM Agent Authentication Configuration - MTLS AUTHENTICATION with self signed certs.
 

--- a/docs/VARIABLES.md
+++ b/docs/VARIABLES.md
@@ -8,7 +8,7 @@ Below are the supported variables for the role variables
 
 Version of Confluent Platform to install
 
-Default:  8.1.4
+Default:  8.1.5
 
 ***
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: confluent
 name: platform
-version: 8.1.4
+version: 8.1.5
 readme: README.md
 authors:
   - Confluent Ansible Community

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -2,7 +2,7 @@
 # Custom filters used in this file are defined in plugins/filter/filters.py
 
 ### Version of Confluent Platform to install
-confluent_package_version: 8.1.4
+confluent_package_version: 8.1.5
 
 confluent_full_package_version: "{{ confluent_package_version + '-1' }}"
 confluent_package_redhat_suffix: "{{ '-' + confluent_full_package_version if confluent_full_package_version != '' else ''}}"

--- a/roles/variables/vars/main.yml
+++ b/roles/variables/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-confluent_ansible_branch: 8.1.4-post
+confluent_ansible_branch: 8.1.5-post
 
 systemd_base_dir: "{{'/lib/systemd/system' if ansible_os_family == 'Debian' else '/usr/lib/systemd/system'}}"
 


### PR DESCRIPTION
Prepares the **8.1.5** patch release for the `8.1.x` line.

- Bump CP version to `8.1.5` (via `bump_version` Semaphore task)
- Update generated docs (`docs/VARIABLES.md`)
- Add `8.1.5` entry to `CHANGELOG.rst`
- Bump README `blob/*-post/` doc URLs to `8.1.5-post`

Part of the 2026 Q3 CP Ansible Accelerated Patch Release.