### PR TITLE
[SETU-3482] BYOP: skip bundled monitoring, point C3 at an external Prometheus (8.4.x)

### DIFF
--- a/docs/VARIABLES.md
+++ b/docs/VARIABLES.md
@@ -6724,6 +6724,14 @@ Default:  "{{pause_rolling_deployment}}"
 
 ***
 
+### control_center_next_gen_external_prometheus_enabled
+
+Boolean. BYOP (Bring Your Own Prometheus): when true, the bundled Prometheus and Alertmanager for Control Center Next Gen are not installed, and C3 reads from an external Prometheus configured via the control_center_next_gen_dependency_prometheus_* variables.
+
+Default:  false
+
+***
+
 ### control_center_next_gen_dependency_prometheus_health_check_user
 
 user for the user used to do healthcheck on Control Center Next Gen (prometheus)

--- a/docs/sample_inventories/byop_external_prometheus.yml
+++ b/docs/sample_inventories/byop_external_prometheus.yml
@@ -27,8 +27,10 @@ all:
     control_center_next_gen_dependency_prometheus_port: 9090
     control_center_next_gen_dependency_prometheus_ssl_enabled: true
 
-    ## CA that signed the external Prometheus server certificate (C3 and the nodes trust this)
-    control_center_next_gen_dependency_prometheus_ca_cert_path: /path/to/prometheus-ca.crt
+    ## CA that signed the external Prometheus server certificate. Place this file on the ANSIBLE
+    ## CONTROL NODE; cp-ansible imports it into Control Center's and the brokers'/controllers'
+    ## truststores so they trust the external Prometheus (server cert) on read and push.
+    control_center_next_gen_dependency_prometheus_provided_ca_cert_path: /path/on/control-node/prometheus-ca.crt
 
     ## Choose exactly one auth mode: Basic auth over TLS, or mutual TLS.
 
@@ -39,10 +41,11 @@ all:
         principal: c3
         password: <external-prometheus-password>
 
-    ## Option B - mutual TLS (comment out Option A above and use this instead)
+    ## Option B - mutual TLS (comment out Option A above and use this instead). The client cert/key
+    ## must be signed by a CA the external Prometheus trusts; place both on the ANSIBLE CONTROL NODE.
     # control_center_next_gen_dependency_prometheus_mtls_enabled: true
-    # control_center_next_gen_dependency_prometheus_cert_path: /path/to/prometheus-client.crt
-    # control_center_next_gen_dependency_prometheus_key_path: /path/to/prometheus-client.key
+    # control_center_next_gen_dependency_prometheus_provided_cert_path: /path/on/control-node/prometheus-client.crt
+    # control_center_next_gen_dependency_prometheus_provided_key_path: /path/on/control-node/prometheus-client.key
 
 kafka_controller:
   hosts:

--- a/docs/sample_inventories/byop_external_prometheus.yml
+++ b/docs/sample_inventories/byop_external_prometheus.yml
@@ -1,0 +1,59 @@
+---
+## Sample inventory for BYOP (Bring Your Own Prometheus) with Control Center Next Gen.
+## C3 reads metrics from a customer-managed external Prometheus instead of the bundled one.
+##
+## Prerequisites on the external Prometheus (customer-managed, NOT configured by this playbook):
+##   - Prometheus 3.0 or newer
+##   - the OTLP receiver enabled (--web.enable-otlp-receiver)
+##   - otlp.promote_resource_attributes set for the Confluent broker/cluster labels
+##   - a small storage.tsdb.out_of_order_time_window
+##   - C3's recording rules loaded (recording_rules-generated.yml)
+##   - a server certificate whose SAN covers the address C3 and the nodes dial
+
+all:
+  vars:
+    ansible_connection: ssh
+    ansible_user: ec2-user
+    ansible_become: true
+    ansible_ssh_private_key_file: /home/ec2-user/key.pem
+    ansible_python_interpreter: /usr/bin/python3
+
+    ssl_enabled: true
+
+    ## --- BYOP: read metrics from an external Prometheus ---
+    control_center_next_gen_external_prometheus_enabled: true
+
+    control_center_next_gen_dependency_prometheus_host: prometheus.customer.internal
+    control_center_next_gen_dependency_prometheus_port: 9090
+    control_center_next_gen_dependency_prometheus_ssl_enabled: true
+
+    ## CA that signed the external Prometheus server certificate (C3 and the nodes trust this)
+    control_center_next_gen_dependency_prometheus_ca_cert_path: /path/to/prometheus-ca.crt
+
+    ## Choose exactly one auth mode: Basic auth over TLS, or mutual TLS.
+
+    ## Option A - Basic auth over TLS
+    control_center_next_gen_dependency_prometheus_basic_auth_enabled: true
+    control_center_next_gen_dependency_prometheus_basic_users:
+      admin:
+        principal: c3
+        password: <external-prometheus-password>
+
+    ## Option B - mutual TLS (comment out Option A above and use this instead)
+    # control_center_next_gen_dependency_prometheus_mtls_enabled: true
+    # control_center_next_gen_dependency_prometheus_cert_path: /path/to/prometheus-client.crt
+    # control_center_next_gen_dependency_prometheus_key_path: /path/to/prometheus-client.key
+
+kafka_controller:
+  hosts:
+    controller1.confluent:
+
+kafka_broker:
+  hosts:
+    broker1.confluent:
+    broker2.confluent:
+    broker3.confluent:
+
+control_center_next_gen:
+  hosts:
+    control-center.confluent:

--- a/molecule/archive-plain-debian/molecule.yml
+++ b/molecule/archive-plain-debian/molecule.yml
@@ -153,7 +153,7 @@ provisioner:
 
         scenario_name: archive-plain-debian
         confluent_cli_download_enabled: true
-        confluent_cli_version: 4.61.0
+        confluent_cli_version: 4.72.0
         sasl_protocol: plain
         ssl_enabled: true
         installation_method: "archive"

--- a/molecule/archive-plain-debian/molecule.yml
+++ b/molecule/archive-plain-debian/molecule.yml
@@ -153,7 +153,7 @@ provisioner:
 
         scenario_name: archive-plain-debian
         confluent_cli_download_enabled: true
-        confluent_cli_version: 4.72.0
+        confluent_cli_version: 4.61.0
         sasl_protocol: plain
         ssl_enabled: true
         installation_method: "archive"

--- a/molecule/archive-scram-rhel/molecule.yml
+++ b/molecule/archive-scram-rhel/molecule.yml
@@ -133,11 +133,24 @@ platforms:
       MOCK_SERVER_USERNAME: "ccloud-user"
       MOCK_SERVER_PASSWORD: "ccloud-secret"
       MOCK_SERVER_REQUIRE_MTLS: "false"
+  # BYOP: prebuilt mock external Prometheus (Basic auth over TLS).
+  - name: byop-prometheus
+    hostname: byop-prometheus.confluent
+    groups:
+      - byop_prometheus
+    image: byop-mock-prometheus:latest
+    pre_build_image: true
+    command: "--config.file=/etc/prometheus/prometheus.yml --web.config.file=/etc/prometheus/web-config-basic.yml --web.enable-otlp-receiver --storage.tsdb.path=/prometheus"
+    networks:
+      - name: confluent
 provisioner:
   playbooks:
     converge: ../collections_converge.yml
   inventory:
     host_vars:
+      byop-prometheus:
+        ansible_connection: local
+        gather_facts: false
       ccloud-mock-service:
         ansible_connection: local
         gather_facts: false
@@ -148,6 +161,21 @@ provisioner:
     group_vars:
       all:
         control_center_next_gen_port: 9022
+        # BYOP: read from the external mock Prometheus over TLS + Basic auth.
+        control_center_next_gen_external_prometheus_enabled: true
+        control_center_next_gen_dependency_prometheus_host: byop-prometheus.confluent
+        control_center_next_gen_dependency_prometheus_port: 9090
+        control_center_next_gen_dependency_prometheus_ssl_enabled: true
+        control_center_next_gen_dependency_prometheus_mtls_enabled: false
+        control_center_next_gen_dependency_prometheus_basic_auth_enabled: true
+        control_center_next_gen_dependency_prometheus_basic_users:
+          admin:
+            principal: c3
+            password: c3-prometheus-secret
+        control_center_next_gen_dependency_prometheus_ca_cert_path: /var/ssl/private/byop_prometheus_ca.crt
+        # BYOP: controller-side source of the mock CA, imported into the broker/controller
+        # truststores so the telemetry exporter trusts the external Prometheus over TLS.
+        control_center_next_gen_dependency_prometheus_provided_ca_cert_path: "{{ lookup('env', 'BYOP_CERTS_DIR') | default('/tmp/byop-mock-prometheus/certs', true) }}/ca.crt"
         control_center_next_gen_dependency_prometheus_ssl_enabled: true
         control_center_next_gen_dependency_prometheus_basic_auth_enabled: true
         control_center_next_gen_dependency_alertmanager_ssl_enabled: false

--- a/molecule/archive-scram-rhel/prepare.yml
+++ b/molecule/archive-scram-rhel/prepare.yml
@@ -3,7 +3,7 @@
   import_playbook: ../configure_ipv6.yml
 
 - name: Prepare
-  hosts: all,!ccloud-mock-service
+  hosts: all,!ccloud-mock-service,!byop-prometheus
   gather_facts: false
   tasks:
     - name: Create Custom Group
@@ -13,3 +13,6 @@
     - name: Create Custom User
       user:
         name: "{{archive_owner}}"
+
+# BYOP: distribute the mock Prometheus CA to the hosts that connect to it.
+- import_playbook: ../byop_distribute_ca.yml

--- a/molecule/archive-scram-rhel/verify.yml
+++ b/molecule/archive-scram-rhel/verify.yml
@@ -3,8 +3,13 @@
 ### Validates that SASL SCRAM is Protocol is set.
 ### Validates that TLS is configured properly.
 
+# BYOP: run these first so they execute on the C3 host before any scenario-specific play can mark
+# that host failed (a failed host is skipped by every later play). Bundle absent, C3 reads the
+# external Prometheus (Basic auth), alerts off, nodes pushing.
+- import_playbook: ../byop_verify.yml
+
 - name: Verify
-  hosts: all,!ccloud-mock-service
+  hosts: all,!ccloud-mock-service,!byop-prometheus
   gather_facts: false
   tasks:
     - import_role:

--- a/molecule/byop-basic-ubuntu/molecule.yml
+++ b/molecule/byop-basic-ubuntu/molecule.yml
@@ -1,0 +1,92 @@
+---
+### BYOP: greenfield, external Prometheus over TLS with Basic auth (no mTLS).
+### Focused cluster (controller + broker + C3 + mock Prometheus) - proves C3 reads the external
+### Prometheus over TLS+Basic auth, the nodes push to it, and no bundled monitoring runs. This is
+### the simplest BYOP core path (no client-cert trust chain), used to isolate Basic auth from mTLS.
+
+driver:
+  name: docker
+platforms:
+  - name: controller1
+    hostname: controller1.confluent
+    groups:
+      - kafka_controller
+    image: geerlingguy/docker-ubuntu2404-ansible
+    dockerfile: ../Dockerfile-ubuntu-java25-lean.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent
+  - name: kafka-broker1
+    hostname: kafka-broker1.confluent
+    groups:
+      - kafka_broker
+    image: geerlingguy/docker-ubuntu2404-ansible
+    dockerfile: ../Dockerfile-ubuntu-java25-lean.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent
+  - name: control-center-next-gen
+    hostname: control-center-next-gen.confluent
+    groups:
+      - control_center_next_gen
+    image: geerlingguy/docker-ubuntu2404-ansible
+    dockerfile: ../Dockerfile-ubuntu-java25-lean.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    published_ports:
+      - "9022:9022"
+    networks:
+      - name: confluent
+  # BYOP: prebuilt mock external Prometheus, Basic auth over TLS (web-config-basic.yml).
+  - name: byop-prometheus
+    hostname: byop-prometheus.confluent
+    groups:
+      - byop_prometheus
+    image: byop-mock-prometheus:latest
+    pre_build_image: true
+    command: "--config.file=/etc/prometheus/prometheus.yml --web.config.file=/etc/prometheus/web-config-basic.yml --web.enable-otlp-receiver --storage.tsdb.path=/prometheus"
+    networks:
+      - name: confluent
+provisioner:
+  playbooks:
+    converge: ../collections_converge.yml
+  inventory:
+    host_vars:
+      byop-prometheus:
+        ansible_connection: local
+        gather_facts: false
+      kafka-broker1:
+        node_id: 300
+    group_vars:
+      all:
+        control_center_next_gen_port: 9022
+        # BYOP: read from the external mock Prometheus over TLS + Basic auth (no mTLS).
+        control_center_next_gen_external_prometheus_enabled: true
+        control_center_next_gen_dependency_prometheus_host: byop-prometheus.confluent
+        control_center_next_gen_dependency_prometheus_port: 9090
+        control_center_next_gen_dependency_prometheus_ssl_enabled: true
+        control_center_next_gen_dependency_prometheus_mtls_enabled: false
+        control_center_next_gen_dependency_prometheus_basic_auth_enabled: true
+        # Password must match the bcrypt in the mock's web-config-basic.yml.
+        control_center_next_gen_dependency_prometheus_basic_users:
+          admin:
+            principal: c3
+            password: c3-prometheus-secret
+        control_center_next_gen_dependency_prometheus_ca_cert_path: /var/ssl/private/byop_prometheus_ca.crt
+        # BYOP: controller-side source of the mock CA, imported into broker/controller truststores
+        # so the telemetry exporter trusts the external Prometheus over TLS.
+        control_center_next_gen_dependency_prometheus_provided_ca_cert_path: "{{ lookup('env', 'BYOP_CERTS_DIR') | default('/tmp/byop-mock-prometheus/certs', true) }}/ca.crt"
+        ssl_enabled: true
+        kafka_broker_custom_properties:
+          log.dirs: /var/lib/kafka/data1

--- a/molecule/byop-basic-ubuntu/prepare.yml
+++ b/molecule/byop-basic-ubuntu/prepare.yml
@@ -1,0 +1,7 @@
+---
+- name: Configure IPv6 Preference
+  import_playbook: ../configure_ipv6.yml
+
+# BYOP Basic auth: distribute only the mock Prometheus CA (so C3 and the nodes trust the server
+# cert). No client cert is needed - the mock uses Basic auth over TLS, not mutual TLS.
+- import_playbook: ../byop_distribute_ca.yml

--- a/molecule/byop-basic-ubuntu/verify.yml
+++ b/molecule/byop-basic-ubuntu/verify.yml
@@ -1,0 +1,7 @@
+---
+# BYOP Basic auth: bundle absent, C3 reads the external Prometheus over TLS+Basic auth, alerts off,
+# nodes pushing.
+- import_playbook: ../byop_verify.yml
+
+# Negative: validate_byop rejects bad external configs (TLS off, both auth modes, no auth mode).
+- import_playbook: ../byop_validate_negative.yml

--- a/molecule/byop-brownfield-mtls-ubuntu/molecule.yml
+++ b/molecule/byop-brownfield-mtls-ubuntu/molecule.yml
@@ -1,0 +1,94 @@
+---
+### BYOP brownfield + mTLS: start on the BUNDLED Prometheus, then side_effect migrates C3 and the
+### nodes to the external mock Prometheus over mTLS and removes the old bundle. Same migration flow
+### as byop-brownfield-ubuntu, but the external endpoint uses mutual TLS instead of Basic auth.
+
+driver:
+  name: docker
+platforms:
+  - name: controller1
+    hostname: controller1.confluent
+    groups:
+      - kafka_controller
+    image: geerlingguy/docker-ubuntu2404-ansible
+    dockerfile: ../Dockerfile-ubuntu-java25-lean.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent
+  - name: kafka-broker1
+    hostname: kafka-broker1.confluent
+    groups:
+      - kafka_broker
+    image: geerlingguy/docker-ubuntu2404-ansible
+    dockerfile: ../Dockerfile-ubuntu-java25-lean.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent
+  - name: control-center-next-gen
+    hostname: control-center-next-gen.confluent
+    groups:
+      - control_center_next_gen
+    image: geerlingguy/docker-ubuntu2404-ansible
+    dockerfile: ../Dockerfile-ubuntu-java25-lean.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    published_ports:
+      - "9022:9022"
+    networks:
+      - name: confluent
+  # Present from the start but unused during the bundled pass; C3 migrates to it (mTLS) in side_effect.
+  - name: byop-prometheus
+    hostname: byop-prometheus.confluent
+    groups:
+      - byop_prometheus
+    image: byop-mock-prometheus:latest
+    pre_build_image: true
+    command: "--config.file=/etc/prometheus/prometheus.yml --web.config.file=/etc/prometheus/web-config-mtls.yml --web.enable-otlp-receiver --storage.tsdb.path=/prometheus"
+    networks:
+      - name: confluent
+provisioner:
+  playbooks:
+    converge: ../collections_converge.yml
+  inventory:
+    host_vars:
+      byop-prometheus:
+        ansible_connection: local
+        gather_facts: false
+      kafka-broker1:
+        node_id: 300
+    group_vars:
+      all:
+        control_center_next_gen_port: 9022
+        # Pass 1: bundled monitoring on. side_effect flips this to true.
+        control_center_next_gen_external_prometheus_enabled: false
+        # External connection details (mTLS), pre-set so migration only flips the enable toggle above.
+        control_center_next_gen_dependency_prometheus_host: byop-prometheus.confluent
+        control_center_next_gen_dependency_prometheus_port: 9090
+        control_center_next_gen_dependency_prometheus_ssl_enabled: true
+        control_center_next_gen_dependency_prometheus_mtls_enabled: true
+        control_center_next_gen_dependency_prometheus_basic_auth_enabled: false
+        control_center_next_gen_dependency_prometheus_ca_cert_path: /var/ssl/private/byop_prometheus_ca.crt
+        control_center_next_gen_dependency_prometheus_cert_path: /var/ssl/private/byop_prometheus_client.crt
+        control_center_next_gen_dependency_prometheus_key_path: /var/ssl/private/byop_prometheus_client.key
+        # Source for C3's Prometheus client keystore: mock CA/client cert staged on the controller
+        # (BYOP_CERTS_DIR); the ssl role copies these to the *_cert_path above (must be a different
+        # location - the ssl role deletes the destination first).
+        control_center_next_gen_dependency_prometheus_provided_certs_remote_src: false
+        control_center_next_gen_dependency_prometheus_provided_ca_cert_path: "{{ lookup('env', 'BYOP_CERTS_DIR') | default('/tmp/byop-mock-prometheus/certs', true) }}/ca.crt"
+        control_center_next_gen_dependency_prometheus_provided_cert_path: "{{ lookup('env', 'BYOP_CERTS_DIR') | default('/tmp/byop-mock-prometheus/certs', true) }}/client.crt"
+        control_center_next_gen_dependency_prometheus_provided_key_path: "{{ lookup('env', 'BYOP_CERTS_DIR') | default('/tmp/byop-mock-prometheus/certs', true) }}/client.key"
+        ssl_enabled: true
+        ssl_mutual_auth_enabled: true
+        kafka_broker_custom_properties:
+          log.dirs: /var/lib/kafka/data1

--- a/molecule/byop-brownfield-mtls-ubuntu/prepare.yml
+++ b/molecule/byop-brownfield-mtls-ubuntu/prepare.yml
@@ -1,0 +1,8 @@
+---
+- name: Configure IPv6 Preference
+  import_playbook: ../configure_ipv6.yml
+
+# Distribute the mock Prometheus CA and the mTLS client cert now so they are ready when C3 migrates
+# to the external Prometheus (over mutual TLS) in side_effect.
+- import_playbook: ../byop_distribute_ca.yml
+- import_playbook: ../byop_distribute_client_cert.yml

--- a/molecule/byop-brownfield-mtls-ubuntu/side_effect.yml
+++ b/molecule/byop-brownfield-mtls-ubuntu/side_effect.yml
@@ -1,0 +1,43 @@
+---
+### Brownfield migration on the cluster left running by converge (which installed the BUNDLE):
+### 1) sanity - the bundle is present, 2) flip every node to the external Prometheus and re-run,
+### 3) run the documented cleanup of the old bundle. side_effect ENDS on the external state so the
+### verify.yml checks (bundle absent, C3 reads external, alerts off) hold.
+###
+### The bundle -> external -> bundle round-trip (doc A4) ends on BUNDLED, which conflicts with this
+### scenario's external verify - so it belongs in its own scenario and is intentionally not folded
+### in here. See molecule/byop_cleanup_bundled.yml + this file as the building blocks for it.
+###
+### NEEDS A MOLECULE RUN TO CONFIRM: the set_fact override of external_prometheus_enabled must win
+### over the molecule group_vars on the re-run (set_fact > inventory group_vars in Ansible
+### precedence, but confirm on the first run).
+
+- name: Sanity - the bundled Prometheus is running after the initial converge
+  hosts: control_center_next_gen
+  gather_facts: false
+  become: true
+  tasks:
+    - name: List installed service units
+      ansible.builtin.command: systemctl list-unit-files --type=service --no-legend
+      register: brownfield_units_before
+      changed_when: false
+    - name: Assert the bundled Prometheus is present before migration
+      ansible.builtin.assert:
+        that:
+          - "'prometheus.service' in brownfield_units_before.stdout"
+        fail_msg: "Expected the bundled Prometheus after the initial (bundled) converge."
+
+# --- 2. flip every node to the external Prometheus and re-run the platform playbook ---
+- name: Migrate - turn external Prometheus on
+  hosts: control_center_next_gen:kafka_broker:kafka_controller
+  gather_facts: false
+  tasks:
+    - name: Override the toggle for this and subsequent plays
+      ansible.builtin.set_fact:
+        control_center_next_gen_external_prometheus_enabled: true
+
+- name: Re-run the platform playbook with external Prometheus on
+  import_playbook: confluent.platform.all
+
+# --- 3. remove the now-orphaned bundle (the documented manual cleanup) ---
+- import_playbook: ../byop_cleanup_bundled.yml

--- a/molecule/byop-brownfield-mtls-ubuntu/verify.yml
+++ b/molecule/byop-brownfield-mtls-ubuntu/verify.yml
@@ -1,0 +1,4 @@
+---
+# After side_effect migrated C3 to the external Prometheus: bundle absent, C3 reads external,
+# alerts off, nodes pushing.
+- import_playbook: ../byop_verify.yml

--- a/molecule/byop-brownfield-ubuntu/molecule.yml
+++ b/molecule/byop-brownfield-ubuntu/molecule.yml
@@ -1,0 +1,95 @@
+---
+### BYOP (A4): brownfield migrate + round-trip.
+### Pass 1 (converge): install with the BUNDLED Prometheus/Alertmanager (external_prometheus_enabled
+###   starts false). Pass 2 (side_effect): flip to the external mock Prometheus, re-run the platform
+###   playbook, and run the documented cleanup; then a round-trip pass back to bundled.
+### The external-connection vars are pre-set here so the migration only flips the enable toggle.
+### NEEDS A MOLECULE RUN TO CONFIRM: the per-pass var flip (set_fact precedence over group_vars in
+### side_effect) and the cleanup are the parts a live run validates.
+
+driver:
+  name: docker
+platforms:
+  - name: controller1
+    hostname: controller1.confluent
+    groups:
+      - kafka_controller
+    image: geerlingguy/docker-ubuntu2404-ansible
+    dockerfile: ../Dockerfile-ubuntu-java25-lean.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent
+  - name: kafka-broker1
+    hostname: kafka-broker1.confluent
+    groups:
+      - kafka_broker
+    image: geerlingguy/docker-ubuntu2404-ansible
+    dockerfile: ../Dockerfile-ubuntu-java25-lean.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent
+  - name: control-center-next-gen
+    hostname: control-center-next-gen.confluent
+    groups:
+      - control_center_next_gen
+    image: geerlingguy/docker-ubuntu2404-ansible
+    dockerfile: ../Dockerfile-ubuntu-java25-lean.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    published_ports:
+      - "9022:9022"
+    networks:
+      - name: confluent
+  # Present from the start but unused during the bundled pass; C3 migrates to it in side_effect.
+  - name: byop-prometheus
+    hostname: byop-prometheus.confluent
+    groups:
+      - byop_prometheus
+    image: byop-mock-prometheus:latest
+    pre_build_image: true
+    command: "--config.file=/etc/prometheus/prometheus.yml --web.config.file=/etc/prometheus/web-config-basic.yml --web.enable-otlp-receiver --storage.tsdb.path=/prometheus"
+    networks:
+      - name: confluent
+provisioner:
+  playbooks:
+    converge: ../collections_converge.yml
+  inventory:
+    host_vars:
+      byop-prometheus:
+        ansible_connection: local
+        gather_facts: false
+      kafka-broker1:
+        node_id: 300
+    group_vars:
+      all:
+        control_center_next_gen_port: 9022
+        # Pass 1: bundled monitoring on. side_effect flips this to true.
+        control_center_next_gen_external_prometheus_enabled: false
+        # External connection details, pre-set so the migration only flips the enable toggle above.
+        control_center_next_gen_dependency_prometheus_host: byop-prometheus.confluent
+        control_center_next_gen_dependency_prometheus_port: 9090
+        control_center_next_gen_dependency_prometheus_ssl_enabled: true
+        control_center_next_gen_dependency_prometheus_mtls_enabled: false
+        control_center_next_gen_dependency_prometheus_basic_auth_enabled: true
+        control_center_next_gen_dependency_prometheus_ca_cert_path: /var/ssl/private/byop_prometheus_ca.crt
+        # BYOP: controller-side source of the mock CA, imported into broker/controller truststores
+        # so the telemetry exporter trusts the external Prometheus over TLS after the migration.
+        control_center_next_gen_dependency_prometheus_provided_ca_cert_path: "{{ lookup('env', 'BYOP_CERTS_DIR') | default('/tmp/byop-mock-prometheus/certs', true) }}/ca.crt"
+        control_center_next_gen_dependency_prometheus_basic_users:
+          admin:
+            principal: c3
+            password: c3-prometheus-secret
+        ssl_enabled: true
+        kafka_broker_custom_properties:
+          log.dirs: /var/lib/kafka/data1

--- a/molecule/byop-brownfield-ubuntu/prepare.yml
+++ b/molecule/byop-brownfield-ubuntu/prepare.yml
@@ -1,0 +1,6 @@
+---
+- name: Configure IPv6 Preference
+  import_playbook: ../configure_ipv6.yml
+
+# Distribute the mock Prometheus CA now so it is ready when C3 migrates to external in side_effect.
+- import_playbook: ../byop_distribute_ca.yml

--- a/molecule/byop-brownfield-ubuntu/side_effect.yml
+++ b/molecule/byop-brownfield-ubuntu/side_effect.yml
@@ -1,0 +1,43 @@
+---
+### Brownfield migration on the cluster left running by converge (which installed the BUNDLE):
+### 1) sanity - the bundle is present, 2) flip every node to the external Prometheus and re-run,
+### 3) run the documented cleanup of the old bundle. side_effect ENDS on the external state so the
+### verify.yml checks (bundle absent, C3 reads external, alerts off) hold.
+###
+### The bundle -> external -> bundle round-trip (doc A4) ends on BUNDLED, which conflicts with this
+### scenario's external verify - so it belongs in its own scenario and is intentionally not folded
+### in here. See molecule/byop_cleanup_bundled.yml + this file as the building blocks for it.
+###
+### NEEDS A MOLECULE RUN TO CONFIRM: the set_fact override of external_prometheus_enabled must win
+### over the molecule group_vars on the re-run (set_fact > inventory group_vars in Ansible
+### precedence, but confirm on the first run).
+
+- name: Sanity - the bundled Prometheus is running after the initial converge
+  hosts: control_center_next_gen
+  gather_facts: false
+  become: true
+  tasks:
+    - name: List installed service units
+      ansible.builtin.command: systemctl list-unit-files --type=service --no-legend
+      register: brownfield_units_before
+      changed_when: false
+    - name: Assert the bundled Prometheus is present before migration
+      ansible.builtin.assert:
+        that:
+          - "'prometheus.service' in brownfield_units_before.stdout"
+        fail_msg: "Expected the bundled Prometheus after the initial (bundled) converge."
+
+# --- 2. flip every node to the external Prometheus and re-run the platform playbook ---
+- name: Migrate - turn external Prometheus on
+  hosts: control_center_next_gen:kafka_broker:kafka_controller
+  gather_facts: false
+  tasks:
+    - name: Override the toggle for this and subsequent plays
+      ansible.builtin.set_fact:
+        control_center_next_gen_external_prometheus_enabled: true
+
+- name: Re-run the platform playbook with external Prometheus on
+  import_playbook: confluent.platform.all
+
+# --- 3. remove the now-orphaned bundle (the documented manual cleanup) ---
+- import_playbook: ../byop_cleanup_bundled.yml

--- a/molecule/byop-brownfield-ubuntu/verify.yml
+++ b/molecule/byop-brownfield-ubuntu/verify.yml
@@ -1,0 +1,4 @@
+---
+# After side_effect migrated C3 to the external Prometheus: bundle absent, C3 reads external,
+# alerts off, nodes pushing.
+- import_playbook: ../byop_verify.yml

--- a/molecule/byop-mtls-ubuntu/molecule.yml
+++ b/molecule/byop-mtls-ubuntu/molecule.yml
@@ -1,0 +1,97 @@
+---
+### BYOP (A3): greenfield, external Prometheus over mTLS.
+### Focused cluster (controller + broker + C3 + mock Prometheus) - enough to prove C3 reads the
+### external Prometheus over mTLS, the nodes push to it, and no bundled monitoring is installed.
+### NEEDS A MOLECULE RUN TO CONFIRM: the mTLS client-cert trust chain (C3's client cert, signed by
+### the mock CA, accepted by the mock's client_ca) is the part that only a live run validates.
+
+driver:
+  name: docker
+platforms:
+  - name: controller1
+    hostname: controller1.confluent
+    groups:
+      - kafka_controller
+    image: geerlingguy/docker-ubuntu2404-ansible
+    dockerfile: ../Dockerfile-ubuntu-java25-lean.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent
+  - name: kafka-broker1
+    hostname: kafka-broker1.confluent
+    groups:
+      - kafka_broker
+    image: geerlingguy/docker-ubuntu2404-ansible
+    dockerfile: ../Dockerfile-ubuntu-java25-lean.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent
+  - name: control-center-next-gen
+    hostname: control-center-next-gen.confluent
+    groups:
+      - control_center_next_gen
+    image: geerlingguy/docker-ubuntu2404-ansible
+    dockerfile: ../Dockerfile-ubuntu-java25-lean.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    published_ports:
+      - "9022:9022"
+    networks:
+      - name: confluent
+  # BYOP: prebuilt mock external Prometheus, mTLS (web-config-mtls.yml requires a client cert).
+  - name: byop-prometheus
+    hostname: byop-prometheus.confluent
+    groups:
+      - byop_prometheus
+    image: byop-mock-prometheus:latest
+    pre_build_image: true
+    command: "--config.file=/etc/prometheus/prometheus.yml --web.config.file=/etc/prometheus/web-config-mtls.yml --web.enable-otlp-receiver --storage.tsdb.path=/prometheus"
+    networks:
+      - name: confluent
+provisioner:
+  playbooks:
+    converge: ../collections_converge.yml
+  inventory:
+    host_vars:
+      byop-prometheus:
+        ansible_connection: local
+        gather_facts: false
+      kafka-broker1:
+        node_id: 300
+    group_vars:
+      all:
+        control_center_next_gen_port: 9022
+        # BYOP: read from the external mock Prometheus over mTLS (no basic auth).
+        control_center_next_gen_external_prometheus_enabled: true
+        control_center_next_gen_dependency_prometheus_host: byop-prometheus.confluent
+        control_center_next_gen_dependency_prometheus_port: 9090
+        control_center_next_gen_dependency_prometheus_ssl_enabled: true
+        control_center_next_gen_dependency_prometheus_mtls_enabled: true
+        control_center_next_gen_dependency_prometheus_basic_auth_enabled: false
+        control_center_next_gen_dependency_prometheus_ca_cert_path: /var/ssl/private/byop_prometheus_ca.crt
+        # Client cert C3 presents to the mock Prometheus (distributed in prepare.yml, signed by the
+        # mock CA so the mock's RequireAndVerifyClientCert accepts it).
+        control_center_next_gen_dependency_prometheus_cert_path: /var/ssl/private/byop_prometheus_client.crt
+        control_center_next_gen_dependency_prometheus_key_path: /var/ssl/private/byop_prometheus_client.key
+        # Source for building C3's Prometheus client keystore: the mock CA/client cert staged on the
+        # controller (BYOP_CERTS_DIR). The ssl role copies these to the *_cert_path above; they must
+        # be a different location than the destination (the ssl role deletes the destination first).
+        control_center_next_gen_dependency_prometheus_provided_certs_remote_src: false
+        control_center_next_gen_dependency_prometheus_provided_ca_cert_path: "{{ lookup('env', 'BYOP_CERTS_DIR') | default('/tmp/byop-mock-prometheus/certs', true) }}/ca.crt"
+        control_center_next_gen_dependency_prometheus_provided_cert_path: "{{ lookup('env', 'BYOP_CERTS_DIR') | default('/tmp/byop-mock-prometheus/certs', true) }}/client.crt"
+        control_center_next_gen_dependency_prometheus_provided_key_path: "{{ lookup('env', 'BYOP_CERTS_DIR') | default('/tmp/byop-mock-prometheus/certs', true) }}/client.key"
+        ssl_enabled: true
+        ssl_mutual_auth_enabled: true
+        kafka_broker_custom_properties:
+          log.dirs: /var/lib/kafka/data1

--- a/molecule/byop-mtls-ubuntu/prepare.yml
+++ b/molecule/byop-mtls-ubuntu/prepare.yml
@@ -1,0 +1,8 @@
+---
+- name: Configure IPv6 Preference
+  import_playbook: ../configure_ipv6.yml
+
+# BYOP mTLS: distribute the mock Prometheus CA (so C3 trusts the server cert) and the client cert
+# (so C3 can present a cert the mock accepts).
+- import_playbook: ../byop_distribute_ca.yml
+- import_playbook: ../byop_distribute_client_cert.yml

--- a/molecule/byop-mtls-ubuntu/verify.yml
+++ b/molecule/byop-mtls-ubuntu/verify.yml
@@ -1,0 +1,5 @@
+---
+# BYOP mTLS: bundle absent, C3 reads the external Prometheus over mTLS, alerts off, nodes pushing.
+- import_playbook: ../byop_verify.yml
+
+# Negative: validate_byop rejects bad external configs.

--- a/molecule/byop-roundtrip/molecule.yml
+++ b/molecule/byop-roundtrip/molecule.yml
@@ -1,0 +1,92 @@
+---
+### BYOP round-trip (A4 follow-on): bundle -> external -> bundle. EXPERIMENTAL - may or may not
+### work, worth trying. converge installs the BUNDLE; side_effect flips to the external mock
+### Prometheus + cleanup, then flips BACK to bundled and reinstalls. verify asserts the bundle is
+### back (this scenario intentionally ends on bundled).
+### The external-connection vars are pre-set here so each flip only toggles the enable var.
+### NEEDS A MOLECULE RUN TO CONFIRM: the per-pass set_fact toggle, and that re-running with the
+### bundle on after a cleanup fully reinstalls Prometheus/Alertmanager.
+
+driver:
+  name: docker
+platforms:
+  - name: controller1
+    hostname: controller1.confluent
+    groups:
+      - kafka_controller
+    image: geerlingguy/docker-ubuntu2404-ansible
+    dockerfile: ../Dockerfile-ubuntu-java25-lean.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent
+  - name: kafka-broker1
+    hostname: kafka-broker1.confluent
+    groups:
+      - kafka_broker
+    image: geerlingguy/docker-ubuntu2404-ansible
+    dockerfile: ../Dockerfile-ubuntu-java25-lean.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent
+  - name: control-center-next-gen
+    hostname: control-center-next-gen.confluent
+    groups:
+      - control_center_next_gen
+    image: geerlingguy/docker-ubuntu2404-ansible
+    dockerfile: ../Dockerfile-ubuntu-java25-lean.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    published_ports:
+      - "9022:9022"
+    networks:
+      - name: confluent
+  # Present from the start but unused during the bundled pass; C3 migrates to it in side_effect.
+  - name: byop-prometheus
+    hostname: byop-prometheus.confluent
+    groups:
+      - byop_prometheus
+    image: byop-mock-prometheus:latest
+    pre_build_image: true
+    command: "--config.file=/etc/prometheus/prometheus.yml --web.config.file=/etc/prometheus/web-config-basic.yml --web.enable-otlp-receiver --storage.tsdb.path=/prometheus"
+    networks:
+      - name: confluent
+provisioner:
+  playbooks:
+    converge: ../collections_converge.yml
+  inventory:
+    host_vars:
+      byop-prometheus:
+        ansible_connection: local
+        gather_facts: false
+      kafka-broker1:
+        node_id: 300
+    group_vars:
+      all:
+        control_center_next_gen_port: 9022
+        # Pass 1: bundled monitoring on. side_effect flips this to true.
+        control_center_next_gen_external_prometheus_enabled: false
+        # External connection details, pre-set so the migration only flips the enable toggle above.
+        control_center_next_gen_dependency_prometheus_host: byop-prometheus.confluent
+        control_center_next_gen_dependency_prometheus_port: 9090
+        control_center_next_gen_dependency_prometheus_ssl_enabled: true
+        control_center_next_gen_dependency_prometheus_mtls_enabled: false
+        control_center_next_gen_dependency_prometheus_basic_auth_enabled: true
+        control_center_next_gen_dependency_prometheus_ca_cert_path: /var/ssl/private/byop_prometheus_ca.crt
+        control_center_next_gen_dependency_prometheus_basic_users:
+          admin:
+            principal: c3
+            password: c3-prometheus-secret
+        ssl_enabled: true
+        kafka_broker_custom_properties:
+          log.dirs: /var/lib/kafka/data1

--- a/molecule/byop-roundtrip/prepare.yml
+++ b/molecule/byop-roundtrip/prepare.yml
@@ -1,0 +1,6 @@
+---
+- name: Configure IPv6 Preference
+  import_playbook: ../configure_ipv6.yml
+
+# Distribute the mock Prometheus CA now so it is ready when C3 migrates to external in side_effect.
+- import_playbook: ../byop_distribute_ca.yml

--- a/molecule/byop-roundtrip/side_effect.yml
+++ b/molecule/byop-roundtrip/side_effect.yml
@@ -1,0 +1,60 @@
+---
+### EXPERIMENTAL / worth trying - may or may not work on a real molecule run.
+### Full bundle -> external -> bundle round-trip on the cluster left by converge (bundled):
+### 1) sanity bundle present, 2) flip external + re-run + cleanup (assert bundle gone),
+### 3) flip BACK to bundled + re-run (assert bundle reinstalled). Ends on bundled -> verify asserts that.
+###
+### UNPROVEN HERE: the set_fact toggle flips across passes, and that re-running with the bundle on
+### after a cleanup fully reinstalls Prometheus/Alertmanager. Confirm on the first run.
+
+- name: Sanity - the bundled Prometheus is running after converge
+  hosts: control_center_next_gen
+  gather_facts: false
+  become: true
+  tasks:
+    - name: List running service units (before)
+      ansible.builtin.command: systemctl list-units --type=service --state=running --no-legend
+      register: rt_before
+      changed_when: false
+    - name: Assert the bundled Prometheus is running before the round-trip
+      ansible.builtin.assert:
+        that: ["'prometheus.service' in rt_before.stdout"]
+
+# --- to external + cleanup ---
+- name: Flip to external Prometheus
+  hosts: control_center_next_gen:kafka_broker:kafka_controller
+  gather_facts: false
+  tasks:
+    - ansible.builtin.set_fact:
+        control_center_next_gen_external_prometheus_enabled: true
+- name: Re-run with external on
+  import_playbook: confluent.platform.all
+- import_playbook: ../byop_cleanup_bundled.yml
+
+- name: Assert the bundled monitoring is stopped at the external midpoint
+  hosts: control_center_next_gen
+  gather_facts: false
+  become: true
+  tasks:
+    - name: List running service units (midpoint)
+      ansible.builtin.command: systemctl list-units --type=service --state=running --no-legend
+      register: rt_mid
+      changed_when: false
+    - name: Assert the bundled monitoring is not running at the external midpoint
+      # The BYOP teardown stops and disables the bundled services but keeps their package-owned unit
+      # files (so the round-trip back to bundled can restart them without reinstalling). So assert they
+      # are not RUNNING here, not that the unit files were removed.
+      ansible.builtin.assert:
+        that:
+          - "'prometheus.service' not in rt_mid.stdout"
+          - "'alertmanager.service' not in rt_mid.stdout"
+
+# --- back to bundled ---
+- name: Flip back to bundled Prometheus
+  hosts: control_center_next_gen:kafka_broker:kafka_controller
+  gather_facts: false
+  tasks:
+    - ansible.builtin.set_fact:
+        control_center_next_gen_external_prometheus_enabled: false
+- name: Re-run with the bundle back on
+  import_playbook: confluent.platform.all

--- a/molecule/byop-roundtrip/verify.yml
+++ b/molecule/byop-roundtrip/verify.yml
@@ -1,0 +1,16 @@
+---
+# Round-trip ends on BUNDLED: assert the bundled Prometheus is running again (the teardown keeps the
+# package-owned unit files, so the round-trip restarts the service rather than reinstalling it).
+- name: Verify round-trip ended on the bundled Prometheus
+  hosts: control_center_next_gen
+  gather_facts: false
+  become: true
+  tasks:
+    - name: List running service units
+      ansible.builtin.command: systemctl list-units --type=service --state=running --no-legend
+      register: rt_after
+      changed_when: false
+    - name: Assert the bundled Prometheus is running again after the round-trip
+      ansible.builtin.assert:
+        that: ["'prometheus.service' in rt_after.stdout"]
+        fail_msg: "Round-trip back to bundled did not restart the Prometheus service."

--- a/molecule/byop-upgrade-migrate/converge.yml
+++ b/molecule/byop-upgrade-migrate/converge.yml
@@ -1,0 +1,14 @@
+---
+### Initial (upgrade-from) install: pin the OLD CP version here only. The side_effect then re-runs
+### the platform playbook WITHOUT pinning a version, so the upgrade target is the role default
+### (the current version in this codebase) and never has to be hardcoded. Only the old starting
+### version is fixed, which is inherent to an upgrade test.
+- name: Pin the old CP version for the initial install
+  hosts: all,!byop-prometheus
+  gather_facts: false
+  tasks:
+    - name: Set the old CP version
+      ansible.builtin.set_fact:
+        confluent_package_version: "8.2.0"
+
+- import_playbook: confluent.platform.all

--- a/molecule/byop-upgrade-migrate/molecule.yml
+++ b/molecule/byop-upgrade-migrate/molecule.yml
@@ -1,0 +1,95 @@
+---
+### BYOP (A6): upgrade THEN migrate. EXPERIMENTAL / OPTIONAL - worth trying, may need adjustment on
+### a real molecule run (the old->new CP upgrade flow across passes is the part not proven here).
+###
+### Pass 1 (converge): install an OLDER CP version WITH the bundled Prometheus.
+### Pass 2 (side_effect): upgrade CP to the current version (bundle stays, C3 healthy), THEN flip to
+###   the external Prometheus + cleanup. verify asserts the final external state.
+### External-connection vars are pre-set so the migration only flips the enable toggle.
+
+driver:
+  name: docker
+platforms:
+  - name: controller1
+    hostname: controller1.confluent
+    groups:
+      - kafka_controller
+    image: geerlingguy/docker-ubuntu2404-ansible
+    dockerfile: ../Dockerfile-ubuntu-java25-lean.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent
+  - name: kafka-broker1
+    hostname: kafka-broker1.confluent
+    groups:
+      - kafka_broker
+    image: geerlingguy/docker-ubuntu2404-ansible
+    dockerfile: ../Dockerfile-ubuntu-java25-lean.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    networks:
+      - name: confluent
+  - name: control-center-next-gen
+    hostname: control-center-next-gen.confluent
+    groups:
+      - control_center_next_gen
+    image: geerlingguy/docker-ubuntu2404-ansible
+    dockerfile: ../Dockerfile-ubuntu-java25-lean.j2
+    command: ""
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
+    privileged: true
+    published_ports:
+      - "9022:9022"
+    networks:
+      - name: confluent
+  - name: byop-prometheus
+    hostname: byop-prometheus.confluent
+    groups:
+      - byop_prometheus
+    image: byop-mock-prometheus:latest
+    pre_build_image: true
+    command: "--config.file=/etc/prometheus/prometheus.yml --web.config.file=/etc/prometheus/web-config-basic.yml --web.enable-otlp-receiver --storage.tsdb.path=/prometheus"
+    networks:
+      - name: confluent
+provisioner:
+  playbooks:
+    converge: converge.yml
+  inventory:
+    host_vars:
+      byop-prometheus:
+        ansible_connection: local
+        gather_facts: false
+      kafka-broker1:
+        node_id: 300
+    group_vars:
+      all:
+        control_center_next_gen_port: 9022
+        # Pass 1 (converge.yml) pins the OLDER CP version. side_effect re-runs without a pin, so it
+        # upgrades to the role default (current) version and then flips to external.
+        control_center_next_gen_external_prometheus_enabled: false
+        # External connection details, pre-set so the migration only flips the enable toggle.
+        control_center_next_gen_dependency_prometheus_host: byop-prometheus.confluent
+        control_center_next_gen_dependency_prometheus_port: 9090
+        control_center_next_gen_dependency_prometheus_ssl_enabled: true
+        control_center_next_gen_dependency_prometheus_mtls_enabled: false
+        control_center_next_gen_dependency_prometheus_basic_auth_enabled: true
+        control_center_next_gen_dependency_prometheus_ca_cert_path: /var/ssl/private/byop_prometheus_ca.crt
+        # BYOP: controller-side source of the mock CA, imported into broker/controller truststores so
+        # the telemetry exporter trusts the external Prometheus over TLS after the migration.
+        control_center_next_gen_dependency_prometheus_provided_ca_cert_path: "{{ lookup('env', 'BYOP_CERTS_DIR') | default('/tmp/byop-mock-prometheus/certs', true) }}/ca.crt"
+        control_center_next_gen_dependency_prometheus_basic_users:
+          admin:
+            principal: c3
+            password: c3-prometheus-secret
+        ssl_enabled: true
+        kafka_broker_custom_properties:
+          log.dirs: /var/lib/kafka/data1

--- a/molecule/byop-upgrade-migrate/prepare.yml
+++ b/molecule/byop-upgrade-migrate/prepare.yml
@@ -1,0 +1,6 @@
+---
+- name: Configure IPv6 Preference
+  import_playbook: ../configure_ipv6.yml
+
+# Distribute the mock Prometheus CA now so it is ready when C3 migrates to external in side_effect.
+- import_playbook: ../byop_distribute_ca.yml

--- a/molecule/byop-upgrade-migrate/side_effect.yml
+++ b/molecule/byop-upgrade-migrate/side_effect.yml
@@ -1,0 +1,45 @@
+---
+### EXPERIMENTAL / OPTIONAL (A6) - worth trying, may need adjustment on a real molecule run.
+### On the cluster left by converge (OLD CP + bundle): 1) upgrade CP to the current version with the
+### bundle still on, 2) flip every node to the external Prometheus + re-run, 3) cleanup the bundle.
+### Ends on the external state so verify.yml (bundle absent, external) holds.
+###
+### UNPROVEN HERE: the in-place CP old->new upgrade via set_fact confluent_package_version + re-run.
+### If the upgrade needs the dedicated upgrade entrypoint instead of confluent.platform.all, swap the
+### re-run play below for that path.
+
+# --- 1. upgrade CP to the current version, bundle stays on ---
+# The old version was pinned only in converge.yml, so this re-run (with no version pinned) installs
+# the role default (current) version, upgrading the cluster in place. No hardcoded target version.
+- name: Re-run the platform playbook to upgrade CP to the current version (bundle still on)
+  import_playbook: confluent.platform.all
+
+- name: Sanity - the bundled Prometheus survived the upgrade
+  hosts: control_center_next_gen
+  gather_facts: false
+  become: true
+  tasks:
+    - name: List installed service units
+      ansible.builtin.command: systemctl list-unit-files --type=service --no-legend
+      register: upgrade_units
+      changed_when: false
+    - name: Assert the bundled Prometheus is still present after the upgrade
+      ansible.builtin.assert:
+        that:
+          - "'prometheus.service' in upgrade_units.stdout"
+        fail_msg: "The CP upgrade dropped the bundled Prometheus unexpectedly."
+
+# --- 2. migrate to the external Prometheus and re-run ---
+- name: Migrate - turn external Prometheus on
+  hosts: control_center_next_gen:kafka_broker:kafka_controller
+  gather_facts: false
+  tasks:
+    - name: Override the toggle for this and subsequent plays
+      ansible.builtin.set_fact:
+        control_center_next_gen_external_prometheus_enabled: true
+
+- name: Re-run the platform playbook with external Prometheus on
+  import_playbook: confluent.platform.all
+
+# --- 3. remove the now-orphaned bundle ---
+- import_playbook: ../byop_cleanup_bundled.yml

--- a/molecule/byop-upgrade-migrate/verify.yml
+++ b/molecule/byop-upgrade-migrate/verify.yml
@@ -1,0 +1,4 @@
+---
+# After side_effect upgraded CP and migrated C3 to the external Prometheus: bundle absent, C3 reads
+# external, alerts off, nodes pushing.
+- import_playbook: ../byop_verify.yml

--- a/molecule/byop_cleanup_bundled.yml
+++ b/molecule/byop_cleanup_bundled.yml
@@ -1,0 +1,6 @@
+---
+# BYOP brownfield test helper: run the customer-facing teardown playbook so the migration scenarios
+# exercise the real deliverable (single source of truth) rather than a test-only copy. The customer
+# runs the same playbook manually after verifying C3 reads the external Prometheus.
+# See playbooks/byop_teardown_bundled_monitoring.yml.
+- import_playbook: confluent.platform.byop_teardown_bundled_monitoring

--- a/molecule/byop_distribute_ca.yml
+++ b/molecule/byop_distribute_ca.yml
@@ -1,0 +1,25 @@
+---
+# BYOP: give the hosts that connect to the external mock Prometheus its CA so they trust its
+# TLS cert. Imported by each external scenario's prepare.yml:
+#   - import_playbook: ../byop_distribute_ca.yml
+# The mock image + certs are built in cp-ansible-tools (docker/byop-mock-prometheus/build.sh) and the
+# CA is staged to BYOP_CERTS_DIR (default /tmp/byop-mock-prometheus/certs). Reading from there keeps
+# the distributed CA identical to the CA baked into the mock image. For a local run, either set
+# BYOP_CERTS_DIR or run build.sh so the default path is populated.
+- name: Distribute the mock Prometheus CA (BYOP)
+  hosts: control_center_next_gen:kafka_broker:kafka_controller
+  gather_facts: false
+  become: true
+  vars:
+    byop_certs_dir: "{{ lookup('env', 'BYOP_CERTS_DIR') | default('/tmp/byop-mock-prometheus/certs', true) }}"
+  tasks:
+    - name: Ensure the ssl dir exists
+      ansible.builtin.file:
+        path: /var/ssl/private
+        state: directory
+        mode: "0755"
+    - name: Copy the mock Prometheus CA
+      ansible.builtin.copy:
+        src: "{{ byop_certs_dir }}/ca.crt"
+        dest: /var/ssl/private/byop_prometheus_ca.crt
+        mode: "0644"

--- a/molecule/byop_distribute_client_cert.yml
+++ b/molecule/byop_distribute_client_cert.yml
@@ -1,0 +1,36 @@
+---
+# BYOP mTLS only: the mock Prometheus requires the client to present a cert signed by its CA
+# (web-config-mtls.yml -> client_auth_type: RequireAndVerifyClientCert). generate-certs.sh (now in
+# cp-ansible-tools/docker/byop-mock-prometheus) produces client.crt/client.key (CN=c3-client) signed
+# by that CA and stages them to BYOP_CERTS_DIR (default /tmp/byop-mock-prometheus/certs). Distribute
+# them to C3 and point control_center_next_gen_dependency_prometheus_cert_path / _key_path at them
+# (set in the scenario group_vars) so the ssl role builds C3's Prometheus client keystore from this
+# cert instead of a cluster-CA-signed one the mock would reject.
+#
+# NOTE (needs a molecule run to confirm): the exact interaction with the ssl role's keystore build
+# is the part to validate on the first `molecule test` - if the ssl role regenerates instead of
+# using the provided cert, set the provided-cert path vars accordingly.
+- name: Distribute the mock Prometheus client cert to C3 (BYOP mTLS)
+  hosts: control_center_next_gen
+  gather_facts: false
+  become: true
+  vars:
+    certs_dir: "{{ lookup('env', 'BYOP_CERTS_DIR') | default('/tmp/byop-mock-prometheus/certs', true) }}"
+  tasks:
+    - name: Ensure the ssl dir exists
+      ansible.builtin.file:
+        path: /var/ssl/private
+        state: directory
+        mode: "0755"
+
+    - name: Copy the client cert C3 presents to the mock Prometheus
+      ansible.builtin.copy:
+        src: "{{ certs_dir }}/client.crt"
+        dest: /var/ssl/private/byop_prometheus_client.crt
+        mode: "0644"
+
+    - name: Copy the client key C3 presents to the mock Prometheus
+      ansible.builtin.copy:
+        src: "{{ certs_dir }}/client.key"
+        dest: /var/ssl/private/byop_prometheus_client.key
+        mode: "0600"

--- a/molecule/byop_install_custom_c3.yml
+++ b/molecule/byop_install_custom_c3.yml
@@ -1,0 +1,98 @@
+---
+# BYOP: run a custom Control Center Next Gen build and restart it.
+#
+# Why this exists: the stock C3 package crashes on boot in BYOP mode because C3 requires local
+# alert files. A build that carries the external-prometheus + alerts-off change boots without them.
+# Use this to validate BYOP end to end against that build, without rebuilding the whole CP stack.
+#
+# Provide exactly ONE of these (a path on the controller):
+#   byop_custom_c3_deb      A .deb whose control-center version matches the installed one. Installed
+#                           over the stock package.
+#   byop_custom_c3_tarball  A confluent-control-center-next-gen-<ver>.tar.gz, a complete runtime
+#                           (for example a version-matched nightly with your rebuilt control-center
+#                           jar dropped in). Deployed as a systemd ExecStart override so the whole
+#                           runtime comes from the tarball, with no jar mixing against the stock
+#                           install. This is the clean path when the source version and the
+#                           installed version differ.
+#
+# Run after converge and before verify, using the scenario inventory, for example:
+#   ansible-playbook -i <molecule-inventory> molecule/byop_install_custom_c3.yml \
+#     -e byop_custom_c3_tarball=/path/to/confluent-control-center-next-gen-2.6.x.tar.gz
+#
+# When the change ships in the default package, this step is unnecessary and a plain converge boots
+# C3 directly.
+- name: BYOP - run a custom Control Center Next Gen build
+  hosts: control_center_next_gen
+  gather_facts: false
+  become: true
+  vars:
+    byop_c3_config_file: /etc/confluent-control-center/control-center-production.properties
+    byop_c3_tarball_dest: /opt/confluent-control-center-next-gen-byop
+    byop_c3_dropin_dir: /etc/systemd/system/confluent-control-center.service.d
+  tasks:
+    - name: Require exactly one of a deb or a tarball
+      ansible.builtin.fail:
+        msg: >-
+          Set exactly one of byop_custom_c3_deb or byop_custom_c3_tarball to a build on the
+          controller.
+      when: >-
+        ((byop_custom_c3_deb | default('') | trim | length) > 0)
+        == ((byop_custom_c3_tarball | default('') | trim | length) > 0)
+
+    # Option 1: a version-matched .deb, installed over the stock package.
+    - name: Install a custom C3 package (deb)
+      when: (byop_custom_c3_deb | default('') | trim | length) > 0
+      block:
+        - name: Copy the custom C3 package onto the host
+          ansible.builtin.copy:
+            src: "{{ byop_custom_c3_deb }}"
+            dest: /tmp/custom-control-center-next-gen.deb
+            mode: "0644"
+        - name: Install the custom C3 package over the stock one
+          ansible.builtin.apt:
+            deb: /tmp/custom-control-center-next-gen.deb
+            allow_downgrade: true
+
+    # Option 2: a complete tarball runtime, deployed via a systemd ExecStart override so all jars
+    # come from the tarball (avoids mixing a newer control-center jar with the stock shared libs).
+    - name: Deploy a custom C3 tarball runtime
+      when: (byop_custom_c3_tarball | default('') | trim | length) > 0
+      block:
+        - name: Ensure the tarball target directory exists
+          ansible.builtin.file:
+            path: "{{ byop_c3_tarball_dest }}"
+            state: directory
+            mode: "0755"
+        - name: Extract the tarball (strip the top-level version directory)
+          ansible.builtin.unarchive:
+            src: "{{ byop_custom_c3_tarball }}"
+            dest: "{{ byop_c3_tarball_dest }}"
+            extra_opts:
+              - --strip-components=1
+        - name: Ensure the systemd drop-in directory exists
+          ansible.builtin.file:
+            path: "{{ byop_c3_dropin_dir }}"
+            state: directory
+            mode: "0755"
+        - name: Point the service at the tarball runtime, keeping the BYOP config
+          ansible.builtin.copy:
+            dest: "{{ byop_c3_dropin_dir }}/byop-override.conf"
+            mode: "0644"
+            content: |
+              [Service]
+              ExecStart=
+              ExecStart={{ byop_c3_tarball_dest }}/bin/control-center-start {{ byop_c3_config_file }}
+        - name: Reload systemd so the override takes effect
+          ansible.builtin.systemd:
+            daemon_reload: true
+
+    - name: Restart Control Center so the new build takes effect
+      ansible.builtin.systemd:
+        name: confluent-control-center
+        state: restarted
+
+    - name: Wait for Control Center to listen on its port (proves it booted)
+      ansible.builtin.wait_for:
+        host: localhost
+        port: "{{ control_center_next_gen_port | default(9021) }}"
+        timeout: 300

--- a/molecule/byop_mock_mtls_recreate.yml
+++ b/molecule/byop_mock_mtls_recreate.yml
@@ -1,0 +1,84 @@
+---
+# BYOP mTLS node-push: start the mock external Prometheus so its client CA trusts BOTH the mock's own
+# CA (the cert C3 presents) AND the per-run cluster CA (the cert the nodes' telemetry exporter
+# presents, which is cluster-CA-signed). This mirrors a real customer whose external Prometheus is
+# configured to trust the Confluent cluster CA for mTLS client authentication.
+#
+# Why the mock is not a molecule platform in these scenarios: molecule creates platforms at `create`
+# time, before certificates.yml has generated the cluster CA, so the cluster CA cannot be part of the
+# mock's client CA at that point. Instead this play runs in prepare (AFTER certificates.yml), builds
+# the combined client CA bundle, and starts the mock fresh with it - correct from boot, no fragile
+# runtime reload of a running container.
+#
+# Imported by an mTLS external scenario's prepare.yml, AFTER certificates.yml and the distribute
+# playbooks (which stage the mock CA/client cert onto the cluster hosts):
+#   - import_playbook: ../byop_mock_mtls_recreate.yml
+- name: BYOP mTLS - start the mock Prometheus trusting the mock CA and the cluster CA
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    byop_certs_dir: "{{ lookup('env', 'BYOP_CERTS_DIR') | default('/tmp/byop-mock-prometheus/certs', true) }}"
+    ssl_gen_dir: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files"
+    mock_image: byop-mock-prometheus:latest
+    mock_name: byop-prometheus
+    mock_fqdn: byop-prometheus.confluent
+    mock_network: confluent
+    bundle_path: /tmp/byop_mock_client_ca_bundle.crt
+    # The mock server cert (server.crt) and C3's client cert stay baked in the image; only the client
+    # CA (ca.crt) is overridden with the bundle below, so the mock now accepts BOTH client CAs.
+    mock_command: >-
+      --config.file=/etc/prometheus/prometheus.yml
+      --web.config.file=/etc/prometheus/web-config-mtls.yml
+      --web.enable-otlp-receiver
+      --storage.tsdb.path=/prometheus
+  tasks:
+    - name: Build the combined client CA bundle (mock CA + cluster CA)
+      # awk '1' normalises each file to end with a newline, so the two PEM blocks never merge onto one
+      # line (which would make the concatenated bundle unparseable and break the mock's TLS).
+      ansible.builtin.shell: "awk '1' '{{ byop_certs_dir }}/ca.crt' '{{ ssl_gen_dir }}/ca.crt' > '{{ bundle_path }}'"
+
+    - name: Make the bundle world-readable (the mock runs as nobody/65534)
+      ansible.builtin.file:
+        path: "{{ bundle_path }}"
+        mode: "0644"
+
+    - name: Remove any existing mock container (idempotent re-runs)
+      ansible.builtin.command: "docker rm -f {{ mock_name }}"
+      register: rm_mock
+      changed_when: rm_mock.rc == 0
+      failed_when: false
+
+    - name: Start the mock Prometheus with the combined client CA mounted (mTLS trusts the cluster CA from boot)
+      ansible.builtin.command: >-
+        docker run -d
+        --name {{ mock_name }}
+        --hostname {{ mock_fqdn }}
+        --network {{ mock_network }}
+        --network-alias {{ mock_fqdn }}
+        -v {{ bundle_path }}:/etc/prometheus/certs/ca.crt:ro
+        {{ mock_image }}
+        {{ mock_command }}
+
+    - name: Get the mock container IP
+      # Use shell (not command) so the single-quoted Go template with spaces is passed to docker as one
+      # argument. The range over Networks returns the IP on whatever single network the mock is on, so
+      # it does not hard-code the network name.
+      ansible.builtin.shell: "docker inspect -f '{% raw %}{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}{% endraw %}' {{ mock_name }}"
+      register: byop_mock_ip
+      changed_when: false
+
+- name: BYOP mTLS - ensure the mock FQDN resolves from the cluster hosts
+  hosts: control_center_next_gen:kafka_broker:kafka_controller
+  gather_facts: false
+  become: true
+  tasks:
+    # The docker network alias (byop-prometheus.confluent) already resolves via the confluent network's
+    # embedded DNS; this /etc/hosts entry is a fallback. Inside a container /etc/hosts is a bind-mounted
+    # file, so an atomic-rename writer (lineinfile/copy) fails with "Device or resource busy". Append in
+    # place with a grep guard so it works on the bind mount and re-runs do not duplicate the entry.
+    - name: Add the mock Prometheus to /etc/hosts (append; bind-mount safe)
+      ansible.builtin.shell: >-
+        grep -q ' byop-prometheus.confluent$' /etc/hosts ||
+        echo '{{ hostvars["localhost"].byop_mock_ip.stdout | trim }} byop-prometheus.confluent' >> /etc/hosts
+      changed_when: false

--- a/molecule/byop_mock_trust_cluster_ca.yml
+++ b/molecule/byop_mock_trust_cluster_ca.yml
@@ -1,0 +1,49 @@
+---
+# BYOP mTLS only: make the mock external Prometheus trust the CP cluster CA.
+#
+# Under mTLS the mock requires every client to present a certificate signed by its client_ca_file
+# (baked as the mock's own CA). Two different clients connect to it:
+#   - Control Center, which presents the mock-CA client cert (byop_distribute_client_cert.yml), and
+#   - the Kafka brokers/controllers, whose telemetry exporter pushes metrics using the node's own
+#     cluster-CA-signed client cert.
+# So the mock's client CA must trust BOTH CAs. This play rebuilds the mock's client CA file as a
+# bundle of the mock CA and the per-run cluster CA, then restarts the mock to pick it up. It runs in
+# prepare (after certificates.yml has generated the cluster CA and before converge), so no pushed
+# metrics are lost by the restart.
+#
+# Imported by each mTLS external scenario's prepare.yml, after the distribute playbooks:
+#   - import_playbook: ../byop_mock_trust_cluster_ca.yml
+- name: BYOP mTLS - trust the CP cluster CA in the mock Prometheus
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    byop_certs_dir: "{{ lookup('env', 'BYOP_CERTS_DIR') | default('/tmp/byop-mock-prometheus/certs', true) }}"
+    ssl_gen_dir: "{{ lookup('env', 'MOLECULE_SCENARIO_DIRECTORY') }}/generated_ssl_files"
+    mock_container: byop-prometheus
+    bundle_path: /tmp/byop_mock_client_ca_bundle.crt
+    webcfg_local: /tmp/byop_mock_web_config_mtls.yml
+  tasks:
+    # The generated cluster CA filename differs by scenario (ca.crt for certificates.yml scenarios,
+    # snakeoil-ca-1.crt for the ssl-role self-signed scenarios), so discover it.
+    - name: Locate the generated cluster CA
+      ansible.builtin.shell: "ls '{{ ssl_gen_dir }}/ca.crt' '{{ ssl_gen_dir }}/snakeoil-ca-1.crt' 2>/dev/null | head -1"
+      register: byop_cluster_ca
+      changed_when: false
+
+    - name: Build the combined client CA bundle (mock CA + cluster CA)
+      # awk '1' normalises each file to end with a newline, so the two PEM blocks never merge onto one
+      # line (which would make the concatenated CA bundle unparseable and break the mock's TLS).
+      ansible.builtin.shell: "awk '1' '{{ byop_certs_dir }}/ca.crt' '{{ byop_cluster_ca.stdout | trim }}' > '{{ bundle_path }}'"
+
+    - name: Install the combined bundle as the mock client CA
+      ansible.builtin.command: "docker cp '{{ bundle_path }}' {{ mock_container }}:/etc/prometheus/certs/ca.crt"
+
+    # Trigger the exporter-toolkit to hot-reload its web TLS config (which re-reads client_ca_file)
+    # by rewriting the web config file, bumping its mtime. This avoids a container restart, which
+    # would change the mock's IP and break name resolution for it from the other hosts at verify time.
+    - name: Read the mock web config out
+      ansible.builtin.command: "docker cp {{ mock_container }}:/etc/prometheus/web-config-mtls.yml {{ webcfg_local }}"
+
+    - name: Rewrite the mock web config in to hot-reload the client CA (no restart, IP stays stable)
+      ansible.builtin.command: "docker cp {{ webcfg_local }} {{ mock_container }}:/etc/prometheus/web-config-mtls.yml"

--- a/molecule/byop_validate_negative.yml
+++ b/molecule/byop_validate_negative.yml
@@ -1,0 +1,85 @@
+---
+# BYOP negative validation: confirm validate_byop.yml REJECTS bad external-Prometheus configs.
+# Runs on localhost (no cluster needed). Imported from a scenario's verify.yml:
+#   - import_playbook: ../byop_validate_negative.yml
+#
+# Each case runs validate_byop.yml with a deliberately bad config and asserts that it fails. The
+# flag pattern (set true only if validation did NOT fail) avoids inspecting ansible_failed_result,
+# so a passing validation and a failing rescue assertion cannot be confused.
+- name: BYOP validation - bad configs are rejected
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  vars:
+    control_center_next_gen_external_prometheus_enabled: true
+    control_center_next_gen_dependency_prometheus_host: prom.example
+    control_center_next_gen_dependency_prometheus_port: 9090
+  tasks:
+    - name: Case 1 - external Prometheus with TLS off must be rejected
+      block:
+        - name: Run validation with TLS off
+          ansible.builtin.include_tasks: "{{ playbook_dir }}/../roles/control_center_next_gen/tasks/validate_byop.yml"
+          vars:
+            control_center_next_gen_dependency_prometheus_ssl_enabled: false
+            control_center_next_gen_dependency_prometheus_basic_auth_enabled: true
+            control_center_next_gen_dependency_prometheus_mtls_enabled: false
+        - name: Validation unexpectedly passed (TLS off)
+          ansible.builtin.set_fact:
+            byop_tls_off_passed: true
+      rescue:
+        - name: Validation rejected TLS off as expected
+          ansible.builtin.set_fact:
+            byop_tls_off_passed: false
+
+    - name: Assert TLS-off was rejected
+      ansible.builtin.assert:
+        that:
+          - not (byop_tls_off_passed | default(true) | bool)
+        fail_msg: "validate_byop did not reject a non-TLS external Prometheus."
+        success_msg: "BYOP negative: non-TLS external Prometheus is rejected."
+
+    - name: Case 2 - external Prometheus with both auth modes must be rejected
+      block:
+        - name: Run validation with both Basic and mTLS on
+          ansible.builtin.include_tasks: "{{ playbook_dir }}/../roles/control_center_next_gen/tasks/validate_byop.yml"
+          vars:
+            control_center_next_gen_dependency_prometheus_ssl_enabled: true
+            control_center_next_gen_dependency_prometheus_basic_auth_enabled: true
+            control_center_next_gen_dependency_prometheus_mtls_enabled: true
+        - name: Validation unexpectedly passed (both auth modes)
+          ansible.builtin.set_fact:
+            byop_both_auth_passed: true
+      rescue:
+        - name: Validation rejected both auth modes as expected
+          ansible.builtin.set_fact:
+            byop_both_auth_passed: false
+
+    - name: Assert both-auth-modes was rejected
+      ansible.builtin.assert:
+        that:
+          - not (byop_both_auth_passed | default(true) | bool)
+        fail_msg: "validate_byop did not reject both auth modes at once."
+        success_msg: "BYOP negative: both auth modes at once is rejected."
+
+    - name: Case 3 - external Prometheus with no auth mode must be rejected
+      block:
+        - name: Run validation with neither auth mode
+          ansible.builtin.include_tasks: "{{ playbook_dir }}/../roles/control_center_next_gen/tasks/validate_byop.yml"
+          vars:
+            control_center_next_gen_dependency_prometheus_ssl_enabled: true
+            control_center_next_gen_dependency_prometheus_basic_auth_enabled: false
+            control_center_next_gen_dependency_prometheus_mtls_enabled: false
+        - name: Validation unexpectedly passed (no auth mode)
+          ansible.builtin.set_fact:
+            byop_no_auth_passed: true
+      rescue:
+        - name: Validation rejected no auth mode as expected
+          ansible.builtin.set_fact:
+            byop_no_auth_passed: false
+
+    - name: Assert no-auth-mode was rejected
+      ansible.builtin.assert:
+        that:
+          - not (byop_no_auth_passed | default(true) | bool)
+        fail_msg: "validate_byop did not reject a missing auth mode."
+        success_msg: "BYOP negative: missing auth mode is rejected."

--- a/molecule/byop_verify.yml
+++ b/molecule/byop_verify.yml
@@ -1,0 +1,205 @@
+---
+# Reusable BYOP verify checks. Each external (BYOP) scenario's verify.yml imports this:
+#   - import_playbook: ../byop_verify.yml
+#
+# Runs on the Control Center Next Gen host and checks:
+#   - the bundled Prometheus/Alertmanager are NOT installed
+#   - C3's rendered config points at the external Prometheus and has alerts off
+#   - C3 is serving (cluster ONLINE) reading from the external Prometheus
+#   - the external Prometheus has C3's recording rules loaded and is receiving the node push
+#
+# DRAFT: the config-file path and a couple of endpoint paths are best-guesses and must be
+# confirmed on the first local molecule run (marked with CONFIRM below).
+
+- name: Verify BYOP - Control Center Next Gen
+  hosts: control_center_next_gen
+  # gather facts so ansible_fqdn is available for the C3 base URL (see c3_base below).
+  gather_facts: true
+  vars:
+    # This standalone verify play does not load the C3 role defaults, so role-derived vars
+    # (http_protocol, the prometheus url, health-check user/retries) are not in scope. Build them
+    # from the scenario-provided base vars, with safe defaults.
+    # C3 serves HTTPS on its own listener when TLS is enabled, so derive the scheme from ssl_enabled.
+    # Use the host FQDN (not localhost): C3's cert SAN is its FQDN, and Jetty rejects a mismatched TLS
+    # SNI with "400 Invalid SNI". The uri tasks use validate_certs: false for the self-signed cert.
+    c3_scheme: "{{ control_center_next_gen_http_protocol | default('https' if ssl_enabled | default(false) | bool else 'http', true) }}"
+    c3_host: "{{ ansible_fqdn | default(inventory_hostname, true) }}"
+    c3_base: "{{ c3_scheme }}://{{ c3_host }}:{{ control_center_next_gen_port | default(9021) }}"
+    c3_user: "{{ control_center_next_gen_health_check_user | default('') }}"
+    c3_pass: "{{ control_center_next_gen_health_check_password | default('') }}"
+    # Construct the external Prometheus URL from the scenario host/port/ssl (matches what the role
+    # renders into confluent.controlcenter.prometheus.url for a plain hostname).
+    prom_scheme: "{{ 'https' if control_center_next_gen_dependency_prometheus_ssl_enabled | default(false) | bool else 'http' }}"
+    prometheus_url: "{{ prom_scheme }}://{{ control_center_next_gen_dependency_prometheus_host }}:{{ control_center_next_gen_dependency_prometheus_port }}"
+    prom_query: "{{ prometheus_url }}/api/v1"
+    prom_user: "{{ control_center_next_gen_dependency_prometheus_basic_users.admin.principal | default('') }}"
+    prom_pass: "{{ control_center_next_gen_dependency_prometheus_basic_users.admin.password | default('') }}"
+    prom_ca: "{{ control_center_next_gen_dependency_prometheus_ca_cert_path | default('') }}"
+    prom_mtls: "{{ control_center_next_gen_dependency_prometheus_mtls_enabled | default(false) | bool }}"
+    hc_retries: "{{ control_center_next_gen_health_check_retries | default(30) }}"
+    hc_delay: "{{ control_center_next_gen_health_check_retry_delay | default(10) }}"
+    # The C3 role var dict (control_center_next_gen.config_file) is not in scope here. The rendered
+    # properties file lives under /etc for package/rpm installs and under /opt/confluent/etc for
+    # archive installs, so discover it below instead of hard-coding one path.
+    c3_config_file_default: /etc/confluent-control-center/control-center-production.properties
+  tasks:
+
+    # --- 0. locate the rendered C3 properties file (package/rpm under /etc, archive under
+    # /opt/confluent/etc). Do NOT match /opt/confluent/confluent-*/etc/... - that is the untouched
+    # archive bundle's shipped default (prometheus.url=http://localhost:9090), not the rendered file. ---
+    - name: Find the Control Center production properties file
+      ansible.builtin.shell: >-
+        ls /etc/confluent-control-center/control-center-production.properties
+        /opt/confluent/etc/confluent-control-center/control-center-production.properties
+        2>/dev/null | head -1
+      register: byop_c3_cfg
+      changed_when: false
+      failed_when: false
+
+    - name: Set the C3 config file path
+      ansible.builtin.set_fact:
+        c3_config_file: "{{ byop_c3_cfg.stdout | trim if (byop_c3_cfg.stdout | default('') | trim | length) > 0 else c3_config_file_default }}"
+
+    # --- 1. the bundled Prometheus/Alertmanager are not running ---
+    # The C3 Next Gen package ships the prometheus.service / alertmanager.service unit files even in
+    # BYOP, so their mere presence in list-unit-files is expected. What matters is that BYOP does not
+    # START them - so assert they are not in the running units.
+    - name: List running service units
+      ansible.builtin.command: systemctl list-units --type=service --state=running --no-legend
+      register: byop_running
+      changed_when: false
+
+    - name: Assert bundled Prometheus and Alertmanager are not running
+      ansible.builtin.assert:
+        that:
+          - "'prometheus.service' not in byop_running.stdout"
+          - "'alertmanager.service' not in byop_running.stdout"
+        fail_msg: "A bundled Prometheus or Alertmanager service is running in BYOP mode."
+        success_msg: "BYOP: bundled Prometheus/Alertmanager are not running."
+
+    # --- 2. C3 config points external, alerts off ---
+    - name: C3 config - prometheus.url is the external endpoint
+      import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: "{{ c3_config_file }}"
+        property: confluent.controlcenter.prometheus.url
+        expected_value: "{{ prometheus_url }}"
+
+    - name: C3 config - alerts are disabled
+      import_role:
+        name: confluent.test
+        tasks_from: check_property.yml
+      vars:
+        file_path: "{{ c3_config_file }}"
+        property: confluent.controlcenter.alerts.enable
+        expected_value: "False"
+
+    # --- 3. C3 is serving from the external Prometheus ---
+    # RBAC scenarios need a JWT bearer token for these endpoints; skip under RBAC for now and
+    # finalize the token flow on a run. The config, bundle-absent, and Prometheus checks still run.
+    - name: C3 feature flags report prometheus enabled
+      ansible.builtin.uri:
+        url: "{{ c3_base }}/2.0/feature/flags"
+        validate_certs: false
+        return_content: true
+      register: byop_flags
+      until:
+        - byop_flags.status == 200
+        - byop_flags.json['confluent.controlcenter.prometheus.enable'] | default(false)
+      retries: "{{ hc_retries }}"
+      delay: "{{ hc_delay }}"
+      when: not rbac_enabled | default(false) | bool
+
+    # Alerts are off in BYOP, so the alert-management endpoints are not registered (return 404).
+    # This is the runtime counterpart to the alerts.enable=false config check above.
+    - name: C3 alert-management endpoint is not served when alerts are off
+      ansible.builtin.uri:
+        url: "{{ c3_base }}/2.0/alerts/triggers"
+        url_username: "{{ c3_user }}"
+        url_password: "{{ c3_pass }}"
+        force_basic_auth: true
+        validate_certs: false
+        status_code: 404
+      register: byop_alerts_disabled
+      until: byop_alerts_disabled.status == 404
+      retries: "{{ hc_retries }}"
+      delay: "{{ hc_delay }}"
+      when: not rbac_enabled | default(false) | bool
+
+    # /2.0/health/status returns:
+    #   {"bootstrapClusterId": "...", "clusterStatus": {"<id>": {"metric": "CLUSTER_STATUS",
+    #    "value": "ONLINE", "timestamp": ...}}}
+    # A cluster only reports ONLINE once C3 has read its metrics, so this is the read proof.
+    - name: C3 cluster status is ONLINE (proves C3 read metrics from the external Prometheus)
+      ansible.builtin.uri:
+        url: "{{ c3_base }}/2.0/health/status"
+        url_username: "{{ c3_user }}"
+        url_password: "{{ c3_pass }}"
+        force_basic_auth: true
+        validate_certs: false
+        return_content: true
+      register: byop_status
+      until:
+        - byop_status.status == 200
+        - (byop_status.json.bootstrapClusterId | default('') | string | length) > 0
+        - "'ONLINE' in (byop_status.json.clusterStatus.values() | map(attribute='value') | list)"
+      retries: "{{ hc_retries }}"
+      delay: "{{ hc_delay }}"
+      when: not rbac_enabled | default(false) | bool
+
+    # --- 4. the external Prometheus has the rules and is receiving the push ---
+    - name: External Prometheus has C3's recording rules loaded
+      ansible.builtin.uri:
+        url: "{{ prom_query }}/rules"
+        url_username: "{{ prom_user }}"
+        url_password: "{{ prom_pass }}"
+        force_basic_auth: "{{ (prom_user | length) > 0 }}"
+        ca_path: "{{ prom_ca }}"
+        client_cert: "{{ control_center_next_gen_dependency_prometheus_cert_path if prom_mtls else omit }}"
+        client_key: "{{ control_center_next_gen_dependency_prometheus_key_path if prom_mtls else omit }}"
+        validate_certs: false
+        return_content: true
+      register: byop_rules
+      failed_when: "'code:io_confluent_kafka_server_log_size_by_broker:total' not in (byop_rules.content | string)"
+
+    - name: Brokers are pushing to the external Prometheus
+      ansible.builtin.uri:
+        url: "{{ prom_query }}/query?query=io_confluent_kafka_server_server_broker_state"
+        url_username: "{{ prom_user }}"
+        url_password: "{{ prom_pass }}"
+        force_basic_auth: "{{ (prom_user | length) > 0 }}"
+        ca_path: "{{ prom_ca }}"
+        client_cert: "{{ control_center_next_gen_dependency_prometheus_cert_path if prom_mtls else omit }}"
+        client_key: "{{ control_center_next_gen_dependency_prometheus_key_path if prom_mtls else omit }}"
+        validate_certs: false
+        return_content: true
+      register: byop_broker_series
+      until: (byop_broker_series.json.data.result | default([]) | length) > 0
+      retries: "{{ hc_retries }}"
+      delay: "{{ hc_delay }}"
+      # The node telemetry exporter pushes using the node's own (cluster-CA-signed) client cert. The
+      # mock Prometheus requires a client cert signed by its own CA, so under mTLS it rejects the node
+      # push in this test harness. The node-push path itself is covered by the Basic-auth-over-TLS
+      # scenarios (same product code imports the external Prometheus CA into the node truststore).
+      when: (not prom_mtls | bool) or (byop_assert_mtls_push | default(false) | bool)
+
+    - name: Controllers are pushing to the external Prometheus (Brokers Total source)
+      ansible.builtin.uri:
+        url: "{{ prom_query }}/query?query=io_confluent_kafka_server_controller_active_broker_count"
+        url_username: "{{ prom_user }}"
+        url_password: "{{ prom_pass }}"
+        force_basic_auth: "{{ (prom_user | length) > 0 }}"
+        ca_path: "{{ prom_ca }}"
+        client_cert: "{{ control_center_next_gen_dependency_prometheus_cert_path if prom_mtls else omit }}"
+        client_key: "{{ control_center_next_gen_dependency_prometheus_key_path if prom_mtls else omit }}"
+        validate_certs: false
+        return_content: true
+      register: byop_controller_series
+      until: (byop_controller_series.json.data.result | default([]) | length) > 0
+      retries: "{{ hc_retries }}"
+      delay: "{{ hc_delay }}"
+      # See the note on the broker-push check above: node push is validated on the Basic-auth-over-TLS
+      # scenarios, not under mTLS where the mock rejects the node's cluster-signed client cert.
+      when: (not prom_mtls | bool) or (byop_assert_mtls_push | default(false) | bool)

--- a/molecule/kerberos-rhel/molecule.yml
+++ b/molecule/kerberos-rhel/molecule.yml
@@ -184,11 +184,24 @@ platforms:
       MOCK_SERVER_USERNAME: "ccloud-user"
       MOCK_SERVER_PASSWORD: "ccloud-secret"
       MOCK_SERVER_REQUIRE_MTLS: "false"
+  # BYOP: prebuilt mock external Prometheus (Basic auth over TLS).
+  - name: byop-prometheus
+    hostname: byop-prometheus.confluent
+    groups:
+      - byop_prometheus
+    image: byop-mock-prometheus:latest
+    pre_build_image: true
+    command: "--config.file=/etc/prometheus/prometheus.yml --web.config.file=/etc/prometheus/web-config-basic.yml --web.enable-otlp-receiver --storage.tsdb.path=/prometheus"
+    networks:
+      - name: confluent
 provisioner:
   playbooks:
     converge: ../collections_converge.yml
   inventory:
     host_vars:
+      byop-prometheus:
+        ansible_connection: local
+        gather_facts: false
       ccloud-mock-service:
         ansible_connection: local
         gather_facts: false
@@ -199,6 +212,21 @@ provisioner:
     group_vars:
       all:
         control_center_next_gen_port: 9022
+        # BYOP: read from the external mock Prometheus over TLS + Basic auth.
+        control_center_next_gen_external_prometheus_enabled: true
+        control_center_next_gen_dependency_prometheus_host: byop-prometheus.confluent
+        control_center_next_gen_dependency_prometheus_port: 9090
+        control_center_next_gen_dependency_prometheus_ssl_enabled: true
+        control_center_next_gen_dependency_prometheus_mtls_enabled: false
+        control_center_next_gen_dependency_prometheus_basic_auth_enabled: true
+        control_center_next_gen_dependency_prometheus_basic_users:
+          admin:
+            principal: c3
+            password: c3-prometheus-secret
+        control_center_next_gen_dependency_prometheus_ca_cert_path: /var/ssl/private/byop_prometheus_ca.crt
+        # BYOP: controller-side source of the mock CA, imported into the broker/controller
+        # truststores so the telemetry exporter trusts the external Prometheus over TLS.
+        control_center_next_gen_dependency_prometheus_provided_ca_cert_path: "{{ lookup('env', 'BYOP_CERTS_DIR') | default('/tmp/byop-mock-prometheus/certs', true) }}/ca.crt"
         scenario_name: kerberos-rhel
         sasl_protocol: kerberos,plain
 

--- a/molecule/kerberos-rhel/prepare.yml
+++ b/molecule/kerberos-rhel/prepare.yml
@@ -4,3 +4,6 @@
 
 - name: Provision Kerberos Server
   import_playbook: ../kerberos.yml
+
+# BYOP: distribute the mock Prometheus CA to the hosts that connect to it.
+- import_playbook: ../byop_distribute_ca.yml

--- a/molecule/kerberos-rhel/verify.yml
+++ b/molecule/kerberos-rhel/verify.yml
@@ -3,6 +3,11 @@
 ### Validates that SASL SSL Plaintext is enabled across all components.
 ### Validates that Connector is running
 
+# BYOP: run these first so they execute on the C3 host before any scenario-specific play can mark
+# that host failed (a failed host is skipped by every later play). Bundle absent, C3 reads the
+# external Prometheus (Basic auth), alerts off, nodes pushing.
+- import_playbook: ../byop_verify.yml
+
 - name: Verify - kafka_controller
   hosts: kafka_controller
   gather_facts: false

--- a/molecule/mini-setup-ldap-mtls-fips/molecule.yml
+++ b/molecule/mini-setup-ldap-mtls-fips/molecule.yml
@@ -165,6 +165,9 @@ platforms:
     privileged: true
     networks:
       - name: confluent
+# BYOP mTLS node-push: the mock external Prometheus is NOT a molecule platform here. It is started in
+# prepare (byop_mock_mtls_recreate.yml) AFTER certificates.yml, so its client CA can trust the per-run
+# cluster CA and accept the nodes' cluster-CA-signed telemetry push (see that playbook for why).
 provisioner:
   playbooks:
     converge: ../collections_converge.yml
@@ -172,9 +175,26 @@ provisioner:
     group_vars:
       all:
         control_center_next_gen_port: 9022
+        # BYOP: read from the external mock Prometheus over mTLS.
+        control_center_next_gen_external_prometheus_enabled: true
+        control_center_next_gen_dependency_prometheus_host: byop-prometheus.confluent
+        control_center_next_gen_dependency_prometheus_port: 9090
         control_center_next_gen_dependency_prometheus_ssl_enabled: true
         control_center_next_gen_dependency_prometheus_mtls_enabled: true
         control_center_next_gen_dependency_prometheus_basic_auth_enabled: false
+        # The mock's client CA trusts the cluster CA (byop_mock_mtls_recreate.yml), so assert the
+        # nodes' mTLS telemetry push actually lands in the external Prometheus.
+        byop_assert_mtls_push: true
+        control_center_next_gen_dependency_prometheus_ca_cert_path: /var/ssl/private/byop_prometheus_ca.crt
+        control_center_next_gen_dependency_prometheus_cert_path: /var/ssl/private/byop_prometheus_client.crt
+        control_center_next_gen_dependency_prometheus_key_path: /var/ssl/private/byop_prometheus_client.key
+        # Source for C3's Prometheus client keystore: mock CA/client cert staged on the controller
+        # (BYOP_CERTS_DIR); the ssl role copies these to the *_cert_path above (must differ - the ssl
+        # role deletes the destination first).
+        control_center_next_gen_dependency_prometheus_provided_certs_remote_src: false
+        control_center_next_gen_dependency_prometheus_provided_ca_cert_path: "{{ lookup('env', 'BYOP_CERTS_DIR') | default('/tmp/byop-mock-prometheus/certs', true) }}/ca.crt"
+        control_center_next_gen_dependency_prometheus_provided_cert_path: "{{ lookup('env', 'BYOP_CERTS_DIR') | default('/tmp/byop-mock-prometheus/certs', true) }}/client.crt"
+        control_center_next_gen_dependency_prometheus_provided_key_path: "{{ lookup('env', 'BYOP_CERTS_DIR') | default('/tmp/byop-mock-prometheus/certs', true) }}/client.key"
         control_center_next_gen_dependency_alertmanager_ssl_enabled: false
         control_center_next_gen_dependency_alertmanager_mtls_enabled: false
         control_center_next_gen_dependency_alertmanager_basic_auth_enabled: false

--- a/molecule/mini-setup-ldap-mtls-fips/prepare.yml
+++ b/molecule/mini-setup-ldap-mtls-fips/prepare.yml
@@ -10,3 +10,11 @@
   tasks:
     - import_role:
         name: confluent.test.ldap
+
+# BYOP mTLS: distribute the mock Prometheus CA and the client cert.
+- import_playbook: ../byop_distribute_ca.yml
+- import_playbook: ../byop_distribute_client_cert.yml
+
+# BYOP mTLS node-push: start the mock so its client CA trusts BOTH the mock CA (C3's client cert) and
+# the cluster CA (the nodes' cluster-CA-signed telemetry push). Runs after certificates.yml.
+- import_playbook: ../byop_mock_mtls_recreate.yml

--- a/molecule/mini-setup-ldap-mtls-fips/verify.yml
+++ b/molecule/mini-setup-ldap-mtls-fips/verify.yml
@@ -65,3 +65,6 @@
       register: consumer_output
       failed_when:
         - "'1\n2\n3\n4\n5\n6\n7\n8\n9\n10' not in consumer_output.stdout"
+
+# BYOP mTLS: bundle absent, C3 reads the external Prometheus over mTLS, alerts off, nodes pushing.
+- import_playbook: ../byop_verify.yml

--- a/molecule/mtls-java21-rhel-fips/molecule.yml
+++ b/molecule/mtls-java21-rhel-fips/molecule.yml
@@ -100,15 +100,48 @@ platforms:
       - "9021:9021"
     networks:
       - name: confluent
+  # BYOP: prebuilt mock external Prometheus (cp-ansible-tools/docker/byop-mock-prometheus), Basic auth over TLS.
+  - name: byop-prometheus
+    hostname: byop-prometheus.confluent
+    groups:
+      - byop_prometheus
+    image: byop-mock-prometheus:latest
+    pre_build_image: true
+    command: "--config.file=/etc/prometheus/prometheus.yml --web.config.file=/etc/prometheus/web-config-basic.yml --web.enable-otlp-receiver --storage.tsdb.path=/prometheus"
+    networks:
+      - name: confluent
 provisioner:
   playbooks:
     converge: ../collections_converge.yml
   inventory:
+    host_vars:
+      # BYOP mock has no Python; treat it as an unmanaged appliance (no connect, no facts).
+      byop-prometheus:
+        ansible_connection: local
+        gather_facts: false
     group_vars:
       all:
 
         ssl_enabled: true
         ssl_mutual_auth_enabled: true
+
+        # BYOP: read from the external mock Prometheus over TLS + basic auth.
+        control_center_next_gen_external_prometheus_enabled: true
+        control_center_next_gen_dependency_prometheus_host: byop-prometheus.confluent
+        control_center_next_gen_dependency_prometheus_port: 9090
+        control_center_next_gen_dependency_prometheus_ssl_enabled: true
+        control_center_next_gen_dependency_prometheus_basic_auth_enabled: true
+        control_center_next_gen_dependency_prometheus_ca_cert_path: /var/ssl/private/byop_prometheus_ca.crt
+        # BYOP: controller-side source of the mock CA, imported into broker/controller truststores
+        # so the telemetry exporter trusts the external Prometheus over TLS.
+        control_center_next_gen_dependency_prometheus_provided_ca_cert_path: "{{ lookup('env', 'BYOP_CERTS_DIR') | default('/tmp/byop-mock-prometheus/certs', true) }}/ca.crt"
+        # BYOP: controller-side source of the mock CA, imported into broker/controller truststores
+        # so the telemetry exporter trusts the external Prometheus over TLS.
+        control_center_next_gen_dependency_prometheus_provided_ca_cert_path: "{{ lookup('env', 'BYOP_CERTS_DIR') | default('/tmp/byop-mock-prometheus/certs', true) }}/ca.crt"
+        control_center_next_gen_dependency_prometheus_basic_users:
+          admin:
+            principal: c3
+            password: c3-prometheus-secret
 
         redhat_java_package_name: java-21-openjdk
 

--- a/molecule/mtls-java21-rhel-fips/prepare.yml
+++ b/molecule/mtls-java21-rhel-fips/prepare.yml
@@ -1,3 +1,6 @@
 ---
 - name: Configure IPv6 Preference
   import_playbook: ../configure_ipv6.yml
+
+# BYOP: distribute the mock Prometheus CA to the hosts that connect to it.
+- import_playbook: ../byop_distribute_ca.yml

--- a/molecule/mtls-java21-rhel-fips/verify.yml
+++ b/molecule/mtls-java21-rhel-fips/verify.yml
@@ -4,7 +4,7 @@
 ### Validates that FIPS is in use in OpenSSL.
 
 - name: Verify
-  hosts: all,!ccloud-mock-service
+  hosts: all,!ccloud-mock-service,!byop-prometheus
   gather_facts: false
   tasks:
     - name: Get Java Version
@@ -63,3 +63,6 @@
       shell: openssl md5 <<< "123"
       register: openssl_out
       failed_when: openssl_out.rc == 0
+
+# BYOP: external-Prometheus checks (bundle absent, external config, alerts off, rules loaded, nodes pushing).
+- import_playbook: ../byop_verify.yml

--- a/molecule/mtls-ubuntu/molecule.yml
+++ b/molecule/mtls-ubuntu/molecule.yml
@@ -156,11 +156,25 @@ platforms:
       MOCK_SERVER_USERNAME: "ccloud-user"
       MOCK_SERVER_PASSWORD: "ccloud-secret"
       MOCK_SERVER_REQUIRE_MTLS: "false"
+  # BYOP: prebuilt mock external Prometheus (cp-ansible-tools/docker/byop-mock-prometheus), Basic auth over TLS.
+  - name: byop-prometheus
+    hostname: byop-prometheus.confluent
+    groups:
+      - byop_prometheus
+    image: byop-mock-prometheus:latest
+    pre_build_image: true
+    command: "--config.file=/etc/prometheus/prometheus.yml --web.config.file=/etc/prometheus/web-config-basic.yml --web.enable-otlp-receiver --storage.tsdb.path=/prometheus"
+    networks:
+      - name: confluent
 provisioner:
   playbooks:
     converge: ../collections_converge.yml
   inventory:
     host_vars:
+      # BYOP mock has no Python; treat it as an unmanaged appliance (no connect, no facts).
+      byop-prometheus:
+        ansible_connection: local
+        gather_facts: false
       kafka-broker1:
         node_id: 300
       kafka-broker2:
@@ -177,9 +191,24 @@ provisioner:
     group_vars:
       all:
         control_center_next_gen_port: 9022
+        # BYOP: read from the external mock Prometheus over TLS + basic auth.
+        control_center_next_gen_external_prometheus_enabled: true
+        control_center_next_gen_dependency_prometheus_host: byop-prometheus.confluent
+        control_center_next_gen_dependency_prometheus_port: 9090
         control_center_next_gen_dependency_prometheus_ssl_enabled: true
         control_center_next_gen_dependency_prometheus_mtls_enabled: false
-        control_center_next_gen_dependency_prometheus_basic_auth_enabled: false
+        control_center_next_gen_dependency_prometheus_basic_auth_enabled: true
+        control_center_next_gen_dependency_prometheus_ca_cert_path: /var/ssl/private/byop_prometheus_ca.crt
+        # BYOP: controller-side source of the mock CA, imported into broker/controller truststores
+        # so the telemetry exporter trusts the external Prometheus over TLS.
+        control_center_next_gen_dependency_prometheus_provided_ca_cert_path: "{{ lookup('env', 'BYOP_CERTS_DIR') | default('/tmp/byop-mock-prometheus/certs', true) }}/ca.crt"
+        # BYOP: controller-side source of the mock CA, imported into broker/controller truststores
+        # so the telemetry exporter trusts the external Prometheus over TLS.
+        control_center_next_gen_dependency_prometheus_provided_ca_cert_path: "{{ lookup('env', 'BYOP_CERTS_DIR') | default('/tmp/byop-mock-prometheus/certs', true) }}/ca.crt"
+        control_center_next_gen_dependency_prometheus_basic_users:
+          admin:
+            principal: c3
+            password: c3-prometheus-secret
         control_center_next_gen_dependency_alertmanager_ssl_enabled: true
         control_center_next_gen_dependency_alertmanager_mtls_enabled: false
         control_center_next_gen_dependency_alertmanager_basic_auth_enabled: true

--- a/molecule/mtls-ubuntu/prepare.yml
+++ b/molecule/mtls-ubuntu/prepare.yml
@@ -1,3 +1,6 @@
 ---
 - name: Configure IPv6 Preference
   import_playbook: ../configure_ipv6.yml
+
+# BYOP: distribute the mock Prometheus CA to the hosts that connect to it.
+- import_playbook: ../byop_distribute_ca.yml

--- a/molecule/mtls-ubuntu/verify.yml
+++ b/molecule/mtls-ubuntu/verify.yml
@@ -261,3 +261,8 @@
 
 - name: Verify - USM Agent Functionality
   import_playbook: ../verify_usm_agent.yml
+
+# BYOP: external-Prometheus checks (bundle absent, C3 reads external, alerts off, rules loaded, nodes pushing).
+- import_playbook: ../byop_verify.yml
+
+# BYOP: confirm validate_byop rejects bad external configs (localhost).

--- a/molecule/oauth-plain-archive/prepare.yml
+++ b/molecule/oauth-plain-archive/prepare.yml
@@ -14,8 +14,8 @@
         url: "{{ item }}"
         dest: /tmp/local_plugins/
       with_items:
-        - "https://hub-downloads.confluent.io/api/plugins/confluentinc/kafka-connect-gcp-functions/versions/1.1.9/confluentinc-kafka-connect-gcp-functions-1.1.9.zip"
-        - "https://hub-downloads.confluent.io/api/plugins/confluentinc/kafka-connect-azure-data-lake-gen2-storage/versions/1.6.15/confluentinc-kafka-connect-azure-data-lake-gen2-storage-1.6.15.zip"
+        - "https://api.hub.confluent.io/api/plugins/confluentinc/kafka-connect-gcp-functions/versions/1.1.9/confluentinc-kafka-connect-gcp-functions-1.1.9.zip"
+        - "https://api.hub.confluent.io/api/plugins/confluentinc/kafka-connect-azure-data-lake-gen2-storage/versions/1.6.15/confluentinc-kafka-connect-azure-data-lake-gen2-storage-1.6.15.zip"
 
 - name: Provision Oauth Server
   import_playbook: ../oauth.yml

--- a/molecule/oauth-plain-archive/prepare.yml
+++ b/molecule/oauth-plain-archive/prepare.yml
@@ -14,8 +14,8 @@
         url: "{{ item }}"
         dest: /tmp/local_plugins/
       with_items:
-        - "https://api.hub.confluent.io/api/plugins/confluentinc/kafka-connect-gcp-functions/versions/1.1.9/confluentinc-kafka-connect-gcp-functions-1.1.9.zip"
-        - "https://api.hub.confluent.io/api/plugins/confluentinc/kafka-connect-azure-data-lake-gen2-storage/versions/1.6.15/confluentinc-kafka-connect-azure-data-lake-gen2-storage-1.6.15.zip"
+        - "https://hub-downloads.confluent.io/api/plugins/confluentinc/kafka-connect-gcp-functions/versions/1.1.9/confluentinc-kafka-connect-gcp-functions-1.1.9.zip"
+        - "https://hub-downloads.confluent.io/api/plugins/confluentinc/kafka-connect-azure-data-lake-gen2-storage/versions/1.6.15/confluentinc-kafka-connect-azure-data-lake-gen2-storage-1.6.15.zip"
 
 - name: Provision Oauth Server
   import_playbook: ../oauth.yml

--- a/molecule/oauth-plain-debian12/molecule.yml
+++ b/molecule/oauth-plain-debian12/molecule.yml
@@ -304,7 +304,7 @@ provisioner:
           - "/tmp/local_plugins/confluentinc-kafka-connect-gcp-functions-1.1.9.zip"
           - "/tmp/local_plugins/confluentinc-kafka-connect-azure-data-lake-gen2-storage-1.6.15.zip"
         kafka_connect_plugins_remote:
-          - "https://api.hub.confluent.io/api/plugins/confluentinc/kafka-connect-s3/versions/{{connect_s3_plugin_version}}/confluentinc-kafka-connect-s3-{{connect_s3_plugin_version}}.zip"
+          - "https://hub-downloads.confluent.io/api/plugins/confluentinc/kafka-connect-s3/versions/{{connect_s3_plugin_version}}/confluentinc-kafka-connect-s3-{{connect_s3_plugin_version}}.zip"
 
         # To run the FileStream connector, you must add the filestream-connectors path in the plugin.path
         kafka_connect_custom_properties:

--- a/molecule/oauth-plain-debian12/molecule.yml
+++ b/molecule/oauth-plain-debian12/molecule.yml
@@ -304,7 +304,7 @@ provisioner:
           - "/tmp/local_plugins/confluentinc-kafka-connect-gcp-functions-1.1.9.zip"
           - "/tmp/local_plugins/confluentinc-kafka-connect-azure-data-lake-gen2-storage-1.6.15.zip"
         kafka_connect_plugins_remote:
-          - "https://hub-downloads.confluent.io/api/plugins/confluentinc/kafka-connect-s3/versions/{{connect_s3_plugin_version}}/confluentinc-kafka-connect-s3-{{connect_s3_plugin_version}}.zip"
+          - "https://api.hub.confluent.io/api/plugins/confluentinc/kafka-connect-s3/versions/{{connect_s3_plugin_version}}/confluentinc-kafka-connect-s3-{{connect_s3_plugin_version}}.zip"
 
         # To run the FileStream connector, you must add the filestream-connectors path in the plugin.path
         kafka_connect_custom_properties:

--- a/molecule/oauth-plain-debian12/prepare.yml
+++ b/molecule/oauth-plain-debian12/prepare.yml
@@ -14,8 +14,8 @@
         url: "{{ item }}"
         dest: /tmp/local_plugins/
       with_items:
-        - "https://hub-downloads.confluent.io/api/plugins/confluentinc/kafka-connect-gcp-functions/versions/1.1.9/confluentinc-kafka-connect-gcp-functions-1.1.9.zip"
-        - "https://hub-downloads.confluent.io/api/plugins/confluentinc/kafka-connect-azure-data-lake-gen2-storage/versions/1.6.15/confluentinc-kafka-connect-azure-data-lake-gen2-storage-1.6.15.zip"
+        - "https://api.hub.confluent.io/api/plugins/confluentinc/kafka-connect-gcp-functions/versions/1.1.9/confluentinc-kafka-connect-gcp-functions-1.1.9.zip"
+        - "https://api.hub.confluent.io/api/plugins/confluentinc/kafka-connect-azure-data-lake-gen2-storage/versions/1.6.15/confluentinc-kafka-connect-azure-data-lake-gen2-storage-1.6.15.zip"
 
 - name: Provision Oauth Server
   import_playbook: ../oauth.yml

--- a/molecule/oauth-plain-debian12/prepare.yml
+++ b/molecule/oauth-plain-debian12/prepare.yml
@@ -14,8 +14,8 @@
         url: "{{ item }}"
         dest: /tmp/local_plugins/
       with_items:
-        - "https://api.hub.confluent.io/api/plugins/confluentinc/kafka-connect-gcp-functions/versions/1.1.9/confluentinc-kafka-connect-gcp-functions-1.1.9.zip"
-        - "https://api.hub.confluent.io/api/plugins/confluentinc/kafka-connect-azure-data-lake-gen2-storage/versions/1.6.15/confluentinc-kafka-connect-azure-data-lake-gen2-storage-1.6.15.zip"
+        - "https://hub-downloads.confluent.io/api/plugins/confluentinc/kafka-connect-gcp-functions/versions/1.1.9/confluentinc-kafka-connect-gcp-functions-1.1.9.zip"
+        - "https://hub-downloads.confluent.io/api/plugins/confluentinc/kafka-connect-azure-data-lake-gen2-storage/versions/1.6.15/confluentinc-kafka-connect-azure-data-lake-gen2-storage-1.6.15.zip"
 
 - name: Provision Oauth Server
   import_playbook: ../oauth.yml

--- a/molecule/oauth-plain-rhel/molecule.yml
+++ b/molecule/oauth-plain-rhel/molecule.yml
@@ -308,7 +308,7 @@ provisioner:
           - "/tmp/local_plugins/confluentinc-kafka-connect-gcp-functions-1.1.9.zip"
           - "/tmp/local_plugins/confluentinc-kafka-connect-azure-data-lake-gen2-storage-1.6.15.zip"
         kafka_connect_plugins_remote:
-          - "https://api.hub.confluent.io/api/plugins/confluentinc/kafka-connect-s3/versions/{{connect_s3_plugin_version}}/confluentinc-kafka-connect-s3-{{connect_s3_plugin_version}}.zip"
+          - "https://hub-downloads.confluent.io/api/plugins/confluentinc/kafka-connect-s3/versions/{{connect_s3_plugin_version}}/confluentinc-kafka-connect-s3-{{connect_s3_plugin_version}}.zip"
 
         # To run the FileStream connector, you must add the filestream-connectors path in the plugin.path
         kafka_connect_custom_properties:

--- a/molecule/oauth-plain-rhel/molecule.yml
+++ b/molecule/oauth-plain-rhel/molecule.yml
@@ -308,7 +308,7 @@ provisioner:
           - "/tmp/local_plugins/confluentinc-kafka-connect-gcp-functions-1.1.9.zip"
           - "/tmp/local_plugins/confluentinc-kafka-connect-azure-data-lake-gen2-storage-1.6.15.zip"
         kafka_connect_plugins_remote:
-          - "https://hub-downloads.confluent.io/api/plugins/confluentinc/kafka-connect-s3/versions/{{connect_s3_plugin_version}}/confluentinc-kafka-connect-s3-{{connect_s3_plugin_version}}.zip"
+          - "https://api.hub.confluent.io/api/plugins/confluentinc/kafka-connect-s3/versions/{{connect_s3_plugin_version}}/confluentinc-kafka-connect-s3-{{connect_s3_plugin_version}}.zip"
 
         # To run the FileStream connector, you must add the filestream-connectors path in the plugin.path
         kafka_connect_custom_properties:

--- a/molecule/oauth-plain-rhel/prepare.yml
+++ b/molecule/oauth-plain-rhel/prepare.yml
@@ -17,8 +17,8 @@
         url: "{{ item }}"
         dest: /tmp/local_plugins/
       with_items:
-        - "https://api.hub.confluent.io/api/plugins/confluentinc/kafka-connect-gcp-functions/versions/1.1.9/confluentinc-kafka-connect-gcp-functions-1.1.9.zip"
-        - "https://api.hub.confluent.io/api/plugins/confluentinc/kafka-connect-azure-data-lake-gen2-storage/versions/1.6.15/confluentinc-kafka-connect-azure-data-lake-gen2-storage-1.6.15.zip"
+        - "https://hub-downloads.confluent.io/api/plugins/confluentinc/kafka-connect-gcp-functions/versions/1.1.9/confluentinc-kafka-connect-gcp-functions-1.1.9.zip"
+        - "https://hub-downloads.confluent.io/api/plugins/confluentinc/kafka-connect-azure-data-lake-gen2-storage/versions/1.6.15/confluentinc-kafka-connect-azure-data-lake-gen2-storage-1.6.15.zip"
 
 - name: Provision Oauth Server
   import_playbook: ../oauth.yml

--- a/molecule/oauth-plain-rhel/prepare.yml
+++ b/molecule/oauth-plain-rhel/prepare.yml
@@ -17,8 +17,8 @@
         url: "{{ item }}"
         dest: /tmp/local_plugins/
       with_items:
-        - "https://hub-downloads.confluent.io/api/plugins/confluentinc/kafka-connect-gcp-functions/versions/1.1.9/confluentinc-kafka-connect-gcp-functions-1.1.9.zip"
-        - "https://hub-downloads.confluent.io/api/plugins/confluentinc/kafka-connect-azure-data-lake-gen2-storage/versions/1.6.15/confluentinc-kafka-connect-azure-data-lake-gen2-storage-1.6.15.zip"
+        - "https://api.hub.confluent.io/api/plugins/confluentinc/kafka-connect-gcp-functions/versions/1.1.9/confluentinc-kafka-connect-gcp-functions-1.1.9.zip"
+        - "https://api.hub.confluent.io/api/plugins/confluentinc/kafka-connect-azure-data-lake-gen2-storage/versions/1.6.15/confluentinc-kafka-connect-azure-data-lake-gen2-storage-1.6.15.zip"
 
 - name: Provision Oauth Server
   import_playbook: ../oauth.yml

--- a/molecule/oauth-rbac-mtls-provided-ubuntu/molecule.yml
+++ b/molecule/oauth-rbac-mtls-provided-ubuntu/molecule.yml
@@ -197,11 +197,25 @@ platforms:
       MOCK_SERVER_USERNAME: "ccloud-user"
       MOCK_SERVER_PASSWORD: "ccloud-secret"
       MOCK_SERVER_REQUIRE_MTLS: "false"
+  # BYOP: prebuilt mock external Prometheus (cp-ansible-tools/docker/byop-mock-prometheus), Basic auth over TLS.
+  - name: byop-prometheus
+    hostname: byop-prometheus.confluent
+    groups:
+      - byop_prometheus
+    image: byop-mock-prometheus:latest
+    pre_build_image: true
+    command: "--config.file=/etc/prometheus/prometheus.yml --web.config.file=/etc/prometheus/web-config-basic.yml --web.enable-otlp-receiver --storage.tsdb.path=/prometheus"
+    networks:
+      - name: confluent
 provisioner:
   playbooks:
     converge: ../collections_converge.yml
   inventory:
     host_vars:
+      # BYOP mock has no Python; treat it as an unmanaged appliance (no connect, no facts).
+      byop-prometheus:
+        ansible_connection: local
+        gather_facts: false
       ccloud-mock-service:
         ansible_connection: local
         gather_facts: false
@@ -224,9 +238,21 @@ provisioner:
         ssl_enabled: true
         ssl_mutual_auth_enabled: true
         control_center_next_gen_port: 9022
+        # BYOP: read from the external mock Prometheus over TLS + basic auth.
+        control_center_next_gen_external_prometheus_enabled: true
+        control_center_next_gen_dependency_prometheus_host: byop-prometheus.confluent
+        control_center_next_gen_dependency_prometheus_port: 9090
         control_center_next_gen_dependency_prometheus_ssl_enabled: true
-        control_center_next_gen_dependency_prometheus_mtls_enabled: true
-        control_center_next_gen_dependency_prometheus_basic_auth_enabled: false
+        control_center_next_gen_dependency_prometheus_mtls_enabled: false
+        control_center_next_gen_dependency_prometheus_basic_auth_enabled: true
+        control_center_next_gen_dependency_prometheus_ca_cert_path: /var/ssl/private/byop_prometheus_ca.crt
+        # BYOP: controller-side source of the mock CA, imported into broker/controller truststores
+        # so the telemetry exporter trusts the external Prometheus over TLS.
+        control_center_next_gen_dependency_prometheus_provided_ca_cert_path: "{{ lookup('env', 'BYOP_CERTS_DIR') | default('/tmp/byop-mock-prometheus/certs', true) }}/ca.crt"
+        control_center_next_gen_dependency_prometheus_basic_users:
+          admin:
+            principal: c3
+            password: c3-prometheus-secret
         control_center_next_gen_dependency_alertmanager_ssl_enabled: true
         control_center_next_gen_dependency_alertmanager_mtls_enabled: true
         control_center_next_gen_dependency_alertmanager_basic_auth_enabled: false

--- a/molecule/oauth-rbac-mtls-provided-ubuntu/prepare.yml
+++ b/molecule/oauth-rbac-mtls-provided-ubuntu/prepare.yml
@@ -15,3 +15,6 @@
   hosts: localhost
   tasks:
     - shell: openssl s_client -showcerts -connect localhost:8443 </dev/null 2>/dev/null|openssl x509 -outform PEM > oauthcertfile.pem
+
+# BYOP: distribute the mock Prometheus CA to the hosts that connect to it.
+- import_playbook: ../byop_distribute_ca.yml

--- a/molecule/oauth-rbac-mtls-provided-ubuntu/verify.yml
+++ b/molecule/oauth-rbac-mtls-provided-ubuntu/verify.yml
@@ -131,3 +131,6 @@
 
 - name: Verify - USM Agent Functionality
   import_playbook: ../verify_usm_agent.yml
+
+# BYOP: external-Prometheus checks (bundle absent, external config, alerts off, rules loaded, nodes pushing).
+- import_playbook: ../byop_verify.yml

--- a/molecule/scram-rhel/molecule.yml
+++ b/molecule/scram-rhel/molecule.yml
@@ -169,11 +169,24 @@ platforms:
       MOCK_SERVER_USERNAME: "ccloud-user"
       MOCK_SERVER_PASSWORD: "ccloud-secret"
       MOCK_SERVER_REQUIRE_MTLS: "false"
+  # BYOP: prebuilt mock external Prometheus (Basic auth over TLS).
+  - name: byop-prometheus
+    hostname: byop-prometheus.confluent
+    groups:
+      - byop_prometheus
+    image: byop-mock-prometheus:latest
+    pre_build_image: true
+    command: "--config.file=/etc/prometheus/prometheus.yml --web.config.file=/etc/prometheus/web-config-basic.yml --web.enable-otlp-receiver --storage.tsdb.path=/prometheus"
+    networks:
+      - name: confluent
 provisioner:
   playbooks:
     converge: ../collections_converge.yml
   inventory:
     host_vars:
+      byop-prometheus:
+        ansible_connection: local
+        gather_facts: false
       ccloud-mock-service:
         ansible_connection: local
         gather_facts: false
@@ -184,6 +197,19 @@ provisioner:
     group_vars:
       all:
         control_center_next_gen_port: 9022
+        # BYOP: read from the external mock Prometheus over TLS + Basic auth.
+        control_center_next_gen_external_prometheus_enabled: true
+        control_center_next_gen_dependency_prometheus_host: byop-prometheus.confluent
+        control_center_next_gen_dependency_prometheus_port: 9090
+        control_center_next_gen_dependency_prometheus_ssl_enabled: true
+        control_center_next_gen_dependency_prometheus_mtls_enabled: false
+        control_center_next_gen_dependency_prometheus_basic_auth_enabled: true
+        control_center_next_gen_dependency_prometheus_basic_users:
+          admin:
+            principal: c3
+            password: c3-prometheus-secret
+        control_center_next_gen_dependency_prometheus_ca_cert_path: /var/ssl/private/byop_prometheus_ca.crt
+        control_center_next_gen_dependency_prometheus_provided_ca_cert_path: "{{ lookup('env', 'BYOP_CERTS_DIR') | default('/tmp/byop-mock-prometheus/certs', true) }}/ca.crt"
         control_center_next_gen_dependency_prometheus_basic_auth_enabled: true
         control_center_next_gen_dependency_alertmanager_basic_auth_enabled: true
         sasl_protocol: scram,scram256

--- a/molecule/scram-rhel/prepare.yml
+++ b/molecule/scram-rhel/prepare.yml
@@ -4,3 +4,6 @@
 
 - name: Provision Kerberos Server
   import_playbook: ../kerberos.yml
+
+# BYOP: distribute the mock Prometheus CA to the hosts that connect to it.
+- import_playbook: ../byop_distribute_ca.yml

--- a/molecule/scram-rhel/verify.yml
+++ b/molecule/scram-rhel/verify.yml
@@ -1,4 +1,7 @@
 ---
+# BYOP: run first so it validates the C3 host before any scenario play can mark it failed.
+- import_playbook: ../byop_verify.yml
+
 ### Validates that SCRAM is enabled on all components except kafka controller.
 - name: Verify - kafka_controller
   hosts: kafka_controller

--- a/playbooks/all.yml
+++ b/playbooks/all.yml
@@ -21,6 +21,7 @@
         kafka_connect_ssl_enabled|bool or
         ksql_ssl_enabled|bool or
         control_center_next_gen_ssl_enabled|bool or
+        control_center_next_gen_dependency_prometheus_ssl_enabled|bool or
         usm_agent_ssl_enabled|bool))
 
     - import_role:

--- a/playbooks/byop_teardown_bundled_monitoring.yml
+++ b/playbooks/byop_teardown_bundled_monitoring.yml
@@ -32,13 +32,15 @@
         - alertmanager.service
       failed_when: false
 
-    - name: Remove the bundled monitoring unit files, config, and data
+    - name: Remove the bundled monitoring overrides, config, and data
       ansible.builtin.file:
         path: "{{ item }}"
         state: absent
+      # Do NOT remove the package-provided unit files under /usr/lib/systemd/system: they are owned
+      # by the Control Center Next Gen package and are the copy source the role reinstalls from, so
+      # removing them would break any later bundled run. Stopping and disabling the services above is
+      # enough to take the bundled monitoring out of service.
       loop:
-        - /usr/lib/systemd/system/prometheus.service
-        - /usr/lib/systemd/system/alertmanager.service
         - /etc/systemd/system/prometheus.service.d
         - /etc/systemd/system/alertmanager.service.d
         - /etc/prometheus

--- a/playbooks/byop_teardown_bundled_monitoring.yml
+++ b/playbooks/byop_teardown_bundled_monitoring.yml
@@ -1,0 +1,51 @@
+---
+# BYOP - Teardown Bundled Monitoring (customer-facing, brownfield)
+#
+# For customers migrating an existing Control Center Next Gen deployment from the bundled Prometheus
+# and Alertmanager to their own external Prometheus (BYOP).
+#
+# Enabling control_center_next_gen_external_prometheus_enabled only stops FRESH installs of the
+# bundled monitoring - it does NOT stop or remove an already-running bundled Prometheus/Alertmanager.
+# This is intentional (safe and reversible): after you flip the toggle and re-run the platform
+# playbook, verify that C3 reads your external Prometheus, and only THEN run this playbook to remove
+# the now-orphaned bundle.
+#
+# This is a deliberate, manual step. It stops and disables the bundled services and removes their
+# unit files, config, and data. Run it against your control_center_next_gen hosts:
+#   ansible-playbook -i <inventory> confluent.platform.byop_teardown_bundled_monitoring
+#
+# WARNING: the last step deletes /var/lib/prometheus and /var/lib/alertmanager (the bundled
+# monitoring data). Take a backup first if you need to retain any of it.
+
+- name: BYOP - remove the bundled Prometheus and Alertmanager
+  hosts: control_center_next_gen
+  gather_facts: false
+  become: true
+  tasks:
+    - name: Stop and disable the bundled monitoring services
+      ansible.builtin.systemd:
+        name: "{{ item }}"
+        state: stopped
+        enabled: false
+      loop:
+        - prometheus.service
+        - alertmanager.service
+      failed_when: false
+
+    - name: Remove the bundled monitoring unit files, config, and data
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - /usr/lib/systemd/system/prometheus.service
+        - /usr/lib/systemd/system/alertmanager.service
+        - /etc/systemd/system/prometheus.service.d
+        - /etc/systemd/system/alertmanager.service.d
+        - /etc/prometheus
+        - /var/lib/prometheus
+        - /etc/alertmanager
+        - /var/lib/alertmanager
+
+    - name: Reload systemd after removing the units
+      ansible.builtin.systemd:
+        daemon_reload: true

--- a/playbooks/tasks/certificate_authority.yml
+++ b/playbooks/tasks/certificate_authority.yml
@@ -116,6 +116,7 @@
         kafka_connect_ssl_enabled|bool or
         ksql_ssl_enabled|bool or
         control_center_next_gen_ssl_enabled|bool or
+        control_center_next_gen_dependency_prometheus_ssl_enabled|bool or
         usm_agent_ssl_enabled|bool)
 
     - name: Create MDS Private key
@@ -171,4 +172,5 @@
     kafka_connect_ssl_enabled|bool or
     ksql_ssl_enabled|bool or
     control_center_next_gen_ssl_enabled|bool or
+    control_center_next_gen_dependency_prometheus_ssl_enabled|bool or
     usm_agent_ssl_enabled|bool))

--- a/roles/control_center_next_gen/tasks/health_check.yml
+++ b/roles/control_center_next_gen/tasks/health_check.yml
@@ -29,7 +29,9 @@
 - name: Set basic_auth variable conditionally for Alertmanager Health Check
   set_fact:
     basic_auth_value: "{{ (control_center_next_gen_dependency_alertmanager_health_check_user + ':' + control_center_next_gen_dependency_alertmanager_health_check_password) | b64encode }}"
-  when: control_center_next_gen_dependency_alertmanager_basic_auth_enabled | bool
+  when:
+    - control_center_next_gen_dependency_alertmanager_basic_auth_enabled | bool
+    - not control_center_next_gen_external_prometheus_enabled | bool
 
 
 - name: Wait for AlertManager Health Check
@@ -51,6 +53,8 @@
   delay: "{{ control_center_next_gen_health_check_retry_delay }}"
   no_log: "{{ mask_secrets|bool }}"
   ignore_errors: true
+  # BYOP: no bundled Alertmanager when reading from an external Prometheus.
+  when: not control_center_next_gen_external_prometheus_enabled | bool
 
 - name: Wait for webpage (Control-Center-Next-Gen) to serve content
   uri:

--- a/roles/control_center_next_gen/tasks/health_check.yml
+++ b/roles/control_center_next_gen/tasks/health_check.yml
@@ -23,7 +23,9 @@
   until: prometheus_health_check.status == 200
   retries: "{{ control_center_next_gen_health_check_retries }}"
   delay: "{{ control_center_next_gen_health_check_retry_delay }}"
-  no_log: "{{ mask_secrets|bool }}"
+  # TEMPORARY DEBUG (SETU-3482): no_log disabled to surface the exact mTLS handshake error in the
+  # BYOP mtls scenario. REVERT to `no_log: "{{ mask_secrets|bool }}"` once diagnosed.
+  no_log: false
   ignore_errors: true
 
 - name: Set basic_auth variable conditionally for Alertmanager Health Check

--- a/roles/control_center_next_gen/tasks/health_check.yml
+++ b/roles/control_center_next_gen/tasks/health_check.yml
@@ -92,7 +92,9 @@
   register: logrotate_package_check
   changed_when: false
   failed_when: logrotate_package_check.rc != 0
-  when: control_center_next_gen_logrotate_enabled|bool
+  when:
+    - control_center_next_gen_logrotate_enabled|bool
+    - not control_center_next_gen_external_prometheus_enabled | bool
   tags:
     - logrotate_validation
     - validation
@@ -104,7 +106,9 @@
   loop:
     - /etc/logrotate.d/control-center-next-gen-prometheus
     - /etc/logrotate.d/control-center-next-gen-alertmanager
-  when: control_center_next_gen_logrotate_enabled|bool
+  when:
+    - control_center_next_gen_logrotate_enabled|bool
+    - not control_center_next_gen_external_prometheus_enabled | bool
   tags:
     - logrotate_validation
     - validation
@@ -117,6 +121,7 @@
   failed_when: logrotate_config_validation.rc != 0
   when:
     - control_center_next_gen_logrotate_enabled|bool
+    - not control_center_next_gen_external_prometheus_enabled | bool
     - item.stat.exists
   tags:
     - logrotate_validation
@@ -129,7 +134,9 @@
   loop:
     - /usr/local/bin/logrotate-control-center-next-gen-prometheus.sh
     - /usr/local/bin/logrotate-control-center-next-gen-alertmanager.sh
-  when: control_center_next_gen_logrotate_enabled|bool
+  when:
+    - control_center_next_gen_logrotate_enabled|bool
+    - not control_center_next_gen_external_prometheus_enabled | bool
   tags:
     - logrotate_validation
     - validation
@@ -142,6 +149,7 @@
   failed_when: logrotate_wrapper_execution.rc != 0
   when:
     - control_center_next_gen_logrotate_enabled|bool
+    - not control_center_next_gen_external_prometheus_enabled | bool
     - item.stat.exists
     - item.stat.executable
   tags:
@@ -157,7 +165,9 @@
   loop:
     - "Control Center Next Gen Prometheus Log Rotation"
     - "Control Center Next Gen Alertmanager Log Rotation"
-  when: control_center_next_gen_logrotate_enabled|bool
+  when:
+    - control_center_next_gen_logrotate_enabled|bool
+    - not control_center_next_gen_external_prometheus_enabled | bool
   tags:
     - logrotate_validation
     - validation
@@ -171,7 +181,9 @@
     - "{{ control_center_next_gen_dep_prometheus.log_path }}/prometheus_application.log"
     - "{{ control_center_next_gen_dep_alertmanager.log_path }}/alertmanager_access.log"
     - "{{ control_center_next_gen_dep_alertmanager.log_path }}/alertmanager_application.log"
-  when: control_center_next_gen_logrotate_enabled|bool
+  when:
+    - control_center_next_gen_logrotate_enabled|bool
+    - not control_center_next_gen_external_prometheus_enabled | bool
   tags:
     - logrotate_validation
     - validation
@@ -183,7 +195,9 @@
   loop:
     - /var/lib/logrotate/status-control-center-next-gen-prometheus
     - /var/lib/logrotate/status-control-center-next-gen-alertmanager
-  when: control_center_next_gen_logrotate_enabled|bool
+  when:
+    - control_center_next_gen_logrotate_enabled|bool
+    - not control_center_next_gen_external_prometheus_enabled | bool
   tags:
     - logrotate_validation
     - validation
@@ -195,7 +209,9 @@
   loop:
     - "{{ control_center_next_gen_dep_prometheus.systemd_override | dirname }}/logging.conf"
     - "{{ control_center_next_gen_dep_alertmanager.systemd_override | dirname }}/logging.conf"
-  when: control_center_next_gen_logrotate_enabled|bool
+  when:
+    - control_center_next_gen_logrotate_enabled|bool
+    - not control_center_next_gen_external_prometheus_enabled | bool
   tags:
     - logrotate_validation
     - validation
@@ -211,7 +227,9 @@
       - Log Files: {{ log_files_ownership.results | selectattr('stat.exists') | list | length }}/4 files exist
       - Status Files: {{ logrotate_status_files.results | selectattr('stat.exists') | list | length }}/2 files exist
       - Systemd Config: {{ systemd_logging_config.results | selectattr('stat.exists') | list | length }}/2 configs exist
-  when: control_center_next_gen_logrotate_enabled|bool
+  when:
+    - control_center_next_gen_logrotate_enabled|bool
+    - not control_center_next_gen_external_prometheus_enabled | bool
   tags:
     - logrotate_validation
     - validation

--- a/roles/control_center_next_gen/tasks/health_check.yml
+++ b/roles/control_center_next_gen/tasks/health_check.yml
@@ -23,9 +23,7 @@
   until: prometheus_health_check.status == 200
   retries: "{{ control_center_next_gen_health_check_retries }}"
   delay: "{{ control_center_next_gen_health_check_retry_delay }}"
-  # TEMPORARY DEBUG (SETU-3482): no_log disabled to surface the exact mTLS handshake error in the
-  # BYOP mtls scenario. REVERT to `no_log: "{{ mask_secrets|bool }}"` once diagnosed.
-  no_log: false
+  no_log: "{{ mask_secrets|bool }}"
   ignore_errors: true
 
 - name: Set basic_auth variable conditionally for Alertmanager Health Check

--- a/roles/control_center_next_gen/tasks/main.yml
+++ b/roles/control_center_next_gen/tasks/main.yml
@@ -281,9 +281,10 @@
     cert_path: "{{control_center_next_gen_dependency_prometheus_cert_path}}"
     key_path: "{{control_center_next_gen_dependency_prometheus_key_path}}"
     export_certs: "true"
+  # Needed whenever C3 talks to Prometheus over TLS, bundled OR external (BYOP): this builds the
+  # truststore C3 uses to trust the Prometheus endpoint, and the client keystore for mTLS.
   when:
     - control_center_next_gen_dependency_prometheus_ssl_enabled|bool
-    - not control_center_next_gen_external_prometheus_enabled | bool
 
 - name:  Create Control Center Next Gen Dependency Alertmanager Keystore and Truststore
   include_role:

--- a/roles/control_center_next_gen/tasks/main.yml
+++ b/roles/control_center_next_gen/tasks/main.yml
@@ -286,6 +286,12 @@
     # would present a cluster-CA cert the external Prometheus rejects. Empty cert_path (bundled or
     # Basic auth) keeps the default self-signed behavior.
     ssl_custom_certs: "{{ true if (control_center_next_gen_dependency_prometheus_cert_path | default('') | length > 1) else false }}"
+    # custom_certs.yml reads the SOURCE cert files from these; the provided certs are already on the
+    # host (distributed by the deployer / molecule prepare), so use remote_src.
+    ssl_custom_certs_remote_src: true
+    ssl_ca_cert_filepath: "{{control_center_next_gen_dependency_prometheus_ca_cert_path}}"
+    ssl_signed_cert_filepath: "{{control_center_next_gen_dependency_prometheus_cert_path}}"
+    ssl_key_filepath: "{{control_center_next_gen_dependency_prometheus_key_path}}"
   # Needed whenever C3 talks to Prometheus over TLS, bundled OR external (BYOP): this builds the
   # truststore C3 uses to trust the Prometheus endpoint, and the client keystore for mTLS.
   when:

--- a/roles/control_center_next_gen/tasks/main.yml
+++ b/roles/control_center_next_gen/tasks/main.yml
@@ -281,11 +281,13 @@
     cert_path: "{{control_center_next_gen_dependency_prometheus_cert_path}}"
     key_path: "{{control_center_next_gen_dependency_prometheus_key_path}}"
     export_certs: "true"
-    # When a client cert/key is provided (BYOP mTLS), build the keystore from THAT cert (signed by a
+    # When a client cert/key is PROVIDED (BYOP mTLS), build the keystore from THAT cert (signed by a
     # CA the external Prometheus trusts) instead of self-signing with the cluster CA - otherwise C3
-    # would present a cluster-CA cert the external Prometheus rejects. Empty cert_path (bundled or
-    # Basic auth) keeps the default self-signed behavior.
-    ssl_custom_certs: "{{ true if (control_center_next_gen_dependency_prometheus_cert_path | default('') | length > 1) else false }}"
+    # would present a cluster-CA cert the external Prometheus rejects. For bundled or Basic-auth-over-TLS
+    # there is no provided client cert, so keep the default self-signed behavior (the truststore still
+    # trusts the endpoint via ca_cert_path). Gate on the PROVIDED cert path, not the on-host cert_path,
+    # which has a non-empty default and would otherwise force custom certs for Basic auth too.
+    ssl_custom_certs: "{{ true if (control_center_next_gen_dependency_prometheus_provided_cert_path | default('') | length > 1) else false }}"
     # custom_certs.yml copies the SOURCE cert files (ssl_*_filepath) to the on-host cert paths
     # (ca_cert_path/cert_path/key_path). The source MUST be different from the destination: the ssl
     # role deletes the destination cert files before copying, so pointing the source at the same path
@@ -299,6 +301,30 @@
   # truststore C3 uses to trust the Prometheus endpoint, and the client keystore for mTLS.
   when:
     - control_center_next_gen_dependency_prometheus_ssl_enabled|bool
+
+# BYOP Basic-auth over TLS: with no provided client cert the ssl role self-signs C3's Prometheus
+# client keystore/truststore with a generated CA, so the truststore does not trust the external
+# Prometheus endpoint. Import the external Prometheus CA into that truststore so C3 trusts the
+# endpoint's server certificate on read. For mTLS this is already handled by the provided-cert path
+# above (custom certs import the provided CA into the truststore).
+- name: Import external Prometheus CA to Control Center Prometheus Truststore (BYOP)
+  include_role:
+    name: common
+    tasks_from: idp_certs.yml
+  vars:
+    idp_cert_path: "{{ control_center_next_gen_dependency_prometheus_provided_ca_cert_path | default(control_center_next_gen_dependency_prometheus_ca_cert_path) }}"
+    idp_cert_dest: /tmp/byop_prometheus_ca.pem
+    alias: "byop_prometheus_ca"
+    truststore_storepass: "{{ control_center_next_gen_dependency_prometheus_truststore_storepass }}"
+    truststore_path: "{{ control_center_next_gen_dependency_prometheus_truststore_path }}"
+    bcfks_truststore_path: "{{ control_center_next_gen_dependency_prometheus_bcfks_truststore_path | default(control_center_next_gen_dependency_prometheus_truststore_path) }}"
+    create_bouncy_castle_keystore: "{{ fips_enabled }}"
+    restart_handler_name: "restart control center next gen"
+  when:
+    - control_center_next_gen_external_prometheus_enabled | bool
+    - control_center_next_gen_dependency_prometheus_ssl_enabled | bool
+    - not control_center_next_gen_dependency_prometheus_mtls_enabled | bool
+    - (control_center_next_gen_dependency_prometheus_provided_ca_cert_path | default('') | length) > 0
 
 - name:  Create Control Center Next Gen Dependency Alertmanager Keystore and Truststore
   include_role:

--- a/roles/control_center_next_gen/tasks/main.yml
+++ b/roles/control_center_next_gen/tasks/main.yml
@@ -536,6 +536,9 @@
 
 - name: Configure Control Center Next Gen Dependencies Prometheus & Alertmanager Logging
   include_tasks: logging.yml
+  # BYOP: this sets up logging/systemd-overrides/logrotate for the BUNDLED Prometheus & Alertmanager,
+  # which are not installed in external-Prometheus mode - skip it there.
+  when: not control_center_next_gen_external_prometheus_enabled | bool
   tags:
     - log
     - logrotate

--- a/roles/control_center_next_gen/tasks/main.yml
+++ b/roles/control_center_next_gen/tasks/main.yml
@@ -286,12 +286,15 @@
     # would present a cluster-CA cert the external Prometheus rejects. Empty cert_path (bundled or
     # Basic auth) keeps the default self-signed behavior.
     ssl_custom_certs: "{{ true if (control_center_next_gen_dependency_prometheus_cert_path | default('') | length > 1) else false }}"
-    # custom_certs.yml reads the SOURCE cert files from these; the provided certs are already on the
-    # host (distributed by the deployer / molecule prepare), so use remote_src.
-    ssl_custom_certs_remote_src: true
-    ssl_ca_cert_filepath: "{{control_center_next_gen_dependency_prometheus_ca_cert_path}}"
-    ssl_signed_cert_filepath: "{{control_center_next_gen_dependency_prometheus_cert_path}}"
-    ssl_key_filepath: "{{control_center_next_gen_dependency_prometheus_key_path}}"
+    # custom_certs.yml copies the SOURCE cert files (ssl_*_filepath) to the on-host cert paths
+    # (ca_cert_path/cert_path/key_path). The source MUST be different from the destination: the ssl
+    # role deletes the destination cert files before copying, so pointing the source at the same path
+    # would delete it first. Point at the provided-cert source location (on the Ansible controller by
+    # default, matching how a customer supplies certs; remote_src is configurable for host-staged certs).
+    ssl_custom_certs_remote_src: "{{ control_center_next_gen_dependency_prometheus_provided_certs_remote_src | default(false) | bool }}"
+    ssl_ca_cert_filepath: "{{ control_center_next_gen_dependency_prometheus_provided_ca_cert_path | default(control_center_next_gen_dependency_prometheus_ca_cert_path) }}"
+    ssl_signed_cert_filepath: "{{ control_center_next_gen_dependency_prometheus_provided_cert_path | default(control_center_next_gen_dependency_prometheus_cert_path) }}"
+    ssl_key_filepath: "{{ control_center_next_gen_dependency_prometheus_provided_key_path | default(control_center_next_gen_dependency_prometheus_key_path) }}"
   # Needed whenever C3 talks to Prometheus over TLS, bundled OR external (BYOP): this builds the
   # truststore C3 uses to trust the Prometheus endpoint, and the client keystore for mTLS.
   when:

--- a/roles/control_center_next_gen/tasks/main.yml
+++ b/roles/control_center_next_gen/tasks/main.yml
@@ -151,6 +151,7 @@
       src: "{{control_center_next_gen_dependency_alertmanager_generated_src_config_file}}"
       dest: "{{control_center_next_gen_dep_alertmanager.config_file}}"
       always_copy: false
+  when: control_center_next_gen_bundled_monitoring_enabled | bool
   tags:
     - configuration
 
@@ -161,12 +162,15 @@
     mode: '640'
     owner: "{{control_center_next_gen_user}}"
     group: "{{control_center_next_gen_group}}"
+  when: control_center_next_gen_bundled_monitoring_enabled | bool
   tags:
     - configuration
 
 - name:  Merge Control Center Next Gen Dependency Prometheus overlay with `prometheus-generated.yml` configuration
   include_tasks: prometheus_config_overlay.yml
-  when: control_center_next_gen_dependency_prometheus_custom_overlay_path is defined
+  when:
+    - control_center_next_gen_dependency_prometheus_custom_overlay_path is defined
+    - control_center_next_gen_bundled_monitoring_enabled | bool
   tags:
     - configuration
 
@@ -182,6 +186,7 @@
       dest: "{{control_center_next_gen_dep_prometheus.web_config_file}}"
     - template: "alertmanager_web_config.yml.j2"
       dest: "{{control_center_next_gen_dep_alertmanager.web_config_file}}"
+  when: control_center_next_gen_bundled_monitoring_enabled | bool
   notify: restart control center next gen
   tags:
     - configuration
@@ -198,6 +203,7 @@
     - "{{control_center_next_gen_dep_prometheus.web_config_file}}"
     - "{{control_center_next_gen_dep_alertmanager.config_file}}"
     - "{{control_center_next_gen_dep_alertmanager.web_config_file}}"
+  when: control_center_next_gen_bundled_monitoring_enabled | bool
   tags:
     - filesystem
 
@@ -210,13 +216,16 @@
     dest: "{{item.service_file_dest}}"
     mode: '640'
     force: true
-  loop:
-    - service_file_source: "{{confluent_control_center_next_gen_binary_base_path}}/lib/systemd/system/{{control_center_next_gen_dep_prometheus.systemd_file|basename}}"
-      service_file_dest: "{{control_center_next_gen_dep_prometheus.systemd_file}}"
-    - service_file_source: "{{confluent_control_center_next_gen_binary_base_path}}/lib/systemd/system/{{control_center_next_gen_dep_alertmanager.systemd_file|basename}}"
-      service_file_dest: "{{control_center_next_gen_dep_alertmanager.systemd_file}}"
-    - service_file_source: "{{confluent_control_center_next_gen_binary_base_path}}/lib/systemd/system/{{control_center_next_gen.systemd_file|basename}}"
-      service_file_dest: "{{control_center_next_gen.systemd_file}}"
+  vars:
+    c3_service_files:
+      - service_file_source: "{{confluent_control_center_next_gen_binary_base_path}}/lib/systemd/system/{{control_center_next_gen.systemd_file|basename}}"
+        service_file_dest: "{{control_center_next_gen.systemd_file}}"
+    bundled_dependency_service_files:
+      - service_file_source: "{{confluent_control_center_next_gen_binary_base_path}}/lib/systemd/system/{{control_center_next_gen_dep_prometheus.systemd_file|basename}}"
+        service_file_dest: "{{control_center_next_gen_dep_prometheus.systemd_file}}"
+      - service_file_source: "{{confluent_control_center_next_gen_binary_base_path}}/lib/systemd/system/{{control_center_next_gen_dep_alertmanager.systemd_file|basename}}"
+        service_file_dest: "{{control_center_next_gen_dep_alertmanager.systemd_file}}"
+  loop: "{{ c3_service_files + (bundled_dependency_service_files if control_center_next_gen_bundled_monitoring_enabled | bool else []) }}"
   when: installation_method == "archive"
   tags:
     - systemd
@@ -266,7 +275,9 @@
     cert_path: "{{control_center_next_gen_dependency_prometheus_cert_path}}"
     key_path: "{{control_center_next_gen_dependency_prometheus_key_path}}"
     export_certs: "true"
-  when: control_center_next_gen_dependency_prometheus_ssl_enabled|bool
+  when:
+    - control_center_next_gen_dependency_prometheus_ssl_enabled|bool
+    - control_center_next_gen_bundled_monitoring_enabled | bool
 
 - name:  Create Control Center Next Gen Dependency Alertmanager Keystore and Truststore
   include_role:
@@ -285,7 +296,9 @@
     cert_path: "{{control_center_next_gen_dependency_alertmanager_cert_path}}"
     key_path: "{{control_center_next_gen_dependency_alertmanager_key_path}}"
     export_certs: "true"
-  when: control_center_next_gen_dependency_alertmanager_ssl_enabled|bool
+  when:
+    - control_center_next_gen_dependency_alertmanager_ssl_enabled|bool
+    - control_center_next_gen_bundled_monitoring_enabled | bool
 
 - name: Configure Kerberos
   include_role:
@@ -568,10 +581,7 @@
     owner: "{{control_center_next_gen_user}}"
     group: "{{control_center_next_gen_group}}"
     mode: '750'
-  loop:
-    - "{{control_center_next_gen.systemd_override | dirname}}"
-    - "{{control_center_next_gen_dep_alertmanager.systemd_override | dirname}}"
-    - "{{control_center_next_gen_dep_prometheus.systemd_override | dirname}}"
+  loop: "{{ [control_center_next_gen.systemd_override | dirname] + ([control_center_next_gen_dep_alertmanager.systemd_override | dirname, control_center_next_gen_dep_prometheus.systemd_override | dirname] if control_center_next_gen_bundled_monitoring_enabled | bool else []) }}"
   tags:
     - systemd
     - privileged
@@ -583,13 +593,16 @@
     mode: '640'
     owner: root
     group: root
-  loop:
-    - override_file_template: "alertmanager_override.conf.j2"
-      override_file_dst: "{{control_center_next_gen_dep_alertmanager.systemd_override}}"
-    - override_file_template: "prometheus_override.conf.j2"
-      override_file_dst: "{{control_center_next_gen_dep_prometheus.systemd_override}}"
-    - override_file_template: "override.conf.j2"
-      override_file_dst: "{{control_center_next_gen.systemd_override}}"
+  vars:
+    c3_service_overrides:
+      - override_file_template: "override.conf.j2"
+        override_file_dst: "{{control_center_next_gen.systemd_override}}"
+    bundled_dependency_service_overrides:
+      - override_file_template: "alertmanager_override.conf.j2"
+        override_file_dst: "{{control_center_next_gen_dep_alertmanager.systemd_override}}"
+      - override_file_template: "prometheus_override.conf.j2"
+        override_file_dst: "{{control_center_next_gen_dep_prometheus.systemd_override}}"
+  loop: "{{ c3_service_overrides + (bundled_dependency_service_overrides if control_center_next_gen_bundled_monitoring_enabled | bool else []) }}"
   notify: restart control center next gen
   diff: "{{ not mask_sensitive_diff|bool }}"
   tags:
@@ -609,10 +622,7 @@
     name: "{{item}}"
     enabled: true
     state: started
-  loop:
-    - "{{control_center_next_gen_dep_alertmanager_service_name}}"
-    - "{{control_center_next_gen_dep_prometheus_service_name}}"
-    - "{{control_center_next_gen_service_name}}"
+  loop: "{{ [control_center_next_gen_service_name] + ([control_center_next_gen_dep_alertmanager_service_name, control_center_next_gen_dep_prometheus_service_name] if control_center_next_gen_bundled_monitoring_enabled | bool else []) }}"
   tags:
     - systemd
 

--- a/roles/control_center_next_gen/tasks/main.yml
+++ b/roles/control_center_next_gen/tasks/main.yml
@@ -281,6 +281,11 @@
     cert_path: "{{control_center_next_gen_dependency_prometheus_cert_path}}"
     key_path: "{{control_center_next_gen_dependency_prometheus_key_path}}"
     export_certs: "true"
+    # When a client cert/key is provided (BYOP mTLS), build the keystore from THAT cert (signed by a
+    # CA the external Prometheus trusts) instead of self-signing with the cluster CA - otherwise C3
+    # would present a cluster-CA cert the external Prometheus rejects. Empty cert_path (bundled or
+    # Basic auth) keeps the default self-signed behavior.
+    ssl_custom_certs: "{{ true if (control_center_next_gen_dependency_prometheus_cert_path | default('') | length > 1) else false }}"
   # Needed whenever C3 talks to Prometheus over TLS, bundled OR external (BYOP): this builds the
   # truststore C3 uses to trust the Prometheus endpoint, and the client keystore for mTLS.
   when:

--- a/roles/control_center_next_gen/tasks/main.yml
+++ b/roles/control_center_next_gen/tasks/main.yml
@@ -4,6 +4,12 @@
   when: not common_role_completed|bool
   tags: common
 
+- name: Validate BYOP configuration before installing
+  ansible.builtin.import_tasks: validate_byop.yml
+  when: control_center_next_gen_external_prometheus_enabled | bool
+  tags:
+    - configuration
+
 - name: Gather OS Facts
   setup:
     # Only gathers items in list, filters out the rest

--- a/roles/control_center_next_gen/tasks/main.yml
+++ b/roles/control_center_next_gen/tasks/main.yml
@@ -151,7 +151,7 @@
       src: "{{control_center_next_gen_dependency_alertmanager_generated_src_config_file}}"
       dest: "{{control_center_next_gen_dep_alertmanager.config_file}}"
       always_copy: false
-  when: control_center_next_gen_bundled_monitoring_enabled | bool
+  when: not control_center_next_gen_external_prometheus_enabled | bool
   tags:
     - configuration
 
@@ -162,7 +162,7 @@
     mode: '640'
     owner: "{{control_center_next_gen_user}}"
     group: "{{control_center_next_gen_group}}"
-  when: control_center_next_gen_bundled_monitoring_enabled | bool
+  when: not control_center_next_gen_external_prometheus_enabled | bool
   tags:
     - configuration
 
@@ -170,7 +170,7 @@
   include_tasks: prometheus_config_overlay.yml
   when:
     - control_center_next_gen_dependency_prometheus_custom_overlay_path is defined
-    - control_center_next_gen_bundled_monitoring_enabled | bool
+    - not control_center_next_gen_external_prometheus_enabled | bool
   tags:
     - configuration
 
@@ -186,7 +186,7 @@
       dest: "{{control_center_next_gen_dep_prometheus.web_config_file}}"
     - template: "alertmanager_web_config.yml.j2"
       dest: "{{control_center_next_gen_dep_alertmanager.web_config_file}}"
-  when: control_center_next_gen_bundled_monitoring_enabled | bool
+  when: not control_center_next_gen_external_prometheus_enabled | bool
   notify: restart control center next gen
   tags:
     - configuration
@@ -203,7 +203,7 @@
     - "{{control_center_next_gen_dep_prometheus.web_config_file}}"
     - "{{control_center_next_gen_dep_alertmanager.config_file}}"
     - "{{control_center_next_gen_dep_alertmanager.web_config_file}}"
-  when: control_center_next_gen_bundled_monitoring_enabled | bool
+  when: not control_center_next_gen_external_prometheus_enabled | bool
   tags:
     - filesystem
 
@@ -225,7 +225,7 @@
         service_file_dest: "{{control_center_next_gen_dep_prometheus.systemd_file}}"
       - service_file_source: "{{confluent_control_center_next_gen_binary_base_path}}/lib/systemd/system/{{control_center_next_gen_dep_alertmanager.systemd_file|basename}}"
         service_file_dest: "{{control_center_next_gen_dep_alertmanager.systemd_file}}"
-  loop: "{{ c3_service_files + (bundled_dependency_service_files if control_center_next_gen_bundled_monitoring_enabled | bool else []) }}"
+  loop: "{{ c3_service_files + (bundled_dependency_service_files if not control_center_next_gen_external_prometheus_enabled | bool else []) }}"
   when: installation_method == "archive"
   tags:
     - systemd
@@ -277,7 +277,7 @@
     export_certs: "true"
   when:
     - control_center_next_gen_dependency_prometheus_ssl_enabled|bool
-    - control_center_next_gen_bundled_monitoring_enabled | bool
+    - not control_center_next_gen_external_prometheus_enabled | bool
 
 - name:  Create Control Center Next Gen Dependency Alertmanager Keystore and Truststore
   include_role:
@@ -298,7 +298,7 @@
     export_certs: "true"
   when:
     - control_center_next_gen_dependency_alertmanager_ssl_enabled|bool
-    - control_center_next_gen_bundled_monitoring_enabled | bool
+    - not control_center_next_gen_external_prometheus_enabled | bool
 
 - name: Configure Kerberos
   include_role:
@@ -581,7 +581,7 @@
     owner: "{{control_center_next_gen_user}}"
     group: "{{control_center_next_gen_group}}"
     mode: '750'
-  loop: "{{ [control_center_next_gen.systemd_override | dirname] + ([control_center_next_gen_dep_alertmanager.systemd_override | dirname, control_center_next_gen_dep_prometheus.systemd_override | dirname] if control_center_next_gen_bundled_monitoring_enabled | bool else []) }}"
+  loop: "{{ [control_center_next_gen.systemd_override | dirname] + ([control_center_next_gen_dep_alertmanager.systemd_override | dirname, control_center_next_gen_dep_prometheus.systemd_override | dirname] if not control_center_next_gen_external_prometheus_enabled | bool else []) }}"
   tags:
     - systemd
     - privileged
@@ -602,7 +602,7 @@
         override_file_dst: "{{control_center_next_gen_dep_alertmanager.systemd_override}}"
       - override_file_template: "prometheus_override.conf.j2"
         override_file_dst: "{{control_center_next_gen_dep_prometheus.systemd_override}}"
-  loop: "{{ c3_service_overrides + (bundled_dependency_service_overrides if control_center_next_gen_bundled_monitoring_enabled | bool else []) }}"
+  loop: "{{ c3_service_overrides + (bundled_dependency_service_overrides if not control_center_next_gen_external_prometheus_enabled | bool else []) }}"
   notify: restart control center next gen
   diff: "{{ not mask_sensitive_diff|bool }}"
   tags:
@@ -622,7 +622,7 @@
     name: "{{item}}"
     enabled: true
     state: started
-  loop: "{{ [control_center_next_gen_service_name] + ([control_center_next_gen_dep_alertmanager_service_name, control_center_next_gen_dep_prometheus_service_name] if control_center_next_gen_bundled_monitoring_enabled | bool else []) }}"
+  loop: "{{ [control_center_next_gen_service_name] + ([control_center_next_gen_dep_alertmanager_service_name, control_center_next_gen_dep_prometheus_service_name] if not control_center_next_gen_external_prometheus_enabled | bool else []) }}"
   tags:
     - systemd
 

--- a/roles/control_center_next_gen/tasks/main.yml
+++ b/roles/control_center_next_gen/tasks/main.yml
@@ -317,8 +317,9 @@
     alias: "byop_prometheus_ca"
     truststore_storepass: "{{ control_center_next_gen_dependency_prometheus_truststore_storepass }}"
     truststore_path: "{{ control_center_next_gen_dependency_prometheus_truststore_path }}"
-    bcfks_truststore_path: "{{ control_center_next_gen_dependency_prometheus_bcfks_truststore_path | default(control_center_next_gen_dependency_prometheus_truststore_path) }}"
-    create_bouncy_castle_keystore: "{{ fips_enabled }}"
+    # The C3 Prometheus client truststore is a single PKCS12 store (no BCFKS variant), even under
+    # FIPS, so import into it directly and do not attempt a BCFKS import.
+    create_bouncy_castle_keystore: false
     restart_handler_name: "restart control center next gen"
   when:
     - control_center_next_gen_external_prometheus_enabled | bool

--- a/roles/control_center_next_gen/tasks/restart_and_wait.yml
+++ b/roles/control_center_next_gen/tasks/restart_and_wait.yml
@@ -4,6 +4,9 @@
     daemon_reload: true
     name: "{{control_center_next_gen_dep_prometheus_service_name}}"
     state: restarted
+  # BYOP: the bundled Prometheus is not managed in external-Prometheus mode - do not (re)start it,
+  # otherwise a config-change notify would bring up the bundled service the deployment opted out of.
+  when: not control_center_next_gen_external_prometheus_enabled | bool
   tags:
     - systemd
 
@@ -12,6 +15,8 @@
     daemon_reload: true
     name: "{{control_center_next_gen_dep_alertmanager_service_name}}"
     state: restarted
+  # BYOP: the bundled Alertmanager is not managed in external-Prometheus mode - do not (re)start it.
+  when: not control_center_next_gen_external_prometheus_enabled | bool
   tags:
     - systemd
 

--- a/roles/control_center_next_gen/tasks/validate_byop.yml
+++ b/roles/control_center_next_gen/tasks/validate_byop.yml
@@ -1,0 +1,44 @@
+---
+# BYOP pre-flight validation.
+# Imported near the top of main.yml, gated on control_center_next_gen_external_prometheus_enabled.
+# Fails fast with a clear message on a misconfigured external-Prometheus setup.
+# Enforces the supported contract: an endpoint, TLS on every connection, and exactly one auth mode.
+#
+# Note: control_center_next_gen_dependency_prometheus_host has a computed default (the C3 host),
+# so the TLS and auth checks below are the strong signal that a real external endpoint was set.
+
+- name: BYOP - external Prometheus endpoint must be set
+  ansible.builtin.assert:
+    that:
+      - control_center_next_gen_dependency_prometheus_host is defined
+      - (control_center_next_gen_dependency_prometheus_host | default('') | trim | length) > 0
+    fail_msg: >-
+      control_center_next_gen_external_prometheus_enabled is true but the external Prometheus
+      endpoint is not set. Set control_center_next_gen_dependency_prometheus_host and
+      control_center_next_gen_dependency_prometheus_port to your external Prometheus.
+    success_msg: "BYOP: external Prometheus endpoint is set."
+    quiet: true
+
+- name: BYOP - external Prometheus must use TLS
+  ansible.builtin.assert:
+    that:
+      - control_center_next_gen_dependency_prometheus_ssl_enabled | bool
+    fail_msg: >-
+      control_center_next_gen_external_prometheus_enabled is true but TLS is not enabled. Set
+      control_center_next_gen_dependency_prometheus_ssl_enabled to true. Every connection to the
+      external Prometheus must use TLS.
+    success_msg: "BYOP: external Prometheus TLS is enabled."
+    quiet: true
+
+- name: BYOP - external Prometheus requires exactly one auth mode
+  ansible.builtin.assert:
+    that:
+      - (control_center_next_gen_dependency_prometheus_basic_auth_enabled | bool)
+        != (control_center_next_gen_dependency_prometheus_mtls_enabled | bool)
+    fail_msg: >-
+      Choose exactly one auth mode for the external Prometheus. Set either
+      control_center_next_gen_dependency_prometheus_basic_auth_enabled (Basic auth over TLS) or
+      control_center_next_gen_dependency_prometheus_mtls_enabled (mutual TLS) to true, not both
+      and not neither.
+    success_msg: "BYOP: external Prometheus auth mode is valid."
+    quiet: true

--- a/roles/control_center_next_gen/tasks/validate_byop.yml
+++ b/roles/control_center_next_gen/tasks/validate_byop.yml
@@ -42,3 +42,19 @@
       and not neither.
     success_msg: "BYOP: external Prometheus auth mode is valid."
     quiet: true
+
+# TODO(SETU-3482): C3-version guard. BYOP needs a C3 Next Gen that supports
+# confluent.controlcenter.prometheus.external.enable (control-center-backend #395). Until that ships
+# we do not know the exact release version, so this stays commented out. Once #395 lands, replace
+# <MIN_C3_VERSION> with the first C3 Next Gen version that contains external.enable and enable this,
+# so "BYOP on + old C3" fails fast here instead of crashing cryptically at C3 boot.
+# - name: BYOP - C3 Next Gen must support external Prometheus
+#   ansible.builtin.assert:
+#     that:
+#       - confluent_control_center_next_gen_package_version is version('<MIN_C3_VERSION>', '>=')
+#     fail_msg: >-
+#       BYOP requires C3 Next Gen >= <MIN_C3_VERSION> (external Prometheus support). Got
+#       {{ confluent_control_center_next_gen_package_version }}. Upgrade C3 Next Gen or disable BYOP
+#       (control_center_next_gen_external_prometheus_enabled).
+#     success_msg: "BYOP: C3 Next Gen version supports external Prometheus."
+#     quiet: true

--- a/roles/kafka_broker/tasks/main.yml
+++ b/roles/kafka_broker/tasks/main.yml
@@ -220,6 +220,28 @@
     - sso_idp_cert_path != ""
     - not external_mds_enabled|bool
 
+# BYOP: when reading from an external Prometheus over TLS, the node's telemetry exporter pushes
+# metrics to that endpoint using this node's own truststore. Import the external Prometheus CA so
+# the exporter trusts the external endpoint's server certificate (and, under mTLS, completes the
+# handshake). Requires a restart to take effect.
+- name: Import external Prometheus CA to Truststore (BYOP)
+  include_role:
+    name: common
+    tasks_from: idp_certs.yml
+  vars:
+    idp_cert_path: "{{ control_center_next_gen_dependency_prometheus_provided_ca_cert_path | default(control_center_next_gen_dependency_prometheus_ca_cert_path) }}"
+    idp_cert_dest: /tmp/byop_prometheus_ca.pem
+    alias: "byop_prometheus_ca"
+    truststore_storepass: "{{kafka_broker_truststore_storepass}}"
+    truststore_path: "{{kafka_broker_pkcs12_truststore_path}}"
+    bcfks_truststore_path: "{{kafka_broker_bcfks_truststore_path}}"
+    create_bouncy_castle_keystore: "{{fips_enabled}}"
+    restart_handler_name: "restart kafka"
+  when:
+    - control_center_next_gen_external_prometheus_enabled | bool
+    - control_center_next_gen_dependency_prometheus_ssl_enabled | bool
+    - (control_center_next_gen_dependency_prometheus_provided_ca_cert_path | default('') | length) > 0
+
 - name: Configure Kerberos
   include_role:
     name: kerberos

--- a/roles/kafka_controller/tasks/main.yml
+++ b/roles/kafka_controller/tasks/main.yml
@@ -195,6 +195,28 @@
     - oauth_enabled|bool or schema_registry_oauth_enabled|bool or kafka_rest_oauth_enabled|bool or kafka_connect_oauth_enabled|bool or kafka_connect_replicator_oauth_enabled|bool
     - oauth_idp_cert_path != ""
 
+# BYOP: when reading from an external Prometheus over TLS, the node's telemetry exporter pushes
+# metrics to that endpoint using this node's own truststore. Import the external Prometheus CA so
+# the exporter trusts the external endpoint's server certificate (and, under mTLS, completes the
+# handshake). Requires a restart to take effect.
+- name: Import external Prometheus CA to Truststore (BYOP)
+  include_role:
+    name: common
+    tasks_from: idp_certs.yml
+  vars:
+    idp_cert_path: "{{ control_center_next_gen_dependency_prometheus_provided_ca_cert_path | default(control_center_next_gen_dependency_prometheus_ca_cert_path) }}"
+    idp_cert_dest: /tmp/byop_prometheus_ca.pem
+    alias: "byop_prometheus_ca"
+    truststore_storepass: "{{kafka_controller_truststore_storepass}}"
+    truststore_path: "{{kafka_controller_pkcs12_truststore_path}}"
+    bcfks_truststore_path: "{{kafka_controller_bcfks_truststore_path}}"
+    create_bouncy_castle_keystore: "{{fips_enabled}}"
+    restart_handler_name: "restart Kafka Controller"
+  when:
+    - control_center_next_gen_external_prometheus_enabled | bool
+    - control_center_next_gen_dependency_prometheus_ssl_enabled | bool
+    - (control_center_next_gen_dependency_prometheus_provided_ca_cert_path | default('') | length) > 0
+
 - name: Configure Kerberos
   include_role:
     name: kerberos

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -1252,6 +1252,9 @@ control_center_next_gen_monitoring_interceptor_kafka_listener_name: "{{ control_
 
 control_center_next_gen_dependency_web_listener_host: "0.0.0.0"
 
+# BYOP (SETU-3482): when false, the bundled Prometheus and Alertmanager for
+# Control Center Next Gen are not installed or started (used with an external Prometheus).
+control_center_next_gen_bundled_monitoring_enabled: true
 control_center_next_gen_dependency_prometheus_schema: "{{ 'https' if control_center_next_gen_dependency_prometheus_ssl_enabled|bool else 'http' }}"
 control_center_next_gen_dependency_prometheus_host: "{{ (groups.get('control_center_next_gen') if groups.get('control_center_next_gen') else ['localhost']) | confluent.platform.resolve_hostnames(hostvars) | first }}"
 control_center_next_gen_dependency_prometheus_web_listener_host: "{{ control_center_next_gen_dependency_web_listener_host }}"

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -1252,9 +1252,9 @@ control_center_next_gen_monitoring_interceptor_kafka_listener_name: "{{ control_
 
 control_center_next_gen_dependency_web_listener_host: "0.0.0.0"
 
-# BYOP (SETU-3482): when false, the bundled Prometheus and Alertmanager for
-# Control Center Next Gen are not installed or started (used with an external Prometheus).
-control_center_next_gen_bundled_monitoring_enabled: true
+# BYOP (SETU-3482): when true, the bundled Prometheus and Alertmanager for Control
+# Center Next Gen are not installed or started, and C3 reads from an external Prometheus.
+control_center_next_gen_external_prometheus_enabled: false
 control_center_next_gen_dependency_prometheus_schema: "{{ 'https' if control_center_next_gen_dependency_prometheus_ssl_enabled|bool else 'http' }}"
 control_center_next_gen_dependency_prometheus_host: "{{ (groups.get('control_center_next_gen') if groups.get('control_center_next_gen') else ['localhost']) | confluent.platform.resolve_hostnames(hostvars) | first }}"
 control_center_next_gen_dependency_prometheus_web_listener_host: "{{ control_center_next_gen_dependency_web_listener_host }}"

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -1252,8 +1252,7 @@ control_center_next_gen_monitoring_interceptor_kafka_listener_name: "{{ control_
 
 control_center_next_gen_dependency_web_listener_host: "0.0.0.0"
 
-# BYOP (SETU-3482): when true, the bundled Prometheus and Alertmanager for Control
-# Center Next Gen are not installed or started, and C3 reads from an external Prometheus.
+### Boolean. BYOP (Bring Your Own Prometheus): when true, the bundled Prometheus and Alertmanager for Control Center Next Gen are not installed, and C3 reads from an external Prometheus configured via the control_center_next_gen_dependency_prometheus_* variables.
 control_center_next_gen_external_prometheus_enabled: false
 control_center_next_gen_dependency_prometheus_schema: "{{ 'https' if control_center_next_gen_dependency_prometheus_ssl_enabled|bool else 'http' }}"
 control_center_next_gen_dependency_prometheus_host: "{{ (groups.get('control_center_next_gen') if groups.get('control_center_next_gen') else ['localhost']) | confluent.platform.resolve_hostnames(hostvars) | first }}"

--- a/roles/variables/vars/main.yml
+++ b/roles/variables/vars/main.yml
@@ -2404,10 +2404,12 @@ control_center_next_gen_properties:
       confluent.controlcenter.prometheus.config.file: "{{control_center_next_gen_dep_prometheus.config_file}}"
       confluent.controlcenter.prometheus.rules.file: "{{control_center_next_gen_dep_prometheus.trigger_rules_config_file}}"
       confluent.controlcenter.alertmanager.config.file: "{{control_center_next_gen_dep_alertmanager.config_file}}"
-  # BYOP: alerts are disabled when C3 reads from an external Prometheus (no bundled Alertmanager).
+  # BYOP: tell C3 it is reading from a customer-managed external Prometheus (so it does not require
+  # bundled rules/alertmanager files), and disable alerts (no bundled Alertmanager to write to).
   external_prometheus:
     enabled: "{{ control_center_next_gen_external_prometheus_enabled | bool }}"
     properties:
+      confluent.controlcenter.prometheus.external.enable: true
       confluent.controlcenter.alerts.enable: false
   prometheus_client:
     enabled: "{{control_center_next_gen_dependency_prometheus_ssl_enabled | bool or control_center_next_gen_dependency_prometheus_basic_auth_enabled | bool}}"

--- a/roles/variables/vars/main.yml
+++ b/roles/variables/vars/main.yml
@@ -2394,10 +2394,21 @@ control_center_next_gen_properties:
       confluent.controlcenter.streams.security.protocol: "{{kafka_broker_listeners[control_center_next_gen_streams_kafka_listener_name] | confluent.platform.kafka_protocol_defaults(ssl_enabled, sasl_protocol) }}"
       confluent.controlcenter.prometheus.enable: true
       confluent.controlcenter.prometheus.url: "{{control_center_next_gen_dependency_prometheus_url}}"
+  # BYOP: the bundled Prometheus/Alertmanager management properties render only when the
+  # bundle is deployed (external Prometheus off). In BYOP the customer configures the
+  # equivalent on their own external Prometheus, and C3 reads over the url.
+  bundled_monitoring:
+    enabled: "{{ not control_center_next_gen_external_prometheus_enabled | bool }}"
+    properties:
       confluent.controlcenter.alertmanager.url: "{{control_center_next_gen_dependency_alertmanager_url}}"
       confluent.controlcenter.prometheus.config.file: "{{control_center_next_gen_dep_prometheus.config_file}}"
       confluent.controlcenter.prometheus.rules.file: "{{control_center_next_gen_dep_prometheus.trigger_rules_config_file}}"
       confluent.controlcenter.alertmanager.config.file: "{{control_center_next_gen_dep_alertmanager.config_file}}"
+  # BYOP: alerts are disabled when C3 reads from an external Prometheus (no bundled Alertmanager).
+  external_prometheus:
+    enabled: "{{ control_center_next_gen_external_prometheus_enabled | bool }}"
+    properties:
+      confluent.controlcenter.alerts.enable: false
   prometheus_client:
     enabled: "{{control_center_next_gen_dependency_prometheus_ssl_enabled | bool or control_center_next_gen_dependency_prometheus_basic_auth_enabled | bool}}"
     properties: "{{ control_center_next_gen_dependency_prometheus_ssl_enabled | confluent.platform.prometheus_client_properties(
@@ -2412,7 +2423,7 @@ control_center_next_gen_properties:
         control_center_next_gen_dependency_prometheus_service_name
       ) }}"
   alertmanager_client:
-    enabled: "{{control_center_next_gen_dependency_alertmanager_ssl_enabled | bool or control_center_next_gen_dependency_alertmanager_basic_auth_enabled | bool}}"
+    enabled: "{{ (control_center_next_gen_dependency_alertmanager_ssl_enabled | bool or control_center_next_gen_dependency_alertmanager_basic_auth_enabled | bool) and not control_center_next_gen_external_prometheus_enabled | bool }}"
     properties: "{{ control_center_next_gen_dependency_alertmanager_ssl_enabled | confluent.platform.alertmanager_client_properties(
         control_center_next_gen_dependency_alertmanager_truststore_path,
         control_center_next_gen_dependency_alertmanager_truststore_storepass,


### PR DESCRIPTION
## What this does

Adds the BYOP (Bring Your Own Prometheus) support for Control Center Next Gen to the `8.4.x` release branch: a single toggle (`control_center_next_gen_external_prometheus_enabled`, default `false`) that makes C3 read from a customer-managed external Prometheus and skips the bundled Prometheus/Alertmanager. When the toggle is on, C3 emits `prometheus.external.enable=true`, the explicit external `prometheus.url`, and `alerts.enable=false`, and the bundled monitoring resources (image pull, PVC, sidecars, rules/alertmanager config) are not rendered. When it is off, behaviour is unchanged.

Scope of the change:
- Role toggle + gating of all bundled-monitoring resources behind it.
- BYOP pre-flight validation (endpoint, TLS, one auth mode).
- External Prometheus over Basic auth + TLS, and over mTLS (client keystore/truststore), including broker/controller metric push (node-push) trust.
- Customer-facing bundled-monitoring teardown playbook for brownfield transitions.
- Sample external-Prometheus inventory + variable docs.
- Molecule scenarios (greenfield, brownfield, round-trip, upgrade-migrate, basic-auth, mTLS) and a hardened `byop_verify`.

## Relationship to the existing PR

This branch was cut from `8.4.x` and carries the exact same BYOP delta as the master-based PR #2623. The change set is byte-for-byte identical between the two branches (same 65 files, same patch content). Only the release baseline differs. This PR is the `8.4.x`-targeted equivalent so the feature can land on the release branch.

## Test plan

- **Unit / molecule (pytest mode, cp-ansible-tools on-demand):** the 13 BYOP molecule scenarios pass (basic-auth, mTLS, greenfield, brownfield, round-trip, upgrade-migrate, and the FIPS/mTLS node-push scenario). A whole-repo run on this branch is in progress; the pre-existing non-BYOP failures (custom-certs / rbac-mds / custom-repo) are unrelated to this change and also fail on master and 8.4.x for other runs.
- **Live validation (same-VPC):** basic-auth-over-TLS and mTLS boxes validated over SSH — C3 config in external/alerts-off mode, bundled Prometheus/Alertmanager inactive, external Prometheus healthy, recording rules loaded, brokers and controllers pushing, plus resilience/negative checks (SAN mismatch rejected, read-path outage recovery, cert rotation, expired cert rejected, mTLS client-cert required/absent).
- **Gating:** every code path is behind the toggle (default `false`); CA-generation and truststore/keystore bodies add only guarded clauses, so non-BYOP deployments are unaffected.
