### PR TITLE
SETU-3393: kafka_controller: set confluent.catalog.collector.multitenant.cluster.link.enable=false for USM

### DIFF
--- a/roles/variables/vars/main.yml
+++ b/roles/variables/vars/main.yml
@@ -505,6 +505,7 @@ kafka_controller_properties:
       confluent.catalog.collector.destination.topic: catalog-events
       confluent.catalog.collector.full.configs.enable: true
       confluent.catalog.collector.multitenant.topics.enable: false
+      confluent.catalog.collector.multitenant.cluster.link.enable: false
       confluent.catalog.collector.max.bytes.per.snapshot: 52428800
       confluent.telemetry.exporter._usm.events.filtering.routes.allowed: catalog-events
       confluent.telemetry.exporter._usm.events.filtering.enabled: true


### PR DESCRIPTION
## Summary
- ce-kafka [#35226](https://github.com/confluentinc/ce-kafka/pull/35226) introduced `confluent.catalog.collector.multitenant.cluster.link.enable` (default `true`, CCloud-oriented). Confluent Platform clusters need it set to `false` so the KRaft controller's catalog collector emits cluster-link metadata for USM (companion receiver-side work in cc-setu-metadata-receiver [#761](https://github.com/confluentinc/cc-setu-metadata-receiver/pull/761)).
- This config is controller-only, so it's added to the `usm_agent_telemetry` block in `roles/variables/vars/main.yml` (gated on `'usm_agent' in groups`), right next to the existing sibling default `confluent.catalog.collector.multitenant.topics.enable: false`.
- Targets `8.4.x`; will be forward-ported (cherry-picked) to `master` in a follow-up once this merges.

Jira: https://confluentinc.atlassian.net/browse/SETU-3393

## Test plan
- [x] Manually verified YAML structure/indentation/quoting against the diff (matches sibling key style exactly)
- [x] No exhaustive/golden-file tests exist for `kafka_controller_properties` in this repo (`test_roles`/`molecule` only do single-property spot-checks), so nothing else is expected to break