### PR TITLE
Fix class name for JAAS login module in Jetty 12

### DIFF
--- a/docs/MOLECULE_SCENARIOS.md
+++ b/docs/MOLECULE_SCENARIOS.md
@@ -1188,6 +1188,8 @@ Validates that Rest Proxy has correct auth property.
 
 Validates that Java 25 is in Use
 
+Validates that Control Center Next Gen's jaas.conf uses the Jetty login module matching the installed Control Center Next Gen version.
+
 ***
 
 ### molecule/plaintext-rhel-customrepo

--- a/docs/VARIABLES.md
+++ b/docs/VARIABLES.md
@@ -2420,6 +2420,14 @@ Default:  none
 
 ***
 
+### control_center_next_gen_jaas_login_module
+
+Jetty JAAS login module written to Control Center Next Gen's jaas.conf when control_center_next_gen_authentication_type is basic. Control Center Next Gen 2.2.0 and later bundle Jetty 12, which moved the login module from org.eclipse.jetty.jaas.spi to org.eclipse.jetty.security.jaas.spi. Override this variable when installing a version whose Jetty packaging is not covered by the default expression, for example an archive install where confluent_control_center_next_gen_archive_version differs from confluent_control_center_next_gen_package_version.
+
+Default:  "{{ 'org.eclipse.jetty.security.jaas.spi.PropertyFileLoginModule' if confluent_control_center_next_gen_package_version is version('2.2.0', '>=') else 'org.eclipse.jetty.jaas.spi.PropertyFileLoginModule' }}"
+
+***
+
 ### control_center_next_gen_log_dir
 
 Set this variable to customize the directory that Control Center writes log files to. Default location is /var/log/confluent/control-center. NOTE- control_center_next_gen.appender_log_path is deprecated.

--- a/molecule/plaintext-basic-rhel/verify.yml
+++ b/molecule/plaintext-basic-rhel/verify.yml
@@ -2,6 +2,7 @@
 ### Validates that each component has a unique auth user.
 ### Validates that Rest Proxy has correct auth property.
 ### Validates that Java 25 is in Use
+### Validates that Control Center Next Gen's jaas.conf uses the Jetty login module matching the installed Control Center Next Gen version.
 
 - name: Verify Java
   hosts: all,!ccloud-mock-service
@@ -131,7 +132,7 @@
 
 - name: Verify - control_center_next_gen
   hosts: control_center_next_gen
-  gather_facts: false
+  gather_facts: true
   tasks:
     - import_role:
         name: confluent.test
@@ -140,6 +141,71 @@
         file_path: /etc/confluent-control-center/control-center-production.properties
         property: confluent.controlcenter.rest.authentication.roles
         expected_value: admin,client,Restricted
+
+    - import_role:
+        name: variables
+
+    - name: Load Control Center Next Gen jaas.conf
+      slurp:
+        src: "{{control_center_next_gen.jaas_file}}"
+      register: c3_jaas_slurped
+
+    - name: Assert jaas.conf points at the Control Center Next Gen password file
+      vars:
+        c3_jaas_content: "{{ c3_jaas_slurped.content | b64decode }}"
+        c3_expected_password_file_line: 'file="{{control_center_next_gen.password_file}}"'
+      assert:
+        that:
+          - c3_expected_password_file_line in c3_jaas_content
+        fail_msg: "jaas.conf: {{c3_jaas_content}} should reference {{control_center_next_gen.password_file}}"
+        quiet: true
+
+    - name: Assert jaas.conf uses the Jetty 12 login module, as Control Center Next Gen is 2.2.0 or later
+      vars:
+        c3_jaas_content: "{{ c3_jaas_slurped.content | b64decode }}"
+      assert:
+        that:
+          - "'org.eclipse.jetty.security.jaas.spi.PropertyFileLoginModule required' in c3_jaas_content"
+          - "'org.eclipse.jetty.jaas.spi.PropertyFileLoginModule' not in c3_jaas_content"
+        fail_msg: "jaas.conf: {{c3_jaas_content}} should use org.eclipse.jetty.security.jaas.spi.PropertyFileLoginModule for Control Center Next Gen {{confluent_control_center_next_gen_package_version}}"
+        quiet: true
+      when: confluent_control_center_next_gen_package_version is version('2.2.0', '>=')
+
+    - name: Assert jaas.conf uses the pre Jetty 12 login module, as Control Center Next Gen is older than 2.2.0
+      vars:
+        c3_jaas_content: "{{ c3_jaas_slurped.content | b64decode }}"
+      assert:
+        that:
+          - "'org.eclipse.jetty.jaas.spi.PropertyFileLoginModule required' in c3_jaas_content"
+        fail_msg: "jaas.conf: {{c3_jaas_content}} should use org.eclipse.jetty.jaas.spi.PropertyFileLoginModule for Control Center Next Gen {{confluent_control_center_next_gen_package_version}}"
+        quiet: true
+      when: confluent_control_center_next_gen_package_version is version('2.2.0', '<')
+
+    - name: Assert the login module is selected from the Control Center Next Gen version
+      vars:
+        confluent_control_center_next_gen_package_version: "{{item.version}}"
+        rendered_jaas: "{{ lookup('template', playbook_dir + '/../../roles/control_center_next_gen/templates/jaas.conf.j2') }}"
+      assert:
+        that:
+          - item.expected_module + ' required' in rendered_jaas
+          - item.unexpected_module not in rendered_jaas
+        fail_msg: "jaas.conf rendered for Control Center Next Gen {{item.version}}: {{rendered_jaas}} should use {{item.expected_module}}"
+        quiet: true
+      loop:
+        - version: 2.0.0
+          expected_module: org.eclipse.jetty.jaas.spi.PropertyFileLoginModule
+          unexpected_module: org.eclipse.jetty.security.jaas.spi.PropertyFileLoginModule
+        - version: 2.1.0
+          expected_module: org.eclipse.jetty.jaas.spi.PropertyFileLoginModule
+          unexpected_module: org.eclipse.jetty.security.jaas.spi.PropertyFileLoginModule
+        - version: 2.2.0
+          expected_module: org.eclipse.jetty.security.jaas.spi.PropertyFileLoginModule
+          unexpected_module: org.eclipse.jetty.jaas.spi.PropertyFileLoginModule
+        - version: 2.5.0
+          expected_module: org.eclipse.jetty.security.jaas.spi.PropertyFileLoginModule
+          unexpected_module: org.eclipse.jetty.jaas.spi.PropertyFileLoginModule
+      loop_control:
+        label: "Control Center Next Gen {{item.version}}"
 
 - name: Verify - USM Agent Functionality
   import_playbook: ../verify_usm_agent.yml

--- a/roles/control_center_next_gen/templates/jaas.conf.j2
+++ b/roles/control_center_next_gen/templates/jaas.conf.j2
@@ -1,5 +1,5 @@
 ControlCenter {
-  org.eclipse.jetty.jaas.spi.PropertyFileLoginModule required
+  {{control_center_next_gen_jaas_login_module}} required
   file="{{control_center_next_gen.password_file}}"
   debug="false";
 };

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -1223,6 +1223,9 @@ control_center_next_gen_mds_cert_auth_only: false
 ### Control Center Authentication. Available options: [basic, none].
 control_center_next_gen_authentication_type: none
 
+### Jetty JAAS login module written to Control Center Next Gen's jaas.conf when control_center_next_gen_authentication_type is basic. Control Center Next Gen 2.2.0 and later bundle Jetty 12, which moved the login module from org.eclipse.jetty.jaas.spi to org.eclipse.jetty.security.jaas.spi. Override this variable when installing a version whose Jetty packaging is not covered by the default expression, for example an archive install where confluent_control_center_next_gen_archive_version differs from confluent_control_center_next_gen_package_version.
+control_center_next_gen_jaas_login_module: "{{ 'org.eclipse.jetty.security.jaas.spi.PropertyFileLoginModule' if confluent_control_center_next_gen_package_version is version('2.2.0', '>=') else 'org.eclipse.jetty.jaas.spi.PropertyFileLoginModule' }}"
+
 ### Set this variable to customize the directory that Control Center writes log files to. Default location is /var/log/confluent/control-center. NOTE- control_center_next_gen.appender_log_path is deprecated.
 control_center_next_gen_log_dir: "{{control_center_next_gen_default_log_dir}}"
 


### PR DESCRIPTION
# Description

More complex logic than https://github.com/confluentinc/cp-ansible/pull/2599 to make it work with both with all C3 Next Gen versions.

C3 Next Gen uses Jetty 12, and the PropertyFileLoginModule class has changed to: https://github.com/jetty/jetty.project/blob/jetty-12.1.x/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/jaas/spi/PropertyFileLoginModule.java

Before, on Jetty 11 and previous, it was located at https://github.com/jetty/jetty.project/blob/jetty-11.0.x/jetty-jaas/src/main/java/org/eclipse/jetty/jaas/spi/PropertyFileLoginModule.java

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Molecule tests added.

# Checklist:

- [X] Any variable/code changes have been validated to be backwards compatible (doesn't break upgrade)
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] If required, I have ensured the changes can be discovered by cp-ansible discovery codebase
- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
