### PR TITLE
[ANSIENG-5906] | Scope archive ownership chown to binary_base_path instead of archive_destination_path

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -89,7 +89,7 @@
 
 - name: Set Group and Owner for Confluent Platform archive
   file:
-    path: "{{archive_destination_path}}"
+    path: "{{binary_base_path}}"
     group: "{{ omit if archive_group == '' else archive_group }}"
     owner: "{{ omit if archive_owner == '' else archive_owner }}"
     mode: '755'


### PR DESCRIPTION
## Summary

Same fix as the companion 8.1.x PR (ANSIENG-5906), backported to 7.9.x since USM Agent is
present here too (confirmed via `git ls-tree -d origin/7.9.x -- roles/usm_agent`; not present on
7.7.x/7.8.x/8.0.x, so no fix needed there).

`roles/common/tasks/main.yml`'s "Set Group and Owner for Confluent Platform archive" task
recursively `chown`s the entire `archive_destination_path` tree (default `/opt/confluent`) to
`archive_owner`/`archive_group`, mode 755, on every archive-install run. USM Agent extracts its
own archive as a **sibling** directory under that same parent, so re-running any single
component's standalone playbook (e.g. `playbooks/kafka_broker.yml`) re-triggers this recursive
chown and resets USM Agent's already-deployed config/secrets (normally
`cp-usm-agent:confluent`, modes 600/700/750) to `archive_owner:archive_group` mode 755 —
breaking the agent's access to its own credentials.

```diff
- name: Set Group and Owner for Confluent Platform archive
  file:
-   path: "{{archive_destination_path}}"
+   path: "{{binary_base_path}}"
    group: "{{ omit if archive_group == '' else archive_group }}"
    owner: "{{ omit if archive_owner == '' else archive_owner }}"
    mode: '755'
    recurse: true
  when: installation_method == "archive"
```

## Evidence (live EC2, RHEL 9, archive install, custom `archive_owner: ec2-user`, USM Agent
co-located with kafka_broker/kafka_controller on one host, cp-ansible 7.9.x / CP 7.9.9 / USM
Agent 1.2.1)
<img width="922" height="455" alt="image" src="https://github.com/user-attachments/assets/9d60472d-6da5-4ec0-9768-9bf58d2e7f4c" />

**1. Baseline — after greenfield `playbooks/all.yml` deploy (unfixed code):**
```
drwx------. 2 cp-usm-agent confluent 88 /opt/confluent/confluent-usm-agent-1.2.1-amd64/etc/confluent/usm-agent/secrets
-rw-------. 1 cp-usm-agent confluent 385 .../secrets/ccloud_credential.yaml
```

**2. The issue — after re-running standalone `playbooks/kafka_broker.yml` (unfixed code):**
```
drwxr-xr-x. 2 ec2-user ec2-user 88 /opt/confluent/confluent-usm-agent-1.2.1-amd64/etc/confluent/usm-agent/secrets
-rwxr-xr-x. 1 ec2-user ec2-user 385 .../secrets/ccloud_credential.yaml
```
Same clobber reproduced on 7.9.x: the CCloud API credential file goes from mode 600, owned by
`cp-usm-agent`, to mode 755 (world readable), owned by `ec2-user`.

**3. Upgrade path — after applying the fix and re-running `playbooks/usm_agent.yml` once to
heal:** ownership restored to `cp-usm-agent:confluent` 700/600 (fix is not retroactive).

**4. The fix — after re-running standalone `playbooks/kafka_broker.yml` again (fixed code):**
```
drwx------. 2 cp-usm-agent confluent 88 /opt/confluent/confluent-usm-agent-1.2.1-amd64/etc/confluent/usm-agent/secrets
-rw-------. 1 cp-usm-agent confluent 385 .../secrets/ccloud_credential.yaml
```
Ownership survives the standalone re-run. The shared CP binary tree
(`/opt/confluent/confluent-7.9.9/bin`) still correctly receives `archive_owner:archive_group`
in all cases.

## Upgrade note

This fix is **not retroactive**. Existing archive-install clusters running USM Agent that have
already hit this clobber need one `playbooks/usm_agent.yml` re-run after upgrading to restore
correct ownership; the fix only prevents *future* clobbering.

## Merge-forward note

`8.0.x` does not have USM Agent (`roles/usm_agent` absent) and doesn't need this change. When
this branch's routine forward-sync merges `7.9.x` into `8.0.x`, that merge should use
`git merge -X ours` (consistent with this repo's existing practice, e.g.
`802560489 Merge branch '8.0.x' into 8.1.x ... using strategy ours`) so `8.0.x` keeps its own
unmodified copy of the file. `8.1.x` receives the same fix independently via a companion PR.

## Test plan
- [x] Live EC2 greenfield deploy + standalone-playbook-rerun reproduction (unfixed code)
- [x] Live EC2 fix verification + upgrade/heal path (fixed code)
- [ ] CI (molecule) — no new scenario added; existing usm_agent scenarios always run it on a
      dedicated container and don't exercise this co-located trigger

## CI results (Semaphore on-demand, `SCENARIO=ALL`)

- `confluentinc/cp-ansible@7.9.x-ANSIENG-5906`: 2/~90 failed (`connect-scale-up`, `mtls-ubuntu`),
  both `installation_method: package` (outside this fix's `archive`-only scope) —
  https://semaphore.ci.confluent.io/workflows/f5012aef-4ae5-4397-8f49-6c6fb5219276?pipeline_id=39f724f8-a623-48d4-bcc1-cb9ca516808a

No archive-install scenario failed.
