### PR TITLE
[ANSIENG-5900] Fix rootless_bootstrap.yml for mixed inventories (found via pytest-mode CI)

### DIFF
--- a/molecule/rootless-oauth-ubuntu2004/molecule.yml
+++ b/molecule/rootless-oauth-ubuntu2004/molecule.yml
@@ -144,16 +144,6 @@ provisioner:
   inventory:
     group_vars:
       all:
-        rootless_enabled: true
-        deployment_user: cp-user
-        deployment_group: cp-user
-        deployment_path: /home/cp-user/cp-data
-        installation_method: archive
-
-        # Ubuntu's systemd --user manager needs dbus-user-session, which the archive
-        # Dockerfile doesn't bake in - exercise rootless_bootstrap.yml's apt branch for it.
-        rootless_install_packages: true
-
         ssl_enabled: true
         ssl_mutual_auth_enabled: true
         ssl_client_authentication: required
@@ -192,14 +182,26 @@ provisioner:
         kafka_broker_custom_properties: *ldap_base_properties
         kafka_controller_custom_properties: *ldap_base_properties
 
-      kafka_controller:
+      # Rootless vars scoped to the CP component groups only (not group_vars/all) - ldap1/oauth1
+      # are unmanaged hosts sharing this inventory, not rootless deploy targets. Scoping these
+      # here keeps them out of playbooks/rootless_bootstrap.yml's hosts:all bootstrap treatment
+      # entirely, the same way ansible_user already is.
+      kafka_controller: &rootless_component_vars
         ansible_user: "{{ deployment_user }}"
+        rootless_enabled: true
+        deployment_user: cp-user
+        deployment_group: cp-user
+        deployment_path: /home/cp-user/cp-data
+        installation_method: archive
+        # Ubuntu's systemd --user manager needs dbus-user-session, which the archive
+        # Dockerfile doesn't bake in - exercise rootless_bootstrap.yml's apt branch for it.
+        rootless_install_packages: true
 
       # OAuth/OIDC SSO for Control Center, layered on top of the LDAP-backed MDS above.
       # sso_* config is read from roles/kafka_broker/tasks/main.yml (the only consumer in
       # this collection - it imports the IDP cert into the broker's MDS truststore for C3 SSO).
       kafka_broker:
-        ansible_user: "{{ deployment_user }}"
+        <<: *rootless_component_vars
         sso_mode: oidc
         keycloak_oauth_server_port: 8443
         keycloak_http_protocol: https
@@ -246,16 +248,10 @@ provisioner:
             uid: 9994
             guid: 94
 
-      # Rootless components connect as the deploy user; ldap1/oauth1 stay root (not part of the deploy).
-      schema_registry:
-        ansible_user: "{{ deployment_user }}"
-      kafka_connect:
-        ansible_user: "{{ deployment_user }}"
-      kafka_rest:
-        ansible_user: "{{ deployment_user }}"
-      ksql:
-        ansible_user: "{{ deployment_user }}"
-      control_center:
-        ansible_user: "{{ deployment_user }}"
+      schema_registry: *rootless_component_vars
+      kafka_connect: *rootless_component_vars
+      kafka_rest: *rootless_component_vars
+      ksql: *rootless_component_vars
+      control_center: *rootless_component_vars
 verifier:
   name: ansible

--- a/molecule/rootless-rbac-ldap-rhel9/molecule.yml
+++ b/molecule/rootless-rbac-ldap-rhel9/molecule.yml
@@ -119,12 +119,6 @@ provisioner:
   inventory:
     group_vars:
       all:
-        rootless_enabled: true
-        deployment_user: cp-user
-        deployment_group: cp-user
-        deployment_path: /home/cp-user/cp-data
-        installation_method: archive
-
         ssl_enabled: true
         ssl_mutual_auth_enabled: true
         ssl_client_authentication: required
@@ -196,20 +190,22 @@ provisioner:
             uid: 9994
             guid: 94
 
-      # Rootless components connect as the deploy user; ldap1 stays root (not part of the deploy).
-      kafka_controller:
+      # Rootless vars scoped to the CP component groups only (not group_vars/all) - ldap1 is an
+      # unmanaged host sharing this inventory, not a rootless deploy target. Scoping these here
+      # keeps ldap1 out of playbooks/rootless_bootstrap.yml's hosts:all bootstrap treatment
+      # entirely, the same way ansible_user already is.
+      kafka_controller: &rootless_component_vars
         ansible_user: "{{ deployment_user }}"
-      kafka_broker:
-        ansible_user: "{{ deployment_user }}"
-      schema_registry:
-        ansible_user: "{{ deployment_user }}"
-      kafka_connect:
-        ansible_user: "{{ deployment_user }}"
-      kafka_rest:
-        ansible_user: "{{ deployment_user }}"
-      ksql:
-        ansible_user: "{{ deployment_user }}"
-      control_center:
-        ansible_user: "{{ deployment_user }}"
+        rootless_enabled: true
+        deployment_user: cp-user
+        deployment_group: cp-user
+        deployment_path: /home/cp-user/cp-data
+        installation_method: archive
+      kafka_broker: *rootless_component_vars
+      schema_registry: *rootless_component_vars
+      kafka_connect: *rootless_component_vars
+      kafka_rest: *rootless_component_vars
+      ksql: *rootless_component_vars
+      control_center: *rootless_component_vars
 verifier:
   name: ansible

--- a/playbooks/rootless_bootstrap.yml
+++ b/playbooks/rootless_bootstrap.yml
@@ -21,7 +21,10 @@
     deployment_group: "{{ deployment_user }}"
     rootless_enable_linger: true
     rootless_install_packages: false
-    rootless_bootstrap_authorized_keys_src: "/home/{{ ansible_user }}/.ssh/authorized_keys"
+    # default('') so hosts:all tolerates a host with no ansible_user set (e.g. an unmanaged
+    # LDAP/OAuth server sharing the inventory but outside the rootless deploy group) - the
+    # resulting path just won't exist, and both uses below are already stat.exists-guarded.
+    rootless_bootstrap_authorized_keys_src: "/home/{{ ansible_user | default('') }}/.ssh/authorized_keys"
   tasks:
     - name: Assert required rootless bootstrap vars
       assert:

--- a/playbooks/rootless_bootstrap.yml
+++ b/playbooks/rootless_bootstrap.yml
@@ -5,7 +5,10 @@
 # Does only what needs root; everything else (archive install, config, systemd --user
 # units, start, PyYAML) runs unprivileged in the main deploy.
 #
-# Required: deployment_user, deployment_path (deployment_group defaults to deployment_user).
+# Required per-host: deployment_user, deployment_path (deployment_group defaults to
+# deployment_user). Runs against hosts:all so a mixed inventory works - a host with neither
+# set (e.g. an existing LDAP/Kerberos server sharing the inventory but not a deploy target)
+# is skipped informationally rather than failed, so it's never excluded from later plays.
 # Optional: rootless_enable_linger (default true); rootless_install_packages (default false -
 # installs openssl/rsync/unzip/pip/pyyaml + Java, honoring install_java/custom_java_path);
 # rootless_bootstrap_authorized_keys_src (default: the connecting admin's key).
@@ -26,135 +29,141 @@
     # resulting path just won't exist, and both uses below are already stat.exists-guarded.
     rootless_bootstrap_authorized_keys_src: "/home/{{ ansible_user | default('') }}/.ssh/authorized_keys"
   tasks:
-    - name: Assert required rootless bootstrap vars
-      assert:
-        that:
-          - deployment_user | default('') | length > 0
-          - deployment_path | default('') | length > 0
-        fail_msg: "Set deployment_user and deployment_path (the rootless deploy vars) in your inventory."
-
-    - name: Create deploy group
-      group:
-        name: "{{ deployment_group }}"
-
-    - name: Create deploy user
-      user:
-        name: "{{ deployment_user }}"
-        group: "{{ deployment_group }}"
-        shell: /bin/bash
-        create_home: true
-
-    - name: Ensure deploy user's .ssh directory
-      file:
-        path: "/home/{{ deployment_user }}/.ssh"
-        state: directory
-        owner: "{{ deployment_user }}"
-        group: "{{ deployment_group }}"
-        mode: '0700'
-
-    - name: Check source authorized_keys exists
-      stat:
-        path: "{{ rootless_bootstrap_authorized_keys_src }}"
-      register: rootless_ak_src
-
-    - name: Authorize the deploy user's SSH key
-      copy:
-        src: "{{ rootless_bootstrap_authorized_keys_src }}"
-        remote_src: true
-        dest: "/home/{{ deployment_user }}/.ssh/authorized_keys"
-        owner: "{{ deployment_user }}"
-        group: "{{ deployment_group }}"
-        mode: '0600'
-      when: rootless_ak_src.stat.exists
-
-    - name: Create deployment base directory
-      file:
-        path: "{{ deployment_path }}"
-        state: directory
-        owner: "{{ deployment_user }}"
-        group: "{{ deployment_group }}"
-        mode: '0755'
-
-    - name: Enable systemd linger for the deploy user
-      # So systemd --user units survive without an active login/reboot.
-      command: "loginctl enable-linger {{ deployment_user }}"
-      args:
-        creates: "/var/lib/systemd/linger/{{ deployment_user }}"
-      when: rootless_enable_linger | bool
-
-    # PyYAML/pip for update_log4j2 - a minimal host may ship neither, and rootless can't
-    # install them itself. RHEL's per-user D-Bus starts on its own once linger is enabled.
-    - name: Install cert tools + python (openssl/rsync/unzip/pip/PyYAML) - RedHat
-      yum:
-        name:
-          - openssl
-          - rsync
-          - unzip
-          - python3-pip
-          - python3-pyyaml
-        state: present
-      when: rootless_install_packages | bool and ansible_os_family == "RedHat"
-
-    # dbus-user-session: Debian/Ubuntu's systemd --user manager needs it, or systemctl --user
-    # fails with "Failed to connect to bus". Requires root, hence installed here.
-    - name: Install cert tools + python (+ user D-Bus) - Debian/Ubuntu
-      apt:
-        name:
-          - openssl
-          - rsync
-          - unzip
-          - python3-pip
-          - python3-yaml
-          - dbus-user-session
-        state: present
-        update_cache: true
-      when: rootless_install_packages | bool and ansible_os_family == "Debian"
-
-    # The privileged/package-tagged Java install is skipped under rootless, so install it here
-    # instead, honoring the existing model: install_java is false when custom_java_path is set
-    # (bring-your-own JDK), package name from {redhat,ubuntu,debian}_java_package_name.
-    - name: Install Java (respects install_java + redhat_java_package_name) - RedHat
-      yum:
-        name: "{{ redhat_java_package_name | default('java-17-openjdk') }}"
-        state: present
-      when:
-        - rootless_install_packages | bool
-        - ansible_os_family == "RedHat"
-        - install_java | default((custom_java_path | default('') | length) == 0) | bool
-
-    - name: Install Java (respects install_java + {ubuntu,debian}_java_package_name) - Debian/Ubuntu
-      apt:
-        name: "{{ (ubuntu_java_package_name if ansible_distribution == 'Ubuntu' else debian_java_package_name) | default('openjdk-17-jdk') }}"
-        state: present
-        update_cache: true
-      when:
-        - rootless_install_packages | bool
-        - ansible_os_family == "Debian"
-        - install_java | default((custom_java_path | default('') | length) == 0) | bool
-
-    # custom_java_install.yml's own alternatives tasks are skipped under rootless_enabled
-    # (privileged, write to /usr/bin). Without them, java/keytool are never on PATH anywhere -
-    # not for the deploy itself (keytool-based keystore/truststore tasks, Get Java Version) nor
-    # for an operator who SSHes in later. Do the exact same symlink here instead, once, as root.
-    - name: Java Update Alternatives (custom_java_path, rootless)
-      alternatives:
-        name: java
-        link: /usr/bin/java
-        path: "{{ custom_java_path }}/bin/java"
-        priority: 1
-      when: custom_java_path | default('') | length > 0
-
-    - name: Keytool Update Alternatives (custom_java_path, rootless)
-      alternatives:
-        name: keytool
-        link: /usr/bin/keytool
-        path: "{{ custom_java_path }}/bin/keytool"
-        priority: 1
-      when: custom_java_path | default('') | length > 0
-
-    - name: Rootless bootstrap summary
+    # hosts:all is meant for a mixed inventory - e.g. an existing LDAP/Kerberos server sharing
+    # the same inventory as the rootless CP deploy but never intended as a target. Skip those
+    # hosts entirely (informationally) rather than asserting, so they're never marked failed -
+    # a failed host here would be excluded from every later playbook/play in the same run,
+    # including the actual LDAP/OAuth setup a molecule scenario or real deploy may still need.
+    - name: Skip rootless bootstrap on this host - deployment_user/deployment_path not set
       debug:
-        msg:
-          - "Rootless bootstrap complete: user '{{ deployment_user }}' ready at '{{ deployment_path }}'."
-          - "Linger: {{ rootless_enable_linger | bool }}; OS packages installed: {{ rootless_install_packages | bool }}."
-          - "Next: run the rootless deploy as {{ deployment_user }} (playbooks/rootless_deploy.sh -i <inventory>)."
+        msg: "deployment_user/deployment_path not set for {{ inventory_hostname }}; assuming it's not a rootless deploy target and skipping bootstrap here."
+      when: deployment_user | default('') | length == 0 or deployment_path | default('') | length == 0
+
+    - name: Rootless bootstrap tasks
+      when: deployment_user | default('') | length > 0 and deployment_path | default('') | length > 0
+      block:
+        - name: Create deploy group
+          group:
+            name: "{{ deployment_group }}"
+
+        - name: Create deploy user
+          user:
+            name: "{{ deployment_user }}"
+            group: "{{ deployment_group }}"
+            shell: /bin/bash
+            create_home: true
+
+        - name: Ensure deploy user's .ssh directory
+          file:
+            path: "/home/{{ deployment_user }}/.ssh"
+            state: directory
+            owner: "{{ deployment_user }}"
+            group: "{{ deployment_group }}"
+            mode: '0700'
+
+        - name: Check source authorized_keys exists
+          stat:
+            path: "{{ rootless_bootstrap_authorized_keys_src }}"
+          register: rootless_ak_src
+
+        - name: Authorize the deploy user's SSH key
+          copy:
+            src: "{{ rootless_bootstrap_authorized_keys_src }}"
+            remote_src: true
+            dest: "/home/{{ deployment_user }}/.ssh/authorized_keys"
+            owner: "{{ deployment_user }}"
+            group: "{{ deployment_group }}"
+            mode: '0600'
+          when: rootless_ak_src.stat.exists
+
+        - name: Create deployment base directory
+          file:
+            path: "{{ deployment_path }}"
+            state: directory
+            owner: "{{ deployment_user }}"
+            group: "{{ deployment_group }}"
+            mode: '0755'
+
+        - name: Enable systemd linger for the deploy user
+          # So systemd --user units survive without an active login/reboot.
+          command: "loginctl enable-linger {{ deployment_user }}"
+          args:
+            creates: "/var/lib/systemd/linger/{{ deployment_user }}"
+          when: rootless_enable_linger | bool
+
+        # PyYAML/pip for update_log4j2 - a minimal host may ship neither, and rootless can't
+        # install them itself. RHEL's per-user D-Bus starts on its own once linger is enabled.
+        - name: Install cert tools + python (openssl/rsync/unzip/pip/PyYAML) - RedHat
+          yum:
+            name:
+              - openssl
+              - rsync
+              - unzip
+              - python3-pip
+              - python3-pyyaml
+            state: present
+          when: rootless_install_packages | bool and ansible_os_family == "RedHat"
+
+        # dbus-user-session: Debian/Ubuntu's systemd --user manager needs it, or systemctl --user
+        # fails with "Failed to connect to bus". Requires root, hence installed here.
+        - name: Install cert tools + python (+ user D-Bus) - Debian/Ubuntu
+          apt:
+            name:
+              - openssl
+              - rsync
+              - unzip
+              - python3-pip
+              - python3-yaml
+              - dbus-user-session
+            state: present
+            update_cache: true
+          when: rootless_install_packages | bool and ansible_os_family == "Debian"
+
+        # The privileged/package-tagged Java install is skipped under rootless, so install it here
+        # instead, honoring the existing model: install_java is false when custom_java_path is set
+        # (bring-your-own JDK), package name from {redhat,ubuntu,debian}_java_package_name.
+        - name: Install Java (respects install_java + redhat_java_package_name) - RedHat
+          yum:
+            name: "{{ redhat_java_package_name | default('java-17-openjdk') }}"
+            state: present
+          when:
+            - rootless_install_packages | bool
+            - ansible_os_family == "RedHat"
+            - install_java | default((custom_java_path | default('') | length) == 0) | bool
+
+        - name: Install Java (respects install_java + {ubuntu,debian}_java_package_name) - Debian/Ubuntu
+          apt:
+            name: "{{ (ubuntu_java_package_name if ansible_distribution == 'Ubuntu' else debian_java_package_name) | default('openjdk-17-jdk') }}"
+            state: present
+            update_cache: true
+          when:
+            - rootless_install_packages | bool
+            - ansible_os_family == "Debian"
+            - install_java | default((custom_java_path | default('') | length) == 0) | bool
+
+        # custom_java_install.yml's own alternatives tasks are skipped under rootless_enabled
+        # (privileged, write to /usr/bin). Without them, java/keytool are never on PATH anywhere -
+        # not for the deploy itself (keytool-based keystore/truststore tasks, Get Java Version) nor
+        # for an operator who SSHes in later. Do the exact same symlink here instead, once, as root.
+        - name: Java Update Alternatives (custom_java_path, rootless)
+          alternatives:
+            name: java
+            link: /usr/bin/java
+            path: "{{ custom_java_path }}/bin/java"
+            priority: 1
+          when: custom_java_path | default('') | length > 0
+
+        - name: Keytool Update Alternatives (custom_java_path, rootless)
+          alternatives:
+            name: keytool
+            link: /usr/bin/keytool
+            path: "{{ custom_java_path }}/bin/keytool"
+            priority: 1
+          when: custom_java_path | default('') | length > 0
+
+        - name: Rootless bootstrap summary
+          debug:
+            msg:
+              - "Rootless bootstrap complete: user '{{ deployment_user }}' ready at '{{ deployment_path }}'."
+              - "Linger: {{ rootless_enable_linger | bool }}; OS packages installed: {{ rootless_install_packages | bool }}."
+              - "Next: run the rootless deploy as {{ deployment_user }} (playbooks/rootless_deploy.sh -i <inventory>)."

--- a/playbooks/rootless_bootstrap.yml
+++ b/playbooks/rootless_bootstrap.yml
@@ -19,7 +19,11 @@
 - name: Rootless bootstrap (privileged, one-time)
   hosts: all
   become: true
-  gather_facts: true
+  # Not gathered here (see the block below) - the implicit play-level gather_facts runs before
+  # any task when: can guard it, and inherits become: true. A host with no sudo (e.g. an
+  # unmanaged, non-Linux-shell service container sharing the inventory) would fail hard on
+  # that alone, before ever reaching the deployment_user/deployment_path check.
+  gather_facts: false
   vars:
     deployment_group: "{{ deployment_user }}"
     rootless_enable_linger: true
@@ -42,6 +46,9 @@
     - name: Rootless bootstrap tasks
       when: deployment_user | default('') | length > 0 and deployment_path | default('') | length > 0
       block:
+        - name: Gather facts
+          setup:
+
         - name: Create deploy group
           group:
             name: "{{ deployment_group }}"


### PR DESCRIPTION
## Summary

Found by running pytest mode (\`molecule test\`'s full lifecycle) instead of the \`converge+verify\` shortcut used earlier - more rigorous, and it surfaced 3 related real bugs in \`playbooks/rootless_bootstrap.yml\` that only show up on a **mixed inventory** (rootless CP hosts alongside an unmanaged host, like an existing LDAP or OAuth server sharing the same inventory - exactly what \`rootless-rbac-ldap-rhel9\` and \`rootless-oauth-ubuntu2004\` exercise, and a realistic real-customer scenario too).

1. **\`ansible_user\` undefined for unmanaged hosts.** \`rootless_bootstrap.yml\`'s \`hosts: all\` play templated \`{{ ansible_user }}\` directly for \`rootless_bootstrap_authorized_keys_src\`. \`ldap1\`/\`oauth1\` never have \`ansible_user\` set (only the CP component groups do), so this was a hard template-undefined failure, marking the host failed and excluding it from every later play in the run - including the actual LDAP/OAuth setup. Fixed with \`default('')\`.
2. **Deeper cause: molecule.yml scoping.** \`deployment_user\`/\`deployment_path\`/\`rootless_enabled\` lived in \`group_vars/all\`, so \`ldap1\`/\`oauth1\` satisfied \`rootless_bootstrap.yml\`'s "is this a rootless target" check and got swept into real bootstrap work never meant for them (e.g. \`loginctl enable-linger\` failing on \`ldap1\`'s minimal container, since it doesn't run a full systemd-logind). Fixed two ways: \`rootless_bootstrap.yml\` now wraps the actual bootstrap work in a block gated on \`deployment_user\`/\`deployment_path\` both being set, with an informational message (not an assert) when they're not, so a non-target host is skipped rather than failed; both scenarios' \`molecule.yml\` move those vars out of \`group_vars/all\` into the 7 CP component groups only, matching how \`ansible_user\` was already scoped.
3. **\`gather_facts\` + \`become\` ran before any \`when:\` could guard it.** The play's implicit fact-gathering happens before task-level conditions, and inherits \`become: true\` - so \`oauth1\` (a Keycloak container with no \`sudo\`) failed hard on that alone, cascading to a second failure on \`kafka-broker1\` (the SSO IDP cert never got set up). Fixed by moving fact-gathering inside the gated block as an explicit \`setup:\` task.

## Verification

All three fixes tested together on this branch before opening this PR (not merge-then-test-then-new-PR per fix). Confirmed via direct XML report inspection (not just the top-level Semaphore result), stripped of ANSI codes, full PLAY RECAP across every host:

- \`rootless-rbac-ldap-rhel9\`: **0 fatal errors**.
- \`rootless-oauth-ubuntu2004\`: **\`failed=0\` for every host** (converge + verify) - \`oauth1\` progresses normally (\`ok=7\`), \`ldap1\` fully participates (\`ok=40\`), \`kafka-broker1\`'s one \`ignored=1\` is the pre-existing, deliberate \`ignore_errors: true\` "check if cert already imported" pattern (expected to report non-zero on first run).
- \`plain-rhel\` and \`rbac-mds-mtls-custom-rhel-fips\` (flagged in an unrelated 58-scenario full-suite pytest run) re-ran individually with **0 fatal errors both** - confirmed pre-existing CI flakiness at that scale, not a regression from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)