### PR TITLE
[ANSIENG-5881] | Changes for Decoupling CP Ansible Patch Releases from CP Patch Releases

### DIFF
--- a/docs/VARIABLES.md
+++ b/docs/VARIABLES.md
@@ -8,7 +8,7 @@ Below are the supported variables for the role variables
 
 Version of Confluent Platform to install
 
-Default:  8.3.1
+Default:  ""
 
 ***
 

--- a/roles/variables/defaults/main.yml
+++ b/roles/variables/defaults/main.yml
@@ -2,7 +2,7 @@
 # Custom filters used in this file are defined in plugins/filter/filters.py
 
 ### Version of Confluent Platform to install
-confluent_package_version: 8.3.1
+confluent_package_version: ""
 
 confluent_full_package_version: "{{ confluent_package_version + '-1' }}"
 confluent_package_redhat_suffix: "{{ '-' + confluent_full_package_version if confluent_full_package_version != '' else ''}}"

--- a/roles/variables/tasks/main.yml
+++ b/roles/variables/tasks/main.yml
@@ -1,4 +1,20 @@
 ---
+- name: Assert confluent_package_version is defined and not empty
+  assert:
+    that:
+      - confluent_package_version is defined and confluent_package_version | length > 0
+    fail_msg: |
+      ERROR: confluent_package_version is not set!
+      CP-Ansible no longer defaults confluent_package_version to a specific Confluent Platform version.
+      Please set confluent_package_version explicitly in your inventory (e.g. group_vars/all/all.yml) to the
+      Confluent Platform version you want to install.
+      Refer to the CP-Ansible / Confluent Platform version compatibility matrix:
+      https://docs.confluent.io/ansible/current/ansible-requirements.html
+    success_msg: "confluent_package_version is set to {{ confluent_package_version }}"
+  tags:
+    - validate
+    - validate_confluent_package_version
+
 - name: Validate broker_id and node_id consistency when enable_node_id is true
   assert:
     that:


### PR DESCRIPTION
Removes the hardcoded `confluent_package_version` default and adds an early validation check requiring it to be set explicitly.

Part of decoupling CP-Ansible patch releases from CP patch releases. This is the same change already merged to 7.6.x (#2603), applied per-branch so that `pint merge` forward-merges auto-resolve (identical change on both sides) instead of conflicting on the `confluent_package_version` default.

- ANSIENG-5907
- ANSIENG-5908

🤖 Generated with [Claude Code](https://claude.com/claude-code)