### PR TITLE
Fix oauth-plain molecule plugin download IncompleteRead (use hub-downloads.confluent.io)

### DIFF
--- a/molecule/oauth-plain-archive/prepare.yml
+++ b/molecule/oauth-plain-archive/prepare.yml
@@ -14,8 +14,8 @@
         url: "{{ item }}"
         dest: /tmp/local_plugins/
       with_items:
-        - "https://api.hub.confluent.io/api/plugins/confluentinc/kafka-connect-gcp-functions/versions/1.1.9/confluentinc-kafka-connect-gcp-functions-1.1.9.zip"
-        - "https://api.hub.confluent.io/api/plugins/confluentinc/kafka-connect-azure-data-lake-gen2-storage/versions/1.6.15/confluentinc-kafka-connect-azure-data-lake-gen2-storage-1.6.15.zip"
+        - "https://hub-downloads.confluent.io/api/plugins/confluentinc/kafka-connect-gcp-functions/versions/1.1.9/confluentinc-kafka-connect-gcp-functions-1.1.9.zip"
+        - "https://hub-downloads.confluent.io/api/plugins/confluentinc/kafka-connect-azure-data-lake-gen2-storage/versions/1.6.15/confluentinc-kafka-connect-azure-data-lake-gen2-storage-1.6.15.zip"
 
 - name: Provision Oauth Server
   import_playbook: ../oauth.yml

--- a/molecule/oauth-plain-debian12/prepare.yml
+++ b/molecule/oauth-plain-debian12/prepare.yml
@@ -14,8 +14,8 @@
         url: "{{ item }}"
         dest: /tmp/local_plugins/
       with_items:
-        - "https://api.hub.confluent.io/api/plugins/confluentinc/kafka-connect-gcp-functions/versions/1.1.9/confluentinc-kafka-connect-gcp-functions-1.1.9.zip"
-        - "https://api.hub.confluent.io/api/plugins/confluentinc/kafka-connect-azure-data-lake-gen2-storage/versions/1.6.15/confluentinc-kafka-connect-azure-data-lake-gen2-storage-1.6.15.zip"
+        - "https://hub-downloads.confluent.io/api/plugins/confluentinc/kafka-connect-gcp-functions/versions/1.1.9/confluentinc-kafka-connect-gcp-functions-1.1.9.zip"
+        - "https://hub-downloads.confluent.io/api/plugins/confluentinc/kafka-connect-azure-data-lake-gen2-storage/versions/1.6.15/confluentinc-kafka-connect-azure-data-lake-gen2-storage-1.6.15.zip"
 
 - name: Provision Oauth Server
   import_playbook: ../oauth.yml

--- a/molecule/oauth-plain-rhel/prepare.yml
+++ b/molecule/oauth-plain-rhel/prepare.yml
@@ -17,8 +17,8 @@
         url: "{{ item }}"
         dest: /tmp/local_plugins/
       with_items:
-        - "https://api.hub.confluent.io/api/plugins/confluentinc/kafka-connect-gcp-functions/versions/1.1.9/confluentinc-kafka-connect-gcp-functions-1.1.9.zip"
-        - "https://api.hub.confluent.io/api/plugins/confluentinc/kafka-connect-azure-data-lake-gen2-storage/versions/1.6.15/confluentinc-kafka-connect-azure-data-lake-gen2-storage-1.6.15.zip"
+        - "https://hub-downloads.confluent.io/api/plugins/confluentinc/kafka-connect-gcp-functions/versions/1.1.9/confluentinc-kafka-connect-gcp-functions-1.1.9.zip"
+        - "https://hub-downloads.confluent.io/api/plugins/confluentinc/kafka-connect-azure-data-lake-gen2-storage/versions/1.6.15/confluentinc-kafka-connect-azure-data-lake-gen2-storage-1.6.15.zip"
 
 - name: Provision Oauth Server
   import_playbook: ../oauth.yml


### PR DESCRIPTION
## Problem

The on-demand release-validation pipeline fails persistently on the `oauth-plain-*` scenarios during the **Prepare kafka connect plugins on ansible controller** task:

```
http.client.IncompleteRead: IncompleteRead(1562 bytes read)
msg: "failed to create temporary content file: IncompleteRead(...)"
```

Reported failing: `kr--8.3.x--0--oauth-plain-{debian12,archive,rhel}` (same code path on this branch).

## Root cause

`prepare.yml` downloads the gcp-functions and azure-data-lake-gen2 plugin zips directly from the legacy `api.hub.confluent.io` endpoint. That endpoint truncates the response mid-stream (reproduced on every attempt; each returns a different partial size, e.g. 633KB/294KB/587KB vs the real 13.2MB). Ansible `get_url` surfaces this truncated stream as `http.client.IncompleteRead`. This is not OS-specific — all `oauth-plain` variants hit the same broken URL.

## Fix

Swap the host to `hub-downloads.confluent.io` — the host the plugin manifest itself resolves archives to. Verified it returns the complete file consistently, with md5 matching the manifest. Path is otherwise unchanged. Applied to all three scenarios present on this branch: `oauth-plain-archive`, `oauth-plain-debian12`, `oauth-plain-rhel`.

Companion PRs cover 7.7.x (rhel) and 7.8.x (rhel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)