### PR TITLE
Honor hostname aliasing for kafka_controller_quorum_voters

### DIFF
--- a/molecule/mtls-ubuntu/molecule.yml
+++ b/molecule/mtls-ubuntu/molecule.yml
@@ -153,6 +153,7 @@ provisioner:
   inventory:
     group_vars:
       all:
+        hostname_aliasing_enabled: true
         jolokia_enabled: true
         ssl_enabled: true
         ssl_mutual_auth_enabled: true

--- a/molecule/mtls-ubuntu/molecule.yml
+++ b/molecule/mtls-ubuntu/molecule.yml
@@ -19,6 +19,8 @@ platforms:
     privileged: true
     networks:
       - name: confluent
+        aliases:
+          - ${KRAFT_CONTROLLER:-zookeeper}1.confluent
   - name: kafka-broker1
     hostname: kafka-broker1.confluent
     groups:
@@ -152,8 +154,10 @@ provisioner:
     converge: ${MIGRATION_CONVERGE:-../collections_converge.yml}
   inventory:
     group_vars:
-      all:
+      kafka_controller:
         hostname_aliasing_enabled: true
+        hostname: "{{ inventory_hostname }}.confluent"
+      all:
         jolokia_enabled: true
         ssl_enabled: true
         ssl_mutual_auth_enabled: true

--- a/molecule/mtls-ubuntu/verify.yml
+++ b/molecule/mtls-ubuntu/verify.yml
@@ -18,6 +18,7 @@
       assert:
         that:
           - hostvars[inventory_hostname].hostname_aliasing_enabled | bool
+          - kafka_controller_quorum_voters is search(hostvars[inventory_hostname] | confluent.platform.resolve_hostname)
           - kafka_controller_quorum_voters is not search('@' + inventory_hostname + ':')
         fail_msg: >-
           controller.quorum.voters '{{ kafka_controller_quorum_voters }}' is not using the aliased

--- a/molecule/mtls-ubuntu/verify.yml
+++ b/molecule/mtls-ubuntu/verify.yml
@@ -17,13 +17,13 @@
     - name: Assert controller quorum voters honor hostname aliasing
       assert:
         that:
-          - hostvars[inventory_hostname].hostname_aliasing_enabled | bool
           - kafka_controller_quorum_voters is search(hostvars[inventory_hostname] | confluent.platform.resolve_hostname)
           - kafka_controller_quorum_voters is not search('@' + inventory_hostname + ':')
         fail_msg: >-
           controller.quorum.voters '{{ kafka_controller_quorum_voters }}' is not using the aliased
           hostname '{{ hostvars[inventory_hostname] | confluent.platform.resolve_hostname }}'
         success_msg: "controller.quorum.voters correctly uses aliased hostname"
+      when: hostvars[inventory_hostname].hostname_aliasing_enabled | default(false) | bool
     - import_role:
         name: confluent.test
         tasks_from: check_property.yml

--- a/molecule/mtls-ubuntu/verify.yml
+++ b/molecule/mtls-ubuntu/verify.yml
@@ -14,6 +14,15 @@
         file_path: /etc/controller/server.properties
         property: controller.quorum.voters
         expected_value: "{{ kafka_controller_quorum_voters }}"
+    - name: Assert controller quorum voters honor hostname aliasing
+      assert:
+        that:
+          - hostvars[inventory_hostname].hostname_aliasing_enabled | bool
+          - kafka_controller_quorum_voters is not search('@' + inventory_hostname + ':')
+        fail_msg: >-
+          controller.quorum.voters '{{ kafka_controller_quorum_voters }}' is not using the aliased
+          hostname '{{ hostvars[inventory_hostname] | confluent.platform.resolve_hostname }}'
+        success_msg: "controller.quorum.voters correctly uses aliased hostname"
     - import_role:
         name: confluent.test
         tasks_from: check_property.yml

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -531,7 +531,7 @@ jolokia_endpoint_health_check_retries: 3
 jolokia_endpoint_health_check_delay: 30
 
 ### Default controller quorum voters
-kafka_controller_quorum_voters: "{% for controller_hostname in groups.kafka_controller|default([]) %}{% if loop.index > 1%},{% endif %}{{groups.kafka_controller.index(controller_hostname)|int + 9991}}@{{controller_hostname}}:{{ kafka_controller_listeners['controller']['port'] }}{%endfor%}"
+kafka_controller_quorum_voters: "{% for controller_hostname in groups.kafka_controller|default([]) %}{% if loop.index > 1%},{% endif %}{{groups.kafka_controller.index(controller_hostname)|int + 9991}}@{{hostvars[controller_hostname]|confluent.platform.resolve_hostname}}:{{ kafka_controller_listeners['controller']['port'] }}{%endfor%}"
 
 ### Default Kafka config prefix. Only valid to customize when installation_method: archive
 kafka_controller_config_prefix: "{{ config_prefix }}/controller"


### PR DESCRIPTION
### Issue
`kafka_controller_quorum_voters` (KRaft) used the raw inventory hostname, so `hostname_aliasing_enabled` was ignored for controller quorum voters while honored everywhere else.

### Fix
Pass the controller hostname through the `resolve_hostname` filter, matching the rest of the collection. No change when hostname aliasing is off.

### Test
Enabled `hostname_aliasing_enabled: true` in the `mtls-ubuntu` scenario and added an assert on the controllers that checks:
- hostname aliasing is on
- `controller.quorum.voters` contains the aliased hostname
- `controller.quorum.voters` does not use the raw inventory hostname