### PR TITLE
[ANSIENG-5900] | Rootless: fix serial/parallel detection, simplify RBAC bootstrap to mirror root

### DIFF
--- a/playbooks/control_center.yml
+++ b/playbooks/control_center.yml
@@ -10,12 +10,24 @@
 
     - name: Populate service facts
       service_facts:
+      when: not (rootless_lifecycle_enabled | bool)
+
+    - name: Query rootless service state (systemd --user, read-only)
+      include_role:
+        name: common
+        tasks_from: rootless_service_state.yml
+      vars:
+        rootless_component_name: control_center
+      when: rootless_lifecycle_enabled | bool
 
     - name: Determine Installation Pattern - Parallel or Serial
       set_fact:
         install_pattern: "{{ 'parallel' if service_state != 'running' or control_center_deployment_strategy == 'parallel' else 'serial' }}"
       vars:
-        service_state: "{{ ansible_facts.services[control_center_service_name + '.service'].state | default('unknown') }}"
+        service_state: >-
+          {{ rootless_service_state | default('unknown')
+             if rootless_lifecycle_enabled | bool
+             else (ansible_facts.services[control_center_service_name + '.service'].state | default('unknown')) }}
 
     - name: Group Hosts by Installation Pattern
       group_by:

--- a/playbooks/kafka_broker.yml
+++ b/playbooks/kafka_broker.yml
@@ -10,12 +10,24 @@
 
     - name: Populate service facts
       service_facts:
+      when: not (rootless_lifecycle_enabled | bool)
+
+    - name: Query rootless service state (systemd --user, read-only)
+      include_role:
+        name: common
+        tasks_from: rootless_service_state.yml
+      vars:
+        rootless_component_name: kafka_broker
+      when: rootless_lifecycle_enabled | bool
 
     - name: Determine Installation Pattern - Parallel or Serial
       set_fact:
         install_pattern: "{{ 'parallel' if service_state != 'running' or kafka_broker_deployment_strategy == 'parallel' else 'serial' }}"
       vars:
-        service_state: "{{ ansible_facts.services[kafka_broker_service_name + '.service'].state | default('unknown') }}"
+        service_state: >-
+          {{ rootless_service_state | default('unknown')
+             if rootless_lifecycle_enabled | bool
+             else (ansible_facts.services[kafka_broker_service_name + '.service'].state | default('unknown')) }}
 
     - name: Group Hosts by Installation Pattern
       group_by:

--- a/playbooks/kafka_connect.yml
+++ b/playbooks/kafka_connect.yml
@@ -10,12 +10,24 @@
 
     - name: Populate service facts
       service_facts:
+      when: not (rootless_lifecycle_enabled | bool)
+
+    - name: Query rootless service state (systemd --user, read-only)
+      include_role:
+        name: common
+        tasks_from: rootless_service_state.yml
+      vars:
+        rootless_component_name: kafka_connect
+      when: rootless_lifecycle_enabled | bool
 
     - name: Determine Installation Pattern - Parallel or Serial
       set_fact:
         install_pattern: "{{ 'parallel' if service_state != 'running' or kafka_connect_deployment_strategy == 'parallel' else 'serial' }}"
       vars:
-        service_state: "{{ ansible_facts.services[kafka_connect_service_name + '.service'].state | default('unknown') }}"
+        service_state: >-
+          {{ rootless_service_state | default('unknown')
+             if rootless_lifecycle_enabled | bool
+             else (ansible_facts.services[kafka_connect_service_name + '.service'].state | default('unknown')) }}
 
     - name: Group Hosts by Installation Pattern
       group_by:

--- a/playbooks/kafka_controller.yml
+++ b/playbooks/kafka_controller.yml
@@ -10,12 +10,24 @@
 
     - name: Populate service facts
       service_facts:
+      when: not (rootless_lifecycle_enabled | bool)
+
+    - name: Query rootless service state (systemd --user, read-only)
+      include_role:
+        name: common
+        tasks_from: rootless_service_state.yml
+      vars:
+        rootless_component_name: kafka_controller
+      when: rootless_lifecycle_enabled | bool
 
     - name: Determine Installation Pattern - Parallel or Serial
       set_fact:
         install_pattern: "{{ 'parallel' if service_state != 'running' or kafka_controller_deployment_strategy == 'parallel' else 'serial' }}"
       vars:
-        service_state: "{{ ansible_facts.services[kafka_controller_service_name + '.service'].state | default('unknown') }}"
+        service_state: >-
+          {{ rootless_service_state | default('unknown')
+             if rootless_lifecycle_enabled | bool
+             else (ansible_facts.services[kafka_controller_service_name + '.service'].state | default('unknown')) }}
 
     - name: Group Hosts by Installation Pattern
       group_by:

--- a/playbooks/kafka_rest.yml
+++ b/playbooks/kafka_rest.yml
@@ -10,12 +10,24 @@
 
     - name: Populate service facts
       service_facts:
+      when: not (rootless_lifecycle_enabled | bool)
+
+    - name: Query rootless service state (systemd --user, read-only)
+      include_role:
+        name: common
+        tasks_from: rootless_service_state.yml
+      vars:
+        rootless_component_name: kafka_rest
+      when: rootless_lifecycle_enabled | bool
 
     - name: Determine Installation Pattern - Parallel or Serial
       set_fact:
         install_pattern: "{{ 'parallel' if service_state != 'running' or kafka_rest_deployment_strategy == 'parallel' else 'serial' }}"
       vars:
-        service_state: "{{ ansible_facts.services[kafka_rest_service_name + '.service'].state | default('unknown') }}"
+        service_state: >-
+          {{ rootless_service_state | default('unknown')
+             if rootless_lifecycle_enabled | bool
+             else (ansible_facts.services[kafka_rest_service_name + '.service'].state | default('unknown')) }}
 
     - name: Group Hosts by Installation Pattern
       group_by:

--- a/playbooks/ksql.yml
+++ b/playbooks/ksql.yml
@@ -10,12 +10,24 @@
 
     - name: Populate service facts
       service_facts:
+      when: not (rootless_lifecycle_enabled | bool)
+
+    - name: Query rootless service state (systemd --user, read-only)
+      include_role:
+        name: common
+        tasks_from: rootless_service_state.yml
+      vars:
+        rootless_component_name: ksql
+      when: rootless_lifecycle_enabled | bool
 
     - name: Determine Installation Pattern - Parallel or Serial
       set_fact:
         install_pattern: "{{ 'parallel' if service_state != 'running' or ksql_deployment_strategy == 'parallel' else 'serial' }}"
       vars:
-        service_state: "{{ ansible_facts.services[ksql_service_name + '.service'].state | default('unknown') }}"
+        service_state: >-
+          {{ rootless_service_state | default('unknown')
+             if rootless_lifecycle_enabled | bool
+             else (ansible_facts.services[ksql_service_name + '.service'].state | default('unknown')) }}
 
     - name: Group Hosts by Installation Pattern
       group_by:

--- a/roles/common/tasks/rootless_service_state.yml
+++ b/roles/common/tasks/rootless_service_state.yml
@@ -1,0 +1,41 @@
+---
+# Read-only counterpart to service_facts for a rootless systemd --user unit -
+# service_facts never queries --user scope, so it always reports 'unknown'
+# for these. Used by each "<Component> Status Finding" play to pick serial
+# vs. parallel re-provisioning.
+#
+# Var:  rootless_component_name (queries cp-<name>.service)
+# Sets: rootless_service_state -> 'running' | 'stopped' | 'unknown'
+#
+# state/enabled/masked/daemon_reload are omitted below, so this only runs
+# `systemctl --user show` - never mutates the unit.
+
+- name: "Gather ansible_user_uid if not already cached (needed for XDG_RUNTIME_DIR)"
+  ansible.builtin.setup:
+    gather_subset:
+      - '!all'
+      - '!any'
+      - user
+  when: ansible_user_uid is not defined
+
+- name: "Query cp-{{ rootless_component_name }}.service state (systemd --user, read-only)"
+  ansible.builtin.systemd_service:
+    name: "cp-{{ rootless_component_name }}.service"
+    scope: user
+  environment:
+    XDG_RUNTIME_DIR: "/run/user/{{ ansible_user_uid }}"
+  register: rootless_service_query
+  changed_when: false
+  failed_when: false
+
+- name: "Normalize rootless service state to match service_facts' state values"
+  set_fact:
+    rootless_service_state: >-
+      {%- set query_status = rootless_service_query.status | default({}) -%}
+      {%- if query_status.get('SubState', '') == 'running' -%}
+      running
+      {%- elif query_status -%}
+      stopped
+      {%- else -%}
+      unknown
+      {%- endif -%}

--- a/roles/control_center/tasks/main.yml
+++ b/roles/control_center/tasks/main.yml
@@ -417,7 +417,6 @@
   when:
     - control_center_health_checks_enabled|bool
     - not ansible_check_mode
-    - not (rootless_enabled | bool)
   tags: health_check
 
 - name: Delete temporary keys/certs when keystore and trustore is provided

--- a/roles/kafka_broker/tasks/main.yml
+++ b/roles/kafka_broker/tasks/main.yml
@@ -595,7 +595,8 @@
   tags:
     - systemd
 
-# Non-RBAC: a simple systemd --user start + wait for the client listener is enough.
+# Same start path for RBAC and non-RBAC, mirroring root: start once and let
+# Restart=on-failure recover a transient AuthorizerNotReady during RBAC cold bootstrap.
 - name: Start Kafka Broker (rootless, systemd --user)
   include_role:
     name: common
@@ -603,63 +604,13 @@
   vars:
     rootless_component_name: kafka_broker
     rootless_component_port: "{{ kafka_broker_listeners['internal']['port'] }}"
-  when: rootless_lifecycle_enabled | bool and not rbac_enabled | bool
-
-# RBAC cold bootstrap is circular: controller authorizer init waits on the broker, and the
-# broker exits AuthorizerNotReady until the authorizer is ready - per-unit Restart alone never
-# converges this. Co-restart controller+broker together (delegated when on separate hosts) and
-# wait for MDS, mirroring what the root/systemd deploy does.
-- name: Enable Kafka Broker systemd --user unit (rootless RBAC)
-  ansible.builtin.systemd_service:
-    name: cp-kafka_broker.service
-    scope: user
-    enabled: true
-  environment:
-    XDG_RUNTIME_DIR: "/run/user/{{ ansible_user_uid }}"
-  when: rootless_lifecycle_enabled | bool and rbac_enabled | bool
-
-# Non-co-located controllers only; co-located ones restart together with the broker below.
-- name: Converge RBAC bootstrap (rootless) - restart standalone controllers
-  ansible.builtin.systemd_service:
-    name: cp-kafka_controller.service
-    scope: user
-    state: restarted
-  environment:
-    XDG_RUNTIME_DIR: "/run/user/{{ hostvars[item].ansible_user_uid | default(ansible_user_uid) }}"
-  delegate_to: "{{ item }}"
-  loop: "{{ groups['kafka_controller'] | default([]) | difference(groups['kafka_broker'] | default([])) }}"
-  run_once: true
-  when:
-    - rootless_lifecycle_enabled | bool
-    - rbac_enabled | bool
-
-- name: Converge controller+broker RBAC bootstrap - co-restart local units + wait for MDS (rootless)
-  shell:
-    executable: /bin/bash
-    cmd: |
-      export XDG_RUNTIME_DIR=/run/user/{{ ansible_user_uid }}
-      # Bash builtin, not ss/iproute - iproute may be absent and ss would misreport "down".
-      mds_up(){ (exec 3<>/dev/tcp/127.0.0.1/{{ mds_port }}) 2>/dev/null; }
-      mds_up && exit 0
-      # Restart only units present on this host; avoids "Unit not found" on a broker-only host.
-      units="cp-kafka_broker.service"
-      systemctl --user cat cp-kafka_controller.service >/dev/null 2>&1 && units="cp-kafka_controller.service $units"
-      systemctl --user restart $units
-      for _ in $(seq 1 24); do mds_up && exit 0; sleep 5; done
-      exit 1
-  register: rootless_rbac_converge
-  until: rootless_rbac_converge.rc == 0
-  retries: "{{ rootless_rbac_bootstrap_attempts | default(10) }}"
-  delay: 5
-  changed_when: false
-  when: rootless_lifecycle_enabled | bool and rbac_enabled | bool
+  when: rootless_lifecycle_enabled | bool
 
 - name: Wait for Broker health checks to complete
   include_tasks: health_check.yml
   when:
     - kafka_broker_health_checks_enabled|bool
     - not ansible_check_mode
-    - not (rootless_enabled | bool)
   tags: health_check
 
 - name: Register Cluster

--- a/roles/kafka_connect/tasks/main.yml
+++ b/roles/kafka_connect/tasks/main.yml
@@ -447,7 +447,6 @@
   when:
     - kafka_connect_health_checks_enabled|bool
     - not ansible_check_mode
-    - not (rootless_enabled | bool)
   tags: health_check
 
 # Set a host fact with the direct cluster parent group

--- a/roles/kafka_controller/tasks/main.yml
+++ b/roles/kafka_controller/tasks/main.yml
@@ -525,7 +525,6 @@
     - confluent_server_enabled|bool # metadata-quorum doesn't work on community kafka
     - kafka_controller_health_checks_enabled|bool
     - not ansible_check_mode
-    - not (rootless_enabled | bool)
   tags: health_check
 
 - name: Delete temporary keys/certs when keystore and trustore is provided

--- a/roles/kafka_rest/tasks/main.yml
+++ b/roles/kafka_rest/tasks/main.yml
@@ -465,7 +465,6 @@
   when:
     - kafka_rest_health_checks_enabled|bool
     - not ansible_check_mode
-    - not (rootless_enabled | bool)
   tags: health_check
 
 - name: Delete temporary keys/certs when keystore and trustore is provided

--- a/roles/ksql/tasks/main.yml
+++ b/roles/ksql/tasks/main.yml
@@ -462,7 +462,6 @@
   when:
     - ksql_health_checks_enabled|bool
     - not ansible_check_mode
-    - not (rootless_enabled | bool)
   tags: health_check
 
 # Set a host fact with the direct cluster parent group

--- a/roles/schema_registry/tasks/main.yml
+++ b/roles/schema_registry/tasks/main.yml
@@ -424,7 +424,6 @@
   when:
     - schema_registry_health_checks_enabled|bool
     - not ansible_check_mode
-    - not (rootless_enabled | bool)
   tags: health_check
 
 - name: Register Cluster


### PR DESCRIPTION
## Summary
- `service_facts` never queries systemd `--user` scope, so rootless components always reported `unknown` state and `install_pattern` was always `parallel` - even on a re-run against an already-live cluster. Added `roles/common/tasks/rootless_service_state.yml` (read-only `systemctl --user show`) as the rootless equivalent, wired into each affected playbook's Status Finding play.
- Removed the active RBAC co-restart mechanism in `kafka_broker` - it had a latent bug (`run_once` doesn't dedupe across serial batches, so it re-fired once per broker under a serial rollout) and root has never needed more than `Restart=on-failure` + a passive MDS poll. Rootless RBAC now takes the same start-once + `health_check.yml` path root always has.
- Removed the blanket `not (rootless_enabled)` guard on `health_check.yml` for `schema_registry`, `kafka_connect`, `kafka_controller`, `kafka_rest`, `ksql`, and `control_center` - inherited wholesale from the old `--skip-tags` convention, but these are all client-side polls with no root requirement. `zookeeper` intentionally excluded (no rootless start mechanism at all).

## Test plan
- [x] YAML + `ansible-playbook --syntax-check` on all edited playbooks/roles
- [x] Live EC2: `install_pattern` correctly routes to Serial Provisioning on a re-run against a live 3-node KRaft cluster (previously always routed to Parallel)
- [x] Live EC2: RBAC cold bootstrap against a real LDAP server converges cleanly with the passive mechanism, `failed=0`, in both co-located and separate-host controller/broker topologies
- [x] Live EC2: full 7-component deploy (co-located and non-co-located) with every component's health check now running and passing

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>