### PR TITLE
Bump default USM Agent version to 1.2.1

### DIFF
--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -3056,7 +3056,7 @@ password_encoder_secret: ""
 # USM Agent Variables
 
 ### Version of Confluent USM Agent to install
-confluent_usm_agent_package_version: 1.2.0
+confluent_usm_agent_package_version: 1.2.1
 
 confluent_usm_agent_goarch:
   x86_64: "amd64"


### PR DESCRIPTION
Bumps the default `confluent_usm_agent_package_version` from 1.2.0 to 1.2.1 in `roles/variables/defaults/main.yml`.

Part of the USM Agent 1.2.1 release post-release default-version bump (SETU-3596). PR raised on the two lowest supported CP lines (7.9.x, 8.1.x); 8.2.x/8.3.x/master receive it via pint merge-down.