### PR TITLE
[ANSIENG-5882] Fix security.properties copy failure for static masterkey with no supplied file

### DIFF
--- a/roles/common/tasks/secrets_protection.yml
+++ b/roles/common/tasks/secrets_protection.yml
@@ -44,7 +44,21 @@
     - filesystem
     - privileged
 
+- name: Check if security.properties exists on Ansible Controller
+  stat:
+    path: "{{ secrets_protection_security_file }}"
+  delegate_to: localhost
+  vars:
+    ansible_connection: local
+    ansible_become: "{{ ansible_become_localhost }}"
+  run_once: true
+  register: local_security_properties_file
+
 - name: Copy security.properties file to Host
+  # Only copy when a real file was supplied on the controller. For a static/BYO
+  # masterkey with no secrets_protection_security_file override, nothing exists
+  # here to copy - the Encrypt Properties task below creates security.properties
+  # on the target host directly from CONFLUENT_SECURITY_MASTER_KEY.
   copy:
     src: "{{ secrets_protection_security_file }}"
     dest: "{{ secrets_file }}"
@@ -52,6 +66,7 @@
     group: "{{ secrets_file_group }}"
     mode: '640'
   diff: "{{ not mask_sensitive_diff|bool }}"
+  when: local_security_properties_file.stat.exists
 
 - name: Load masterkey
   slurp:


### PR DESCRIPTION
## Summary
- With `secrets_protection_masterkey` set (static/BYO key), `regenerate_masterkey: false`, and no `secrets_protection_security_file` override, the "Copy security.properties file to Host" task in `roles/common/tasks/secrets_protection.yml` ran unconditionally and failed with `AnsibleFileNotFound: Could not find or access 'generated_ssl_files/security.properties'`, since nothing exists on the Ansible controller to copy.
- The prior guard (`when: regenerate_masterkey|bool`) on this task was removed in ANSIENG-5864 (epic ANSIENG-5857) to fix a case where the copy was silently skipped for customers who had genuinely supplied a real `secrets_protection_security_file`.
- This adds a `stat` check on the Ansible controller for `secrets_protection_security_file` and gates the copy on the file actually existing there, instead of on `regenerate_masterkey`. This correctly handles all three scenarios:
  - Auto-generated key (`regenerate_masterkey: true`): `masterkey.yml` creates the file first, so it exists → copy runs.
  - Static key with a genuinely-supplied `secrets_protection_security_file`: file exists → copy runs (preserves the ANSIENG-5857 fix).
  - Static key with nothing supplied (this bug): file doesn't exist on the controller → copy skips cleanly, and the downstream "Encrypt Properties" task creates `security.properties` on the target host directly via `CONFLUENT_SECURITY_MASTER_KEY`.

Jira: https://confluentinc.atlassian.net/browse/ANSIENG-5882

## Test plan
- [ ] Deploy with `secrets_protection_masterkey` set (static key), `regenerate_masterkey: false`, no `secrets_protection_security_file` override — confirm the copy task skips and deploy succeeds.
- [ ] Deploy with `regenerate_masterkey: true` — confirm the generated file still exists and copy still runs.
- [ ] Deploy with a real `secrets_protection_security_file` supplied — confirm it is still copied (regression check for ANSIENG-5857).

🤖 Generated with [Claude Code](https://claude.com/claude-code)