### PR TITLE
Fix oauth-plain molecule S3 plugin download IncompleteRead (use hub-downloads.confluent.io)

### DIFF
--- a/molecule/oauth-plain-debian12/molecule.yml
+++ b/molecule/oauth-plain-debian12/molecule.yml
@@ -351,7 +351,7 @@ provisioner:
           - "/tmp/local_plugins/confluentinc-kafka-connect-gcp-functions-1.1.9.zip"
           - "/tmp/local_plugins/confluentinc-kafka-connect-azure-data-lake-gen2-storage-1.6.15.zip"
         kafka_connect_plugins_remote:
-          - "https://api.hub.confluent.io/api/plugins/confluentinc/kafka-connect-s3/versions/{{connect_s3_plugin_version}}/confluentinc-kafka-connect-s3-{{connect_s3_plugin_version}}.zip"
+          - "https://hub-downloads.confluent.io/api/plugins/confluentinc/kafka-connect-s3/versions/{{connect_s3_plugin_version}}/confluentinc-kafka-connect-s3-{{connect_s3_plugin_version}}.zip"
 
         # To run the FileStream connector, you must add the filestream-connectors path in the plugin.path
         kafka_connect_custom_properties:

--- a/molecule/oauth-plain-rhel/molecule.yml
+++ b/molecule/oauth-plain-rhel/molecule.yml
@@ -354,7 +354,7 @@ provisioner:
           - "/tmp/local_plugins/confluentinc-kafka-connect-gcp-functions-1.1.9.zip"
           - "/tmp/local_plugins/confluentinc-kafka-connect-azure-data-lake-gen2-storage-1.6.15.zip"
         kafka_connect_plugins_remote:
-          - "https://api.hub.confluent.io/api/plugins/confluentinc/kafka-connect-s3/versions/{{connect_s3_plugin_version}}/confluentinc-kafka-connect-s3-{{connect_s3_plugin_version}}.zip"
+          - "https://hub-downloads.confluent.io/api/plugins/confluentinc/kafka-connect-s3/versions/{{connect_s3_plugin_version}}/confluentinc-kafka-connect-s3-{{connect_s3_plugin_version}}.zip"
 
         # To run the FileStream connector, you must add the filestream-connectors path in the plugin.path
         kafka_connect_custom_properties:


### PR DESCRIPTION
## Problem

After the `prepare.yml` fix (merged), the `oauth-plain` molecule scenarios still fail at a **later stage** — in the `Download Remote Plugins` task.

## Root cause

The `kafka_connect_plugins_remote` S3 plugin URL in `molecule.yml` still points at the legacy `api.hub.confluent.io` endpoint, which truncates the response mid-stream. Verified: the 41MB `kafka-connect-s3` zip truncates to ~600KB there (`http.client.IncompleteRead`), and the task retries eventually exhaust.

## Fix

Swap the host to `hub-downloads.confluent.io` — the host the plugin manifest resolves archives to. Verified it returns the complete file with md5 matching the manifest. Path unchanged.

Follow-up to the merged `prepare.yml` fix (ANSIENG-5920). Companion PRs cover the other active branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)