### PR TITLE
[ANSIENG-5841] Fix DN extraction truncating on colon-containing certificate fields

### DIFF
--- a/roles/kafka_broker/tasks/set_principal.yml
+++ b/roles/kafka_broker/tasks/set_principal.yml
@@ -23,7 +23,9 @@
   # Examine the keystore
   # Search lines with Entry type: "PrivateKeyEntry" and return that line and all after, ca cert is of type "trustedCertEntry"
   # Search for first "Owner" line
-  # Extract DNAME from line
+  # Extract DNAME from line - strip only up to the first colon, since a DN field
+  # (e.g. an Apple-style OU containing a colon) can itself contain colons, and
+  # cut -d ":" would truncate the DN at that inner colon instead of just the label.
   # Remove spaces after commas
   shell: |
     keytool -list -keystore {{kb_keystore_path}} \
@@ -36,8 +38,7 @@
         -v \
         | grep PrivateKeyEntry -A1000 \
         | grep Owner -m1 \
-        | cut -d ":" -f2 \
-        | cut -c2- \
+        | sed 's/^[^:]*: *//' \
         | sed 's/\s*,\s*/,/g'
   args:
     executable: "{{ shell_executable }}"

--- a/roles/kafka_controller/tasks/set_principal.yml
+++ b/roles/kafka_controller/tasks/set_principal.yml
@@ -23,7 +23,9 @@
   # Examine the keystore
   # Search lines with Entry type: "PrivateKeyEntry" and return that line and all after, ca cert is of type "trustedCertEntry"
   # Search for first "Owner" line
-  # Extract DNAME from line
+  # Extract DNAME from line - strip only up to the first colon, since a DN field
+  # (e.g. an Apple-style OU containing a colon) can itself contain colons, and
+  # cut -d ":" would truncate the DN at that inner colon instead of just the label.
   # Remove spaces after commas
   shell: |
     keytool -list -keystore {{kc_keystore_path}} \
@@ -36,8 +38,7 @@
         -v \
         | grep PrivateKeyEntry -A1000 \
         | grep Owner -m1 \
-        | cut -d ":" -f2 \
-        | cut -c2- \
+        | sed 's/^[^:]*: *//' \
         | sed 's/\s*,\s*/,/g'
   args:
     executable: "{{ shell_executable }}"

--- a/roles/ksql/tasks/set_principal.yml
+++ b/roles/ksql/tasks/set_principal.yml
@@ -23,7 +23,9 @@
   # Examine the keystore
   # Search lines with Entry type: "PrivateKeyEntry" and return that line and all after, ca cert is of type "trustedCertEntry"
   # Search for first "Owner" line
-  # Extract DNAME from line
+  # Extract DNAME from line - strip only up to the first colon, since a DN field
+  # (e.g. an Apple-style OU containing a colon) can itself contain colons, and
+  # cut -d ":" would truncate the DN at that inner colon instead of just the label.
   # Remove spaces after commas
   # Extract just the CN
   # Extract just the principal without any other formatting
@@ -33,8 +35,7 @@
         -storepass {{ksql_keystore_storepass}} -v \
         | grep PrivateKeyEntry -A1000 \
         | grep Owner -m1 \
-        | cut -d ":" -f2 \
-        | cut -c2- \
+        | sed 's/^[^:]*: *//' \
         | sed 's/^.*CN=//' \
         | cut -d "," -f1
   args:


### PR DESCRIPTION
## Summary
- `Extract Distinguished Name from Keystore - SSL Mutual Auth` in `kafka_broker`, `kafka_controller`, and `ksql`'s `set_principal.yml` used `cut -d ":" -f2` to pull the DN out of `keytool -list -v`'s `Owner: ...` line.
- `cut -d ":" -f2` splits on **every** colon in the line, not just the `Owner:` label separator. A customer's certificate (Apple-issued) had a colon embedded inside a DN field, e.g. `Owner: CN=device-12345,OU=MacBookPro:Data,O=Apple Inc.,C=US`. The cut truncated the extracted DN at that inner colon (`CN=device-12345,OU=MacBookPro`), silently dropping the rest (`Data,O=Apple Inc.,C=US`) — corrupting `ssl.principal.mapping.rules` input.
- Root cause and fix direction confirmed on the Jira ticket (see comments from Pratul Yadav / Ankur Garg).

## Fix
Replace `cut -d ":" -f2 | cut -c2-` with `sed 's/^[^:]*: *//'` in all three affected `set_principal.yml` files. This strips only the label up to the *first* colon (a single substitution, not a field split), leaving any subsequent colons in the DN intact.

Verified:
- Normal DN (`Owner: CN=kafka-broker-1,OU=Platform,O=Confluent,L=Bangalore,C=IN`) → unchanged output.
- Colon-containing DN (`Owner: CN=device-12345,OU=MacBookPro:Data,O=Apple Inc.,C=US`) → full DN preserved instead of truncated.

Jira: https://confluentinc.atlassian.net/browse/ANSIENG-5841

## Additional DN formats verified
The ticket's example has one extra colon. Stress-tested against other realistic shapes to make sure the fix generalizes rather than just patching the one reported case:

| Format | Colons in value | Result |
|---|---|---|
| Baseline (ticket): `OU=MacBookPro:Data` | 1 extra | preserved |
| IPv6 address as CN: `CN=fe80::1234:5678:9abc` | 4 extra | preserved |
| URL with port in OU: `OU=http://internal:8080/path` | 3 extra | preserved |
| Time range: `OU=Shift:09:00-17:00` | 3 extra | preserved |
| Multi-valued RDN (`+`-joined) with colon in 2nd value | 1 extra | preserved |
| RFC 2253 escaped comma (`\,`) alongside a real colon | 1 extra | preserved (pre-existing comma-space quirk unaffected, see note below) |
| Colon with no comma at all | 1 extra | preserved |
| Empty/minimal subject | none | still empty, no crash |
| Multi-byte UTF-8 value containing `:` | 1 extra | preserved — `[^:]*` is byte-safe since UTF-8 continuation bytes never collide with ASCII `:` (0x3A) |
| ksql's CN-only extraction with colon *inside* the CN itself (IPv6, `Room:42`, multi-valued RDN) | varies | preserved |

No case broke the fix, because `sed 's/^[^:]*: *//'` only ever removes the *first* colon boundary — everything downstream of that (however many colons it contains, whatever encoding) is untouched by construction. That's structurally different from the old `cut -d ":" -f2`, which re-splits the whole line on every colon regardless of how many appear, so no number or placement of embedded colons can regress it.

Note: the trailing `sed 's/\s*,\s*/,/g'` also strips the space after an RFC 2253 backslash-escaped comma (`\, West` → `\,West`). Confirmed this behavior pre-dates this fix (reproduces with the old `cut`-based pipeline too) — unrelated to this change, called out here only for visibility.

## Test plan
semaphore run: https://semaphore.ci.confluent.io/workflows/45263c23-359b-4184-bb0f-b5b23bf4edcf

🤖 Generated with [Claude Code](https://claude.com/claude-code)
