### PR TITLE
[ANSIENG-5841] Fix DN extraction truncating on colon-containing certificate fields (7.8.x)

### DIFF
--- a/roles/common/tasks/cert_principal_extract.yml
+++ b/roles/common/tasks/cert_principal_extract.yml
@@ -3,7 +3,9 @@
   # Examine the keystore
   # Search lines with Entry type: "PrivateKeyEntry" and return that line and all after, ca cert is of type "trustedCertEntry"
   # Search for first "Owner" line
-  # Extract DNAME from line
+  # Extract DNAME from line - strip only up to the first colon, since a DN field
+  # (e.g. an Apple-style OU containing a colon) can itself contain colons, and
+  # cut -d ":" would truncate the DN at that inner colon instead of just the label.
   # Remove spaces after commas
   # we dont need to handle fips seperately as in fips bouncy castle is used but normal jks keystore is also present.
   # In case we try to fetch from bouncy castle keystore we need to handle each component differently as it is only present on kafka others dont have it
@@ -18,8 +20,7 @@
         -v \
         | grep PrivateKeyEntry -A1000 \
         | grep Owner -m1 \
-        | cut -d ":" -f2 \
-        | cut -c2- \
+        | sed 's/^[^:]*: *//' \
         | sed 's/\s*,\s*/,/g'
   args:
     executable: "{{ shell_executable }}"

--- a/roles/kafka_broker/tasks/set_principal.yml
+++ b/roles/kafka_broker/tasks/set_principal.yml
@@ -23,7 +23,9 @@
   # Examine the keystore
   # Search lines with Entry type: "PrivateKeyEntry" and return that line and all after, ca cert is of type "trustedCertEntry"
   # Search for first "Owner" line
-  # Extract DNAME from line
+  # Extract DNAME from line - strip only up to the first colon, since a DN field
+  # (e.g. an Apple-style OU containing a colon) can itself contain colons, and
+  # cut -d ":" would truncate the DN at that inner colon instead of just the label.
   # Remove spaces after commas
   shell: |
     keytool -list -keystore {{kb_keystore_path}} \
@@ -36,8 +38,7 @@
         -v \
         | grep PrivateKeyEntry -A1000 \
         | grep Owner -m1 \
-        | cut -d ":" -f2 \
-        | cut -c2- \
+        | sed 's/^[^:]*: *//' \
         | sed 's/\s*,\s*/,/g'
   args:
     executable: "{{ shell_executable }}"

--- a/roles/kafka_controller/tasks/set_principal.yml
+++ b/roles/kafka_controller/tasks/set_principal.yml
@@ -23,7 +23,9 @@
   # Examine the keystore
   # Search lines with Entry type: "PrivateKeyEntry" and return that line and all after, ca cert is of type "trustedCertEntry"
   # Search for first "Owner" line
-  # Extract DNAME from line
+  # Extract DNAME from line - strip only up to the first colon, since a DN field
+  # (e.g. an Apple-style OU containing a colon) can itself contain colons, and
+  # cut -d ":" would truncate the DN at that inner colon instead of just the label.
   # Remove spaces after commas
   shell: |
     keytool -list -keystore {{kc_keystore_path}} \
@@ -36,8 +38,7 @@
         -v \
         | grep PrivateKeyEntry -A1000 \
         | grep Owner -m1 \
-        | cut -d ":" -f2 \
-        | cut -c2- \
+        | sed 's/^[^:]*: *//' \
         | sed 's/\s*,\s*/,/g'
   args:
     executable: "{{ shell_executable }}"

--- a/roles/ksql/tasks/set_principal.yml
+++ b/roles/ksql/tasks/set_principal.yml
@@ -23,7 +23,9 @@
   # Examine the keystore
   # Search lines with Entry type: "PrivateKeyEntry" and return that line and all after, ca cert is of type "trustedCertEntry"
   # Search for first "Owner" line
-  # Extract DNAME from line
+  # Extract DNAME from line - strip only up to the first colon, since a DN field
+  # (e.g. an Apple-style OU containing a colon) can itself contain colons, and
+  # cut -d ":" would truncate the DN at that inner colon instead of just the label.
   # Remove spaces after commas
   # Extract just the CN
   # Extract just the principal without any other formatting
@@ -33,8 +35,7 @@
         -storepass {{ksql_keystore_storepass}} -v \
         | grep PrivateKeyEntry -A1000 \
         | grep Owner -m1 \
-        | cut -d ":" -f2 \
-        | cut -c2- \
+        | sed 's/^[^:]*: *//' \
         | sed 's/^.*CN=//' \
         | cut -d "," -f1
   args:


### PR DESCRIPTION
## Summary
Supersedes #2649 (which targeted `master`). Retargeted to `7.8.x` — the branch that actually introduced `roles/common/tasks/cert_principal_extract.yml` (commit `4abe39172`, "Temp mtls combined") — so the fix flows forward through the normal `7.8.x -> 7.9.x -> 8.0.x -> ... -> master` branch chain instead of living only on `master`.

`cert_principal_extract.yml` is not present on `7.6.x`/`7.7.x` (see #2637, which fixes the 3 files that do exist there), but from `7.8.x` onward it's included from **11 sites across 9 roles** for RBAC super-user cert-principal extraction:
- `control_center_next_gen`
- `kafka_broker/tasks/rbac.yml`, `kafka_controller/tasks/rbac.yml`
- `kafka_connect` (main + deploy_connectors)
- `kafka_connect_replicator` (consumer, producer, monitoring interceptor, main — 4 sites)
- `kafka_rest`
- `ksql`
- `schema_registry/tasks/configure_rbac.yml`

Originally flagged in review on #2637: https://github.com/confluentinc/cp-ansible/pull/2637#discussion_r3829980493

This PR:
- Fixes `roles/common/tasks/cert_principal_extract.yml`.
- Also re-applies the same fix to `kafka_broker`, `kafka_controller`, and `ksql`'s own `set_principal.yml` on `7.8.x` — independent copies of the file, not shared with `cert_principal_extract.yml`.

## Fix
Same as #2637: replace `cut -d ":" -f2 | cut -c2-` with `sed 's/^[^:]*: *//'` everywhere. This strips only the label up to the *first* colon (a single substitution, not a field split), leaving any subsequent colons in the DN intact — fixes DNs like `Owner: CN=device-12345,OU=MacBookPro:Data,O=Apple Inc.,C=US` which were previously truncated at the embedded colon.

Jira: https://confluentinc.atlassian.net/browse/ANSIENG-5841

## Test plan
- [ ] RBAC deployment exercising `cert_principal_extract.yml` (e.g. Connect, Schema Registry, or C3 with cert-based super-user auth) with a colon-containing DN — confirm full DN/principal extracted correctly.
- [ ] SSL mutual-auth deployment for `kafka_broker`/`kafka_controller`/`ksql` with a colon-containing DN — confirm full DN preserved (regression parity with #2637).
- [ ] Standard DN (no embedded colons) — confirm principal extraction unchanged.
- [ ] Confirm this fix actually appears on `7.9.x`+ after the next branch-cascade merge (some historical merges in this repo used `git merge -s ours`, which doesn't carry file diffs forward) — may need explicit cherry-picks if it doesn't propagate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)