### PR TITLE
[ANSIENG-5841] Fix DN extraction truncating on colon-containing certificate fields (master)

### DIFF
--- a/roles/common/tasks/cert_principal_extract.yml
+++ b/roles/common/tasks/cert_principal_extract.yml
@@ -3,7 +3,9 @@
   # Examine the keystore
   # Search lines with Entry type: "PrivateKeyEntry" and return that line and all after, ca cert is of type "trustedCertEntry"
   # Search for first "Owner" line
-  # Extract DNAME from line
+  # Extract DNAME from line - strip only up to the first colon, since a DN field
+  # (e.g. an Apple-style OU containing a colon) can itself contain colons, and
+  # cut -d ":" would truncate the DN at that inner colon instead of just the label.
   # Remove spaces after commas
   shell: |
     keytool -list -keystore {{keystore_path}} \
@@ -16,8 +18,7 @@
         -v \
         | grep PrivateKeyEntry -A1000 \
         | grep Owner -m1 \
-        | cut -d ":" -f2 \
-        | cut -c2- \
+        | sed 's/^[^:]*: *//' \
         | sed 's/\s*,\s*/,/g'
   args:
     executable: "{{ shell_executable }}"

--- a/roles/kafka_broker/tasks/set_principal.yml
+++ b/roles/kafka_broker/tasks/set_principal.yml
@@ -23,7 +23,9 @@
   # Examine the keystore
   # Search lines with Entry type: "PrivateKeyEntry" and return that line and all after, ca cert is of type "trustedCertEntry"
   # Search for first "Owner" line
-  # Extract DNAME from line
+  # Extract DNAME from line - strip only up to the first colon, since a DN field
+  # (e.g. an Apple-style OU containing a colon) can itself contain colons, and
+  # cut -d ":" would truncate the DN at that inner colon instead of just the label.
   # Remove spaces after commas
   shell: |
     keytool -list -keystore {{kb_keystore_path}} \
@@ -36,8 +38,7 @@
         -v \
         | grep PrivateKeyEntry -A1000 \
         | grep Owner -m1 \
-        | cut -d ":" -f2 \
-        | cut -c2- \
+        | sed 's/^[^:]*: *//' \
         | sed 's/\s*,\s*/,/g'
   args:
     executable: "{{ shell_executable }}"

--- a/roles/kafka_controller/tasks/set_principal.yml
+++ b/roles/kafka_controller/tasks/set_principal.yml
@@ -23,7 +23,9 @@
   # Examine the keystore
   # Search lines with Entry type: "PrivateKeyEntry" and return that line and all after, ca cert is of type "trustedCertEntry"
   # Search for first "Owner" line
-  # Extract DNAME from line
+  # Extract DNAME from line - strip only up to the first colon, since a DN field
+  # (e.g. an Apple-style OU containing a colon) can itself contain colons, and
+  # cut -d ":" would truncate the DN at that inner colon instead of just the label.
   # Remove spaces after commas
   shell: |
     keytool -list -keystore {{kc_keystore_path}} \
@@ -36,8 +38,7 @@
         -v \
         | grep PrivateKeyEntry -A1000 \
         | grep Owner -m1 \
-        | cut -d ":" -f2 \
-        | cut -c2- \
+        | sed 's/^[^:]*: *//' \
         | sed 's/\s*,\s*/,/g'
   args:
     executable: "{{ shell_executable }}"

--- a/roles/ksql/tasks/set_principal.yml
+++ b/roles/ksql/tasks/set_principal.yml
@@ -23,7 +23,9 @@
   # Examine the keystore
   # Search lines with Entry type: "PrivateKeyEntry" and return that line and all after, ca cert is of type "trustedCertEntry"
   # Search for first "Owner" line
-  # Extract DNAME from line
+  # Extract DNAME from line - strip only up to the first colon, since a DN field
+  # (e.g. an Apple-style OU containing a colon) can itself contain colons, and
+  # cut -d ":" would truncate the DN at that inner colon instead of just the label.
   # Remove spaces after commas
   # Extract just the CN
   # Extract just the principal without any other formatting
@@ -33,8 +35,7 @@
         -storepass {{ksql_keystore_storepass}} -v \
         | grep PrivateKeyEntry -A1000 \
         | grep Owner -m1 \
-        | cut -d ":" -f2 \
-        | cut -c2- \
+        | sed 's/^[^:]*: *//' \
         | sed 's/^.*CN=//' \
         | cut -d "," -f1
   args:


### PR DESCRIPTION
## Summary
Companion to #2637 (targets `7.6.x`). That PR fixes the `cut -d ":" -f2` DN-truncation bug in `kafka_broker`, `kafka_controller`, and `ksql`'s `set_principal.yml` for SSL mutual-auth listener principals.

On `master`, this same bug also exists in `roles/common/tasks/cert_principal_extract.yml` — a consolidated task file that doesn't exist on `7.6.x` (introduced later) and is included from **11 sites across 9 roles** for RBAC super-user cert-principal extraction:
- `control_center_next_gen`
- `kafka_broker/tasks/rbac.yml`, `kafka_controller/tasks/rbac.yml`
- `kafka_connect` (main + deploy_connectors)
- `kafka_connect_replicator` (consumer, producer, monitoring interceptor, main — 4 sites)
- `kafka_rest`
- `ksql`
- `schema_registry/tasks/configure_rbac.yml`

That's a materially larger blast radius than the 3 files fixed on `7.6.x` — flagged in review on #2637 (https://github.com/confluentinc/cp-ansible/pull/2637#discussion_r3829980493).

This PR:
- Fixes `roles/common/tasks/cert_principal_extract.yml`.
- Also re-applies the same fix directly to `kafka_broker`, `kafka_controller`, and `ksql`'s own `set_principal.yml` on `master` — these are independent copies of the file that have diverged from `7.6.x` (different `when` conditions for multi-protocol listener support), so this doesn't rely on the `7.6.x` fix eventually merging upward through the branch chain.

## Fix
Same as #2637: replace `cut -d ":" -f2 | cut -c2-` with `sed 's/^[^:]*: *//'` everywhere. This strips only the label up to the *first* colon (a single substitution, not a field split), leaving any subsequent colons in the DN intact — fixes DNs like `Owner: CN=device-12345,OU=MacBookPro:Data,O=Apple Inc.,C=US` which were previously truncated at the embedded colon.

Jira: https://confluentinc.atlassian.net/browse/ANSIENG-5841

## Test plan
- [ ] RBAC deployment exercising `cert_principal_extract.yml` (e.g. Connect, Schema Registry, or C3 with cert-based super-user auth) with a colon-containing DN — confirm full DN/principal extracted correctly.
- [ ] SSL mutual-auth deployment for `kafka_broker`/`kafka_controller`/`ksql` with a colon-containing DN — confirm full DN preserved (regression parity with #2637).
- [ ] Standard DN (no embedded colons) — confirm principal extraction unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)