### PR TITLE
[ANSIENG-5900] | Rootless: Kerberos support, review fixes, molecule hardening, FIPS/assert restoration

### DIFF
--- a/.semaphore/rootless_become_check.py
+++ b/.semaphore/rootless_become_check.py
@@ -1,0 +1,120 @@
+"""
+Rootless unguarded-become sanity check.
+
+A rootless deploy user (rootless_enabled: true) has no privilege escalation path at
+all - a task with a literal `become: true` that isn't skipped under rootless fails
+loudly with a sudo error, which is fine. The real risk is the opposite: a task that
+*should* be skipped under rootless but has no guard referencing rootless_enabled at
+all, so it silently attempts to escalate (and either fails confusingly deep in the
+run, or - on a host where the connecting user happens to have passwordless sudo -
+succeeds without anyone noticing rootless was never actually rootless).
+
+Scans roles/*/tasks/*.yml for a task with a literal `become: true`/`become: yes`
+(not a templated expression, which is already conditional by definition) whose
+own + inherited `when:` conditions never mention rootless_enabled. Block-level
+`when:` and `become` are inherited by children, same as Ansible itself.
+"""
+
+import glob
+import os
+import sys
+
+import yaml
+
+ROOTLESS_VAR = "rootless_enabled"
+
+
+def normalize_when(when):
+    """Return a task's `when:` value as a list of condition strings."""
+    if when is None:
+        return []
+    if isinstance(when, str):
+        return [when]
+    if isinstance(when, (list, tuple)):
+        return [str(w) for w in when]
+    return [str(when)]
+
+
+def is_literal_become_true(become):
+    """True only for an actual boolean True (become: true/yes) - not a template string."""
+    return become is True
+
+
+def _walk(tasks, inherited_when, inherited_become, filepath, violations):
+    """Recursively walk a task list, propagating block when/become to children."""
+    if not isinstance(tasks, list):
+        return
+    for task in tasks:
+        if not isinstance(task, dict):
+            continue
+        effective_when = inherited_when + normalize_when(task.get("when"))
+        # A block's own `become` applies to children that don't set their own.
+        own_become = task.get("become", inherited_become)
+        is_block = any(k in task for k in ("block", "rescue", "always"))
+        if is_block:
+            for key in ("block", "rescue", "always"):
+                if key in task:
+                    _walk(task[key], effective_when, own_become, filepath, violations)
+            continue
+        name = task.get("name", "<unnamed>")
+        if is_literal_become_true(own_become):
+            guarded = any(ROOTLESS_VAR in w for w in effective_when)
+            if not guarded:
+                violations.append({"file": filepath, "task": name})
+
+
+def find_violations_in_docs(docs, filepath):
+    """Find violations in a list of parsed YAML documents from one file."""
+    violations = []
+    for doc in docs:
+        _walk(doc, [], None, filepath, violations)
+    return violations
+
+
+def scan_tree(collection_root):
+    """Scan every roles/*/tasks/*.yml file under collection_root."""
+    violations = []
+    pattern = os.path.join(collection_root, "roles", "*", "tasks", "*.yml")
+    for filepath in sorted(glob.glob(pattern)):
+        try:
+            with open(filepath, "r", encoding="utf-8") as handle:
+                docs = list(yaml.safe_load_all(handle))
+        except (yaml.YAMLError, OSError) as exc:
+            print(f"Warning: could not parse {filepath}: {exc}")
+            continue
+        rel = os.path.relpath(filepath, collection_root)
+        violations.extend(find_violations_in_docs(docs, rel))
+    return violations
+
+
+def main():
+    collection_root = os.environ.get("PATH_TO_CPA") or os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..")
+    )
+    print("Running rootless unguarded-become sanity check...")
+    print(f"Scanning roles under: {collection_root}")
+
+    violations = scan_tree(collection_root)
+
+    if not violations:
+        print(f"✅ No literal 'become: true' found without a {ROOTLESS_VAR} guard.")
+        return 0
+
+    print(f"❌ Found {len(violations)} unguarded become violation(s):")
+    print("=" * 60)
+    for v in violations:
+        print(f"File: {v['file']}")
+        print(f"Task: {v['task']!r}")
+        print("-" * 40)
+    print(
+        "\nA task with a literal 'become: true' must have 'rootless_enabled' in its "
+        "own or an enclosing block's `when:` (e.g. "
+        f"`when: not ({ROOTLESS_VAR} | bool)`), or use a templated `become:` expression "
+        "instead - otherwise it silently attempts privilege escalation under a rootless "
+        "deploy instead of failing loudly or being skipped."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.semaphore/sanity_tests.sh
+++ b/.semaphore/sanity_tests.sh
@@ -86,3 +86,9 @@ echo "Running rootless privileged-tag sanity check..."
 python$PYTHON_VERSION $PATH_TO_CPA/.semaphore/rootless_privileged_tag_check.py
 
 echo "Rootless privileged-tag sanity check completed."
+
+# Test6 - Rootless unguarded-become Check
+echo "Running rootless unguarded-become sanity check..."
+python$PYTHON_VERSION $PATH_TO_CPA/.semaphore/rootless_become_check.py
+
+echo "Rootless unguarded-become sanity check completed."

--- a/.semaphore/tests/test_rootless_become_check.py
+++ b/.semaphore/tests/test_rootless_become_check.py
@@ -1,0 +1,132 @@
+"""
+Tests for rootless_become_check.py
+"""
+
+import os
+import sys
+
+# Add parent directory to path to import the script
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from rootless_become_check import (  # noqa: E402
+    normalize_when,
+    find_violations_in_docs,
+    scan_tree,
+)
+
+
+class TestNormalizeWhen:
+    def test_none(self):
+        assert normalize_when(None) == []
+
+    def test_string(self):
+        assert normalize_when("rootless_enabled | bool") == ["rootless_enabled | bool"]
+
+    def test_list(self):
+        assert normalize_when(["a", "b"]) == ["a", "b"]
+
+
+class TestFindViolations:
+    def test_unguarded_become_flagged(self):
+        docs = [[{"name": "Install package", "yum": {}, "become": True}]]
+        violations = find_violations_in_docs(docs, "roles/x/tasks/main.yml")
+        assert len(violations) == 1
+        assert violations[0]["task"] == "Install package"
+
+    def test_unrelated_when_still_flagged(self):
+        # A when: exists, but it never mentions rootless_enabled - still a gap.
+        docs = [
+            [
+                {
+                    "name": "Install package",
+                    "yum": {},
+                    "become": True,
+                    "when": "ansible_os_family == 'RedHat'",
+                }
+            ]
+        ]
+        violations = find_violations_in_docs(docs, "roles/x/tasks/main.yml")
+        assert len(violations) == 1
+
+    def test_guarded_task_level_ok(self):
+        docs = [
+            [
+                {
+                    "name": "Install package",
+                    "yum": {},
+                    "become": True,
+                    "when": "not (rootless_enabled | bool)",
+                }
+            ]
+        ]
+        assert find_violations_in_docs(docs, "roles/x/tasks/main.yml") == []
+
+    def test_guarded_via_when_list_ok(self):
+        docs = [
+            [
+                {
+                    "name": "Install package",
+                    "yum": {},
+                    "become": True,
+                    "when": ["some_other_cond", "not (rootless_enabled | bool)"],
+                }
+            ]
+        ]
+        assert find_violations_in_docs(docs, "roles/x/tasks/main.yml") == []
+
+    def test_guarded_via_inherited_block_when_ok(self):
+        docs = [
+            [
+                {
+                    "name": "blk",
+                    "when": "not (rootless_enabled | bool)",
+                    "block": [{"name": "Install package", "yum": {}, "become": True}],
+                }
+            ]
+        ]
+        assert find_violations_in_docs(docs, "roles/x/tasks/main.yml") == []
+
+    def test_inherited_block_become_flagged(self):
+        # become set at block level, inherited by a child with no rootless guard.
+        docs = [
+            [
+                {
+                    "name": "blk",
+                    "become": True,
+                    "block": [{"name": "Install package", "yum": {}}],
+                }
+            ]
+        ]
+        violations = find_violations_in_docs(docs, "roles/x/tasks/main.yml")
+        assert len(violations) == 1
+
+    def test_templated_become_not_flagged(self):
+        # A templated become: is already conditional by definition.
+        docs = [
+            [
+                {
+                    "name": "Install package",
+                    "yum": {},
+                    "become": "{{ not (rootless_enabled | bool) }}",
+                }
+            ]
+        ]
+        assert find_violations_in_docs(docs, "roles/x/tasks/main.yml") == []
+
+    def test_become_false_not_flagged(self):
+        docs = [[{"name": "no-op", "debug": {}, "become": False}]]
+        assert find_violations_in_docs(docs, "roles/x/tasks/main.yml") == []
+
+    def test_no_become_not_flagged(self):
+        docs = [[{"name": "no-op", "debug": {}}]]
+        assert find_violations_in_docs(docs, "roles/x/tasks/main.yml") == []
+
+
+class TestScanTreeAgainstRepo:
+    def test_repo_tree_is_clean(self):
+        """The actual collection tree must satisfy the invariant."""
+        collection_root = os.path.abspath(
+            os.path.join(os.path.dirname(__file__), "..", "..")
+        )
+        violations = scan_tree(collection_root)
+        assert violations == [], f"Unexpected unguarded become violations: {violations}"

--- a/ROOTLESS_DEPLOYMENT_STEPS.md
+++ b/ROOTLESS_DEPLOYMENT_STEPS.md
@@ -110,6 +110,33 @@ journalctl --user -u cp-kafka_broker           # logs
 # produce/consume; RBAC: curl -sk -u mds:password https://<host>:8090/security/1.0/authenticate → 200
 ```
 
+## 5. Proving it's actually rootless
+
+Creating `deployment_user` (step 2) doesn't by itself prove the *deploy* (step 3) never escalates —
+that admin account still has sudo. Confirm the deploy user genuinely can't escalate, and that
+nothing did, with checks like these:
+
+**Before the run** — the deploy user has no path to root:
+```bash
+sudo -u <deployment_user> sudo -n true; echo $?   # non-zero = no passwordless sudo
+```
+If you're provisioning `deployment_user` yourself (the no-sudo path in step 2), give it its own
+account with **no** entry in `wheel`/`sudo`/any sudoers file — don't just reuse a cloud image's
+default admin account (e.g. `ec2-user`), which usually has passwordless sudo and so proves
+nothing about rootlessness.
+
+**After the run** — nothing escalated:
+```bash
+find <deployment_path> -not -user <deployment_user>   # no root-owned files - empty output
+ps -eo user,cmd | awk '$1 == "root"' | grep -i 'kafka\|confluent'  # no root-owned CP process
+systemctl list-units 'cp-*' --no-legend                # system-scope - empty, none exist
+systemctl --user list-units 'cp-*' --no-legend         # user-scope - the real running units
+```
+A task that's missing its `when: not (rootless_enabled|bool)` guard on `become: true` fails loudly
+here (`sudo: a password is required`) instead of silently succeeding, precisely because the deploy
+user has nothing to escalate to - so a clean run through these checks is a real proof of
+rootlessness, not just an absence of errors.
+
 ---
 
 ## Per-config notes

--- a/docs/VARIABLES.md
+++ b/docs/VARIABLES.md
@@ -152,7 +152,7 @@ Default:  false
 
 Full path to download the Jolokia Agent Jar
 
-Default:  /opt/jolokia/jolokia.jar
+Default:  "{{ (deployment_path ~ '/jolokia/jolokia.jar') if deployment_path | length > 0 else '/opt/jolokia/jolokia.jar' }}"
 
 ***
 
@@ -352,7 +352,7 @@ Default:  false
 
 Full path to download the Prometheus Exporter Agent Jar
 
-Default:  /opt/prometheus/jmx_prometheus_javaagent.jar
+Default:  "{{ (deployment_path ~ '/jmx_exporter/jmx_prometheus_javaagent.jar') if deployment_path | length > 0 else '/opt/prometheus/jmx_prometheus_javaagent.jar' }}"
 
 ***
 
@@ -432,7 +432,7 @@ Default:  true
 
 Custom path for the location of kerberos client configuration file, works with any value of kerberos_configure
 
-Default:  /etc/krb5.conf
+Default:  "{{ (deployment_path ~ '/krb5.conf') if deployment_path | length > 0 else '/etc/krb5.conf' }}"
 
 ***
 
@@ -612,11 +612,43 @@ Default:  "package"
 
 ***
 
+### deployment_path
+
+Rootless base path/user/group - install paths, users/groups, and data/log dirs derive from these. Empty = no change.
+
+Default:  ""
+
+***
+
+### rootless_enabled
+
+Master switch for rootless deploys - skips root-requiring steps and runs the systemd --user lifecycle instead. Default false = no change.
+
+Default:  false
+
+***
+
+### rootless_lifecycle_enabled
+
+Generates a systemd --user unit per component instead of system-level systemd. Defaults to rootless_enabled; can be set independently.
+
+Default:  "{{ rootless_enabled }}"
+
+***
+
+### rootless_lifecycle_bin_dir
+
+Directory the rootless lifecycle env-file + start/stop scripts are written to.
+
+Default:  "{{ (deployment_path ~ '/rootless-bin') if deployment_path | length > 0 else (archive_destination_path ~ '/rootless-bin') }}"
+
+***
+
 ### archive_destination_path
 
 The path the downloaded archive is expanded into. Using the default with a `confluent_package_version` of *5.5.1* results in the following installation path `/opt/confluent/confluent-5.5.1/` that contains directories such as `bin` and `share`, but may be overridden usinf the `binary_base_path` property.
 
-Default:  "/opt/confluent"
+Default:  "{{ (deployment_path ~ '/confluent') if deployment_path | length > 0 else '/opt/confluent' }}"
 
 ***
 
@@ -672,7 +704,7 @@ Default:  "{{ secrets_protection_enabled }}"
 
 The path the Confluent CLI archive is expanded into.
 
-Default:  /opt/confluent-cli
+Default:  "{{ (deployment_path ~ '/confluent-cli') if deployment_path | length > 0 else '/opt/confluent-cli' }}"
 
 ***
 
@@ -680,7 +712,7 @@ Default:  /opt/confluent-cli
 
 Full path on hosts for Confluent CLI symlink to executable
 
-Default:  "/usr/local/bin/confluent"
+Default:  "{{ (confluent_cli_base_path ~ '/confluent') if deployment_path | length > 0 else '/usr/local/bin/confluent' }}"
 
 ***
 
@@ -744,7 +776,7 @@ Default:  "{{ false if ssl_provided_keystore_and_truststore|bool or ssl_custom_c
 
 Directory on hosts to store all ssl files.
 
-Default:  /var/ssl/private/
+Default:  "{{ (deployment_path ~ '/ssl') if deployment_path | length > 0 else '/var/ssl/private/' }}"
 
 ***
 
@@ -1120,7 +1152,7 @@ Default:  zookeeper.yml
 
 Destination path for Zookeeper jmx config file
 
-Default:  /opt/prometheus/zookeeper.yml
+Default:  "{{ (deployment_path ~ '/jmx_exporter/zookeeper.yml') if deployment_path | length > 0 else '/opt/prometheus/zookeeper.yml' }}"
 
 ***
 
@@ -1360,7 +1392,7 @@ Default:  kafka.yml.j2
 
 Destination path for Kafka controller jmx config file
 
-Default:  /opt/prometheus/kafka.yml
+Default:  "{{ (deployment_path ~ '/jmx_exporter/kafka_controller.yml') if deployment_path | length > 0 else '/opt/prometheus/kafka.yml' }}"
 
 ***
 
@@ -1592,7 +1624,7 @@ Default:  kafka.yml.j2
 
 Destination path for Kafka Broker jmx config file
 
-Default:  /opt/prometheus/kafka.yml
+Default:  "{{ (deployment_path ~ '/jmx_exporter/kafka.yml') if deployment_path | length > 0 else '/opt/prometheus/kafka.yml' }}"
 
 ***
 
@@ -1824,7 +1856,7 @@ Default:  schema_registry.yml
 
 Destination path for Schema Registry jmx config file
 
-Default:  /opt/prometheus/schema_registry.yml
+Default:  "{{ (deployment_path ~ '/jmx_exporter/schema_registry.yml') if deployment_path | length > 0 else '/opt/prometheus/schema_registry.yml' }}"
 
 ***
 
@@ -2016,7 +2048,7 @@ Default:  kafka_rest.yml
 
 Destination path for Rest Proxy jmx config file
 
-Default:  /opt/prometheus/kafka_rest.yml
+Default:  "{{ (deployment_path ~ '/jmx_exporter/kafka_rest.yml') if deployment_path | length > 0 else '/opt/prometheus/kafka_rest.yml' }}"
 
 ***
 
@@ -2248,7 +2280,7 @@ Default:  kafka_connect.yml
 
 Destination path for Connect jmx config file
 
-Default:  /opt/prometheus/kafka_connect.yml
+Default:  "{{ (deployment_path ~ '/jmx_exporter/kafka_connect.yml') if deployment_path | length > 0 else '/opt/prometheus/kafka_connect.yml' }}"
 
 ***
 
@@ -2488,7 +2520,7 @@ Default:  ksql.yml
 
 Destination path for ksqlDB jmx config file
 
-Default:  /opt/prometheus/ksql.yml
+Default:  "{{ (deployment_path ~ '/jmx_exporter/ksql.yml') if deployment_path | length > 0 else '/opt/prometheus/ksql.yml' }}"
 
 ***
 
@@ -4040,7 +4072,7 @@ Default:  7777
 
 Full path to download the Jolokia Agent Jar.
 
-Default:  /opt/jolokia/jolokia.jar
+Default:  "{{ (deployment_path ~ '/jolokia/jolokia.jar') if deployment_path | length > 0 else '/opt/jolokia/jolokia.jar' }}"
 
 ***
 

--- a/docs/VARIABLES.md
+++ b/docs/VARIABLES.md
@@ -152,7 +152,7 @@ Default:  false
 
 Full path to download the Jolokia Agent Jar
 
-Default:  "{{ (deployment_path ~ '/jolokia/jolokia.jar') if deployment_path | length > 0 else '/opt/jolokia/jolokia.jar' }}"
+Default:  "{{ (deployment_path_final ~ '/jolokia/jolokia.jar') if deployment_path | length > 0 else '/opt/jolokia/jolokia.jar' }}"
 
 ***
 
@@ -352,7 +352,7 @@ Default:  false
 
 Full path to download the Prometheus Exporter Agent Jar
 
-Default:  "{{ (deployment_path ~ '/jmx_exporter/jmx_prometheus_javaagent.jar') if deployment_path | length > 0 else '/opt/prometheus/jmx_prometheus_javaagent.jar' }}"
+Default:  "{{ (deployment_path_final ~ '/jmx_exporter/jmx_prometheus_javaagent.jar') if deployment_path | length > 0 else '/opt/prometheus/jmx_prometheus_javaagent.jar' }}"
 
 ***
 
@@ -432,7 +432,7 @@ Default:  true
 
 Custom path for the location of kerberos client configuration file, works with any value of kerberos_configure
 
-Default:  "{{ (deployment_path ~ '/krb5.conf') if deployment_path | length > 0 else '/etc/krb5.conf' }}"
+Default:  "{{ (deployment_path_final ~ '/krb5.conf') if deployment_path | length > 0 else '/etc/krb5.conf' }}"
 
 ***
 
@@ -614,7 +614,7 @@ Default:  "package"
 
 ### deployment_path
 
-Rootless base path/user/group - install paths, users/groups, and data/log dirs derive from these. Empty = no change.
+Rootless base path/user/group - install paths, users/groups, and data/log dirs derive from these. Empty deployment_path/deployment_user = no change.
 
 Default:  ""
 
@@ -640,7 +640,7 @@ Default:  "{{ rootless_enabled }}"
 
 Directory the rootless lifecycle env-file + start/stop scripts are written to.
 
-Default:  "{{ (deployment_path ~ '/rootless-bin') if deployment_path | length > 0 else (archive_destination_path ~ '/rootless-bin') }}"
+Default:  "{{ (deployment_path_final ~ '/rootless-bin') if deployment_path | length > 0 else (archive_destination_path ~ '/rootless-bin') }}"
 
 ***
 
@@ -648,7 +648,7 @@ Default:  "{{ (deployment_path ~ '/rootless-bin') if deployment_path | length > 
 
 The path the downloaded archive is expanded into. Using the default with a `confluent_package_version` of *5.5.1* results in the following installation path `/opt/confluent/confluent-5.5.1/` that contains directories such as `bin` and `share`, but may be overridden usinf the `binary_base_path` property.
 
-Default:  "{{ (deployment_path ~ '/confluent') if deployment_path | length > 0 else '/opt/confluent' }}"
+Default:  "{{ (deployment_path_final ~ '/confluent') if deployment_path | length > 0 else '/opt/confluent' }}"
 
 ***
 
@@ -704,7 +704,7 @@ Default:  "{{ secrets_protection_enabled }}"
 
 The path the Confluent CLI archive is expanded into.
 
-Default:  "{{ (deployment_path ~ '/confluent-cli') if deployment_path | length > 0 else '/opt/confluent-cli' }}"
+Default:  "{{ (deployment_path_final ~ '/confluent-cli') if deployment_path | length > 0 else '/opt/confluent-cli' }}"
 
 ***
 
@@ -776,7 +776,7 @@ Default:  "{{ false if ssl_provided_keystore_and_truststore|bool or ssl_custom_c
 
 Directory on hosts to store all ssl files.
 
-Default:  "{{ (deployment_path ~ '/ssl') if deployment_path | length > 0 else '/var/ssl/private/' }}"
+Default:  "{{ (deployment_path_final ~ '/ssl') if deployment_path | length > 0 else '/var/ssl/private/' }}"
 
 ***
 
@@ -1152,7 +1152,7 @@ Default:  zookeeper.yml
 
 Destination path for Zookeeper jmx config file
 
-Default:  "{{ (deployment_path ~ '/jmx_exporter/zookeeper.yml') if deployment_path | length > 0 else '/opt/prometheus/zookeeper.yml' }}"
+Default:  "{{ (deployment_path_final ~ '/jmx_exporter/zookeeper.yml') if deployment_path | length > 0 else '/opt/prometheus/zookeeper.yml' }}"
 
 ***
 
@@ -1392,7 +1392,7 @@ Default:  kafka.yml.j2
 
 Destination path for Kafka controller jmx config file
 
-Default:  "{{ (deployment_path ~ '/jmx_exporter/kafka_controller.yml') if deployment_path | length > 0 else '/opt/prometheus/kafka.yml' }}"
+Default:  "{{ (deployment_path_final ~ '/jmx_exporter/kafka_controller.yml') if deployment_path | length > 0 else '/opt/prometheus/kafka.yml' }}"
 
 ***
 
@@ -1624,7 +1624,7 @@ Default:  kafka.yml.j2
 
 Destination path for Kafka Broker jmx config file
 
-Default:  "{{ (deployment_path ~ '/jmx_exporter/kafka.yml') if deployment_path | length > 0 else '/opt/prometheus/kafka.yml' }}"
+Default:  "{{ (deployment_path_final ~ '/jmx_exporter/kafka.yml') if deployment_path | length > 0 else '/opt/prometheus/kafka.yml' }}"
 
 ***
 
@@ -1856,7 +1856,7 @@ Default:  schema_registry.yml
 
 Destination path for Schema Registry jmx config file
 
-Default:  "{{ (deployment_path ~ '/jmx_exporter/schema_registry.yml') if deployment_path | length > 0 else '/opt/prometheus/schema_registry.yml' }}"
+Default:  "{{ (deployment_path_final ~ '/jmx_exporter/schema_registry.yml') if deployment_path | length > 0 else '/opt/prometheus/schema_registry.yml' }}"
 
 ***
 
@@ -2048,7 +2048,7 @@ Default:  kafka_rest.yml
 
 Destination path for Rest Proxy jmx config file
 
-Default:  "{{ (deployment_path ~ '/jmx_exporter/kafka_rest.yml') if deployment_path | length > 0 else '/opt/prometheus/kafka_rest.yml' }}"
+Default:  "{{ (deployment_path_final ~ '/jmx_exporter/kafka_rest.yml') if deployment_path | length > 0 else '/opt/prometheus/kafka_rest.yml' }}"
 
 ***
 
@@ -2280,7 +2280,7 @@ Default:  kafka_connect.yml
 
 Destination path for Connect jmx config file
 
-Default:  "{{ (deployment_path ~ '/jmx_exporter/kafka_connect.yml') if deployment_path | length > 0 else '/opt/prometheus/kafka_connect.yml' }}"
+Default:  "{{ (deployment_path_final ~ '/jmx_exporter/kafka_connect.yml') if deployment_path | length > 0 else '/opt/prometheus/kafka_connect.yml' }}"
 
 ***
 
@@ -2520,7 +2520,7 @@ Default:  ksql.yml
 
 Destination path for ksqlDB jmx config file
 
-Default:  "{{ (deployment_path ~ '/jmx_exporter/ksql.yml') if deployment_path | length > 0 else '/opt/prometheus/ksql.yml' }}"
+Default:  "{{ (deployment_path_final ~ '/jmx_exporter/ksql.yml') if deployment_path | length > 0 else '/opt/prometheus/ksql.yml' }}"
 
 ***
 
@@ -4072,7 +4072,7 @@ Default:  7777
 
 Full path to download the Jolokia Agent Jar.
 
-Default:  "{{ (deployment_path ~ '/jolokia/jolokia.jar') if deployment_path | length > 0 else '/opt/jolokia/jolokia.jar' }}"
+Default:  "{{ (deployment_path_final ~ '/jolokia/jolokia.jar') if deployment_path | length > 0 else '/opt/jolokia/jolokia.jar' }}"
 
 ***
 
@@ -4080,7 +4080,7 @@ Default:  "{{ (deployment_path ~ '/jolokia/jolokia.jar') if deployment_path | le
 
 Set this variable to customize the directory that Kafka Connect Replicator writes log files to.
 
-Default:  /var/log/confluent/kafka-connect-replicator
+Default:  "{{ (deployment_path_final ~ '/log/kafka-connect-replicator') if deployment_path | length > 0 else '/var/log/confluent/kafka-connect-replicator' }}"
 
 ***
 
@@ -4248,7 +4248,7 @@ Default:  ""
 
 Set this variable to override the default location of the public pem file for connecting to the ERP when RBAC is enabled.
 
-Default:  /var/ssl/private/kafka_connect_replicator/public.pem
+Default:  "{{ (deployment_path_final ~ '/kafka_connect_replicator/public.pem') if deployment_path | length > 0 else '/var/ssl/private/kafka_connect_replicator/public.pem' }}"
 
 ***
 
@@ -4448,7 +4448,7 @@ Default:  ""
 
 Set this variable to override the default location of the public pem file for connecting to the ERP when RBAC is enabled.
 
-Default:  /var/ssl/private/kafka_connect_replicator_consumer/public.pem
+Default:  "{{ (deployment_path_final ~ '/kafka_connect_replicator_consumer/public.pem') if deployment_path | length > 0 else '/var/ssl/private/kafka_connect_replicator_consumer/public.pem' }}"
 
 ***
 

--- a/docs/sample_inventories/non_root_deployment_rbac_ldap.yml
+++ b/docs/sample_inventories/non_root_deployment_rbac_ldap.yml
@@ -1,0 +1,100 @@
+---
+### NON-ROOT CP installation - RBAC over LDAP + mTLS
+##
+## Sample inventory for a rootless install with RBAC authorization backed by an external
+## LDAP server. Builds on non_root_deployment.yml (read that one first) - only the RBAC/LDAP/
+## mTLS-specific additions are new here.
+##
+## What you need before running this: a reachable LDAP server with an "ou=rbac" tree
+## (uid-based users, objectClass account), and its bind DN/password for the mds service
+## account. Fill in ldap_base_properties, mds_super_user*, and each component's
+## <component>_ldap_user/<component>_ldap_password below to match your real LDAP directory.
+
+all:
+  vars:
+    ansible_user: cp-user
+    ansible_become: false
+
+    rootless_enabled: true
+    deployment_user: cp-user
+    deployment_group: cp-user
+    deployment_path: /cp-data
+    installation_method: archive
+
+    ## --- How to run: same two-phase flow as non_root_deployment.yml ---------------------
+    ## 1. ansible-playbook -i <this-inventory> confluent.platform.rootless_bootstrap -e ansible_user=<admin>
+    ## 2. ansible-playbook -i <this-inventory> confluent.platform.all
+
+    ## --- mTLS: cp-ansible generates a self-signed CA + certs per component ---------------
+    ssl_enabled: true
+    ssl_mutual_auth_enabled: true
+
+    ## --- RBAC over LDAP --------------------------------------------------------------------
+    rbac_enabled: true
+
+    # The MDS super user account, as provisioned in your LDAP directory (uid + password).
+    mds_super_user: mds
+    mds_super_user_password: "<fill in - LDAP bind password for the mds account>"
+
+    # LDAP connection + schema mapping MDS uses to resolve users/groups. Adjust the DNs,
+    # search bases, and attribute names to match your actual LDAP directory's schema -
+    # this example assumes a flat "ou=rbac,dc=<domain>" tree with uid-keyed POSIX accounts.
+    ldap_base_properties: &ldap_base_properties
+      confluent.authorizer.init.timeout.ms: 1800000
+      ldap.java.naming.factory.initial: com.sun.jndi.ldap.LdapCtxFactory
+      ldap.com.sun.jndi.ldap.read.timeout: 3000
+      ldap.java.naming.provider.url: "ldap://<your-ldap-host>:389"
+      ldap.java.naming.security.principal: "uid=mds,OU=rbac,DC=<your-dc>,DC=<your-dc-extension>"
+      ldap.java.naming.security.credentials: "{{ mds_super_user_password }}"
+      ldap.java.naming.security.authentication: simple
+      ldap.user.search.base: "OU=rbac,DC=<your-dc>,DC=<your-dc-extension>"
+      ldap.group.search.base: "OU=rbac,DC=<your-dc>,DC=<your-dc-extension>"
+      ldap.user.name.attribute: uid
+      ldap.user.memberof.attribute.pattern: "CN=(.*),OU=rbac,DC=<your-dc>,DC=<your-dc-extension>"
+      ldap.group.name.attribute: cn
+      ldap.group.member.attribute.pattern: "CN=(.*),OU=rbac,DC=<your-dc>,DC=<your-dc-extension>"
+      ldap.user.object.class: account
+
+    kafka_broker_custom_properties: *ldap_base_properties
+    kafka_controller_custom_properties: *ldap_base_properties
+
+    # Each component authenticates to MDS as its own LDAP-provisioned account.
+    schema_registry_ldap_user: schema-registry1
+    schema_registry_ldap_password: "<fill in>"
+    kafka_connect_ldap_user: kafka-connect1
+    kafka_connect_ldap_password: "<fill in>"
+    kafka_rest_ldap_user: kafka-rest1
+    kafka_rest_ldap_password: "<fill in>"
+    ksql_ldap_user: ksql1
+    ksql_ldap_password: "<fill in>"
+    control_center_ldap_user: control-center1
+    control_center_ldap_password: "<fill in>"
+
+kafka_controller:
+  hosts:
+    <your-controller-hostname>:
+      ansible_user: "{{ deployment_user }}"
+kafka_broker:
+  hosts:
+    <your-broker-hostname>:
+      ansible_user: "{{ deployment_user }}"
+schema_registry:
+  hosts:
+    <your-schema-registry-hostname>:
+      ansible_user: "{{ deployment_user }}"
+kafka_connect:
+  hosts:
+    <your-kafka-connect-hostname>:
+      ansible_user: "{{ deployment_user }}"
+kafka_rest:
+  hosts:
+    <your-kafka-rest-hostname>:
+      ansible_user: "{{ deployment_user }}"
+ksql:
+  hosts:
+    <your-ksql-hostname>:
+      ansible_user: "{{ deployment_user }}"
+control_center:
+  hosts:
+    <your-control-center-hostname>:
+      ansible_user: "{{ deployment_user }}"

--- a/docs/sample_inventories/non_root_deployment_rbac_oauth.yml
+++ b/docs/sample_inventories/non_root_deployment_rbac_oauth.yml
@@ -1,0 +1,110 @@
+---
+### NON-ROOT CP installation - RBAC over LDAP + OAuth/OIDC SSO for Control Center
+##
+## Sample inventory for a rootless install where Control Center's own login uses SSO via an
+## external OAuth/OIDC provider (e.g. Keycloak, Okta, Azure AD), layered on top of the same
+## LDAP-backed RBAC authorization as non_root_deployment_rbac_ldap.yml - read that one first,
+## everything in it still applies. This file only adds the sso_* block.
+##
+## OAuth/OIDC here replaces nothing about how MDS authorizes access (still LDAP-backed) - it
+## only changes how a human logs into the Control Center UI. sso_client_id/sso_client_password
+## must be a confidential client registered on your IdP with service accounts enabled.
+
+all:
+  vars:
+    ansible_user: cp-user
+    ansible_become: false
+
+    rootless_enabled: true
+    deployment_user: cp-user
+    deployment_group: cp-user
+    deployment_path: /cp-data
+    installation_method: archive
+
+    ## --- How to run: same two-phase flow as non_root_deployment.yml ---------------------
+    ## 1. ansible-playbook -i <this-inventory> confluent.platform.rootless_bootstrap -e ansible_user=<admin>
+    ## 2. ansible-playbook -i <this-inventory> confluent.platform.all
+
+    ssl_enabled: true
+    ssl_mutual_auth_enabled: true
+
+    ## --- RBAC over LDAP: identical to non_root_deployment_rbac_ldap.yml -----------------
+    rbac_enabled: true
+    mds_super_user: mds
+    mds_super_user_password: "<fill in - LDAP bind password for the mds account>"
+
+    ldap_base_properties: &ldap_base_properties
+      confluent.authorizer.init.timeout.ms: 1800000
+      ldap.java.naming.factory.initial: com.sun.jndi.ldap.LdapCtxFactory
+      ldap.com.sun.jndi.ldap.read.timeout: 3000
+      ldap.java.naming.provider.url: "ldap://<your-ldap-host>:389"
+      ldap.java.naming.security.principal: "uid=mds,OU=rbac,DC=<your-dc>,DC=<your-dc-extension>"
+      ldap.java.naming.security.credentials: "{{ mds_super_user_password }}"
+      ldap.java.naming.security.authentication: simple
+      ldap.user.search.base: "OU=rbac,DC=<your-dc>,DC=<your-dc-extension>"
+      ldap.group.search.base: "OU=rbac,DC=<your-dc>,DC=<your-dc-extension>"
+      ldap.user.name.attribute: uid
+      ldap.user.memberof.attribute.pattern: "CN=(.*),OU=rbac,DC=<your-dc>,DC=<your-dc-extension>"
+      ldap.group.name.attribute: cn
+      ldap.group.member.attribute.pattern: "CN=(.*),OU=rbac,DC=<your-dc>,DC=<your-dc-extension>"
+      ldap.user.object.class: account
+
+    kafka_broker_custom_properties: *ldap_base_properties
+    kafka_controller_custom_properties: *ldap_base_properties
+
+    schema_registry_ldap_user: schema-registry1
+    schema_registry_ldap_password: "<fill in>"
+    kafka_connect_ldap_user: kafka-connect1
+    kafka_connect_ldap_password: "<fill in>"
+    kafka_rest_ldap_user: kafka-rest1
+    kafka_rest_ldap_password: "<fill in>"
+    ksql_ldap_user: ksql1
+    ksql_ldap_password: "<fill in>"
+    control_center_ldap_user: control-center1
+    control_center_ldap_password: "<fill in>"
+
+    ## --- OAuth/OIDC SSO for Control Center, layered on top of the LDAP-backed MDS above ---
+    ## sso_* is read by roles/kafka_broker/tasks/main.yml (the MDS/broker side of the OIDC
+    ## integration) - set these from your IdP's OIDC discovery document
+    ## (<issuer>/.well-known/openid-configuration) and the confidential client you register there.
+    sso_mode: oidc
+    sso_groups_claim: groups
+    sso_sub_claim: sub
+    sso_issuer_url: "https://<your-idp-host>/realms/<your-realm>"
+    sso_jwks_uri: "https://<your-idp-host>/realms/<your-realm>/protocol/openid-connect/certs"
+    sso_authorize_uri: "https://<your-idp-host>/realms/<your-realm>/protocol/openid-connect/auth"
+    sso_token_uri: "https://<your-idp-host>/realms/<your-realm>/protocol/openid-connect/token"
+    sso_client_id: control_center
+    sso_client_password: "<fill in - the client secret from your IdP>"
+    # Only needed if your IdP's HTTPS listener uses a certificate your hosts don't already
+    # trust (e.g. self-signed/internal CA). Path is on the Ansible control node.
+    # sso_idp_cert_path: /path/to/idp-ca-or-leaf-cert.pem
+
+kafka_controller:
+  hosts:
+    <your-controller-hostname>:
+      ansible_user: "{{ deployment_user }}"
+kafka_broker:
+  hosts:
+    <your-broker-hostname>:
+      ansible_user: "{{ deployment_user }}"
+schema_registry:
+  hosts:
+    <your-schema-registry-hostname>:
+      ansible_user: "{{ deployment_user }}"
+kafka_connect:
+  hosts:
+    <your-kafka-connect-hostname>:
+      ansible_user: "{{ deployment_user }}"
+kafka_rest:
+  hosts:
+    <your-kafka-rest-hostname>:
+      ansible_user: "{{ deployment_user }}"
+ksql:
+  hosts:
+    <your-ksql-hostname>:
+      ansible_user: "{{ deployment_user }}"
+control_center:
+  hosts:
+    <your-control-center-hostname>:
+      ansible_user: "{{ deployment_user }}"

--- a/molecule/rootless-oauth-ubuntu2004/molecule.yml
+++ b/molecule/rootless-oauth-ubuntu2004/molecule.yml
@@ -5,6 +5,15 @@
 ### apt/dbus-user-session branch on Ubuntu. ldap1 mirrors
 ### rootless-rbac-ldap-rhel9 (native openldap-servers, CentOS8). oauth1 is the
 ### same Keycloak container rbac-mds-scram-custom-rhel uses.
+###
+### Known container limitations (not fixable here, called out for reviewers):
+### - privileged: true + cgroupns_mode: host is required for systemd --user to run inside
+###   Docker at all - it does NOT mean the deploy itself used root. That's verified instead
+###   by asserting every file under deployment_path is owned by deployment_user (verify.yml)
+###   and by the extensive live-EC2 (non-containerized) verification recorded in
+###   ROOTLESS_DEPLOYMENT_STEPS.md.
+### - loginctl enable-linger surviving an actual host reboot is a design promise that isn't
+###   exercisable in a container (no real reboot) - also only verified live on EC2.
 
 driver:
   name: docker
@@ -140,6 +149,7 @@ platforms:
 provisioner:
   playbooks:
     converge: converge.yml
+    side_effect: side_effect.yml
     verify: verify.yml
   inventory:
     group_vars:

--- a/molecule/rootless-oauth-ubuntu2004/side_effect.yml
+++ b/molecule/rootless-oauth-ubuntu2004/side_effect.yml
@@ -1,0 +1,35 @@
+---
+### Regression test for the restart-propagation fix in this PR: rootless_lifecycle.yml's
+### "Generate ... EnvironmentFile" / "Generate ... systemd --user unit" tasks now notify
+### the component's restart handler on change (previously they didn't - a rewritten file
+### never actually restarted the running unit). Give kafka_broker a *_service_unit_overrides
+### value it didn't have before (default is empty) and let verify.yml confirm the unit
+### actually restarted, not just that the file on disk changed.
+
+- name: Capture kafka_broker's unit start time before the side effect
+  hosts: kafka_broker
+  gather_facts: false
+  tasks:
+    - name: Get ActiveEnterTimestamp before the change
+      command: systemctl --user show cp-kafka_broker.service -p ActiveEnterTimestamp --value
+      environment:
+        XDG_RUNTIME_DIR: "/run/user/{{ ansible_user_uid }}"
+      register: before_ts
+      changed_when: false
+
+    - name: Save it so verify.yml (a separate ansible-playbook run) can compare
+      copy:
+        content: "{{ before_ts.stdout }}"
+        dest: /tmp/molecule_side_effect_before_ts
+        mode: '0644'
+
+- name: Inject a new unit override to force a real config change on kafka_broker
+  hosts: kafka_controller:kafka_broker:schema_registry:kafka_connect:kafka_rest:ksql:control_center
+  gather_facts: false
+  tasks:
+    - set_fact:
+        kafka_broker_service_unit_overrides:
+          StartLimitIntervalSec: "10"
+      when: "'kafka_broker' in group_names"
+
+- import_playbook: ../collections_converge.yml

--- a/molecule/rootless-oauth-ubuntu2004/side_effect.yml
+++ b/molecule/rootless-oauth-ubuntu2004/side_effect.yml
@@ -8,7 +8,7 @@
 
 - name: Capture kafka_broker's unit start time before the side effect
   hosts: kafka_broker
-  gather_facts: false
+  gather_facts: true
   tasks:
     - name: Get ActiveEnterTimestamp before the change
       command: systemctl --user show cp-kafka_broker.service -p ActiveEnterTimestamp --value

--- a/molecule/rootless-oauth-ubuntu2004/verify.yml
+++ b/molecule/rootless-oauth-ubuntu2004/verify.yml
@@ -88,10 +88,13 @@
     - name: Assert the EnvironmentFile actually rendered content, not empty or unrendered Jinja
       vars:
         env_content: "{{ env_file_slurp.content | b64decode }}"
+        # Built via multiplication, not a literal '{{', so ansible's own templating of this
+        # assert's `that:` strings doesn't try to parse it as the start of an expression.
+        unrendered_jinja_marker: "{{ '{' * 2 }}"
       assert:
         that:
           - env_content | trim | length > 0
-          - "'{{' not in env_content"
+          - unrendered_jinja_marker not in env_content
         fail_msg: "{{ rootless_component }}.env is empty or has unrendered template syntax:\n{{ env_content }}"
         quiet: true
 

--- a/molecule/rootless-oauth-ubuntu2004/verify.yml
+++ b/molecule/rootless-oauth-ubuntu2004/verify.yml
@@ -19,9 +19,10 @@
       ksql: cp-ksql.service
       control_center: cp-control_center.service
   tasks:
-    - name: Determine this host's rootless unit name
+    - name: Determine this host's rootless unit name and component name
       set_fact:
         rootless_unit: "{{ rootless_unit_map[group_names | intersect(rootless_unit_map.keys()) | first] }}"
+        rootless_component: "{{ group_names | intersect(rootless_unit_map.keys()) | first }}"
 
     - name: Check the systemd --user unit is active
       command: "systemctl --user is-active {{ rootless_unit }}"
@@ -44,6 +45,56 @@
         fail_msg: "Expected all component processes to run as {{ deployment_user }}, found: {{ process_owners.stdout_lines }}"
         quiet: true
 
+    - name: Find everything under deployment_path
+      find:
+        paths: "{{ deployment_path }}"
+        recurse: true
+        file_type: any
+      register: deployment_path_contents
+
+    - name: Assert everything under deployment_path is owned by the deploy user, not root
+      # A privileged test container can docker-exec as root regardless of what the deploy
+      # itself did - this, not the container's own privilege level, is what actually proves
+      # nothing in the deploy path used root: a root-owned file here means some task silently
+      # became root.
+      vars:
+        non_deploy_user_files: "{{ deployment_path_contents.files | rejectattr('pw_name', 'equalto', deployment_user) | map(attribute='path') | list }}"
+      assert:
+        that:
+          - non_deploy_user_files | length == 0
+        fail_msg: "Found files under deployment_path not owned by {{ deployment_user }}: {{ non_deploy_user_files }}"
+        quiet: true
+
+    - name: Read the generated systemd --user unit file
+      slurp:
+        src: "{{ ansible_env.HOME }}/.config/systemd/user/{{ rootless_unit }}"
+      register: unit_file_slurp
+
+    - name: Assert the unit's ExecStart/EnvironmentFile point under deployment_path, not a hardcoded root path
+      vars:
+        unit_content: "{{ unit_file_slurp.content | b64decode }}"
+      assert:
+        that:
+          - deployment_path in unit_content
+          - ("EnvironmentFile=" ~ deployment_path) in unit_content
+        fail_msg: "cp-{{ rootless_component }} unit file doesn't reference deployment_path as expected:\n{{ unit_content }}"
+        quiet: true
+
+    - name: Read the generated systemd EnvironmentFile
+      slurp:
+        src: "{{ deployment_path }}/rootless-bin/{{ rootless_component }}.env"
+      register: env_file_slurp
+
+    - name: Assert the EnvironmentFile actually rendered content, not empty or unrendered Jinja
+      vars:
+        env_content: "{{ env_file_slurp.content | b64decode }}"
+      assert:
+        that:
+          - env_content | trim | length > 0
+          - "'{{' not in env_content"
+        fail_msg: "{{ rootless_component }}.env is empty or has unrendered template syntax:\n{{ env_content }}"
+        quiet: true
+
     - name: Check nothing was written under /opt
       find:
         paths: /opt
@@ -55,6 +106,38 @@
         that:
           - opt_contents.matched == 0
         fail_msg: "Rootless install wrote to /opt: {{ opt_contents.files | map(attribute='path') | list }}"
+        quiet: true
+
+- name: Verify - restart-propagation regression (side_effect.yml changed kafka_broker's config)
+  hosts: kafka_broker
+  gather_facts: false
+  tasks:
+    - name: Read the pre-side-effect timestamp
+      slurp:
+        src: /tmp/molecule_side_effect_before_ts
+      register: before_ts_slurp
+
+    - name: Get ActiveEnterTimestamp now
+      command: systemctl --user show cp-kafka_broker.service -p ActiveEnterTimestamp --value
+      environment:
+        XDG_RUNTIME_DIR: "/run/user/{{ ansible_user_uid }}"
+      register: after_ts
+      changed_when: false
+
+    - name: Confirm the generated unit actually carries the injected override
+      command: "grep -c StartLimitIntervalSec {{ ansible_env.HOME }}/.config/systemd/user/cp-kafka_broker.service"
+      register: override_grep
+      changed_when: false
+      failed_when: override_grep.stdout | trim == "0"
+
+    - name: Assert the unit restarted when its service_unit_overrides changed
+      assert:
+        that:
+          - after_ts.stdout != (before_ts_slurp.content | b64decode)
+        fail_msg: >-
+          cp-kafka_broker.service did not restart after its service_unit_overrides changed
+          (before={{ before_ts_slurp.content | b64decode }}, after={{ after_ts.stdout }}) -
+          the notify-on-change chain in rootless_lifecycle.yml regressed.
         quiet: true
 
 - name: Verify - MDS + RBAC/LDAP auth end to end

--- a/molecule/rootless-oauth-ubuntu2004/verify.yml
+++ b/molecule/rootless-oauth-ubuntu2004/verify.yml
@@ -110,7 +110,7 @@
 
 - name: Verify - restart-propagation regression (side_effect.yml changed kafka_broker's config)
   hosts: kafka_broker
-  gather_facts: false
+  gather_facts: true
   tasks:
     - name: Read the pre-side-effect timestamp
       slurp:

--- a/molecule/rootless-plain-debian10/converge.yml
+++ b/molecule/rootless-plain-debian10/converge.yml
@@ -8,7 +8,7 @@
 ### ansible_user via set_fact (which outranks group_vars) around the import.
 
 - name: Cache ansible_user=root so the imported bootstrap playbook connects as root
-  hosts: kafka_controller:kafka_broker:schema_registry:kafka_connect:kafka_rest:ksql:control_center
+  hosts: kafka_controller:kafka_broker:schema_registry:kafka_connect:kafka_rest:ksql:control_center:kafka_connect_replicator
   gather_facts: false
   vars:
     ansible_user: root
@@ -19,7 +19,7 @@
 - import_playbook: confluent.platform.rootless_bootstrap
 
 - name: Cache ansible_user=deployment_user so the unprivileged deploy connects as that user
-  hosts: kafka_controller:kafka_broker:schema_registry:kafka_connect:kafka_rest:ksql:control_center
+  hosts: kafka_controller:kafka_broker:schema_registry:kafka_connect:kafka_rest:ksql:control_center:kafka_connect_replicator
   gather_facts: false
   vars:
     ansible_user: root

--- a/molecule/rootless-plain-debian10/molecule.yml
+++ b/molecule/rootless-plain-debian10/molecule.yml
@@ -83,6 +83,19 @@ platforms:
     privileged: true
     networks:
       - name: confluent
+  - name: kafka-connect-replicator1
+    hostname: kafka-connect-replicator1.confluent
+    groups:
+      - kafka_connect_replicator
+    image: geerlingguy/docker-debian10-ansible
+    dockerfile: ../Dockerfile-debian10-archive.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent
   - name: ksql1
     hostname: ksql1.confluent
     groups:
@@ -166,5 +179,14 @@ provisioner:
         ansible_user: "{{ deployment_user }}"
       control_center:
         ansible_user: "{{ deployment_user }}"
+      kafka_connect_replicator:
+        ansible_user: "{{ deployment_user }}"
+        # Defaults to localhost:9092, which only works when co-located with the broker on
+        # the same host - each component here is its own container, so point explicitly
+        # at kafka-broker1's real address (self-replication: source and destination are the
+        # same cluster, which is fine for exercising the rootless lifecycle/restart/ownership
+        # mechanics - not testing replication correctness itself).
+        kafka_connect_replicator_consumer_bootstrap_servers: "kafka-broker1.confluent:9092"
+        kafka_connect_replicator_producer_bootstrap_servers: "kafka-broker1.confluent:9092"
 verifier:
   name: ansible

--- a/molecule/rootless-plain-debian10/molecule.yml
+++ b/molecule/rootless-plain-debian10/molecule.yml
@@ -188,5 +188,9 @@ provisioner:
         # mechanics - not testing replication correctness itself).
         kafka_connect_replicator_consumer_bootstrap_servers: "kafka-broker1.confluent:9092"
         kafka_connect_replicator_producer_bootstrap_servers: "kafka-broker1.confluent:9092"
+        # kafka_connect_replicator_{keystore,truststore}_storepass default to "" - every other
+        # kafka_connect_replicator molecule scenario sets these explicitly, so do the same here.
+        kafka_connect_replicator_truststore_storepass: confluenttruststorepass
+        kafka_connect_replicator_keystore_storepass: confluentkeystorestorepass
 verifier:
   name: ansible

--- a/molecule/rootless-plain-debian10/molecule.yml
+++ b/molecule/rootless-plain-debian10/molecule.yml
@@ -5,6 +5,15 @@
 ### before CP 7.8 - this branch is 7.6.x, and kraft.py excludes any scenario
 ### with "scram" in its name for exactly that reason. Zookeeper mode would
 ### dodge that but has zero rootless support of its own - out of scope here.)
+###
+### Known container limitations (not fixable here, called out for reviewers):
+### - privileged: true + cgroupns_mode: host is required for systemd --user to run inside
+###   Docker at all - it does NOT mean the deploy itself used root. That's verified instead
+###   by asserting every file under deployment_path is owned by deployment_user (verify.yml)
+###   and by the extensive live-EC2 (non-containerized) verification recorded in
+###   ROOTLESS_DEPLOYMENT_STEPS.md.
+### - loginctl enable-linger surviving an actual host reboot is a design promise that isn't
+###   exercisable in a container (no real reboot) - also only verified live on EC2.
 
 driver:
   name: docker
@@ -103,13 +112,18 @@ platforms:
 provisioner:
   playbooks:
     converge: converge.yml
+    side_effect: side_effect.yml
     verify: verify.yml
   inventory:
     group_vars:
       all:
         rootless_enabled: true
         deployment_user: cp-user
-        deployment_group: cp-user
+        # Deliberately distinct from deployment_user - the other two rootless scenarios
+        # use deployment_group == deployment_user, which never exercises group derivation
+        # as an independent value (e.g. rootless_bootstrap.yml's separate group/user
+        # creation tasks, file group ownership under deployment_path).
+        deployment_group: cp-platform
         deployment_path: /home/cp-user/cp-data
         installation_method: archive
         custom_java_path: /opt/jdk17

--- a/molecule/rootless-plain-debian10/molecule.yml
+++ b/molecule/rootless-plain-debian10/molecule.yml
@@ -118,13 +118,15 @@ provisioner:
     group_vars:
       all:
         rootless_enabled: true
-        deployment_user: cp-user
-        # Deliberately distinct from deployment_user - the other two rootless scenarios
-        # use deployment_group == deployment_user, which never exercises group derivation
-        # as an independent value (e.g. rootless_bootstrap.yml's separate group/user
-        # creation tasks, file group ownership under deployment_path).
+        # Deliberately mutually distinct, and deployment_path deliberately doesn't embed
+        # deployment_user as a path component - the other two rootless scenarios use
+        # deployment_user == deployment_group and deployment_path == /home/<deployment_user>/...,
+        # which never exercises any of the three as an independent value (e.g. code that
+        # accidentally hardcodes /home/{{ deployment_user }}/... instead of deployment_path,
+        # or assumes the group name matches the user name, would pass unnoticed there).
+        deployment_user: cpsvc
         deployment_group: cp-platform
-        deployment_path: /home/cp-user/cp-data
+        deployment_path: /data/confluent-rootless
         installation_method: archive
         custom_java_path: /opt/jdk17
 

--- a/molecule/rootless-plain-debian10/side_effect.yml
+++ b/molecule/rootless-plain-debian10/side_effect.yml
@@ -1,0 +1,35 @@
+---
+### Regression test for the restart-propagation fix in this PR: rootless_lifecycle.yml's
+### "Generate ... EnvironmentFile" / "Generate ... systemd --user unit" tasks now notify
+### the component's restart handler on change (previously they didn't - a rewritten file
+### never actually restarted the running unit). Give kafka_broker a *_service_unit_overrides
+### value it didn't have before (default is empty) and let verify.yml confirm the unit
+### actually restarted, not just that the file on disk changed.
+
+- name: Capture kafka_broker's unit start time before the side effect
+  hosts: kafka_broker
+  gather_facts: false
+  tasks:
+    - name: Get ActiveEnterTimestamp before the change
+      command: systemctl --user show cp-kafka_broker.service -p ActiveEnterTimestamp --value
+      environment:
+        XDG_RUNTIME_DIR: "/run/user/{{ ansible_user_uid }}"
+      register: before_ts
+      changed_when: false
+
+    - name: Save it so verify.yml (a separate ansible-playbook run) can compare
+      copy:
+        content: "{{ before_ts.stdout }}"
+        dest: /tmp/molecule_side_effect_before_ts
+        mode: '0644'
+
+- name: Inject a new unit override to force a real config change on kafka_broker
+  hosts: kafka_controller:kafka_broker:schema_registry:kafka_connect:kafka_rest:ksql:control_center
+  gather_facts: false
+  tasks:
+    - set_fact:
+        kafka_broker_service_unit_overrides:
+          StartLimitIntervalSec: "10"
+      when: "'kafka_broker' in group_names"
+
+- import_playbook: ../collections_converge.yml

--- a/molecule/rootless-plain-debian10/side_effect.yml
+++ b/molecule/rootless-plain-debian10/side_effect.yml
@@ -24,7 +24,7 @@
         mode: '0644'
 
 - name: Inject a new unit override to force a real config change on kafka_broker
-  hosts: kafka_controller:kafka_broker:schema_registry:kafka_connect:kafka_rest:ksql:control_center
+  hosts: kafka_controller:kafka_broker:schema_registry:kafka_connect:kafka_rest:ksql:control_center:kafka_connect_replicator
   gather_facts: false
   tasks:
     - set_fact:

--- a/molecule/rootless-plain-debian10/side_effect.yml
+++ b/molecule/rootless-plain-debian10/side_effect.yml
@@ -8,7 +8,7 @@
 
 - name: Capture kafka_broker's unit start time before the side effect
   hosts: kafka_broker
-  gather_facts: false
+  gather_facts: true
   tasks:
     - name: Get ActiveEnterTimestamp before the change
       command: systemctl --user show cp-kafka_broker.service -p ActiveEnterTimestamp --value

--- a/molecule/rootless-plain-debian10/verify.yml
+++ b/molecule/rootless-plain-debian10/verify.yml
@@ -3,7 +3,7 @@
 ### under /opt, and SASL_PLAIN (+ SSL) is actually configured on each component.
 
 - name: Verify - rootless lifecycle on all CP components
-  hosts: kafka_controller:kafka_broker:schema_registry:kafka_connect:kafka_rest:ksql:control_center
+  hosts: kafka_controller:kafka_broker:schema_registry:kafka_connect:kafka_rest:ksql:control_center:kafka_connect_replicator
   gather_facts: true
   vars:
     rootless_unit_map:
@@ -14,6 +14,7 @@
       kafka_rest: cp-kafka_rest.service
       ksql: cp-ksql.service
       control_center: cp-control_center.service
+      kafka_connect_replicator: cp-kafka_connect_replicator.service
   tasks:
     - name: Determine this host's rootless unit name and component name
       set_fact:
@@ -29,7 +30,10 @@
       failed_when: unit_active.stdout != "active"
 
     - name: Check the process is owned by the deploy user, not root
-      shell: "ps -eo user,cmd | grep -E 'kafka.Kafka|SchemaRegistryMain|ConnectDistributed|KafkaRestMain|KsqlServerMain|ControlCenter' | grep -v grep | awk '{print $1}' | sort -u"
+      # Replicator's own class name isn't matched here, but its ExecStart args (--consumer.config
+      # .../kafka-connect-replicator-consumer.properties etc.) always contain "replicator", so that
+      # catches it too without needing the exact Main class.
+      shell: "ps -eo user,cmd | grep -E 'kafka.Kafka|SchemaRegistryMain|ConnectDistributed|KafkaRestMain|KsqlServerMain|ControlCenter|replicator' | grep -v grep | awk '{print $1}' | sort -u"
       register: process_owners
       changed_when: false
 
@@ -237,6 +241,19 @@
         validate_certs: false
       register: connector_status_response
       until: connector_status_response.json.tasks[0].state == 'RUNNING'
+      retries: 10
+      delay: 5
+
+- name: Verify - Kafka Connect Replicator REST API is up (rootless)
+  hosts: kafka_connect_replicator
+  gather_facts: false
+  tasks:
+    - name: Get Connectors on the replicator's own REST endpoint
+      uri:
+        url: "https://localhost:8083/connectors"
+        validate_certs: false
+      register: replicator_connectors
+      until: replicator_connectors.status == 200
       retries: 10
       delay: 5
 

--- a/molecule/rootless-plain-debian10/verify.yml
+++ b/molecule/rootless-plain-debian10/verify.yml
@@ -84,10 +84,13 @@
     - name: Assert the EnvironmentFile actually rendered content, not empty or unrendered Jinja
       vars:
         env_content: "{{ env_file_slurp.content | b64decode }}"
+        # Built via multiplication, not a literal '{{', so ansible's own templating of this
+        # assert's `that:` strings doesn't try to parse it as the start of an expression.
+        unrendered_jinja_marker: "{{ '{' * 2 }}"
       assert:
         that:
           - env_content | trim | length > 0
-          - "'{{' not in env_content"
+          - unrendered_jinja_marker not in env_content
         fail_msg: "{{ rootless_component }}.env is empty or has unrendered template syntax:\n{{ env_content }}"
         quiet: true
 

--- a/molecule/rootless-plain-debian10/verify.yml
+++ b/molecule/rootless-plain-debian10/verify.yml
@@ -15,9 +15,10 @@
       ksql: cp-ksql.service
       control_center: cp-control_center.service
   tasks:
-    - name: Determine this host's rootless unit name
+    - name: Determine this host's rootless unit name and component name
       set_fact:
         rootless_unit: "{{ rootless_unit_map[group_names | intersect(rootless_unit_map.keys()) | first] }}"
+        rootless_component: "{{ group_names | intersect(rootless_unit_map.keys()) | first }}"
 
     - name: Check the systemd --user unit is active
       command: "systemctl --user is-active {{ rootless_unit }}"
@@ -40,6 +41,56 @@
         fail_msg: "Expected all component processes to run as {{ deployment_user }}, found: {{ process_owners.stdout_lines }}"
         quiet: true
 
+    - name: Find everything under deployment_path
+      find:
+        paths: "{{ deployment_path }}"
+        recurse: true
+        file_type: any
+      register: deployment_path_contents
+
+    - name: Assert everything under deployment_path is owned by the deploy user, not root
+      # A privileged test container can docker-exec as root regardless of what the deploy
+      # itself did - this, not the container's own privilege level, is what actually proves
+      # nothing in the deploy path used root: a root-owned file here means some task silently
+      # became root.
+      vars:
+        non_deploy_user_files: "{{ deployment_path_contents.files | rejectattr('pw_name', 'equalto', deployment_user) | map(attribute='path') | list }}"
+      assert:
+        that:
+          - non_deploy_user_files | length == 0
+        fail_msg: "Found files under deployment_path not owned by {{ deployment_user }}: {{ non_deploy_user_files }}"
+        quiet: true
+
+    - name: Read the generated systemd --user unit file
+      slurp:
+        src: "{{ ansible_env.HOME }}/.config/systemd/user/{{ rootless_unit }}"
+      register: unit_file_slurp
+
+    - name: Assert the unit's ExecStart/EnvironmentFile point under deployment_path, not a hardcoded root path
+      vars:
+        unit_content: "{{ unit_file_slurp.content | b64decode }}"
+      assert:
+        that:
+          - deployment_path in unit_content
+          - ("EnvironmentFile=" ~ deployment_path) in unit_content
+        fail_msg: "cp-{{ rootless_component }} unit file doesn't reference deployment_path as expected:\n{{ unit_content }}"
+        quiet: true
+
+    - name: Read the generated systemd EnvironmentFile
+      slurp:
+        src: "{{ deployment_path }}/rootless-bin/{{ rootless_component }}.env"
+      register: env_file_slurp
+
+    - name: Assert the EnvironmentFile actually rendered content, not empty or unrendered Jinja
+      vars:
+        env_content: "{{ env_file_slurp.content | b64decode }}"
+      assert:
+        that:
+          - env_content | trim | length > 0
+          - "'{{' not in env_content"
+        fail_msg: "{{ rootless_component }}.env is empty or has unrendered template syntax:\n{{ env_content }}"
+        quiet: true
+
     - name: Check nothing was written under /opt
       find:
         paths: /opt
@@ -55,6 +106,38 @@
         that:
           - unexpected_opt_files | length == 0
         fail_msg: "Rootless install wrote to /opt outside custom_java_path: {{ unexpected_opt_files }}"
+        quiet: true
+
+- name: Verify - restart-propagation regression (side_effect.yml changed kafka_broker's config)
+  hosts: kafka_broker
+  gather_facts: false
+  tasks:
+    - name: Read the pre-side-effect timestamp
+      slurp:
+        src: /tmp/molecule_side_effect_before_ts
+      register: before_ts_slurp
+
+    - name: Get ActiveEnterTimestamp now
+      command: systemctl --user show cp-kafka_broker.service -p ActiveEnterTimestamp --value
+      environment:
+        XDG_RUNTIME_DIR: "/run/user/{{ ansible_user_uid }}"
+      register: after_ts
+      changed_when: false
+
+    - name: Confirm the generated unit actually carries the injected override
+      command: "grep -c StartLimitIntervalSec {{ ansible_env.HOME }}/.config/systemd/user/cp-kafka_broker.service"
+      register: override_grep
+      changed_when: false
+      failed_when: override_grep.stdout | trim == "0"
+
+    - name: Assert the unit restarted when its service_unit_overrides changed
+      assert:
+        that:
+          - after_ts.stdout != (before_ts_slurp.content | b64decode)
+        fail_msg: >-
+          cp-kafka_broker.service did not restart after its service_unit_overrides changed
+          (before={{ before_ts_slurp.content | b64decode }}, after={{ after_ts.stdout }}) -
+          the notify-on-change chain in rootless_lifecycle.yml regressed.
         quiet: true
 
 - name: Verify - SASL_PLAIN configured on kafka_controller

--- a/molecule/rootless-plain-debian10/verify.yml
+++ b/molecule/rootless-plain-debian10/verify.yml
@@ -110,7 +110,7 @@
 
 - name: Verify - restart-propagation regression (side_effect.yml changed kafka_broker's config)
   hosts: kafka_broker
-  gather_facts: false
+  gather_facts: true
   tasks:
     - name: Read the pre-side-effect timestamp
       slurp:

--- a/molecule/rootless-rbac-ldap-rhel9/converge.yml
+++ b/molecule/rootless-rbac-ldap-rhel9/converge.yml
@@ -1,7 +1,8 @@
 ---
 ### Bootstrap the rootless deploy user + linger (root) via the shared
-### playbooks/rootless_bootstrap.yml, set up LDAP on ldap1 via the shared
-### molecule/ldap.yml, then run confluent.platform.all as deployment_user.
+### playbooks/rootless_bootstrap.yml, set up LDAP on ldap1 and the KDC on
+### kerberos1 via the shared molecule/ldap.yml + molecule/kerberos.yml, then
+### run confluent.platform.all as deployment_user.
 ###
 ### import_playbook takes no inline vars, and rootless_bootstrap.yml expects
 ### the caller to pass -e ansible_user=<admin>. These two shim plays flip
@@ -28,5 +29,7 @@
         ansible_user: "{{ deployment_user }}"
 
 - import_playbook: ../ldap.yml
+
+- import_playbook: ../kerberos.yml
 
 - import_playbook: ../collections_converge.yml

--- a/molecule/rootless-rbac-ldap-rhel9/molecule.yml
+++ b/molecule/rootless-rbac-ldap-rhel9/molecule.yml
@@ -7,6 +7,15 @@
 ### isn't part of this collection. Kerberos/GSSAPI replaces mTLS as the client
 ### listener's peer-auth mechanism (the two aren't combined in any other scenario
 ### either) - RBAC/LDAP authorization is unchanged.
+###
+### Known container limitations (not fixable here, called out for reviewers):
+### - privileged: true + cgroupns_mode: host is required for systemd --user to run inside
+###   Docker at all - it does NOT mean the deploy itself used root. That's verified instead
+###   by asserting every file under deployment_path is owned by deployment_user (verify.yml)
+###   and by the extensive live-EC2 (non-containerized) verification recorded in
+###   ROOTLESS_DEPLOYMENT_STEPS.md.
+### - loginctl enable-linger surviving an actual host reboot is a design promise that isn't
+###   exercisable in a container (no real reboot) - also only verified live on EC2.
 
 driver:
   name: docker
@@ -131,6 +140,7 @@ platforms:
 provisioner:
   playbooks:
     converge: converge.yml
+    side_effect: side_effect.yml
     verify: verify.yml
   inventory:
     group_vars:

--- a/molecule/rootless-rbac-ldap-rhel9/molecule.yml
+++ b/molecule/rootless-rbac-ldap-rhel9/molecule.yml
@@ -1,9 +1,12 @@
 ---
-### Rootless install on RHEL9, mTLS + RBAC via LDAP. Validates systemd --user
-### (loginctl linger) works unprivileged and RBAC resolves against a real LDAP
-### server. ldap1 uses native openldap-servers on CentOS8 (RHEL9 dropped that
-### package); configured inline in converge.yml since confluent.test.ldap isn't
-### part of this collection.
+### Rootless install on RHEL9, Kerberos/GSSAPI + RBAC via LDAP. Validates systemd
+### --user (loginctl linger) works unprivileged, keytab/krb5.conf placement works
+### under deployment_path, and RBAC resolves against a real LDAP server. ldap1 and
+### kerberos1 use native openldap-servers/krb5-server on CentOS8 (RHEL9 dropped
+### openldap-servers); configured inline in converge.yml since confluent.test.ldap
+### isn't part of this collection. Kerberos/GSSAPI replaces mTLS as the client
+### listener's peer-auth mechanism (the two aren't combined in any other scenario
+### either) - RBAC/LDAP authorization is unchanged.
 
 driver:
   name: docker
@@ -12,6 +15,19 @@ platforms:
     hostname: ldap1.confluent
     groups:
       - ldap_server
+    image: centos:centos8
+    dockerfile: ../Dockerfile-centos8-base.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent
+  - name: kerberos1
+    hostname: kerberos1.confluent
+    groups:
+      - kerberos_server
     image: centos:centos8
     dockerfile: ../Dockerfile-centos8-base.j2
     command: ""
@@ -120,10 +136,20 @@ provisioner:
     group_vars:
       all:
         ssl_enabled: true
-        ssl_mutual_auth_enabled: true
-        ssl_client_authentication: required
-        sasl_protocol: none
+        ssl_mutual_auth_enabled: false
+        sasl_protocol: kerberos
         rbac_enabled: true
+
+        kerberos_kafka_broker_primary: kafka
+        kerberos:
+          realm: realm.example.com
+          kdc_hostname: kerberos1
+          admin_hostname: kerberos1
+
+        kafka_broker_kerberos_principal: "{{kerberos_kafka_broker_primary}}/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
+        kafka_broker_kerberos_keytab_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs/kafka_broker-{{inventory_hostname}}.keytab"
+        kafka_controller_kerberos_principal: "{{kerberos_kafka_broker_primary}}/{{inventory_hostname}}.confluent@{{kerberos.realm | upper}}"
+        kafka_controller_kerberos_keytab_path: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs/kafka_controller-{{inventory_hostname}}.keytab"
 
         mds_super_user: mds
         mds_super_user_password: password
@@ -190,9 +216,18 @@ provisioner:
             uid: 9994
             guid: 94
 
-      # Rootless vars scoped to the CP component groups only (not group_vars/all) - ldap1 is an
-      # unmanaged host sharing this inventory, not a rootless deploy target. Scoping these here
-      # keeps ldap1 out of playbooks/rootless_bootstrap.yml's hosts:all bootstrap treatment
+      kerberos_server:
+        realm_name: "{{ kerberos.realm | upper }}"
+        keytab_output_directory: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/keytabs"
+        kerberos_principals:
+          - principal: "{{kerberos_kafka_broker_primary}}/kafka-broker1.confluent@{{kerberos.realm | upper}}"
+            keytab_path: kafka_broker-kafka-broker1.keytab
+          - principal: "{{kerberos_kafka_broker_primary}}/kafka-controller1.confluent@{{kerberos.realm | upper}}"
+            keytab_path: kafka_controller-kafka-controller1.keytab
+
+      # Rootless vars scoped to the CP component groups only (not group_vars/all) - ldap1/kerberos1
+      # are unmanaged hosts sharing this inventory, not rootless deploy targets. Scoping these here
+      # keeps them out of playbooks/rootless_bootstrap.yml's hosts:all bootstrap treatment
       # entirely, the same way ansible_user already is.
       kafka_controller: &rootless_component_vars
         ansible_user: "{{ deployment_user }}"

--- a/molecule/rootless-rbac-ldap-rhel9/side_effect.yml
+++ b/molecule/rootless-rbac-ldap-rhel9/side_effect.yml
@@ -1,0 +1,35 @@
+---
+### Regression test for the restart-propagation fix in this PR: rootless_lifecycle.yml's
+### "Generate ... EnvironmentFile" / "Generate ... systemd --user unit" tasks now notify
+### the component's restart handler on change (previously they didn't - a rewritten file
+### never actually restarted the running unit). Give kafka_broker a *_service_unit_overrides
+### value it didn't have before (default is empty) and let verify.yml confirm the unit
+### actually restarted, not just that the file on disk changed.
+
+- name: Capture kafka_broker's unit start time before the side effect
+  hosts: kafka_broker
+  gather_facts: false
+  tasks:
+    - name: Get ActiveEnterTimestamp before the change
+      command: systemctl --user show cp-kafka_broker.service -p ActiveEnterTimestamp --value
+      environment:
+        XDG_RUNTIME_DIR: "/run/user/{{ ansible_user_uid }}"
+      register: before_ts
+      changed_when: false
+
+    - name: Save it so verify.yml (a separate ansible-playbook run) can compare
+      copy:
+        content: "{{ before_ts.stdout }}"
+        dest: /tmp/molecule_side_effect_before_ts
+        mode: '0644'
+
+- name: Inject a new unit override to force a real config change on kafka_broker
+  hosts: kafka_controller:kafka_broker:schema_registry:kafka_connect:kafka_rest:ksql:control_center
+  gather_facts: false
+  tasks:
+    - set_fact:
+        kafka_broker_service_unit_overrides:
+          StartLimitIntervalSec: "10"
+      when: "'kafka_broker' in group_names"
+
+- import_playbook: ../collections_converge.yml

--- a/molecule/rootless-rbac-ldap-rhel9/side_effect.yml
+++ b/molecule/rootless-rbac-ldap-rhel9/side_effect.yml
@@ -8,7 +8,7 @@
 
 - name: Capture kafka_broker's unit start time before the side effect
   hosts: kafka_broker
-  gather_facts: false
+  gather_facts: true
   tasks:
     - name: Get ActiveEnterTimestamp before the change
       command: systemctl --user show cp-kafka_broker.service -p ActiveEnterTimestamp --value

--- a/molecule/rootless-rbac-ldap-rhel9/verify.yml
+++ b/molecule/rootless-rbac-ldap-rhel9/verify.yml
@@ -15,9 +15,10 @@
       ksql: cp-ksql.service
       control_center: cp-control_center.service
   tasks:
-    - name: Determine this host's rootless unit name
+    - name: Determine this host's rootless unit name and component name
       set_fact:
         rootless_unit: "{{ rootless_unit_map[group_names | intersect(rootless_unit_map.keys()) | first] }}"
+        rootless_component: "{{ group_names | intersect(rootless_unit_map.keys()) | first }}"
 
     - name: Check the systemd --user unit is active
       command: "systemctl --user is-active {{ rootless_unit }}"
@@ -40,6 +41,56 @@
         fail_msg: "Expected all component processes to run as {{ deployment_user }}, found: {{ process_owners.stdout_lines }}"
         quiet: true
 
+    - name: Find everything under deployment_path
+      find:
+        paths: "{{ deployment_path }}"
+        recurse: true
+        file_type: any
+      register: deployment_path_contents
+
+    - name: Assert everything under deployment_path is owned by the deploy user, not root
+      # A privileged test container can docker-exec as root regardless of what the deploy
+      # itself did - this, not the container's own privilege level, is what actually proves
+      # nothing in the deploy path used root: a root-owned file here means some task silently
+      # became root.
+      vars:
+        non_deploy_user_files: "{{ deployment_path_contents.files | rejectattr('pw_name', 'equalto', deployment_user) | map(attribute='path') | list }}"
+      assert:
+        that:
+          - non_deploy_user_files | length == 0
+        fail_msg: "Found files under deployment_path not owned by {{ deployment_user }}: {{ non_deploy_user_files }}"
+        quiet: true
+
+    - name: Read the generated systemd --user unit file
+      slurp:
+        src: "{{ ansible_env.HOME }}/.config/systemd/user/{{ rootless_unit }}"
+      register: unit_file_slurp
+
+    - name: Assert the unit's ExecStart/EnvironmentFile point under deployment_path, not a hardcoded root path
+      vars:
+        unit_content: "{{ unit_file_slurp.content | b64decode }}"
+      assert:
+        that:
+          - deployment_path in unit_content
+          - ("EnvironmentFile=" ~ deployment_path) in unit_content
+        fail_msg: "cp-{{ rootless_component }} unit file doesn't reference deployment_path as expected:\n{{ unit_content }}"
+        quiet: true
+
+    - name: Read the generated systemd EnvironmentFile
+      slurp:
+        src: "{{ deployment_path }}/rootless-bin/{{ rootless_component }}.env"
+      register: env_file_slurp
+
+    - name: Assert the EnvironmentFile actually rendered content, not empty or unrendered Jinja
+      vars:
+        env_content: "{{ env_file_slurp.content | b64decode }}"
+      assert:
+        that:
+          - env_content | trim | length > 0
+          - "'{{' not in env_content"
+        fail_msg: "{{ rootless_component }}.env is empty or has unrendered template syntax:\n{{ env_content }}"
+        quiet: true
+
     - name: Check nothing was written under /opt
       find:
         paths: /opt
@@ -51,6 +102,38 @@
         that:
           - opt_contents.matched == 0
         fail_msg: "Rootless install wrote to /opt: {{ opt_contents.files | map(attribute='path') | list }}"
+        quiet: true
+
+- name: Verify - restart-propagation regression (side_effect.yml changed kafka_broker's config)
+  hosts: kafka_broker
+  gather_facts: false
+  tasks:
+    - name: Read the pre-side-effect timestamp
+      slurp:
+        src: /tmp/molecule_side_effect_before_ts
+      register: before_ts_slurp
+
+    - name: Get ActiveEnterTimestamp now
+      command: systemctl --user show cp-kafka_broker.service -p ActiveEnterTimestamp --value
+      environment:
+        XDG_RUNTIME_DIR: "/run/user/{{ ansible_user_uid }}"
+      register: after_ts
+      changed_when: false
+
+    - name: Confirm the generated unit actually carries the injected override
+      command: "grep -c StartLimitIntervalSec {{ ansible_env.HOME }}/.config/systemd/user/cp-kafka_broker.service"
+      register: override_grep
+      changed_when: false
+      failed_when: override_grep.stdout | trim == "0"
+
+    - name: Assert the unit restarted when its service_unit_overrides changed
+      assert:
+        that:
+          - after_ts.stdout != (before_ts_slurp.content | b64decode)
+        fail_msg: >-
+          cp-kafka_broker.service did not restart after its service_unit_overrides changed
+          (before={{ before_ts_slurp.content | b64decode }}, after={{ after_ts.stdout }}) -
+          the notify-on-change chain in rootless_lifecycle.yml regressed.
         quiet: true
 
 - name: Verify - MDS + RBAC/LDAP auth end to end

--- a/molecule/rootless-rbac-ldap-rhel9/verify.yml
+++ b/molecule/rootless-rbac-ldap-rhel9/verify.yml
@@ -84,10 +84,13 @@
     - name: Assert the EnvironmentFile actually rendered content, not empty or unrendered Jinja
       vars:
         env_content: "{{ env_file_slurp.content | b64decode }}"
+        # Built via multiplication, not a literal '{{', so ansible's own templating of this
+        # assert's `that:` strings doesn't try to parse it as the start of an expression.
+        unrendered_jinja_marker: "{{ '{' * 2 }}"
       assert:
         that:
           - env_content | trim | length > 0
-          - "'{{' not in env_content"
+          - unrendered_jinja_marker not in env_content
         fail_msg: "{{ rootless_component }}.env is empty or has unrendered template syntax:\n{{ env_content }}"
         quiet: true
 

--- a/molecule/rootless-rbac-ldap-rhel9/verify.yml
+++ b/molecule/rootless-rbac-ldap-rhel9/verify.yml
@@ -71,6 +71,32 @@
       delay: 5
       until: mds_check.status == 200
 
+- name: Verify - kafka_broker/kafka_controller authenticate via Kerberos/GSSAPI
+  hosts: kafka_broker:kafka_controller
+  gather_facts: false
+  vars:
+    server_log_path: "{{ deployment_path }}/log/{{ 'kafka' if 'kafka_broker' in group_names else 'controller' }}/server.log"
+  tasks:
+    - name: krb5.conf landed under deployment_path, not /etc
+      stat:
+        path: "{{ deployment_path }}/krb5.conf"
+      register: krb5_conf_stat
+      failed_when: not krb5_conf_stat.stat.exists
+
+    - name: Keytab landed under deployment_path, not /etc/security/keytabs
+      stat:
+        path: "{{ deployment_path }}/security/keytabs/{{ 'kafka_broker' if 'kafka_broker' in group_names else 'kafka_controller' }}.keytab"
+      register: keytab_stat
+      failed_when: not keytab_stat.stat.exists
+
+    - name: Wait for a successful GSSAPI authentication in the server log
+      shell: "grep -c 'Successfully authenticated client' {{ server_log_path }} || true"
+      register: gssapi_auth_count
+      changed_when: false
+      until: gssapi_auth_count.stdout | trim | int > 0
+      retries: 20
+      delay: 10
+
 - name: Verify - Schema Registry authenticates via its LDAP identity
   hosts: schema_registry
   gather_facts: false

--- a/molecule/rootless-rbac-ldap-rhel9/verify.yml
+++ b/molecule/rootless-rbac-ldap-rhel9/verify.yml
@@ -106,7 +106,7 @@
 
 - name: Verify - restart-propagation regression (side_effect.yml changed kafka_broker's config)
   hosts: kafka_broker
-  gather_facts: false
+  gather_facts: true
   tasks:
     - name: Read the pre-side-effect timestamp
       slurp:

--- a/playbooks/kafka_connect_replicator.yml
+++ b/playbooks/kafka_connect_replicator.yml
@@ -10,12 +10,24 @@
 
     - name: Populate service facts
       service_facts:
+      when: not (rootless_lifecycle_enabled | bool)
+
+    - name: Query rootless service state (systemd --user, read-only)
+      include_role:
+        name: common
+        tasks_from: rootless_service_state.yml
+      vars:
+        rootless_component_name: kafka_connect_replicator
+      when: rootless_lifecycle_enabled | bool
 
     - name: Determine Installation Pattern - Parallel or Serial
       set_fact:
         install_pattern: "{{ 'parallel' if service_state != 'running' or kafka_connect_replicator_deployment_strategy == 'parallel' else 'serial' }}"
       vars:
-        service_state: "{{ ansible_facts.services[kafka_connect_replicator_service_name + '.service'].state | default('unknown') }}"
+        service_state: >-
+          {{ rootless_service_state | default('unknown')
+             if rootless_lifecycle_enabled | bool
+             else (ansible_facts.services[kafka_connect_replicator_service_name + '.service'].state | default('unknown')) }}
 
     - name: Group Hosts by Installation Pattern
       group_by:

--- a/playbooks/rootless_bootstrap.yml
+++ b/playbooks/rootless_bootstrap.yml
@@ -24,14 +24,6 @@
   # unmanaged, non-Linux-shell service container sharing the inventory) would fail hard on
   # that alone, before ever reaching the deployment_user/deployment_path check.
   gather_facts: false
-  vars:
-    deployment_group: "{{ deployment_user }}"
-    rootless_enable_linger: true
-    rootless_install_packages: false
-    # default('') so hosts:all tolerates a host with no ansible_user set (e.g. an unmanaged
-    # LDAP/OAuth server sharing the inventory but outside the rootless deploy group) - the
-    # resulting path just won't exist, and both uses below are already stat.exists-guarded.
-    rootless_bootstrap_authorized_keys_src: "/home/{{ ansible_user | default('') }}/.ssh/authorized_keys"
   tasks:
     # hosts:all is meant for a mixed inventory - e.g. an existing LDAP/Kerberos server sharing
     # the same inventory as the rootless CP deploy but never intended as a target. Skip those
@@ -48,6 +40,23 @@
       block:
         - name: Gather facts
           setup:
+
+        - name: Compute rootless bootstrap defaults
+          # Play-level `vars:` outranks every inventory-sourced variable (group_vars,
+          # host_vars) in Ansible's precedence order, so setting these as play vars would
+          # silently ignore any inventory attempt to override them - only -e on the CLI
+          # would actually win. Computing them here via set_fact + default() instead lets an
+          # inventory-provided value (if any) flow through, falling back to these defaults
+          # only when genuinely unset. default('') on the keys src so hosts:all tolerates a
+          # host with no ansible_user set (e.g. an unmanaged LDAP/OAuth server sharing the
+          # inventory but outside the rootless deploy group) - the resulting path just won't
+          # exist, and both uses below are already stat.exists-guarded.
+          set_fact:
+            deployment_group: "{{ deployment_group | default(deployment_user) }}"
+            rootless_enable_linger: "{{ rootless_enable_linger | default(true) }}"
+            rootless_install_packages: "{{ rootless_install_packages | default(false) }}"
+            rootless_bootstrap_authorized_keys_src: >-
+              {{ rootless_bootstrap_authorized_keys_src | default('/home/' + (ansible_user | default('')) + '/.ssh/authorized_keys') }}
 
         - name: Create deploy group
           group:
@@ -91,15 +100,11 @@
             group: "{{ deployment_group }}"
             mode: '0755'
 
-        - name: Enable systemd linger for the deploy user
-          # So systemd --user units survive without an active login/reboot.
-          command: "loginctl enable-linger {{ deployment_user }}"
-          args:
-            creates: "/var/lib/systemd/linger/{{ deployment_user }}"
-          when: rootless_enable_linger | bool
-
         # PyYAML/pip for update_log4j2 - a minimal host may ship neither, and rootless can't
-        # install them itself. RHEL's per-user D-Bus starts on its own once linger is enabled.
+        # install them itself. Must run before "Enable systemd linger" below: on Debian/Ubuntu,
+        # loginctl needs dbus-user-session (installed here) to even reach the bus - RHEL ships
+        # base D-Bus already, so ordering only matters for the Debian branch, but package
+        # installs never depend on linger so it's safe to always install first regardless of OS.
         - name: Install cert tools + python (openssl/rsync/unzip/pip/PyYAML) - RedHat
           yum:
             name:
@@ -112,7 +117,8 @@
           when: rootless_install_packages | bool and ansible_os_family == "RedHat"
 
         # dbus-user-session: Debian/Ubuntu's systemd --user manager needs it, or systemctl --user
-        # fails with "Failed to connect to bus". Requires root, hence installed here.
+        # (and loginctl enable-linger, right below) fails with "Failed to connect to bus" /
+        # "Failed to create bus connection". Requires root, hence installed here.
         - name: Install cert tools + python (+ user D-Bus) - Debian/Ubuntu
           apt:
             name:
@@ -125,6 +131,13 @@
             state: present
             update_cache: true
           when: rootless_install_packages | bool and ansible_os_family == "Debian"
+
+        - name: Enable systemd linger for the deploy user
+          # So systemd --user units survive without an active login/reboot.
+          command: "loginctl enable-linger {{ deployment_user }}"
+          args:
+            creates: "/var/lib/systemd/linger/{{ deployment_user }}"
+          when: rootless_enable_linger | bool
 
         # The privileged/package-tagged Java install is skipped under rootless, so install it here
         # instead, honoring the existing model: install_java is false when custom_java_path is set

--- a/playbooks/rootless_bootstrap.yml
+++ b/playbooks/rootless_bootstrap.yml
@@ -50,13 +50,19 @@
           # only when genuinely unset. default('') on the keys src so hosts:all tolerates a
           # host with no ansible_user set (e.g. an unmanaged LDAP/OAuth server sharing the
           # inventory but outside the rootless deploy group) - the resulting path just won't
-          # exist, and both uses below are already stat.exists-guarded.
+          # exist, and both uses below are already stat.exists-guarded. That stat guard is
+          # also why root needs its own branch here: root's home is /root, not /home/root -
+          # get this wrong and the copy below silently skips (stat.exists is false), bootstrap
+          # still reports success, and the failure only surfaces later as a confusing
+          # "Permission denied (publickey)" in the deploy phase with nothing linking it back.
           set_fact:
             deployment_group: "{{ deployment_group | default(deployment_user) }}"
             rootless_enable_linger: "{{ rootless_enable_linger | default(true) }}"
             rootless_install_packages: "{{ rootless_install_packages | default(false) }}"
             rootless_bootstrap_authorized_keys_src: >-
-              {{ rootless_bootstrap_authorized_keys_src | default('/home/' + (ansible_user | default('')) + '/.ssh/authorized_keys') }}
+              {{ rootless_bootstrap_authorized_keys_src | default(
+                 (('/root' if (ansible_user | default('')) == 'root' else '/home/' + (ansible_user | default(''))))
+                 + '/.ssh/authorized_keys') }}
 
         - name: Create deploy group
           group:

--- a/playbooks/rootless_bootstrap.yml
+++ b/playbooks/rootless_bootstrap.yml
@@ -173,4 +173,4 @@
             msg:
               - "Rootless bootstrap complete: user '{{ deployment_user }}' ready at '{{ deployment_path }}'."
               - "Linger: {{ rootless_enable_linger | bool }}; OS packages installed: {{ rootless_install_packages | bool }}."
-              - "Next: run the rootless deploy as {{ deployment_user }} (playbooks/rootless_deploy.sh -i <inventory>)."
+              - "Next: run the rootless deploy as {{ deployment_user }}: ansible-playbook -i <inventory> confluent.platform.all"

--- a/playbooks/rootless_bootstrap.yml
+++ b/playbooks/rootless_bootstrap.yml
@@ -56,6 +56,7 @@
           # still reports success, and the failure only surfaces later as a confusing
           # "Permission denied (publickey)" in the deploy phase with nothing linking it back.
           set_fact:
+            deployment_path: "{{ deployment_path | regex_replace('/+$', '') }}"
             deployment_group: "{{ deployment_group | default(deployment_user) }}"
             rootless_enable_linger: "{{ rootless_enable_linger | default(true) }}"
             rootless_install_packages: "{{ rootless_install_packages | default(false) }}"

--- a/roles/common/tasks/collect_support_bundle.yml
+++ b/roles/common/tasks/collect_support_bundle.yml
@@ -31,7 +31,7 @@
         src: "{{ config_file }}"
         dest: "{{ host_bundle_dir }}/configs/"
         flat: true
-      become: true
+      become: "{{ not (rootless_enabled | bool) }}"
       when: not support_bundle_skip_configs
 
     - name: Fetch Log4j config file
@@ -39,7 +39,7 @@
         src: "{{ component.log4j_file }}"
         dest: "{{ host_bundle_dir }}/configs/"
         flat: true
-      become: true
+      become: "{{ not (rootless_enabled | bool) }}"
       when:
         - component.log4j_file is defined
         - not support_bundle_skip_configs
@@ -49,7 +49,7 @@
         src: "{{ component.systemd_file }}"
         dest: "{{ host_bundle_dir }}/configs/"
         flat: true
-      become: true
+      become: "{{ not (rootless_enabled | bool) }}"
       when:
         - component.systemd_file is defined
         - not support_bundle_skip_configs
@@ -59,7 +59,7 @@
         src: "{{ component.systemd_override }}"
         dest: "{{ host_bundle_dir }}/configs/"
         flat: true
-      become: true
+      become: "{{ not (rootless_enabled | bool) }}"
       when:
         - component.systemd_override is defined
         - not support_bundle_skip_configs
@@ -87,7 +87,7 @@
         {% endif %}
       args:
         executable: "{{ shell_executable }}"
-      become: true
+      become: "{{ not (rootless_enabled | bool) }}"
       when: support_bundle_skip_configs
       register: config_metadata_output
       changed_when: false
@@ -116,7 +116,7 @@
     patterns: "{{ support_bundle_log_patterns | default(['*.log']) }}"
     size: "1"
     age: "{{ support_bundle_log_age | default(omit) }}"
-  become: true
+  become: "{{ not (rootless_enabled | bool) }}"
   register: log_files_found
 
 - name: Fetch selected log files directly to localhost
@@ -124,7 +124,7 @@
     src: "{{ item.path }}"
     dest: "{{ host_bundle_dir }}/logs/"
     flat: true
-  become: true
+  become: "{{ not (rootless_enabled | bool) }}"
   loop: "{{ (log_files_found.files | default([]) | sort(attribute='mtime', reverse=true))[:(support_bundle_log_max_count | default(20) | int)] }}"
   when: log_files_found.matched | default(0) > 0
 

--- a/roles/common/tasks/config_validations.yml
+++ b/roles/common/tasks/config_validations.yml
@@ -14,13 +14,9 @@
 - name: Fail fast - rootless does not support FIPS
   fail:
     msg: >-
-      fips_enabled has no rootless equivalent of the privileged OS-level FIPS setup
-      (update-crypto-policies --set FIPS and the JVM java.security tweak, both in
-      fips-redhat.yml, require root and are unconditionally skipped when
-      rootless_enabled - unlike Java/cert-tools, no bootstrap step performs them
-      instead). This combination can never succeed here, not just when
-      misconfigured - enable FIPS at the OS level outside of cp-ansible before
-      rootless_bootstrap runs, or unset rootless_enabled for this host.
+      rootless_enabled has no privileged step to enable FIPS at the OS level
+      (fips-redhat.yml requires root, skipped under rootless). Enable FIPS on the
+      OS outside of cp-ansible first, or unset rootless_enabled for this host.
   when:
     - rootless_enabled | bool
     - fips_enabled | bool

--- a/roles/common/tasks/config_validations.yml
+++ b/roles/common/tasks/config_validations.yml
@@ -11,6 +11,21 @@
     - "'zookeeper' in group_names"
   tags: validate
 
+- name: Fail fast - rootless does not support FIPS
+  fail:
+    msg: >-
+      fips_enabled has no rootless equivalent of the privileged OS-level FIPS setup
+      (update-crypto-policies --set FIPS and the JVM java.security tweak, both in
+      fips-redhat.yml, require root and are unconditionally skipped when
+      rootless_enabled - unlike Java/cert-tools, no bootstrap step performs them
+      instead). This combination can never succeed here, not just when
+      misconfigured - enable FIPS at the OS level outside of cp-ansible before
+      rootless_bootstrap runs, or unset rootless_enabled for this host.
+  when:
+    - rootless_enabled | bool
+    - fips_enabled | bool
+  tags: validate
+
 # Fail fast on an unsupported CLI before any other validation runs.
 - name: Assert Confluent CLI version is compatible with secrets protection
   assert:

--- a/roles/common/tasks/config_validations.yml
+++ b/roles/common/tasks/config_validations.yml
@@ -1,4 +1,16 @@
 ---
+- name: Fail fast - rootless does not support Zookeeper
+  fail:
+    msg: >-
+      rootless_enabled has no systemd --user start/restart mechanism for zookeeper and it
+      is not planned - config would be written but the service would never start. Migrate
+      to the KRaft-based kafka_controller topology instead, or unset rootless_enabled for
+      this host.
+  when:
+    - rootless_enabled | bool
+    - "'zookeeper' in group_names"
+  tags: validate
+
 # Fail fast on an unsupported CLI before any other validation runs.
 - name: Assert Confluent CLI version is compatible with secrets protection
   assert:

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -76,7 +76,7 @@
     mode: '0755'
   register: rootless_writability_mkdir
   loop:
-    - "{{ deployment_path }}"
+    - "{{ deployment_path_final }}"
     - "{{ ssl_file_dir_final }}"
   loop_control:
     label: "{{ item }}"
@@ -91,7 +91,7 @@
     mode: '0644'
   register: rootless_writability_check
   loop:
-    - "{{ deployment_path }}"
+    - "{{ deployment_path_final }}"
     - "{{ ssl_file_dir_final }}"
   loop_control:
     label: "{{ item }}"

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -61,7 +61,7 @@
 
 - name: Rootless (non-root) prerequisite bootstrap
   include_tasks: rootless_prereqs.yml
-  when: deployment_path | length > 0
+  when: rootless_enabled | bool
 
 - name: Red Hat Repo Setup and Java Installation
   include_tasks: redhat.yml

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -63,6 +63,67 @@
   include_tasks: rootless_prereqs.yml
   when: rootless_enabled | bool
 
+# Catches two real footguns early with a clear message, instead of a confusing permission-denied
+# failure deep in the deploy: deployment_path itself not actually writable (e.g. rootless_bootstrap
+# was never run), and an old inventory's explicit override of a deployment_path-derived variable
+# (e.g. ssl_file_dir) pointing at a root-owned path that survived turning rootless_enabled on.
+# ssl_file_dir may not exist yet on a cold deploy (the ssl role creates it later) - ensure it
+# exists first so the write-test below isn't a false positive on a merely-missing directory.
+- name: "Ensure {{ item }} exists (rootless writability check)"
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    mode: '0755'
+  register: rootless_writability_mkdir
+  loop:
+    - "{{ deployment_path }}"
+    - "{{ ssl_file_dir_final }}"
+  loop_control:
+    label: "{{ item }}"
+  ignore_errors: true
+  changed_when: false
+  when: rootless_enabled | bool
+
+- name: "Check {{ item }} is writable (rootless)"
+  ansible.builtin.file:
+    path: "{{ item }}/.rootless_writability_check"
+    state: touch
+    mode: '0644'
+  register: rootless_writability_check
+  loop:
+    - "{{ deployment_path }}"
+    - "{{ ssl_file_dir_final }}"
+  loop_control:
+    label: "{{ item }}"
+  ignore_errors: true
+  changed_when: false
+  when: rootless_enabled | bool
+
+- name: Remove rootless writability check files
+  ansible.builtin.file:
+    path: "{{ item.item }}/.rootless_writability_check"
+    state: absent
+  loop: "{{ rootless_writability_check.results | default([]) }}"
+  loop_control:
+    label: "{{ item.item }}"
+  when:
+    - rootless_enabled | bool
+    - not (item.failed | default(false))
+  changed_when: false
+
+- name: Assert deployment_path and ssl_file_dir are writable (rootless)
+  assert:
+    that: not (item.failed | default(false))
+    fail_msg: >-
+      '{{ item.item }}' is not writable by the connecting user. Under rootless_enabled, every
+      deployment_path-derived path (including ssl_file_dir) must be writable by deployment_user -
+      run confluent.platform.rootless_bootstrap first, or if you've explicitly overridden this
+      variable from an old inventory, point it under deployment_path instead.
+  loop: "{{ rootless_writability_check.results | default([]) }}"
+  loop_control:
+    label: "{{ item.item }}"
+  when: rootless_enabled | bool
+
 - name: Red Hat Repo Setup and Java Installation
   include_tasks: redhat.yml
   when: ansible_os_family == "RedHat"

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -51,9 +51,15 @@
     that:
       - installation_method == "archive"
       - deployment_path | length > 0
+      - deployment_user | length > 0
+      - deployment_group | length > 0
     fail_msg: >-
-      rootless_enabled requires installation_method: archive and deployment_path set
-      (the package method needs root; artifacts must live under a user-writable path).
+      rootless_enabled requires installation_method: archive, deployment_path,
+      deployment_user, and deployment_group all set (the package method needs root;
+      artifacts must live under a user-writable path; deployment_group must be set
+      explicitly because rootless_bootstrap's own fallback for it - deployment_user -
+      diverges from the main deploy's fallback of 'confluent', which doesn't exist as
+      an OS group on a rootless host).
   when: rootless_enabled | bool
   tags:
     - validate

--- a/roles/common/tasks/rbac_setup.yml
+++ b/roles/common/tasks/rbac_setup.yml
@@ -43,11 +43,15 @@
   when: cluster_id_source | default('erp') == 'zookeeper'
 
 - name: Create SSL Certificate Directory
+  # Not skipped under rootless: ssl_file_dir_final still needs to exist for the MDS pem copy
+  # below. Previously masked whenever ssl_enabled created it first as a side effect of a
+  # sibling directory - not the case for rbac_enabled with ssl_enabled: false. Under rootless,
+  # ssl_file_dir_final resolves under deployment_path (already asserted writable), so no
+  # become is needed here - it's created as whatever user Ansible is already connected as.
   file:
     path: "{{ ssl_file_dir_final }}"
     state: directory
     mode: '755'
-  when: not (rootless_enabled | bool)
   tags:
     - privileged
     - filesystem

--- a/roles/common/tasks/rootless_lifecycle.yml
+++ b/roles/common/tasks/rootless_lifecycle.yml
@@ -1,8 +1,9 @@
 ---
 # Generates a systemd --user unit + EnvironmentFile for a component (no root, no nohup).
 # Vars: rootless_component_name (unit = cp-<name>.service), rootless_service_environment_overrides,
-# rootless_service_exec, rootless_service_unit_overrides. Requires one-time
-# `loginctl enable-linger <deployment_user>` (root).
+# rootless_service_exec, rootless_service_unit_overrides, rootless_restart_handler (notified on
+# change, mirroring root's override.conf notify - e.g. a secrets-protection master key rotation).
+# Requires one-time `loginctl enable-linger <deployment_user>` (root).
 
 - name: "Create rootless env-file directory for {{ rootless_component_name }}"
   file:
@@ -23,6 +24,7 @@
     src: rootless_component.env.j2
     dest: "{{ rootless_lifecycle_bin_dir }}/{{ rootless_component_name }}.env"
     mode: '0640'
+  notify: "{{ rootless_restart_handler }}"
   tags: [filesystem]
 
 - name: "Generate {{ rootless_component_name }} systemd --user unit"
@@ -31,6 +33,7 @@
     dest: "{{ ansible_env.HOME }}/.config/systemd/user/cp-{{ rootless_component_name }}.service"
     mode: '0644'
   register: rootless_unit_written
+  notify: "{{ rootless_restart_handler }}"
   tags: [filesystem]
 
 - name: "Reload the per-user systemd manager for {{ rootless_component_name }}"

--- a/roles/common/tasks/rootless_lifecycle.yml
+++ b/roles/common/tasks/rootless_lifecycle.yml
@@ -1,7 +1,8 @@
 ---
 # Generates a systemd --user unit + EnvironmentFile for a component (no root, no nohup).
 # Vars: rootless_component_name (unit = cp-<name>.service), rootless_service_environment_overrides,
-# rootless_service_exec. Requires one-time `loginctl enable-linger <deployment_user>` (root).
+# rootless_service_exec, rootless_service_unit_overrides. Requires one-time
+# `loginctl enable-linger <deployment_user>` (root).
 
 - name: "Create rootless env-file directory for {{ rootless_component_name }}"
   file:

--- a/roles/common/tasks/rootless_lifecycle.yml
+++ b/roles/common/tasks/rootless_lifecycle.yml
@@ -1,9 +1,11 @@
 ---
 # Generates a systemd --user unit + EnvironmentFile for a component (no root, no nohup).
 # Vars: rootless_component_name (unit = cp-<name>.service), rootless_service_environment_overrides,
-# rootless_service_exec, rootless_service_unit_overrides, rootless_restart_handler (notified on
-# change, mirroring root's override.conf notify - e.g. a secrets-protection master key rotation).
-# Requires one-time `loginctl enable-linger <deployment_user>` (root).
+# rootless_service_exec, rootless_service_unit_overrides, rootless_service_overrides (the
+# component's own *_service_overrides dict - rendered into [Service] as extra directives,
+# minus ExecStart/User/Group which rootless already handles its own way), rootless_restart_handler
+# (notified on change, mirroring root's override.conf notify - e.g. a secrets-protection master
+# key rotation). Requires one-time `loginctl enable-linger <deployment_user>` (root).
 
 - name: "Create rootless env-file directory for {{ rootless_component_name }}"
   file:

--- a/roles/common/tasks/secrets_protection.yml
+++ b/roles/common/tasks/secrets_protection.yml
@@ -36,11 +36,16 @@
   diff: "{{ not mask_sensitive_diff|bool }}"
 
 - name: Create Secrets Protection Directory
+  # Not skipped under rootless: ssl_file_dir_final still needs to exist for the
+  # security.properties copy below. Previously masked whenever ssl_enabled created it first
+  # as a side effect of a sibling directory - not the case for secrets protection without SSL.
+  # Under rootless, ssl_file_dir_final resolves under deployment_path (already asserted
+  # writable), so no become is needed - it's created as whatever user Ansible is already
+  # connected as.
   file:
     path: "{{ ssl_file_dir_final }}"
     state: directory
     mode: '755'
-  when: not (rootless_enabled | bool)
   tags:
     - filesystem
     - privileged

--- a/roles/common/templates/rootless.service.j2
+++ b/roles/common/templates/rootless.service.j2
@@ -2,7 +2,7 @@
 # {{ ansible_managed }}
 Description=Confluent {{ rootless_component_name }} (rootless, systemd --user)
 After=network.target
-{% for key, value in (rootless_service_unit_overrides | default({})).items() %}
+{% for key, value in (rootless_service_unit_overrides | default({}, true)).items() %}
 {% if value %}
 {{key}}={{value}}
 {% endif %}

--- a/roles/common/templates/rootless.service.j2
+++ b/roles/common/templates/rootless.service.j2
@@ -2,6 +2,11 @@
 # {{ ansible_managed }}
 Description=Confluent {{ rootless_component_name }} (rootless, systemd --user)
 After=network.target
+{% for key, value in (rootless_service_unit_overrides | default({})).items() %}
+{% if value %}
+{{key}}={{value}}
+{% endif %}
+{% endfor %}
 
 [Service]
 Type=simple

--- a/roles/common/templates/rootless.service.j2
+++ b/roles/common/templates/rootless.service.j2
@@ -15,6 +15,11 @@ ExecStart={{ rootless_service_exec }}
 # Recovers a component that transiently exits during KRaft/RBAC bootstrap.
 Restart=on-failure
 RestartSec={{ rootless_restart_sec | default(5) }}
+{% for key, value in (rootless_service_overrides | default({}, true)).items() %}
+{% if value and key not in ['ExecStart', 'User', 'Group'] %}
+{{ key }}={{ value }}
+{% endif %}
+{% endfor %}
 
 [Install]
 WantedBy=default.target

--- a/roles/common/templates/rootless_component.env.j2
+++ b/roles/common/templates/rootless_component.env.j2
@@ -1,7 +1,7 @@
 # {{ ansible_managed }}
 # systemd EnvironmentFile for {{ rootless_component_name }}. Mirrors the override.conf
 # Environment= lines; empty values dropped. Format: KEY=value, no `export`.
-{% for key, value in rootless_service_environment_overrides.items() %}
+{% for key, value in (rootless_service_environment_overrides | default({}, true)).items() %}
 {% if value %}
 {{ key }}={{ value }}
 {% endif %}

--- a/roles/control_center/tasks/main.yml
+++ b/roles/control_center/tasks/main.yml
@@ -382,6 +382,7 @@
     rootless_component_name: control_center
     rootless_service_environment_overrides: "{{ control_center_service_environment_overrides }}"
     rootless_service_exec: "{{ control_center_service_overrides.ExecStart }}"
+    rootless_service_unit_overrides: "{{ control_center_service_unit_overrides }}"
   when: rootless_lifecycle_enabled | bool
   tags:
     - filesystem

--- a/roles/control_center/tasks/main.yml
+++ b/roles/control_center/tasks/main.yml
@@ -383,6 +383,7 @@
     rootless_service_environment_overrides: "{{ control_center_service_environment_overrides }}"
     rootless_service_exec: "{{ control_center_service_overrides.ExecStart }}"
     rootless_service_unit_overrides: "{{ control_center_service_unit_overrides }}"
+    rootless_restart_handler: restart control center
   when: rootless_lifecycle_enabled | bool
   tags:
     - filesystem

--- a/roles/control_center/tasks/main.yml
+++ b/roles/control_center/tasks/main.yml
@@ -382,6 +382,7 @@
     rootless_component_name: control_center
     rootless_service_environment_overrides: "{{ control_center_service_environment_overrides }}"
     rootless_service_exec: "{{ control_center_service_overrides.ExecStart }}"
+    rootless_service_overrides: "{{ control_center_service_overrides }}"
     rootless_service_unit_overrides: "{{ control_center_service_unit_overrides }}"
     rootless_restart_handler: restart control center
   when: rootless_lifecycle_enabled | bool

--- a/roles/kafka_broker/tasks/main.yml
+++ b/roles/kafka_broker/tasks/main.yml
@@ -322,6 +322,7 @@
     rootless_component_name: kafka_broker
     rootless_service_environment_overrides: "{{ kafka_broker_service_environment_overrides }}"
     rootless_service_exec: "{{ kafka_broker_service_overrides.ExecStart }}"
+    rootless_service_unit_overrides: "{{ kafka_broker_service_unit_overrides }}"
   when: rootless_lifecycle_enabled | bool
   tags:
     - filesystem

--- a/roles/kafka_broker/tasks/main.yml
+++ b/roles/kafka_broker/tasks/main.yml
@@ -323,6 +323,7 @@
     rootless_service_environment_overrides: "{{ kafka_broker_service_environment_overrides }}"
     rootless_service_exec: "{{ kafka_broker_service_overrides.ExecStart }}"
     rootless_service_unit_overrides: "{{ kafka_broker_service_unit_overrides }}"
+    rootless_restart_handler: restart kafka
   when: rootless_lifecycle_enabled | bool
   tags:
     - filesystem

--- a/roles/kafka_broker/tasks/main.yml
+++ b/roles/kafka_broker/tasks/main.yml
@@ -322,6 +322,7 @@
     rootless_component_name: kafka_broker
     rootless_service_environment_overrides: "{{ kafka_broker_service_environment_overrides }}"
     rootless_service_exec: "{{ kafka_broker_service_overrides.ExecStart }}"
+    rootless_service_overrides: "{{ kafka_broker_service_overrides }}"
     rootless_service_unit_overrides: "{{ kafka_broker_service_unit_overrides }}"
     rootless_restart_handler: restart kafka
   when: rootless_lifecycle_enabled | bool

--- a/roles/kafka_connect/tasks/main.yml
+++ b/roles/kafka_connect/tasks/main.yml
@@ -413,6 +413,7 @@
     rootless_service_environment_overrides: "{{ kafka_connect_service_environment_overrides }}"
     rootless_service_exec: "{{ kafka_connect_service_overrides.ExecStart }}"
     rootless_service_unit_overrides: "{{ kafka_connect_service_unit_overrides }}"
+    rootless_restart_handler: restart connect distributed
   when: rootless_lifecycle_enabled | bool
   tags:
     - filesystem

--- a/roles/kafka_connect/tasks/main.yml
+++ b/roles/kafka_connect/tasks/main.yml
@@ -412,6 +412,7 @@
     rootless_component_name: kafka_connect
     rootless_service_environment_overrides: "{{ kafka_connect_service_environment_overrides }}"
     rootless_service_exec: "{{ kafka_connect_service_overrides.ExecStart }}"
+    rootless_service_overrides: "{{ kafka_connect_service_overrides }}"
     rootless_service_unit_overrides: "{{ kafka_connect_service_unit_overrides }}"
     rootless_restart_handler: restart connect distributed
   when: rootless_lifecycle_enabled | bool

--- a/roles/kafka_connect/tasks/main.yml
+++ b/roles/kafka_connect/tasks/main.yml
@@ -412,6 +412,7 @@
     rootless_component_name: kafka_connect
     rootless_service_environment_overrides: "{{ kafka_connect_service_environment_overrides }}"
     rootless_service_exec: "{{ kafka_connect_service_overrides.ExecStart }}"
+    rootless_service_unit_overrides: "{{ kafka_connect_service_unit_overrides }}"
   when: rootless_lifecycle_enabled | bool
   tags:
     - filesystem

--- a/roles/kafka_connect_replicator/tasks/main.yml
+++ b/roles/kafka_connect_replicator/tasks/main.yml
@@ -416,6 +416,31 @@
   tags:
     - systemd
 
+- name: Generate Kafka Connect Replicator rootless lifecycle scripts
+  include_role:
+    name: common
+    tasks_from: rootless_lifecycle.yml
+  vars:
+    rootless_component_name: kafka_connect_replicator
+    rootless_service_environment_overrides: "{{ kafka_connect_replicator_service_environment_overrides }}"
+    # Replicator has no ExecStart in its _service_overrides (unlike the other rootless
+    # components) - its start command is hardcoded in kafka-connect-replicator.service.j2
+    # instead, so mirror that exact command here.
+    rootless_service_exec: >-
+      {{ binary_base_path }}/bin/replicator
+      --consumer.config {{ kafka_connect_replicator.consumer_config_file }}
+      --producer.config {{ kafka_connect_replicator.producer_config_file }}
+      --cluster.id {{ kafka_connect_replicator_cluster_id }}
+      --replication.config {{ kafka_connect_replicator.replication_config_file }}
+      --consumer.monitoring.config {{ kafka_connect_replicator.interceptors_config_file }}
+      --producer.monitoring.config {{ kafka_connect_replicator.interceptors_config_file }}
+    rootless_service_overrides: "{{ kafka_connect_replicator_service_overrides }}"
+    rootless_service_unit_overrides: "{{ kafka_connect_replicator_service_unit_overrides }}"
+    rootless_restart_handler: Restart Kafka Connect Replicator
+  when: rootless_lifecycle_enabled | bool
+  tags:
+    - filesystem
+
 - name: Certs were Updated - Trigger Restart
   command: /bin/true
   notify: Restart Kafka Connect Replicator
@@ -432,6 +457,15 @@
   when: not (rootless_enabled | bool)
   tags:
     - systemd
+
+- name: Start Kafka Connect Replicator (rootless, systemd --user)
+  include_role:
+    name: common
+    tasks_from: rootless_start_service.yml
+  vars:
+    rootless_component_name: kafka_connect_replicator
+    rootless_component_port: "{{ kafka_connect_replicator_port }}"
+  when: rootless_lifecycle_enabled | bool
 
 - name: Run Kafka Connect Replicator Health Check
   include_tasks: health_check.yml

--- a/roles/kafka_connect_replicator/tasks/rbac_replicator.yml
+++ b/roles/kafka_connect_replicator/tasks/rbac_replicator.yml
@@ -1,12 +1,11 @@
 ---
 - name: Create SSL Certificate Directory
   file:
-    path: /var/ssl/private/kafka_connect_replicator
+    path: "{{ kafka_connect_replicator_rbac_enabled_public_pem_path | dirname }}"
     state: directory
     mode: '755'
-  when: not (rootless_enabled | bool)
-  tags:
-    - privileged
+    owner: "{{ kafka_connect_replicator_user }}"
+    group: "{{ kafka_connect_replicator_group }}"
 
 - name: Check if MDS pem file exists on Ansible Controller
   stat:

--- a/roles/kafka_connect_replicator/tasks/rbac_replicator_consumer.yml
+++ b/roles/kafka_connect_replicator/tasks/rbac_replicator_consumer.yml
@@ -1,12 +1,11 @@
 ---
 - name: Create SSL Certificate Directory
   file:
-    path: /var/ssl/private/kafka_connect_replicator_consumer
+    path: "{{ kafka_connect_replicator_consumer_rbac_enabled_public_pem_path | dirname }}"
     state: directory
     mode: '755'
-  when: not (rootless_enabled | bool)
-  tags:
-    - privileged
+    owner: "{{ kafka_connect_replicator_user }}"
+    group: "{{ kafka_connect_replicator_group }}"
 
 - name: Check if MDS pem file exists on Ansible Controller
   stat:

--- a/roles/kafka_connect_replicator/tasks/restart_and_wait.yml
+++ b/roles/kafka_connect_replicator/tasks/restart_and_wait.yml
@@ -8,6 +8,22 @@
   tags:
     - systemd
 
+- name: "Check if the rootless systemd --user unit exists"
+  stat:
+    path: "{{ ansible_env.HOME }}/.config/systemd/user/cp-kafka_connect_replicator.service"
+  register: kafka_connect_replicator_rootless_unit
+  when: rootless_enabled | bool
+
+# Skip if the unit doesn't exist yet; rootless_start_service.yml does the first start later.
+- name: "Restart Kafka Connect Replicator (rootless, systemd --user)"
+  ansible.builtin.systemd_service:
+    name: cp-kafka_connect_replicator.service
+    scope: user
+    state: restarted
+  environment:
+    XDG_RUNTIME_DIR: "/run/user/{{ ansible_user_uid }}"
+  when: rootless_enabled | bool and kafka_connect_replicator_rootless_unit.stat.exists
+
 - name: Startup Delay
   wait_for:
     timeout: "{{ kafka_connect_replicator_health_check_delay }}"

--- a/roles/kafka_controller/tasks/main.yml
+++ b/roles/kafka_controller/tasks/main.yml
@@ -299,6 +299,7 @@
     rootless_component_name: kafka_controller
     rootless_service_environment_overrides: "{{ kafka_controller_service_environment_overrides }}"
     rootless_service_exec: "{{ kafka_controller_service_overrides.ExecStart }}"
+    rootless_service_overrides: "{{ kafka_controller_service_overrides }}"
     rootless_service_unit_overrides: "{{ kafka_controller_service_unit_overrides }}"
     rootless_restart_handler: restart Kafka Controller
   when: rootless_lifecycle_enabled | bool

--- a/roles/kafka_controller/tasks/main.yml
+++ b/roles/kafka_controller/tasks/main.yml
@@ -299,6 +299,7 @@
     rootless_component_name: kafka_controller
     rootless_service_environment_overrides: "{{ kafka_controller_service_environment_overrides }}"
     rootless_service_exec: "{{ kafka_controller_service_overrides.ExecStart }}"
+    rootless_service_unit_overrides: "{{ kafka_controller_service_unit_overrides }}"
   when: rootless_lifecycle_enabled | bool
   tags:
     - filesystem

--- a/roles/kafka_controller/tasks/main.yml
+++ b/roles/kafka_controller/tasks/main.yml
@@ -300,6 +300,7 @@
     rootless_service_environment_overrides: "{{ kafka_controller_service_environment_overrides }}"
     rootless_service_exec: "{{ kafka_controller_service_overrides.ExecStart }}"
     rootless_service_unit_overrides: "{{ kafka_controller_service_unit_overrides }}"
+    rootless_restart_handler: restart Kafka Controller
   when: rootless_lifecycle_enabled | bool
   tags:
     - filesystem

--- a/roles/kafka_rest/tasks/main.yml
+++ b/roles/kafka_rest/tasks/main.yml
@@ -430,6 +430,7 @@
     rootless_component_name: kafka_rest
     rootless_service_environment_overrides: "{{ kafka_rest_service_environment_overrides }}"
     rootless_service_exec: "{{ kafka_rest_service_overrides.ExecStart }}"
+    rootless_service_unit_overrides: "{{ kafka_rest_service_unit_overrides }}"
   when: rootless_lifecycle_enabled | bool
   tags:
     - filesystem

--- a/roles/kafka_rest/tasks/main.yml
+++ b/roles/kafka_rest/tasks/main.yml
@@ -430,6 +430,7 @@
     rootless_component_name: kafka_rest
     rootless_service_environment_overrides: "{{ kafka_rest_service_environment_overrides }}"
     rootless_service_exec: "{{ kafka_rest_service_overrides.ExecStart }}"
+    rootless_service_overrides: "{{ kafka_rest_service_overrides }}"
     rootless_service_unit_overrides: "{{ kafka_rest_service_unit_overrides }}"
     rootless_restart_handler: restart kafka-rest
   when: rootless_lifecycle_enabled | bool

--- a/roles/kafka_rest/tasks/main.yml
+++ b/roles/kafka_rest/tasks/main.yml
@@ -431,6 +431,7 @@
     rootless_service_environment_overrides: "{{ kafka_rest_service_environment_overrides }}"
     rootless_service_exec: "{{ kafka_rest_service_overrides.ExecStart }}"
     rootless_service_unit_overrides: "{{ kafka_rest_service_unit_overrides }}"
+    rootless_restart_handler: restart kafka-rest
   when: rootless_lifecycle_enabled | bool
   tags:
     - filesystem

--- a/roles/kerberos/tasks/main.yml
+++ b/roles/kerberos/tasks/main.yml
@@ -4,6 +4,8 @@
     path: "{{ kerberos_client_config_file_dest | dirname }}"
     state: directory
     mode: '755'
+    owner: "{{ kerberos_user }}"
+    group: "{{ kerberos_group }}"
 
 - name: Copy the client configuration file
   template:
@@ -18,9 +20,6 @@
     state: directory
     group: "{{kerberos_group}}"
     mode: '750'
-  when: not (rootless_enabled | bool)
-  tags:
-    - privileged
 
 - name: Copy in Keytab File
   copy:
@@ -30,6 +29,3 @@
     group: "{{kerberos_group}}"
     mode: '640'
   notify: "{{kerberos_handler}}"
-  when: not (rootless_enabled | bool)
-  tags:
-    - privileged

--- a/roles/ksql/tasks/main.yml
+++ b/roles/ksql/tasks/main.yml
@@ -428,6 +428,7 @@
     rootless_service_environment_overrides: "{{ ksql_service_environment_overrides }}"
     rootless_service_exec: "{{ ksql_service_overrides.ExecStart }}"
     rootless_service_unit_overrides: "{{ ksql_service_unit_overrides }}"
+    rootless_restart_handler: restart ksql
   when: rootless_lifecycle_enabled | bool
   tags:
     - filesystem

--- a/roles/ksql/tasks/main.yml
+++ b/roles/ksql/tasks/main.yml
@@ -427,6 +427,7 @@
     rootless_component_name: ksql
     rootless_service_environment_overrides: "{{ ksql_service_environment_overrides }}"
     rootless_service_exec: "{{ ksql_service_overrides.ExecStart }}"
+    rootless_service_overrides: "{{ ksql_service_overrides }}"
     rootless_service_unit_overrides: "{{ ksql_service_unit_overrides }}"
     rootless_restart_handler: restart ksql
   when: rootless_lifecycle_enabled | bool

--- a/roles/ksql/tasks/main.yml
+++ b/roles/ksql/tasks/main.yml
@@ -427,6 +427,7 @@
     rootless_component_name: ksql
     rootless_service_environment_overrides: "{{ ksql_service_environment_overrides }}"
     rootless_service_exec: "{{ ksql_service_overrides.ExecStart }}"
+    rootless_service_unit_overrides: "{{ ksql_service_unit_overrides }}"
   when: rootless_lifecycle_enabled | bool
   tags:
     - filesystem

--- a/roles/schema_registry/tasks/main.yml
+++ b/roles/schema_registry/tasks/main.yml
@@ -389,6 +389,7 @@
     rootless_component_name: schema_registry
     rootless_service_environment_overrides: "{{ schema_registry_service_environment_overrides }}"
     rootless_service_exec: "{{ schema_registry_service_overrides.ExecStart }}"
+    rootless_service_unit_overrides: "{{ schema_registry_service_unit_overrides }}"
   when: rootless_lifecycle_enabled | bool
   tags:
     - filesystem

--- a/roles/schema_registry/tasks/main.yml
+++ b/roles/schema_registry/tasks/main.yml
@@ -390,6 +390,7 @@
     rootless_service_environment_overrides: "{{ schema_registry_service_environment_overrides }}"
     rootless_service_exec: "{{ schema_registry_service_overrides.ExecStart }}"
     rootless_service_unit_overrides: "{{ schema_registry_service_unit_overrides }}"
+    rootless_restart_handler: restart schema-registry
   when: rootless_lifecycle_enabled | bool
   tags:
     - filesystem

--- a/roles/schema_registry/tasks/main.yml
+++ b/roles/schema_registry/tasks/main.yml
@@ -389,6 +389,7 @@
     rootless_component_name: schema_registry
     rootless_service_environment_overrides: "{{ schema_registry_service_environment_overrides }}"
     rootless_service_exec: "{{ schema_registry_service_overrides.ExecStart }}"
+    rootless_service_overrides: "{{ schema_registry_service_overrides }}"
     rootless_service_unit_overrides: "{{ schema_registry_service_unit_overrides }}"
     rootless_restart_handler: restart schema-registry
   when: rootless_lifecycle_enabled | bool

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -249,10 +249,10 @@ monitoring_interceptors_enabled: "{{ 'control_center' in groups }}"
 ### The method of installation. Valid values are "package" or "archive". If "archive" is selected then services will not be installed via the use of yum or apt, but will instead be installed via expanding the target .tar.gz file from the Confluent archive into the path defined by `archive_destination_path`. Configuration files are also kept in this directory structure instead of `/etc`. SystemD service units are copied from the ardhive for each target service and overrides are created pointing at the new paths. The "package" installation method is the default behavior that utilizes yum/apt.
 installation_method: "package"
 
-### Rootless base path/user/group - install paths, users/groups, and data/log dirs derive from these. Empty = no change.
+### Rootless base path/user/group - install paths, users/groups, and data/log dirs derive from these. Empty deployment_path/deployment_user = no change.
 deployment_path: ""
 deployment_user: ""
-deployment_group: ""
+deployment_group: "confluent"
 
 ### Master switch for rootless deploys - skips root-requiring steps and runs the systemd --user lifecycle instead. Default false = no change.
 rootless_enabled: false

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -2080,7 +2080,7 @@ kafka_connect_replicator_jolokia_config: "{{ (config_base_path, kafka_connect_re
 kafka_connect_replicator_jolokia_jar_path: "{{ (deployment_path ~ '/jolokia/jolokia.jar') if deployment_path | length > 0 else '/opt/jolokia/jolokia.jar' }}"
 
 ### Set this variable to customize the directory that Kafka Connect Replicator writes log files to.
-kafka_connect_replicator_log_dir: /var/log/confluent/kafka-connect-replicator
+kafka_connect_replicator_log_dir: "{{ (deployment_path ~ '/log/kafka-connect-replicator') if deployment_path | length > 0 else '/var/log/confluent/kafka-connect-replicator' }}"
 
 ### Set this variable to customize the default log name that Kafka Connect Replicator writes logs to.
 kafka_connect_replicator_log_name: kafka-connect-replicator.log
@@ -2146,7 +2146,7 @@ kafka_connect_replicator_cert_path: "{{ ssl_file_dir_final }}/kafka_connect_repl
 kafka_connect_replicator_key_path: "{{ ssl_file_dir_final }}/kafka_connect_replicator.key"
 kafka_connect_replicator_export_certs: kafka_connect_replicator_listener ['ssl_mutual_auth_enabled'] | default(ssl_mutual_auth_enabled) | bool
 kafka_connect_replicator_keytab_path: "{{ (deployment_path ~ '/security/keytabs/kafka_connect_replicator.keytab') if deployment_path | length > 0 else '/etc/security/keytabs/kafka_connect_replicator.keytab' }}"
-kafka_connect_replicator_kerberos_keytab_path: /etc/security/keytabs/kafka_connect_replicator.keytab
+kafka_connect_replicator_kerberos_keytab_path: "{{ kafka_connect_replicator_keytab_path }}"
 kafka_connect_replicator_listener_name: kafka_connect_replicator_listener
 kafka_connect_replicator_group_id: replicator
 
@@ -2175,7 +2175,7 @@ kafka_connect_replicator_kafka_cluster_name: ""
 kafka_connect_replicator_erp_pem_file: ""
 
 ### Set this variable to override the default location of the public pem file for connecting to the ERP when RBAC is enabled.
-kafka_connect_replicator_rbac_enabled_public_pem_path: /var/ssl/private/kafka_connect_replicator/public.pem
+kafka_connect_replicator_rbac_enabled_public_pem_path: "{{ (deployment_path ~ '/kafka_connect_replicator/public.pem') if deployment_path | length > 0 else '/var/ssl/private/kafka_connect_replicator/public.pem' }}"
 
 ### Variable to define bootstrap servers for Kafka Connect Replicator Consumer.  Mandatory for Kafka Connect Replicator setup.
 kafka_connect_replicator_consumer_bootstrap_servers: localhost:9092
@@ -2236,7 +2236,7 @@ kafka_connect_replicator_consumer_cert_path: "{{ ssl_file_dir_final }}/kafka_con
 kafka_connect_replicator_consumer_key_path: "{{ ssl_file_dir_final }}/kafka_connect_replicator_consumer.key"
 kafka_connect_replicator_consumer_export_certs: kafka_connect_replicator_consumer_listener ['ssl_mutual_auth_enabled'] | default(ssl_mutual_auth_enabled) | bool
 kafka_connect_replicator_consumer_keytab_path: "{{ (deployment_path ~ '/security/keytabs/kafka_connect_replicator_consumer.keytab') if deployment_path | length > 0 else '/etc/security/keytabs/kafka_connect_replicator_consumer.keytab' }}"
-kafka_connect_replicator_consumer_kerberos_keytab_path: /etc/security/keytabs/kafka_connect_replicator_consumer.keytab
+kafka_connect_replicator_consumer_kerberos_keytab_path: "{{ kafka_connect_replicator_consumer_keytab_path }}"
 
 ### Listener Dictionary that describes Kafka Connect Replicator Consumer Listener. It contains the keys: ssl_enabled, ssl_mutual_auth_enabled, sasl_protocol
 kafka_connect_replicator_consumer_listener:
@@ -2263,7 +2263,7 @@ kafka_connect_replicator_consumer_kafka_cluster_name: ""
 kafka_connect_replicator_consumer_erp_pem_file: ""
 
 ### Set this variable to override the default location of the public pem file for connecting to the ERP when RBAC is enabled.
-kafka_connect_replicator_consumer_rbac_enabled_public_pem_path: /var/ssl/private/kafka_connect_replicator_consumer/public.pem
+kafka_connect_replicator_consumer_rbac_enabled_public_pem_path: "{{ (deployment_path ~ '/kafka_connect_replicator_consumer/public.pem') if deployment_path | length > 0 else '/var/ssl/private/kafka_connect_replicator_consumer/public.pem' }}"
 
 ### Variable to define bootstrap servers for Kafka Connect Replicator Producer.  Mandatory for Kafka Connect Replicator setup.
 kafka_connect_replicator_producer_bootstrap_servers: localhost:9092
@@ -2324,7 +2324,7 @@ kafka_connect_replicator_producer_cert_path: "{{ ssl_file_dir_final }}/kafka_con
 kafka_connect_replicator_producer_key_path: "{{ ssl_file_dir_final }}/kafka_connect_replicator_producer.key"
 kafka_connect_replicator_producer_export_certs: kafka_connect_replicator_producer_listener ['ssl_mutual_auth_enabled'] | default(ssl_mutual_auth_enabled) | bool
 kafka_connect_replicator_producer_keytab_path: "{{ (deployment_path ~ '/security/keytabs/kafka_connect_replicator_producer.keytab') if deployment_path | length > 0 else '/etc/security/keytabs/kafka_connect_replicator_producer.keytab' }}"
-kafka_connect_replicator_producer_kerberos_keytab_path: /etc/security/keytabs/kafka_connect_replicator_producer.keytab
+kafka_connect_replicator_producer_kerberos_keytab_path: "{{ kafka_connect_replicator_producer_keytab_path }}"
 
 ### Listener Dictionary that describes Kafka Connect Replicator Producer Listener. It contains the keys: ssl_enabled, ssl_mutual_auth_enabled, sasl_protocol
 kafka_connect_replicator_producer_listener:

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -66,7 +66,7 @@ jolokia_url_remote: true
 jolokia_enabled: false
 
 ### Full path to download the Jolokia Agent Jar
-jolokia_jar_path: "{{ (deployment_path ~ '/jolokia/jolokia.jar') if deployment_path | length > 0 else '/opt/jolokia/jolokia.jar' }}"
+jolokia_jar_path: "{{ (deployment_path_final ~ '/jolokia/jolokia.jar') if deployment_path | length > 0 else '/opt/jolokia/jolokia.jar' }}"
 
 ### Boolean to force update of Jolokia Agent Jar (must be set to true if jolokia_jar_path already exists)
 jolokia_jar_url_force: false
@@ -137,7 +137,7 @@ jmxexporter_url_remote: true
 jmxexporter_enabled: false
 
 ### Full path to download the Prometheus Exporter Agent Jar
-jmxexporter_jar_path: "{{ (deployment_path ~ '/jmx_exporter/jmx_prometheus_javaagent.jar') if deployment_path | length > 0 else '/opt/prometheus/jmx_prometheus_javaagent.jar' }}"
+jmxexporter_jar_path: "{{ (deployment_path_final ~ '/jmx_exporter/jmx_prometheus_javaagent.jar') if deployment_path | length > 0 else '/opt/prometheus/jmx_prometheus_javaagent.jar' }}"
 
 ### Boolean to force update of Prometheus Exporter Agent Jar (must be set to true if jmxexporter_jar_path already exists)
 jmxexporter_jar_url_force: false
@@ -167,7 +167,7 @@ logredactor_policy_refresh_interval: 0
 kerberos_configure: true
 
 ### Custom path for the location of kerberos client configuration file, works with any value of kerberos_configure
-kerberos_client_config_file_dest: "{{ (deployment_path ~ '/krb5.conf') if deployment_path | length > 0 else '/etc/krb5.conf' }}"
+kerberos_client_config_file_dest: "{{ (deployment_path_final ~ '/krb5.conf') if deployment_path | length > 0 else '/etc/krb5.conf' }}"
 
 # Deprecated variable now that primary can be pulled from kafka_broker_kerberos_principal
 kerberos_kafka_broker_primary: "{{ (hostvars[ groups['kafka_broker'][0] | default('kafka') ] | default({})) ['kafka_broker_kerberos_principal'] | default('kafka/host@EXAMPLE>COM') | regex_replace('/.*') }}"
@@ -261,10 +261,10 @@ rootless_enabled: false
 rootless_lifecycle_enabled: "{{ rootless_enabled }}"
 
 ### Directory the rootless lifecycle env-file + start/stop scripts are written to.
-rootless_lifecycle_bin_dir: "{{ (deployment_path ~ '/rootless-bin') if deployment_path | length > 0 else (archive_destination_path ~ '/rootless-bin') }}"
+rootless_lifecycle_bin_dir: "{{ (deployment_path_final ~ '/rootless-bin') if deployment_path | length > 0 else (archive_destination_path ~ '/rootless-bin') }}"
 
 ### The path the downloaded archive is expanded into. Using the default with a `confluent_package_version` of *5.5.1* results in the following installation path `/opt/confluent/confluent-5.5.1/` that contains directories such as `bin` and `share`, but may be overridden usinf the `binary_base_path` property.
-archive_destination_path: "{{ (deployment_path ~ '/confluent') if deployment_path | length > 0 else '/opt/confluent' }}"
+archive_destination_path: "{{ (deployment_path_final ~ '/confluent') if deployment_path | length > 0 else '/opt/confluent' }}"
 
 archive_version: "{{confluent_package_version}}"
 
@@ -287,7 +287,7 @@ config_prefix: "/etc"
 confluent_cli_download_enabled: "{{ secrets_protection_enabled }}"
 
 ### The path the Confluent CLI archive is expanded into.
-confluent_cli_base_path: "{{ (deployment_path ~ '/confluent-cli') if deployment_path | length > 0 else '/opt/confluent-cli' }}"
+confluent_cli_base_path: "{{ (deployment_path_final ~ '/confluent-cli') if deployment_path | length > 0 else '/opt/confluent-cli' }}"
 
 ### Full path on hosts for Confluent CLI symlink to executable
 confluent_cli_path: "{{ (confluent_cli_base_path ~ '/confluent') if deployment_path | length > 0 else '/usr/local/bin/confluent' }}"
@@ -318,7 +318,7 @@ ssl_self_signed_ca_key_filepath: generated_ssl_files/snakeoil-ca-1.key
 ssl_self_signed_ca_password: capassword123
 
 ### Directory on hosts to store all ssl files.
-ssl_file_dir: "{{ (deployment_path ~ '/ssl') if deployment_path | length > 0 else '/var/ssl/private/' }}"
+ssl_file_dir: "{{ (deployment_path_final ~ '/ssl') if deployment_path | length > 0 else '/var/ssl/private/' }}"
 
 ### Boolean to have reruns of all.yml regenerate the certificate authority used for self signed certs.
 regenerate_ca: false
@@ -447,7 +447,7 @@ zookeeper_ca_cert_path: "{{ ssl_file_dir_final }}/ca.crt"
 zookeeper_cert_path: "{{ ssl_file_dir_final }}/zookeeper.crt"
 zookeeper_key_path: "{{ ssl_file_dir_final }}/zookeeper.key"
 zookeeper_export_certs: "{{ True if zookeeper_client_authentication_type == 'mtls' or zookeeper_quorum_authentication_type in ['mtls', 'digest_over_tls'] else False }}"
-zookeeper_keytab_path: "{{ (deployment_path ~ '/security/keytabs/zookeeper.keytab') if deployment_path | length > 0 else '/etc/security/keytabs/zookeeper.keytab' }}"
+zookeeper_keytab_path: "{{ (deployment_path_final ~ '/security/keytabs/zookeeper.keytab') if deployment_path | length > 0 else '/etc/security/keytabs/zookeeper.keytab' }}"
 
 ### Boolean to enable Jolokia access control on zookeeper
 zookeeper_jolokia_access_control_enabled: "{{jolokia_access_control_enabled}}"
@@ -484,7 +484,7 @@ zookeeper_jmxexporter_port: 8079
 zookeeper_jmxexporter_config_source_path: zookeeper.yml
 
 ### Destination path for Zookeeper jmx config file
-zookeeper_jmxexporter_config_path: "{{ (deployment_path ~ '/jmx_exporter/zookeeper.yml') if deployment_path | length > 0 else '/opt/prometheus/zookeeper.yml' }}"
+zookeeper_jmxexporter_config_path: "{{ (deployment_path_final ~ '/jmx_exporter/zookeeper.yml') if deployment_path | length > 0 else '/opt/prometheus/zookeeper.yml' }}"
 
 zookeeper_health_check_command: "{{ binary_base_path }}/bin/kafka-run-class
 {% if zookeeper_ssl_enabled|bool %}
@@ -599,7 +599,7 @@ kafka_controller_ca_cert_path: "{{ ssl_file_dir_final }}/ca.crt"
 kafka_controller_cert_path: "{{ ssl_file_dir_final }}/kafka_controller.crt"
 kafka_controller_key_path: "{{ ssl_file_dir_final }}/kafka_controller.key"
 kafka_controller_export_certs: "{{ssl_mutual_auth_enabled}}"
-kafka_controller_keytab_path: "{{ (deployment_path ~ '/security/keytabs/kafka_controller.keytab') if deployment_path | length > 0 else '/etc/security/keytabs/kafka_controller.keytab' }}"
+kafka_controller_keytab_path: "{{ (deployment_path_final ~ '/security/keytabs/kafka_controller.keytab') if deployment_path | length > 0 else '/etc/security/keytabs/kafka_controller.keytab' }}"
 
 ### Boolean to enable Jolokia access control on kafka controller
 kafka_controller_jolokia_access_control_enabled: "{{jolokia_access_control_enabled}}"
@@ -641,7 +641,7 @@ kafka_controller_jmxexporter_port: 8079
 kafka_controller_jmxexporter_config_source_path: kafka.yml.j2
 
 ### Destination path for Kafka controller jmx config file
-kafka_controller_jmxexporter_config_path: "{{ (deployment_path ~ '/jmx_exporter/kafka_controller.yml') if deployment_path | length > 0 else '/opt/prometheus/kafka.yml' }}"
+kafka_controller_jmxexporter_config_path: "{{ (deployment_path_final ~ '/jmx_exporter/kafka_controller.yml') if deployment_path | length > 0 else '/opt/prometheus/kafka.yml' }}"
 
 ### Use to copy files from control node to kafka hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '0750') and file_mode (default: '0640') to set directory and file permissions.
 kafka_controller_copy_files: []
@@ -754,7 +754,7 @@ kafka_broker_ca_cert_path: "{{ ssl_file_dir_final }}/ca.crt"
 kafka_broker_cert_path: "{{ ssl_file_dir_final }}/kafka_broker.crt"
 kafka_broker_key_path: "{{ ssl_file_dir_final }}/kafka_broker.key"
 kafka_broker_export_certs: "{{ssl_mutual_auth_enabled}}"
-kafka_broker_keytab_path: "{{ (deployment_path ~ '/security/keytabs/kafka_broker.keytab') if deployment_path | length > 0 else '/etc/security/keytabs/kafka_broker.keytab' }}"
+kafka_broker_keytab_path: "{{ (deployment_path_final ~ '/security/keytabs/kafka_broker.keytab') if deployment_path | length > 0 else '/etc/security/keytabs/kafka_broker.keytab' }}"
 
 ### Boolean to configure Schema Validation on Kafka
 kafka_broker_schema_validation_enabled: true
@@ -795,7 +795,7 @@ kafka_broker_jmxexporter_port: 8080
 kafka_broker_jmxexporter_config_source_path: kafka.yml.j2
 
 ### Destination path for Kafka Broker jmx config file
-kafka_broker_jmxexporter_config_path: "{{ (deployment_path ~ '/jmx_exporter/kafka.yml') if deployment_path | length > 0 else '/opt/prometheus/kafka.yml' }}"
+kafka_broker_jmxexporter_config_path: "{{ (deployment_path_final ~ '/jmx_exporter/kafka.yml') if deployment_path | length > 0 else '/opt/prometheus/kafka.yml' }}"
 
 ### Use to copy files from control node to kafka hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '750') and file_mode (default: '640') to set directory and file permissions.
 kafka_broker_copy_files: []
@@ -876,7 +876,7 @@ schema_registry_ca_cert_path: "{{ ssl_file_dir_final }}/ca.crt"
 schema_registry_cert_path: "{{ ssl_file_dir_final }}/schema_registry.crt"
 schema_registry_key_path: "{{ ssl_file_dir_final }}/schema_registry.key"
 schema_registry_export_certs: "{{ True if schema_registry_authentication_type == 'mtls' else False }}"
-schema_registry_keytab_path: "{{ (deployment_path ~ '/security/keytabs/schema_registry.keytab') if deployment_path | length > 0 else '/etc/security/keytabs/schema_registry.keytab' }}"
+schema_registry_keytab_path: "{{ (deployment_path_final ~ '/security/keytabs/schema_registry.keytab') if deployment_path | length > 0 else '/etc/security/keytabs/schema_registry.keytab' }}"
 schema_registry_kafka_listener_name: internal
 
 ### Boolean to enable Jolokia access control on schema registry
@@ -910,7 +910,7 @@ schema_registry_jmxexporter_enabled: "{{jmxexporter_enabled}}"
 schema_registry_jmxexporter_config_source_path: schema_registry.yml
 
 ### Destination path for Schema Registry jmx config file
-schema_registry_jmxexporter_config_path: "{{ (deployment_path ~ '/jmx_exporter/schema_registry.yml') if deployment_path | length > 0 else '/opt/prometheus/schema_registry.yml' }}"
+schema_registry_jmxexporter_config_path: "{{ (deployment_path_final ~ '/jmx_exporter/schema_registry.yml') if deployment_path | length > 0 else '/opt/prometheus/schema_registry.yml' }}"
 
 ### Port to expose prometheus metrics. Beware of port collisions if colocating components on same host
 schema_registry_jmxexporter_port: 8078
@@ -976,7 +976,7 @@ kafka_rest_ca_cert_path: "{{ ssl_file_dir_final }}/ca.crt"
 kafka_rest_cert_path: "{{ ssl_file_dir_final }}/kafka_rest.crt"
 kafka_rest_key_path: "{{ ssl_file_dir_final }}/kafka_rest.key"
 kafka_rest_export_certs: "{{ True if kafka_rest_authentication_type == 'mtls' else False }}"
-kafka_rest_keytab_path: "{{ (deployment_path ~ '/security/keytabs/kafka_rest.keytab') if deployment_path | length > 0 else '/etc/security/keytabs/kafka_rest.keytab' }}"
+kafka_rest_keytab_path: "{{ (deployment_path_final ~ '/security/keytabs/kafka_rest.keytab') if deployment_path | length > 0 else '/etc/security/keytabs/kafka_rest.keytab' }}"
 kafka_rest_kafka_listener_name: internal
 
 ### Boolean to enable Jolokia access control on kafka rest
@@ -1010,7 +1010,7 @@ kafka_rest_jmxexporter_enabled: "{{jmxexporter_enabled}}"
 kafka_rest_jmxexporter_config_source_path: kafka_rest.yml
 
 ### Destination path for Rest Proxy jmx config file
-kafka_rest_jmxexporter_config_path: "{{ (deployment_path ~ '/jmx_exporter/kafka_rest.yml') if deployment_path | length > 0 else '/opt/prometheus/kafka_rest.yml' }}"
+kafka_rest_jmxexporter_config_path: "{{ (deployment_path_final ~ '/jmx_exporter/kafka_rest.yml') if deployment_path | length > 0 else '/opt/prometheus/kafka_rest.yml' }}"
 
 ### Port to expose prometheus metrics. Beware of port collisions if colocating components on same host
 kafka_rest_jmxexporter_port: 8075
@@ -1085,7 +1085,7 @@ kafka_connect_ca_cert_path: "{{ ssl_file_dir_final }}/{{ kafka_connect_service_n
 kafka_connect_cert_path: "{{ ssl_file_dir_final }}/{{ kafka_connect_service_name + '.crt' if kafka_connect_service_name != kafka_connect_default_service_name else 'kafka_connect.crt'}}"
 kafka_connect_key_path: "{{ ssl_file_dir_final }}/{{ kafka_connect_service_name + '.key' if kafka_connect_service_name != kafka_connect_default_service_name else 'kafka_connect.key'}}"
 kafka_connect_export_certs: "{{ True if kafka_connect_authentication_type == 'mtls' else False }}"
-kafka_connect_keytab_path: "{{ (deployment_path ~ '/security/keytabs/kafka_connect.keytab') if deployment_path | length > 0 else '/etc/security/keytabs/kafka_connect.keytab' }}"
+kafka_connect_keytab_path: "{{ (deployment_path_final ~ '/security/keytabs/kafka_connect.keytab') if deployment_path | length > 0 else '/etc/security/keytabs/kafka_connect.keytab' }}"
 kafka_connect_kafka_listener_name: internal
 
 ### Allows you to select a custom kafka listener for Kafka Connect producers
@@ -1128,7 +1128,7 @@ kafka_connect_jmxexporter_enabled: "{{jmxexporter_enabled}}"
 kafka_connect_jmxexporter_config_source_path: kafka_connect.yml
 
 ### Destination path for Connect jmx config file
-kafka_connect_jmxexporter_config_path: "{{ (deployment_path ~ '/jmx_exporter/kafka_connect.yml') if deployment_path | length > 0 else '/opt/prometheus/kafka_connect.yml' }}"
+kafka_connect_jmxexporter_config_path: "{{ (deployment_path_final ~ '/jmx_exporter/kafka_connect.yml') if deployment_path | length > 0 else '/opt/prometheus/kafka_connect.yml' }}"
 
 ### Port to expose connect prometheus metrics. Beware of port collisions if colocating components on same host
 kafka_connect_jmxexporter_port: 8077
@@ -1157,10 +1157,10 @@ kafka_connect_plugins_path:
 
 
 kafka_connect_confluent_hub_plugins: []
-kafka_connect_confluent_hub_plugins_dest: "{{ (deployment_path ~ '/connect-plugins') if deployment_path | length > 0 else '/usr/share/java/connect_plugins' }}"
+kafka_connect_confluent_hub_plugins_dest: "{{ (deployment_path_final ~ '/connect-plugins') if deployment_path | length > 0 else '/usr/share/java/connect_plugins' }}"
 kafka_connect_plugins: []
 kafka_connect_plugins_remote: []
-kafka_connect_plugins_dest: "{{ (deployment_path ~ '/connect-plugins') if deployment_path | length > 0 else '/usr/share/java/connect_plugins' }}"
+kafka_connect_plugins_dest: "{{ (deployment_path_final ~ '/connect-plugins') if deployment_path | length > 0 else '/usr/share/java/connect_plugins' }}"
 
 ### Use to set custom Connect properties. This variable is a dictionary. Put values true/false in quotation marks to perserve case. NOTE- kafka_connect.properties is deprecated.
 kafka_connect_custom_properties: {}
@@ -1227,7 +1227,7 @@ ksql_ca_cert_path: "{{ ssl_file_dir_final }}/ca.crt"
 ksql_cert_path: "{{ ssl_file_dir_final }}/ksql.crt"
 ksql_key_path: "{{ ssl_file_dir_final }}/ksql.key"
 ksql_export_certs: "{{ True if ksql_authentication_type == 'mtls' else False }}"
-ksql_keytab_path: "{{ (deployment_path ~ '/security/keytabs/ksql.keytab') if deployment_path | length > 0 else '/etc/security/keytabs/ksql.keytab' }}"
+ksql_keytab_path: "{{ (deployment_path_final ~ '/security/keytabs/ksql.keytab') if deployment_path | length > 0 else '/etc/security/keytabs/ksql.keytab' }}"
 ksql_kafka_listener_name: internal
 ksql_processing_log_kafka_listener_name: "{{kafka_broker_inter_broker_listener_name if rbac_enabled else ksql_kafka_listener_name}}"
 
@@ -1262,7 +1262,7 @@ ksql_jmxexporter_enabled: "{{jmxexporter_enabled}}"
 ksql_jmxexporter_config_source_path: ksql.yml
 
 ### Destination path for ksqlDB jmx config file
-ksql_jmxexporter_config_path: "{{ (deployment_path ~ '/jmx_exporter/ksql.yml') if deployment_path | length > 0 else '/opt/prometheus/ksql.yml' }}"
+ksql_jmxexporter_config_path: "{{ (deployment_path_final ~ '/jmx_exporter/ksql.yml') if deployment_path | length > 0 else '/opt/prometheus/ksql.yml' }}"
 
 ### Port to expose ksqlDB prometheus metrics. Beware of port collisions if colocating components on same host
 ksql_jmxexporter_port: 8076
@@ -1343,7 +1343,7 @@ control_center_ca_cert_path: "{{ ssl_file_dir_final }}/ca.crt"
 control_center_cert_path: "{{ ssl_file_dir_final }}/control_center.crt"
 control_center_key_path: "{{ ssl_file_dir_final }}/control_center.key"
 control_center_export_certs: "{{ssl_mutual_auth_enabled}}"
-control_center_keytab_path: "{{ (deployment_path ~ '/security/keytabs/control_center.keytab') if deployment_path | length > 0 else '/etc/security/keytabs/control_center.keytab' }}"
+control_center_keytab_path: "{{ (deployment_path_final ~ '/security/keytabs/control_center.keytab') if deployment_path | length > 0 else '/etc/security/keytabs/control_center.keytab' }}"
 control_center_kafka_listener_name: internal
 
 ### Use to copy files from control node to Control Center hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '750') and file_mode (default: '640') to set directory and file permissions.
@@ -2077,10 +2077,10 @@ kafka_connect_replicator_jolokia_port: 7777
 kafka_connect_replicator_jolokia_config: "{{ (config_base_path, kafka_connect_replicator_config_prefix_path, 'confluent-replicator-jolokia.properties') | path_join }}"
 
 ### Full path to download the Jolokia Agent Jar.
-kafka_connect_replicator_jolokia_jar_path: "{{ (deployment_path ~ '/jolokia/jolokia.jar') if deployment_path | length > 0 else '/opt/jolokia/jolokia.jar' }}"
+kafka_connect_replicator_jolokia_jar_path: "{{ (deployment_path_final ~ '/jolokia/jolokia.jar') if deployment_path | length > 0 else '/opt/jolokia/jolokia.jar' }}"
 
 ### Set this variable to customize the directory that Kafka Connect Replicator writes log files to.
-kafka_connect_replicator_log_dir: "{{ (deployment_path ~ '/log/kafka-connect-replicator') if deployment_path | length > 0 else '/var/log/confluent/kafka-connect-replicator' }}"
+kafka_connect_replicator_log_dir: "{{ (deployment_path_final ~ '/log/kafka-connect-replicator') if deployment_path | length > 0 else '/var/log/confluent/kafka-connect-replicator' }}"
 
 ### Set this variable to customize the default log name that Kafka Connect Replicator writes logs to.
 kafka_connect_replicator_log_name: kafka-connect-replicator.log
@@ -2145,7 +2145,7 @@ kafka_connect_replicator_ca_cert_path: "{{ ssl_file_dir_final }}/kafka_connect_r
 kafka_connect_replicator_cert_path: "{{ ssl_file_dir_final }}/kafka_connect_replicator.crt"
 kafka_connect_replicator_key_path: "{{ ssl_file_dir_final }}/kafka_connect_replicator.key"
 kafka_connect_replicator_export_certs: kafka_connect_replicator_listener ['ssl_mutual_auth_enabled'] | default(ssl_mutual_auth_enabled) | bool
-kafka_connect_replicator_keytab_path: "{{ (deployment_path ~ '/security/keytabs/kafka_connect_replicator.keytab') if deployment_path | length > 0 else '/etc/security/keytabs/kafka_connect_replicator.keytab' }}"
+kafka_connect_replicator_keytab_path: "{{ (deployment_path_final ~ '/security/keytabs/kafka_connect_replicator.keytab') if deployment_path | length > 0 else '/etc/security/keytabs/kafka_connect_replicator.keytab' }}"
 kafka_connect_replicator_kerberos_keytab_path: "{{ kafka_connect_replicator_keytab_path }}"
 kafka_connect_replicator_listener_name: kafka_connect_replicator_listener
 kafka_connect_replicator_group_id: replicator
@@ -2175,7 +2175,7 @@ kafka_connect_replicator_kafka_cluster_name: ""
 kafka_connect_replicator_erp_pem_file: ""
 
 ### Set this variable to override the default location of the public pem file for connecting to the ERP when RBAC is enabled.
-kafka_connect_replicator_rbac_enabled_public_pem_path: "{{ (deployment_path ~ '/kafka_connect_replicator/public.pem') if deployment_path | length > 0 else '/var/ssl/private/kafka_connect_replicator/public.pem' }}"
+kafka_connect_replicator_rbac_enabled_public_pem_path: "{{ (deployment_path_final ~ '/kafka_connect_replicator/public.pem') if deployment_path | length > 0 else '/var/ssl/private/kafka_connect_replicator/public.pem' }}"
 
 ### Variable to define bootstrap servers for Kafka Connect Replicator Consumer.  Mandatory for Kafka Connect Replicator setup.
 kafka_connect_replicator_consumer_bootstrap_servers: localhost:9092
@@ -2235,7 +2235,7 @@ kafka_connect_replicator_consumer_ca_cert_path: "{{ ssl_file_dir_final }}/kafka_
 kafka_connect_replicator_consumer_cert_path: "{{ ssl_file_dir_final }}/kafka_connect_replicator_consumer.crt"
 kafka_connect_replicator_consumer_key_path: "{{ ssl_file_dir_final }}/kafka_connect_replicator_consumer.key"
 kafka_connect_replicator_consumer_export_certs: kafka_connect_replicator_consumer_listener ['ssl_mutual_auth_enabled'] | default(ssl_mutual_auth_enabled) | bool
-kafka_connect_replicator_consumer_keytab_path: "{{ (deployment_path ~ '/security/keytabs/kafka_connect_replicator_consumer.keytab') if deployment_path | length > 0 else '/etc/security/keytabs/kafka_connect_replicator_consumer.keytab' }}"
+kafka_connect_replicator_consumer_keytab_path: "{{ (deployment_path_final ~ '/security/keytabs/kafka_connect_replicator_consumer.keytab') if deployment_path | length > 0 else '/etc/security/keytabs/kafka_connect_replicator_consumer.keytab' }}"
 kafka_connect_replicator_consumer_kerberos_keytab_path: "{{ kafka_connect_replicator_consumer_keytab_path }}"
 
 ### Listener Dictionary that describes Kafka Connect Replicator Consumer Listener. It contains the keys: ssl_enabled, ssl_mutual_auth_enabled, sasl_protocol
@@ -2263,7 +2263,7 @@ kafka_connect_replicator_consumer_kafka_cluster_name: ""
 kafka_connect_replicator_consumer_erp_pem_file: ""
 
 ### Set this variable to override the default location of the public pem file for connecting to the ERP when RBAC is enabled.
-kafka_connect_replicator_consumer_rbac_enabled_public_pem_path: "{{ (deployment_path ~ '/kafka_connect_replicator_consumer/public.pem') if deployment_path | length > 0 else '/var/ssl/private/kafka_connect_replicator_consumer/public.pem' }}"
+kafka_connect_replicator_consumer_rbac_enabled_public_pem_path: "{{ (deployment_path_final ~ '/kafka_connect_replicator_consumer/public.pem') if deployment_path | length > 0 else '/var/ssl/private/kafka_connect_replicator_consumer/public.pem' }}"
 
 ### Variable to define bootstrap servers for Kafka Connect Replicator Producer.  Mandatory for Kafka Connect Replicator setup.
 kafka_connect_replicator_producer_bootstrap_servers: localhost:9092
@@ -2323,7 +2323,7 @@ kafka_connect_replicator_producer_ca_cert_path: "{{ ssl_file_dir_final }}/kafka_
 kafka_connect_replicator_producer_cert_path: "{{ ssl_file_dir_final }}/kafka_connect_replicator_producer.crt"
 kafka_connect_replicator_producer_key_path: "{{ ssl_file_dir_final }}/kafka_connect_replicator_producer.key"
 kafka_connect_replicator_producer_export_certs: kafka_connect_replicator_producer_listener ['ssl_mutual_auth_enabled'] | default(ssl_mutual_auth_enabled) | bool
-kafka_connect_replicator_producer_keytab_path: "{{ (deployment_path ~ '/security/keytabs/kafka_connect_replicator_producer.keytab') if deployment_path | length > 0 else '/etc/security/keytabs/kafka_connect_replicator_producer.keytab' }}"
+kafka_connect_replicator_producer_keytab_path: "{{ (deployment_path_final ~ '/security/keytabs/kafka_connect_replicator_producer.keytab') if deployment_path | length > 0 else '/etc/security/keytabs/kafka_connect_replicator_producer.keytab' }}"
 kafka_connect_replicator_producer_kerberos_keytab_path: "{{ kafka_connect_replicator_producer_keytab_path }}"
 
 ### Listener Dictionary that describes Kafka Connect Replicator Producer Listener. It contains the keys: ssl_enabled, ssl_mutual_auth_enabled, sasl_protocol
@@ -2414,7 +2414,7 @@ kafka_connect_replicator_monitoring_interceptor_ca_cert_path: "{{ ssl_file_dir_f
 kafka_connect_replicator_monitoring_interceptor_cert_path: "{{ ssl_file_dir_final }}/kafka_connect_replicator_monitoring_interceptor.crt"
 kafka_connect_replicator_monitoring_interceptor_key_path: "{{ ssl_file_dir_final }}/kafka_connect_replicator_monitoring_interceptor.key"
 kafka_connect_replicator_monitoring_interceptor_export_certs: kafka_connect_replicator_monitoring_interceptor_listener ['ssl_mutual_auth_enabled'] | default(ssl_mutual_auth_enabled) | bool
-kafka_connect_replicator_monitoring_interceptor_keytab_path: "{{ (deployment_path ~ '/security/keytabs/kafka_connect_replicator_monitoring_interceptor.keytab') if deployment_path | length > 0 else '/etc/security/keytabs/kafka_connect_replicator_monitoring_interceptor.keytab' }}"
+kafka_connect_replicator_monitoring_interceptor_keytab_path: "{{ (deployment_path_final ~ '/security/keytabs/kafka_connect_replicator_monitoring_interceptor.keytab') if deployment_path | length > 0 else '/etc/security/keytabs/kafka_connect_replicator_monitoring_interceptor.keytab' }}"
 
 ### Listener Dictionary that describes Kafka Connect Replicator Monitoring Interceptor Listener. It contains the keys: ssl_enabled, ssl_mutual_auth_enabled, sasl_protocol
 kafka_connect_replicator_monitoring_interceptor_listener:

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -249,21 +249,15 @@ monitoring_interceptors_enabled: "{{ 'control_center' in groups }}"
 ### The method of installation. Valid values are "package" or "archive". If "archive" is selected then services will not be installed via the use of yum or apt, but will instead be installed via expanding the target .tar.gz file from the Confluent archive into the path defined by `archive_destination_path`. Configuration files are also kept in this directory structure instead of `/etc`. SystemD service units are copied from the ardhive for each target service and overrides are created pointing at the new paths. The "package" installation method is the default behavior that utilizes yum/apt.
 installation_method: "package"
 
-### Rootless base path/user/group. When set, install paths, users/groups, and data/log
-### dirs derive from these instead of ~60 per-component overrides. Empty = no change.
+### Rootless base path/user/group - install paths, users/groups, and data/log dirs derive from these. Empty = no change.
 deployment_path: ""
 deployment_user: ""
 deployment_group: ""
 
-### Master switch for rootless deploys: skips root-requiring steps (privileged/package/
-### systemd/sysctl/health_check/logrotate) and runs the systemd --user lifecycle instead,
-### so plain `ansible-playbook confluent.platform.all` works with no --skip-tags. Requires
-### installation_method: archive + deployment_path/user/group. Default false = no change.
+### Master switch for rootless deploys - skips root-requiring steps and runs the systemd --user lifecycle instead. Default false = no change.
 rootless_enabled: false
 
-### Generates a systemd --user unit + EnvironmentFile per component (same JVM env the
-### systemd override.conf would set) instead of system-level systemd. Defaults to
-### rootless_enabled; can be set independently. Default false = no change.
+### Generates a systemd --user unit per component instead of system-level systemd. Defaults to rootless_enabled; can be set independently.
 rootless_lifecycle_enabled: "{{ rootless_enabled }}"
 
 ### Directory the rootless lifecycle env-file + start/stop scripts are written to.

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -167,7 +167,7 @@ logredactor_policy_refresh_interval: 0
 kerberos_configure: true
 
 ### Custom path for the location of kerberos client configuration file, works with any value of kerberos_configure
-kerberos_client_config_file_dest: /etc/krb5.conf
+kerberos_client_config_file_dest: "{{ (deployment_path ~ '/krb5.conf') if deployment_path | length > 0 else '/etc/krb5.conf' }}"
 
 # Deprecated variable now that primary can be pulled from kafka_broker_kerberos_principal
 kerberos_kafka_broker_primary: "{{ (hostvars[ groups['kafka_broker'][0] | default('kafka') ] | default({})) ['kafka_broker_kerberos_principal'] | default('kafka/host@EXAMPLE>COM') | regex_replace('/.*') }}"
@@ -453,7 +453,7 @@ zookeeper_ca_cert_path: "{{ ssl_file_dir_final }}/ca.crt"
 zookeeper_cert_path: "{{ ssl_file_dir_final }}/zookeeper.crt"
 zookeeper_key_path: "{{ ssl_file_dir_final }}/zookeeper.key"
 zookeeper_export_certs: "{{ True if zookeeper_client_authentication_type == 'mtls' or zookeeper_quorum_authentication_type in ['mtls', 'digest_over_tls'] else False }}"
-zookeeper_keytab_path: /etc/security/keytabs/zookeeper.keytab
+zookeeper_keytab_path: "{{ (deployment_path ~ '/security/keytabs/zookeeper.keytab') if deployment_path | length > 0 else '/etc/security/keytabs/zookeeper.keytab' }}"
 
 ### Boolean to enable Jolokia access control on zookeeper
 zookeeper_jolokia_access_control_enabled: "{{jolokia_access_control_enabled}}"
@@ -605,7 +605,7 @@ kafka_controller_ca_cert_path: "{{ ssl_file_dir_final }}/ca.crt"
 kafka_controller_cert_path: "{{ ssl_file_dir_final }}/kafka_controller.crt"
 kafka_controller_key_path: "{{ ssl_file_dir_final }}/kafka_controller.key"
 kafka_controller_export_certs: "{{ssl_mutual_auth_enabled}}"
-kafka_controller_keytab_path: /etc/security/keytabs/kafka_controller.keytab
+kafka_controller_keytab_path: "{{ (deployment_path ~ '/security/keytabs/kafka_controller.keytab') if deployment_path | length > 0 else '/etc/security/keytabs/kafka_controller.keytab' }}"
 
 ### Boolean to enable Jolokia access control on kafka controller
 kafka_controller_jolokia_access_control_enabled: "{{jolokia_access_control_enabled}}"
@@ -760,7 +760,7 @@ kafka_broker_ca_cert_path: "{{ ssl_file_dir_final }}/ca.crt"
 kafka_broker_cert_path: "{{ ssl_file_dir_final }}/kafka_broker.crt"
 kafka_broker_key_path: "{{ ssl_file_dir_final }}/kafka_broker.key"
 kafka_broker_export_certs: "{{ssl_mutual_auth_enabled}}"
-kafka_broker_keytab_path: /etc/security/keytabs/kafka_broker.keytab
+kafka_broker_keytab_path: "{{ (deployment_path ~ '/security/keytabs/kafka_broker.keytab') if deployment_path | length > 0 else '/etc/security/keytabs/kafka_broker.keytab' }}"
 
 ### Boolean to configure Schema Validation on Kafka
 kafka_broker_schema_validation_enabled: true
@@ -882,7 +882,7 @@ schema_registry_ca_cert_path: "{{ ssl_file_dir_final }}/ca.crt"
 schema_registry_cert_path: "{{ ssl_file_dir_final }}/schema_registry.crt"
 schema_registry_key_path: "{{ ssl_file_dir_final }}/schema_registry.key"
 schema_registry_export_certs: "{{ True if schema_registry_authentication_type == 'mtls' else False }}"
-schema_registry_keytab_path: /etc/security/keytabs/schema_registry.keytab
+schema_registry_keytab_path: "{{ (deployment_path ~ '/security/keytabs/schema_registry.keytab') if deployment_path | length > 0 else '/etc/security/keytabs/schema_registry.keytab' }}"
 schema_registry_kafka_listener_name: internal
 
 ### Boolean to enable Jolokia access control on schema registry
@@ -982,7 +982,7 @@ kafka_rest_ca_cert_path: "{{ ssl_file_dir_final }}/ca.crt"
 kafka_rest_cert_path: "{{ ssl_file_dir_final }}/kafka_rest.crt"
 kafka_rest_key_path: "{{ ssl_file_dir_final }}/kafka_rest.key"
 kafka_rest_export_certs: "{{ True if kafka_rest_authentication_type == 'mtls' else False }}"
-kafka_rest_keytab_path: /etc/security/keytabs/kafka_rest.keytab
+kafka_rest_keytab_path: "{{ (deployment_path ~ '/security/keytabs/kafka_rest.keytab') if deployment_path | length > 0 else '/etc/security/keytabs/kafka_rest.keytab' }}"
 kafka_rest_kafka_listener_name: internal
 
 ### Boolean to enable Jolokia access control on kafka rest
@@ -1091,7 +1091,7 @@ kafka_connect_ca_cert_path: "{{ ssl_file_dir_final }}/{{ kafka_connect_service_n
 kafka_connect_cert_path: "{{ ssl_file_dir_final }}/{{ kafka_connect_service_name + '.crt' if kafka_connect_service_name != kafka_connect_default_service_name else 'kafka_connect.crt'}}"
 kafka_connect_key_path: "{{ ssl_file_dir_final }}/{{ kafka_connect_service_name + '.key' if kafka_connect_service_name != kafka_connect_default_service_name else 'kafka_connect.key'}}"
 kafka_connect_export_certs: "{{ True if kafka_connect_authentication_type == 'mtls' else False }}"
-kafka_connect_keytab_path: /etc/security/keytabs/kafka_connect.keytab
+kafka_connect_keytab_path: "{{ (deployment_path ~ '/security/keytabs/kafka_connect.keytab') if deployment_path | length > 0 else '/etc/security/keytabs/kafka_connect.keytab' }}"
 kafka_connect_kafka_listener_name: internal
 
 ### Allows you to select a custom kafka listener for Kafka Connect producers
@@ -1233,7 +1233,7 @@ ksql_ca_cert_path: "{{ ssl_file_dir_final }}/ca.crt"
 ksql_cert_path: "{{ ssl_file_dir_final }}/ksql.crt"
 ksql_key_path: "{{ ssl_file_dir_final }}/ksql.key"
 ksql_export_certs: "{{ True if ksql_authentication_type == 'mtls' else False }}"
-ksql_keytab_path: /etc/security/keytabs/ksql.keytab
+ksql_keytab_path: "{{ (deployment_path ~ '/security/keytabs/ksql.keytab') if deployment_path | length > 0 else '/etc/security/keytabs/ksql.keytab' }}"
 ksql_kafka_listener_name: internal
 ksql_processing_log_kafka_listener_name: "{{kafka_broker_inter_broker_listener_name if rbac_enabled else ksql_kafka_listener_name}}"
 
@@ -1349,7 +1349,7 @@ control_center_ca_cert_path: "{{ ssl_file_dir_final }}/ca.crt"
 control_center_cert_path: "{{ ssl_file_dir_final }}/control_center.crt"
 control_center_key_path: "{{ ssl_file_dir_final }}/control_center.key"
 control_center_export_certs: "{{ssl_mutual_auth_enabled}}"
-control_center_keytab_path: /etc/security/keytabs/control_center.keytab
+control_center_keytab_path: "{{ (deployment_path ~ '/security/keytabs/control_center.keytab') if deployment_path | length > 0 else '/etc/security/keytabs/control_center.keytab' }}"
 control_center_kafka_listener_name: internal
 
 ### Use to copy files from control node to Control Center hosts. Set to list of dictionaries with keys: source_path (full path of file on control node) and destination_path (full path to copy file to). Optionally specify directory_mode (default: '750') and file_mode (default: '640') to set directory and file permissions.
@@ -2151,7 +2151,7 @@ kafka_connect_replicator_ca_cert_path: "{{ ssl_file_dir_final }}/kafka_connect_r
 kafka_connect_replicator_cert_path: "{{ ssl_file_dir_final }}/kafka_connect_replicator.crt"
 kafka_connect_replicator_key_path: "{{ ssl_file_dir_final }}/kafka_connect_replicator.key"
 kafka_connect_replicator_export_certs: kafka_connect_replicator_listener ['ssl_mutual_auth_enabled'] | default(ssl_mutual_auth_enabled) | bool
-kafka_connect_replicator_keytab_path: /etc/security/keytabs/kafka_connect_replicator.keytab
+kafka_connect_replicator_keytab_path: "{{ (deployment_path ~ '/security/keytabs/kafka_connect_replicator.keytab') if deployment_path | length > 0 else '/etc/security/keytabs/kafka_connect_replicator.keytab' }}"
 kafka_connect_replicator_kerberos_keytab_path: /etc/security/keytabs/kafka_connect_replicator.keytab
 kafka_connect_replicator_listener_name: kafka_connect_replicator_listener
 kafka_connect_replicator_group_id: replicator
@@ -2241,7 +2241,7 @@ kafka_connect_replicator_consumer_ca_cert_path: "{{ ssl_file_dir_final }}/kafka_
 kafka_connect_replicator_consumer_cert_path: "{{ ssl_file_dir_final }}/kafka_connect_replicator_consumer.crt"
 kafka_connect_replicator_consumer_key_path: "{{ ssl_file_dir_final }}/kafka_connect_replicator_consumer.key"
 kafka_connect_replicator_consumer_export_certs: kafka_connect_replicator_consumer_listener ['ssl_mutual_auth_enabled'] | default(ssl_mutual_auth_enabled) | bool
-kafka_connect_replicator_consumer_keytab_path: /etc/security/keytabs/kafka_connect_replicator_consumer.keytab
+kafka_connect_replicator_consumer_keytab_path: "{{ (deployment_path ~ '/security/keytabs/kafka_connect_replicator_consumer.keytab') if deployment_path | length > 0 else '/etc/security/keytabs/kafka_connect_replicator_consumer.keytab' }}"
 kafka_connect_replicator_consumer_kerberos_keytab_path: /etc/security/keytabs/kafka_connect_replicator_consumer.keytab
 
 ### Listener Dictionary that describes Kafka Connect Replicator Consumer Listener. It contains the keys: ssl_enabled, ssl_mutual_auth_enabled, sasl_protocol
@@ -2329,7 +2329,7 @@ kafka_connect_replicator_producer_ca_cert_path: "{{ ssl_file_dir_final }}/kafka_
 kafka_connect_replicator_producer_cert_path: "{{ ssl_file_dir_final }}/kafka_connect_replicator_producer.crt"
 kafka_connect_replicator_producer_key_path: "{{ ssl_file_dir_final }}/kafka_connect_replicator_producer.key"
 kafka_connect_replicator_producer_export_certs: kafka_connect_replicator_producer_listener ['ssl_mutual_auth_enabled'] | default(ssl_mutual_auth_enabled) | bool
-kafka_connect_replicator_producer_keytab_path: /etc/security/keytabs/kafka_connect_replicator_producer.keytab
+kafka_connect_replicator_producer_keytab_path: "{{ (deployment_path ~ '/security/keytabs/kafka_connect_replicator_producer.keytab') if deployment_path | length > 0 else '/etc/security/keytabs/kafka_connect_replicator_producer.keytab' }}"
 kafka_connect_replicator_producer_kerberos_keytab_path: /etc/security/keytabs/kafka_connect_replicator_producer.keytab
 
 ### Listener Dictionary that describes Kafka Connect Replicator Producer Listener. It contains the keys: ssl_enabled, ssl_mutual_auth_enabled, sasl_protocol
@@ -2420,7 +2420,7 @@ kafka_connect_replicator_monitoring_interceptor_ca_cert_path: "{{ ssl_file_dir_f
 kafka_connect_replicator_monitoring_interceptor_cert_path: "{{ ssl_file_dir_final }}/kafka_connect_replicator_monitoring_interceptor.crt"
 kafka_connect_replicator_monitoring_interceptor_key_path: "{{ ssl_file_dir_final }}/kafka_connect_replicator_monitoring_interceptor.key"
 kafka_connect_replicator_monitoring_interceptor_export_certs: kafka_connect_replicator_monitoring_interceptor_listener ['ssl_mutual_auth_enabled'] | default(ssl_mutual_auth_enabled) | bool
-kafka_connect_replicator_monitoring_interceptor_keytab_path: /etc/security/keytabs/kafka_connect_replicator_monitoring_interceptor.keytab
+kafka_connect_replicator_monitoring_interceptor_keytab_path: "{{ (deployment_path ~ '/security/keytabs/kafka_connect_replicator_monitoring_interceptor.keytab') if deployment_path | length > 0 else '/etc/security/keytabs/kafka_connect_replicator_monitoring_interceptor.keytab' }}"
 
 ### Listener Dictionary that describes Kafka Connect Replicator Monitoring Interceptor Listener. It contains the keys: ssl_enabled, ssl_mutual_auth_enabled, sasl_protocol
 kafka_connect_replicator_monitoring_interceptor_listener:

--- a/roles/variables/vars/main.yml
+++ b/roles/variables/vars/main.yml
@@ -8,6 +8,11 @@ confluent_repo_version: "{{ confluent_package_version | regex_replace('^([0-9])\
 # Confirm no trailing / on the ssl file directory path
 ssl_file_dir_final: "{{ ssl_file_dir |regex_replace('\\/$', '') }}"
 
+# Confirm no trailing / on deployment_path - used (instead of the raw deployment_path) by every
+# deployment_path-derived path below and in defaults/main.yml, so a trailing slash in the
+# inventory (e.g. deployment_path: /cp-data/) can't produce double-slash paths.
+deployment_path_final: "{{ deployment_path | regex_replace('\\/$', '') }}"
+
 ### The base path for the binary files. When in Archive File deployment mode this results in binary files being based in, for example `/opt/confluent/confluent-5.5.1/bin`, otherwise they are based in `/usr/bin`.
 base_path: "{{ ((config_base_path,('confluent-',archive_version) | join) | path_join) if installation_method == 'archive' else '/' }}"
 
@@ -37,7 +42,7 @@ zookeeper_service_name: confluent-zookeeper
 zookeeper_main_package: "{{ 'confluent-server' if confluent_server_enabled|bool else 'confluent-kafka'}}"
 zookeeper_default_user: "{{ deployment_user if deployment_user | length > 0 else 'cp-kafka' }}"
 zookeeper_default_group: "{{ deployment_group if deployment_group | length > 0 else 'confluent' }}"
-zookeeper_default_log_dir: "{{ (deployment_path ~ '/log/kafka') if deployment_path | length > 0 else '/var/log/kafka' }}"
+zookeeper_default_log_dir: "{{ (deployment_path_final ~ '/log/kafka') if deployment_path | length > 0 else '/var/log/kafka' }}"
 zookeeper:
   server_start_file: "{{ binary_base_path }}/bin/zookeeper-server-start"
   config_file: "{{ (config_base_path, zookeeper_config_prefix_path, 'zookeeper.properties') | path_join }}"
@@ -55,7 +60,7 @@ zookeeper_properties:
       syncLimit: 2
       autopurge.snapRetainCount: 10
       autopurge.purgeInterval: 1
-      dataDir: "{{ (deployment_path ~ '/data/zookeeper') if deployment_path | length > 0 else '/var/lib/zookeeper' }}"
+      dataDir: "{{ (deployment_path_final ~ '/data/zookeeper') if deployment_path | length > 0 else '/var/lib/zookeeper' }}"
       admin.enableServer: "false"
   non_secure:
     enabled: "{{ not zookeeper_ssl_enabled }}"
@@ -113,7 +118,7 @@ kafka_controller_service_name: "confluent-kcontroller"
 kafka_controller_main_package: "{{ 'confluent-server' if confluent_server_enabled|bool else 'confluent-kafka'}}"
 kafka_controller_default_group: "{{ deployment_group if deployment_group | length > 0 else 'confluent' }}"
 kafka_controller_default_user: "{{ deployment_user if deployment_user | length > 0 else 'cp-kafka' }}"
-kafka_controller_default_log_dir: "{{ (deployment_path ~ '/log/controller') if deployment_path | length > 0 else '/var/log/controller' }}"
+kafka_controller_default_log_dir: "{{ (deployment_path_final ~ '/log/controller') if deployment_path | length > 0 else '/var/log/controller' }}"
 kafka_controller:
   server_start_file: "{{ binary_base_path }}/bin/kafka-server-start"
   config_file: "{{ (config_base_path, kafka_controller_config_prefix_path, 'server.properties') | path_join }}"
@@ -149,7 +154,7 @@ kafka_controller_properties:
       confluent.security.event.logger.exporter.kafka.topic.replicas: "{{audit_logs_destination_bootstrap_servers.split(',')|length if audit_logs_destination_enabled and rbac_enabled else kafka_controller_default_internal_replication_factor}}"
       confluent.support.metrics.enable: "true"
       confluent.support.customer.id: anonymous
-      log.dirs: "{{ (deployment_path ~ '/data/controller/data') if deployment_path | length > 0 else '/var/lib/controller/data' }}"
+      log.dirs: "{{ (deployment_path_final ~ '/data/controller/data') if deployment_path | length > 0 else '/var/lib/controller/data' }}"
       kafka.rest.enable: "{{kafka_controller_rest_proxy_enabled|string|lower}}"
       process.roles: controller
       controller.quorum.voters: "{{ kafka_controller_quorum_voters }}"
@@ -335,7 +340,7 @@ kafka_broker_service_name: "{{ 'confluent-server' if confluent_server_enabled|bo
 kafka_broker_main_package: "{{ 'confluent-server' if confluent_server_enabled|bool else 'confluent-kafka'}}"
 kafka_broker_default_user: "{{ deployment_user if deployment_user | length > 0 else 'cp-kafka' }}"
 kafka_broker_default_group: "{{ deployment_group if deployment_group | length > 0 else 'confluent' }}"
-kafka_broker_default_log_dir: "{{ (deployment_path ~ '/log/kafka') if deployment_path | length > 0 else '/var/log/kafka' }}"
+kafka_broker_default_log_dir: "{{ (deployment_path_final ~ '/log/kafka') if deployment_path | length > 0 else '/var/log/kafka' }}"
 kafka_broker:
   server_start_file: "{{ binary_base_path }}/bin/kafka-server-start"
   config_file: "{{ (config_base_path, kafka_broker_config_prefix_path, 'server.properties') | path_join }}"
@@ -377,7 +382,7 @@ kafka_broker_properties:
       confluent.security.event.logger.exporter.kafka.topic.replicas: "{{audit_logs_destination_bootstrap_servers.split(',')|length if audit_logs_destination_enabled and rbac_enabled else kafka_broker_default_internal_replication_factor}}"
       confluent.support.metrics.enable: "true"
       confluent.support.customer.id: anonymous
-      log.dirs: "{{ (deployment_path ~ '/data/kafka/data') if deployment_path | length > 0 else '/var/lib/kafka/data' }}"
+      log.dirs: "{{ (deployment_path_final ~ '/data/kafka/data') if deployment_path | length > 0 else '/var/lib/kafka/data' }}"
       kafka.rest.enable: "{{kafka_broker_rest_proxy_enabled|string|lower}}"
       inter.broker.listener.name: "{{kafka_broker_listeners[kafka_broker_inter_broker_listener_name]['name']}}"
       confluent.cluster.link.metadata.topic.replication.factor: "{{kafka_broker_default_internal_replication_factor}}"
@@ -720,7 +725,7 @@ kafka_broker_client_properties: "{{ kafka_broker_default_client_properties | com
 schema_registry_service_name: confluent-schema-registry
 schema_registry_default_user: "{{ deployment_user if deployment_user | length > 0 else 'cp-schema-registry' }}"
 schema_registry_default_group: "{{ deployment_group if deployment_group | length > 0 else 'confluent' }}"
-schema_registry_default_log_dir: "{{ (deployment_path ~ '/log/confluent/schema-registry') if deployment_path | length > 0 else '/var/log/confluent/schema-registry' }}"
+schema_registry_default_log_dir: "{{ (deployment_path_final ~ '/log/confluent/schema-registry') if deployment_path | length > 0 else '/var/log/confluent/schema-registry' }}"
 schema_registry:
   server_start_file: "{{ binary_base_path }}/bin/schema-registry-start"
   systemd_file: "{{systemd_base_dir}}/{{schema_registry_service_name}}.service"
@@ -835,7 +840,7 @@ kafka_connect_default_service_name: confluent-kafka-connect
 kafka_connect_default_config_filename: connect-distributed.properties
 kafka_connect_default_user: "{{ deployment_user if deployment_user | length > 0 else 'cp-kafka-connect' }}"
 kafka_connect_default_group: "{{ deployment_group if deployment_group | length > 0 else 'confluent' }}"
-kafka_connect_default_log_dir: "{{ (deployment_path ~ '/log/kafka') if deployment_path | length > 0 else '/var/log/kafka' }}"
+kafka_connect_default_log_dir: "{{ (deployment_path_final ~ '/log/kafka') if deployment_path | length > 0 else '/var/log/kafka' }}"
 
 kafka_connect:
   server_start_file: "{{ binary_base_path }}/bin/connect-distributed"
@@ -1046,7 +1051,7 @@ ksql_service_name: "{{(confluent_package_version is version('5.5.0', '>=')) | te
 ksql_main_package: "{{(confluent_package_version is version('5.5.0', '>=')) | ternary('confluent-ksqldb' , 'confluent-ksql')}}"
 ksql_default_user: "{{ deployment_user if deployment_user | length > 0 else 'cp-ksql' }}"
 ksql_default_group: "{{ deployment_group if deployment_group | length > 0 else 'confluent' }}"
-ksql_default_log_dir: "{{ (deployment_path ~ '/log/confluent/ksql') if deployment_path | length > 0 else '/var/log/confluent/ksql' }}"
+ksql_default_log_dir: "{{ (deployment_path_final ~ '/log/confluent/ksql') if deployment_path | length > 0 else '/var/log/confluent/ksql' }}"
 ksql:
   server_start_file: "{{ binary_base_path }}/bin/ksql-server-start"
   config_file: "{{ (config_base_path, ksql_config_prefix_path, 'ksql-server.properties') | path_join }}"
@@ -1068,7 +1073,7 @@ ksql_properties:
       ksql.service.id: "{{ ksql_service_id }}"
       ksql.internal.topic.replicas: "{{ ksql_default_internal_replication_factor }}"
       ksql.streams.replication.factor: "{{ ksql_default_internal_replication_factor }}"
-      ksql.streams.state.dir: "{{ (deployment_path ~ '/data/kafka-streams') if deployment_path | length > 0 else '/var/lib/kafka-streams' }}"
+      ksql.streams.state.dir: "{{ (deployment_path_final ~ '/data/kafka-streams') if deployment_path | length > 0 else '/var/lib/kafka-streams' }}"
       ksql.streams.num.standby.replicas: 1
       ksql.streams.producer.delivery.timeout.ms: 2147483647
       ksql.streams.producer.max.block.ms: 9223372036854775807
@@ -1218,7 +1223,7 @@ ksql_final_properties: "{{ ksql_combined_properties | combine(ksql_custom_proper
 kafka_rest_service_name: confluent-kafka-rest
 kafka_rest_default_user: "{{ deployment_user if deployment_user | length > 0 else 'cp-kafka-rest' }}"
 kafka_rest_default_group: "{{ deployment_group if deployment_group | length > 0 else 'confluent' }}"
-kafka_rest_default_log_dir: "{{ (deployment_path ~ '/log/confluent/kafka-rest') if deployment_path | length > 0 else '/var/log/confluent/kafka-rest' }}"
+kafka_rest_default_log_dir: "{{ (deployment_path_final ~ '/log/confluent/kafka-rest') if deployment_path | length > 0 else '/var/log/confluent/kafka-rest' }}"
 kafka_rest:
   server_start_file: "{{ binary_base_path }}/bin/kafka-rest-start"
   config_file: "{{ (config_base_path, kafka_rest_config_prefix_path, 'kafka-rest.properties') | path_join }}"
@@ -1363,7 +1368,7 @@ kafka_rest_final_properties: "{{ kafka_rest_combined_properties | combine(kafka_
 control_center_service_name: confluent-control-center
 control_center_default_user: "{{ deployment_user if deployment_user | length > 0 else 'cp-control-center' }}"
 control_center_default_group: "{{ deployment_group if deployment_group | length > 0 else 'confluent' }}"
-control_center_default_log_dir: "{{ (deployment_path ~ '/log/confluent/control-center') if deployment_path | length > 0 else '/var/log/confluent/control-center' }}"
+control_center_default_log_dir: "{{ (deployment_path_final ~ '/log/confluent/control-center') if deployment_path | length > 0 else '/var/log/confluent/control-center' }}"
 control_center:
   server_start_file: "{{ binary_base_path }}/bin/control-center-start"
   config_file: "{{ (config_base_path, control_center_config_prefix_path, 'control-center-production.properties') | path_join }}"
@@ -1382,7 +1387,7 @@ control_center_properties:
     enabled: true
     properties:
       confluent.controlcenter.streams.num.stream.threads: 12
-      confluent.controlcenter.data.dir: "{{ (deployment_path ~ '/data/confluent/control-center') if deployment_path | length > 0 else '/var/lib/confluent/control-center' }}"
+      confluent.controlcenter.data.dir: "{{ (deployment_path_final ~ '/data/confluent/control-center') if deployment_path | length > 0 else '/var/lib/confluent/control-center' }}"
       confluent.controlcenter.internal.topics.replication: "{{control_center_default_internal_replication_factor}}"
       confluent.metrics.topic.replication: "{{control_center_default_internal_replication_factor}}"
       confluent.monitoring.interceptor.topic.replication: "{{control_center_default_internal_replication_factor}}"

--- a/roles/variables/vars/main.yml
+++ b/roles/variables/vars/main.yml
@@ -41,7 +41,7 @@ kafka_broker_jolokia_active_controller_url: "{{ 'https' if kafka_broker_jolokia_
 zookeeper_service_name: confluent-zookeeper
 zookeeper_main_package: "{{ 'confluent-server' if confluent_server_enabled|bool else 'confluent-kafka'}}"
 zookeeper_default_user: "{{ deployment_user if deployment_user | length > 0 else 'cp-kafka' }}"
-zookeeper_default_group: "{{ deployment_group if deployment_group | length > 0 else 'confluent' }}"
+zookeeper_default_group: "{{ deployment_group }}"
 zookeeper_default_log_dir: "{{ (deployment_path_final ~ '/log/kafka') if deployment_path | length > 0 else '/var/log/kafka' }}"
 zookeeper:
   server_start_file: "{{ binary_base_path }}/bin/zookeeper-server-start"
@@ -116,7 +116,7 @@ zookeeper_final_properties: "{{ zookeeper_combined_properties | combine(zookeepe
 #### Kafka controller variables
 kafka_controller_service_name: "confluent-kcontroller"
 kafka_controller_main_package: "{{ 'confluent-server' if confluent_server_enabled|bool else 'confluent-kafka'}}"
-kafka_controller_default_group: "{{ deployment_group if deployment_group | length > 0 else 'confluent' }}"
+kafka_controller_default_group: "{{ deployment_group }}"
 kafka_controller_default_user: "{{ deployment_user if deployment_user | length > 0 else 'cp-kafka' }}"
 kafka_controller_default_log_dir: "{{ (deployment_path_final ~ '/log/controller') if deployment_path | length > 0 else '/var/log/controller' }}"
 kafka_controller:
@@ -339,7 +339,7 @@ kafka_controller_client_properties: "{{ kafka_controller_default_client_properti
 kafka_broker_service_name: "{{ 'confluent-server' if confluent_server_enabled|bool else 'confluent-kafka'}}"
 kafka_broker_main_package: "{{ 'confluent-server' if confluent_server_enabled|bool else 'confluent-kafka'}}"
 kafka_broker_default_user: "{{ deployment_user if deployment_user | length > 0 else 'cp-kafka' }}"
-kafka_broker_default_group: "{{ deployment_group if deployment_group | length > 0 else 'confluent' }}"
+kafka_broker_default_group: "{{ deployment_group }}"
 kafka_broker_default_log_dir: "{{ (deployment_path_final ~ '/log/kafka') if deployment_path | length > 0 else '/var/log/kafka' }}"
 kafka_broker:
   server_start_file: "{{ binary_base_path }}/bin/kafka-server-start"
@@ -724,7 +724,7 @@ kafka_broker_client_properties: "{{ kafka_broker_default_client_properties | com
 #### Schema Registry Variables ####
 schema_registry_service_name: confluent-schema-registry
 schema_registry_default_user: "{{ deployment_user if deployment_user | length > 0 else 'cp-schema-registry' }}"
-schema_registry_default_group: "{{ deployment_group if deployment_group | length > 0 else 'confluent' }}"
+schema_registry_default_group: "{{ deployment_group }}"
 schema_registry_default_log_dir: "{{ (deployment_path_final ~ '/log/confluent/schema-registry') if deployment_path | length > 0 else '/var/log/confluent/schema-registry' }}"
 schema_registry:
   server_start_file: "{{ binary_base_path }}/bin/schema-registry-start"
@@ -839,7 +839,7 @@ schema_registry_final_properties: "{{ schema_registry_combined_properties | comb
 kafka_connect_default_service_name: confluent-kafka-connect
 kafka_connect_default_config_filename: connect-distributed.properties
 kafka_connect_default_user: "{{ deployment_user if deployment_user | length > 0 else 'cp-kafka-connect' }}"
-kafka_connect_default_group: "{{ deployment_group if deployment_group | length > 0 else 'confluent' }}"
+kafka_connect_default_group: "{{ deployment_group }}"
 kafka_connect_default_log_dir: "{{ (deployment_path_final ~ '/log/kafka') if deployment_path | length > 0 else '/var/log/kafka' }}"
 
 kafka_connect:
@@ -1050,7 +1050,7 @@ kafka_connect_final_properties: "{{ kafka_connect_combined_properties | combine(
 ksql_service_name: "{{(confluent_package_version is version('5.5.0', '>=')) | ternary('confluent-ksqldb' , 'confluent-ksql')}}"
 ksql_main_package: "{{(confluent_package_version is version('5.5.0', '>=')) | ternary('confluent-ksqldb' , 'confluent-ksql')}}"
 ksql_default_user: "{{ deployment_user if deployment_user | length > 0 else 'cp-ksql' }}"
-ksql_default_group: "{{ deployment_group if deployment_group | length > 0 else 'confluent' }}"
+ksql_default_group: "{{ deployment_group }}"
 ksql_default_log_dir: "{{ (deployment_path_final ~ '/log/confluent/ksql') if deployment_path | length > 0 else '/var/log/confluent/ksql' }}"
 ksql:
   server_start_file: "{{ binary_base_path }}/bin/ksql-server-start"
@@ -1222,7 +1222,7 @@ ksql_final_properties: "{{ ksql_combined_properties | combine(ksql_custom_proper
 #### Kafka Rest Variables ####
 kafka_rest_service_name: confluent-kafka-rest
 kafka_rest_default_user: "{{ deployment_user if deployment_user | length > 0 else 'cp-kafka-rest' }}"
-kafka_rest_default_group: "{{ deployment_group if deployment_group | length > 0 else 'confluent' }}"
+kafka_rest_default_group: "{{ deployment_group }}"
 kafka_rest_default_log_dir: "{{ (deployment_path_final ~ '/log/confluent/kafka-rest') if deployment_path | length > 0 else '/var/log/confluent/kafka-rest' }}"
 kafka_rest:
   server_start_file: "{{ binary_base_path }}/bin/kafka-rest-start"
@@ -1367,7 +1367,7 @@ kafka_rest_final_properties: "{{ kafka_rest_combined_properties | combine(kafka_
 #### Control Center Variables ####
 control_center_service_name: confluent-control-center
 control_center_default_user: "{{ deployment_user if deployment_user | length > 0 else 'cp-control-center' }}"
-control_center_default_group: "{{ deployment_group if deployment_group | length > 0 else 'confluent' }}"
+control_center_default_group: "{{ deployment_group }}"
 control_center_default_log_dir: "{{ (deployment_path_final ~ '/log/confluent/control-center') if deployment_path | length > 0 else '/var/log/confluent/control-center' }}"
 control_center:
   server_start_file: "{{ binary_base_path }}/bin/control-center-start"
@@ -1511,7 +1511,7 @@ control_center_final_properties: "{{ control_center_combined_properties | combin
 #### Kafka Connect Replicator Variables ####
 kafka_connect_replicator_service_name: kafka-connect-replicator
 kafka_connect_replicator_default_user: "{{ deployment_user if deployment_user | length > 0 else 'cp-kafka-connect-replicator' }}"
-kafka_connect_replicator_default_group: "{{ deployment_group if deployment_group | length > 0 else 'confluent' }}"
+kafka_connect_replicator_default_group: "{{ deployment_group }}"
 
 kafka_connect_replicator:
   server_start_file: "{{ binary_base_path }}/bin/kafka-connect-replicator-start"

--- a/roles/zookeeper/tasks/dynamic_groups.yml
+++ b/roles/zookeeper/tasks/dynamic_groups.yml
@@ -7,9 +7,7 @@
   slurp:
     src: "{{ zookeeper.systemd_override }}"
   register: slurped_override
-  when:
-    - installation_method == "archive"
-    - not (rootless_enabled | bool)
+  when: installation_method == "archive"
   tags:
     - systemd
 
@@ -18,9 +16,7 @@
     zookeeper_current_version: "{{ (slurped_override.content|b64decode) .split('\n') |
       select('match', '^ExecStart=' + config_base_path + '/confluent-(.*)/bin/zookeeper-server-start ' + zookeeper.config_file) |
       list | first | regex_search('confluent-([0-9]+(.[0-9]+)+)/bin/', '\\1') | first }}"
-  when:
-    - installation_method == "archive"
-    - not (rootless_enabled | bool)
+  when: installation_method == "archive"
   tags:
     - systemd
 

--- a/roles/zookeeper/tasks/main.yml
+++ b/roles/zookeeper/tasks/main.yml
@@ -26,7 +26,20 @@
     - validate
     - validate_jolokia
 
+# Validate package availability BEFORE removing old packages to ensure we don't leave the node in a broken state if new packages aren't available
+- name: Validate Package Availability Before Removing Old Packages
+  include_role:
+    name: common
+    tasks_from: validate_package_availability.yml
+  vars:
+    validate_packages: "{{ zookeeper_packages }}"
+  when: installation_method == "package"
+  tags:
+    - package
+    - cp_package
+    - validate_package_availability
 
+# Only remove old packages after validating new packages are available
 - name: Stop Service and Remove Packages on Version Change
   include_role:
     name: common

--- a/roles/zookeeper/tasks/main.yml
+++ b/roles/zookeeper/tasks/main.yml
@@ -26,31 +26,14 @@
     - validate
     - validate_jolokia
 
-# Validate package availability BEFORE removing old packages to ensure we don't leave the node in a broken state if new packages aren't available
-- name: Validate Package Availability Before Removing Old Packages
-  include_role:
-    name: common
-    tasks_from: validate_package_availability.yml
-  vars:
-    validate_packages: "{{ zookeeper_packages }}"
-  when:
-    - installation_method == "package"
-    - not (rootless_enabled | bool)
-  tags:
-    - package
-    - cp_package
-    - validate_package_availability
 
-# Only remove old packages after validating new packages are available
 - name: Stop Service and Remove Packages on Version Change
   include_role:
     name: common
     tasks_from: remove_packages.yml
   vars:
     service_name: "{{ zookeeper_service_name }}"
-  when:
-    - installation_method == "package"
-    - not (rootless_enabled | bool)
+  when: installation_method == "package"
   tags:
     - package
     - cp_package
@@ -67,7 +50,6 @@
   when:
     - ansible_os_family == "RedHat"
     - installation_method == "package"
-    - not (rootless_enabled | bool)
   ignore_errors: "{{ ansible_check_mode }}"
   tags:
     - package
@@ -84,7 +66,6 @@
   when:
     - ansible_os_family == "Debian"
     - installation_method == "package"
-    - not (rootless_enabled | bool)
   ignore_errors: "{{ ansible_check_mode }}"
   tags:
     - package
@@ -94,7 +75,6 @@
 - name: Create Zookeeper Group
   group:
     name: "{{zookeeper_group}}"
-  when: not (rootless_enabled | bool)
   tags:
     - privileged
 
@@ -112,9 +92,7 @@
     system: true
     shell: "{{user_login_shell}}"
     group: "{{zookeeper_group}}"
-  when:
-    - (getent_passwd|default({}))[zookeeper_user] is not defined
-    - not (rootless_enabled | bool)
+  when: (getent_passwd|default({}))[zookeeper_user] is not defined
   tags:
     - privileged
 
@@ -127,9 +105,7 @@
     dest: "{{zookeeper.systemd_file}}"
     mode: '644'
     force: true
-  when:
-    - installation_method == "archive"
-    - not (rootless_enabled | bool)
+  when: installation_method == "archive"
   tags:
     - systemd
 
@@ -378,7 +354,6 @@
     group: "{{zookeeper_group}}"
     state: directory
     mode: '750'
-  when: not (rootless_enabled | bool)
   tags:
     - systemd
     - privileged
@@ -392,7 +367,6 @@
     group: root
   notify: restart zookeeper
   diff: "{{ not mask_sensitive_diff|bool }}"
-  when: not (rootless_enabled | bool)
   tags:
     - systemd
     - privileged
@@ -410,7 +384,6 @@
     name: "{{zookeeper_service_name}}"
     enabled: true
     state: started
-  when: not (rootless_enabled | bool)
   tags:
     - systemd
 
@@ -419,7 +392,6 @@
   when:
     - zookeeper_health_checks_enabled|bool
     - not ansible_check_mode
-    - not (rootless_enabled | bool)
   tags: health_check
 
 - name: Delete temporary keys/certs when keystore and trustore is provided

--- a/roles/zookeeper/tasks/restart_and_wait.yml
+++ b/roles/zookeeper/tasks/restart_and_wait.yml
@@ -4,7 +4,6 @@
     daemon_reload: true
     name: "{{zookeeper_service_name}}"
     state: restarted
-  when: not (rootless_enabled | bool)
   tags:
     - systemd
 


### PR DESCRIPTION
## Summary
Continues rootless (non-root) deployment support work. Since the last merge into `ANSIENG-5900`:

- Full Kerberos support under rootless (deployment_path-aware krb5.conf/keytab paths, molecule coverage) - live-verified on EC2 with real GSSAPI mutual auth.
- Fixed several real bugs found via direct review/debugging: rootless_bootstrap.yml play-vars precedence, authorized_keys path for root admin, ssl_file_dir/secrets_protection directory creation under rootless, deployment_path trailing-slash sanitization, kafka_connect_replicator full rootless support (log dir, RBAC pem paths, keytab/kerberos-arg var divergence, SSL storepass).
- Molecule: strengthened rootless scenario coverage (independent deployment_user/group/path, kafka_connect_replicator added to rootless-plain-debian10, fixed several scenario-side bugs).
- Simplified `deployment_group`'s default (every component's group fallback was already the identical literal `confluent` - collapsed the redundant per-component ternary).
- Restored a `deployment_user`/`deployment_group` non-empty assert under rootless that had been collaterally reverted earlier.
- Added an explicit fail-fast assert for the FIPS+rootless unsupported combination (mirroring the existing zookeeper-under-rootless pattern), replacing a misleading generic message.
- Added a static check (`rootless_become_check.py`) for unguarded `become: true` under rootless, and fixed the one real violation it surfaced (`collect_support_bundle.yml`'s 7 unconditional `become: true` tasks).
- Documented how to actually verify a deploy is rootless (`ROOTLESS_DEPLOYMENT_STEPS.md`): sudoers-free deploy user, pre-run escalation check, post-run root-artifact check.
- Regenerated `docs/VARIABLES.md` (stale since `deployment_path_final` was introduced).

## Test plan
- [x] Live EC2: Kerberos rootless (real KDC, GSSAPI mutual auth, `-Djava.security.krb5.conf` wiring) - passed.
- [x] Live EC2: RBAC + `ssl_enabled: false` rootless (real LDAP, MDS over plain HTTP) - passed.
- [x] Live EC2: RBAC + multi-broker (3-node KRaft quorum) + `deployment_strategy: rolling` rootless greenfield - passed, healthy quorum, no circularity.
- [x] Live EC2: root brownfield upgrade safety (`v7.6.12` -> this branch) - static variable audit (47/47 unchanged) + real cluster upgrade with data continuity confirmed (byte-identical inodes/mtimes, checksum match). Evidence to be attached to this PR description separately.
- [x] Molecule: all 3 rootless scenarios green on real CI infra.
- [x] `.semaphore` sanity checks (including the new `rootless_become_check.py`) pass.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>